### PR TITLE
feat(security): harden anti-sybil inbound auth and replay defenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,9 @@ Policy files are located at `nodeops/policies/*.yaml` and can be loaded and eval
 
 ## Test Strategy
 
-Uses Node.js built-in test framework (677+97 tests across 79 test files):
-- **Node layer tests**: `node/src/*.test.ts node/src/**/*.test.ts` (677 tests, 58 files) - chain engine, EVM, RPC, WebSocket, P2P, mempool, storage, IPFS, PoSe, BFT consensus, DHT, wire protocol, fork choice, state snapshot, wire server, DHT network, snap sync, consensus-BFT integration, consensus metrics, wire connection manager, wire tx relay, sync progress, gas histogram, governance stats, wire dedup/relay, security hardening
-- **Service layer tests**: `services/**/*.test.ts` + `nodeops/*.test.ts` + `tests/**/*.test.ts` (97 tests, 21 files)
+Uses Node.js built-in test framework (689+99 tests across 82 test files):
+- **Node layer tests**: `node/src/*.test.ts node/src/**/*.test.ts` (689 tests, 61 files) - chain engine, EVM, RPC, WebSocket, P2P, mempool, storage, IPFS, PoSe, BFT consensus, DHT, wire protocol, fork choice, state snapshot, wire server, DHT network, snap sync, consensus-BFT integration, consensus metrics, wire connection manager, wire tx relay, sync progress, gas histogram, governance stats, wire dedup/relay, security hardening, P2P auth, wire auth handshake, replay guard, nonce registry
+- **Service layer tests**: `services/**/*.test.ts` + `nodeops/*.test.ts` + `tests/**/*.test.ts` (99 tests, 21 files)
 - **Storage layer tests**: `node/src/storage/*.test.ts` (included in node layer)
 
 Running tests:

--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,7 @@
   "agentSampleSize": 2,
   "operatorPrivateKey": "0xYOUR_OPERATOR_PRIVATE_KEY",
   "nonceRegistryPath": "/var/lib/coc/nonce-registry.log",
+  "endpointFingerprintMode": "strict",
   "relayerIntervalMs": 60000,
   "challengerSet": [],
   "aggregatorSet": [],

--- a/docs/phase-24-plan.zh.md
+++ b/docs/phase-24-plan.zh.md
@@ -76,6 +76,27 @@ Phase 24 添加生产就绪工具：健康检查探针、配置验证和 RPC 速
   - 支持注入 `nonceRegistry` 依赖，便于接入持久化实现。
   - 新增 epoch 全局挑战预算（`maxChallengesPerEpoch`），抑制多伪节点刷挑战。
 
+## 本次补充实现（P0 第 1-2 批 + P1 第 1 批）
+
+- `node/src/pose-http.ts`
+  - 新增 PoSe HTTP 入站鉴权能力（`off`/`monitor`/`enforce`），支持签名、时间窗、nonce 防重放、挑战者 allowlist。
+  - `/pose/challenge` 与 `/pose/receipt` 增加 `hex32` 参数校验（`nodeId`、`challengeId`）。
+- `node/src/config.ts`
+  - 新增配置项：`poseRequireInboundAuth`、`poseInboundAuthMode`、`poseAuthMaxClockSkewMs`、`poseAllowedChallengers`（含环境变量与校验）。
+  - 新增配置项：`p2pAuthNonceRegistryPath`、`p2pAuthNonceTtlMs`、`p2pAuthNonceMaxEntries`（含环境变量与校验）。
+  - P2P 入站鉴权默认模式从 `monitor` 调整为 `enforce`（可通过配置显式回退）。
+- `node/src/rpc.ts`、`node/src/index.ts`
+  - RPC 启动链路接入 PoSe 路由鉴权配置。
+- `runtime/coc-agent.ts`
+  - 调用 `/pose/challenge`、`/pose/receipt` 时默认携带签名信封，兼容 `enforce` 模式。
+  - 新增 `endpointFingerprintMode`（`strict`/`legacy`），默认 `strict`，缓解同机多地址绕过。
+- `node/src/peer-discovery.ts`、`node/src/p2p.ts`
+  - discovery 新 peer 先进入待验证队列，通过身份校验后再加入主 peers 池。
+- `node/src/p2p.ts`
+  - P2P auth nonce 防重放升级为“持久化 + TTL + 周期压缩”，覆盖节点重启窗口。
+- `node/src/dht-network.ts`
+  - `verifyPeer` 优先使用带签名的 Wire 握手验证身份；无鉴权配置时再回退 TCP 可达性探测。
+
 ## 后续计划（下一批）
 
 1. P2P 身份绑定灰度
@@ -87,10 +108,136 @@ Phase 24 添加生产就绪工具：健康检查探针、配置验证和 RPC 速
 3. 观测与告警
 - 增加限流命中率、拒绝计数与高频来源统计，联动封禁策略。
 
+## 基于代码实况的残留风险（2026-02-15）
+
+### P0（需优先处理）
+
+1. PoSe HTTP 路由缺乏来源认证与目标约束（可被刷空挑战预算）
+- 现状：`/pose/challenge` 与 `/pose/receipt` 仅做基础字段校验与 IP 频控，未校验请求方身份或挑战者角色。
+- 代码位置：`node/src/pose-http.ts`
+- 风险：外部攻击者可批量构造请求消耗 `maxChallengesPerEpoch`，并干扰正常挑战流程。
+- 状态：已在第 1 批实现入站签名鉴权与挑战者 allowlist，后续继续联动链上角色校验。
+
+2. endpointCommitment 对“同机多地址”约束不足
+- 现状：机器指纹包含 `pubkey`，同一机器换地址会产生不同 commitment。
+- 代码位置：`runtime/coc-agent.ts`
+- 风险：可绕过“同机唯一”假设，削弱对多地址女巫的抑制能力。
+- 状态：已在第 2 批提供 `strict/legacy` 模式并默认 `strict`，保留迁移开关。
+
+3. 发现层身份真实性校验不足（易受伪造 Peer 污染）
+- 现状：Peer discovery 与 DHT 主要依赖格式/可达性检查；DHT 回退校验仅 TCP 可连通，不校验节点身份。
+- 代码位置：`node/src/peer-discovery.ts`、`node/src/dht-network.ts`
+- 风险：伪造节点可污染路由表与发现池，放大 Eclipse/Sybil 风险。
+- 状态：已在第 2 批实现“待验证队列 + 握手优先验证”，后续继续引入信誉分层。
+
+### P1（应在下一阶段完成）
+
+1. P2P 入站鉴权默认仍为 `monitor`
+- 现状：配置默认模式为 `monitor`，即使校验失败也可放行。
+- 代码位置：`node/src/config.ts`、`node/src/p2p.ts`
+- 风险：生产未切到 `enforce` 时，认证收益主要停留在观测层。
+- 状态：已在 P1 第 1 批改为默认 `enforce`，保留显式回退。
+
+2. P2P auth nonce 防重放仅内存窗口
+- 现状：P2P nonce 追踪为进程内 `BoundedSet`，重启后窗口丢失。
+- 代码位置：`node/src/p2p.ts`
+- 风险：重启后短窗口重放与高频冲刷可能绕过历史 nonce 记忆。
+- 状态：已在 P1 第 1 批接入持久化与 TTL，后续继续做分层预算联动。
+
+3. NonceRegistry 长期运行可无限增长
+- 现状：持久化日志逐行追加，无 TTL/分段/压缩；启动时全量加载到内存。
+- 代码位置：`services/verifier/nonce-registry.ts`
+- 风险：长期运行存在磁盘与内存增长风险，可被滥用放大为可用性问题。
+
+### P2（观测与运营增强）
+
+1. 安全指标未完整进入统一 RPC 观测面
+- 现状：`coc_getNetworkStats` 未返回 P2P 鉴权与限流计数。
+- 代码位置：`node/src/rpc.ts`
+- 风险：外部监控系统难以及时识别攻击态势与调参效果。
+
+2. 回执时序校验可再收紧
+- 现状：校验了超时上界，但未限制 `responseAtMs >= issuedAtMs`。
+- 代码位置：`services/verifier/receipt-verifier.ts`
+- 风险：在边界条件下存在时序异常回执被接受的空间。
+
+## 改造计划（执行版）
+
+### P0：身份与入口收口（1 个迭代）
+
+1. PoSe 路由加签与角色校验
+- 目标文件：`node/src/pose-http.ts`、`node/src/index.ts`、`node/src/config.ts`
+- 动作：
+  - 为 `/pose/challenge`、`/pose/receipt` 增加签名信封与时间窗/nonce 防重放。
+  - 增加挑战者 allowlist（静态配置 + 可选链上活跃节点校验）。
+  - 对 `nodeId` 强制 hex32 规范，拒绝无效目标。
+
+2. endpointCommitment 绑定策略修订
+- 目标文件：`runtime/coc-agent.ts`、`docs/anti-sybil-zh.md`
+- 动作：
+  - 将机器指纹从“host+mac+pubkey”改为“host+mac(+可选运营商域分隔)”。
+  - 增加 `COC_ENDPOINT_FINGERPRINT_MODE`（`strict`/`legacy`）用于灰度迁移。
+  - 在文档中明确：NAT/云环境误判与豁免策略。
+
+3. Discovery/DHT 身份验证前置
+- 目标文件：`node/src/peer-discovery.ts`、`node/src/dht-network.ts`、`node/src/wire-client.ts`
+- 动作：
+  - 新 peer 进入隔离池，需通过一次签名握手验证后再入主池。
+  - DHT `verifyPeer` 从“TCP 连通”升级为“握手身份匹配”。
+
+### P1：防重放与预算治理（1 个迭代）
+
+1. P2P 入站鉴权推进到默认 `enforce`
+- 目标文件：`node/src/config.ts`、`node/src/p2p.ts`、`node/src/p2p-auth.test.ts`
+- 动作：
+  - 将默认模式由 `monitor` 切换到 `enforce`（保留显式回退开关）。
+  - 补充兼容窗口和拒绝计数监控阈值。
+
+2. P2P nonce 持久化与 TTL
+- 目标文件：`node/src/p2p.ts`、`node/src/storage/nonce-store.ts`（或新增专用 store）
+- 动作：
+  - 为 P2P auth nonce 引入持久化 + 过期淘汰。
+  - 对 replay key 增加分片清理，避免热键膨胀。
+
+3. NonceRegistry 压缩与滚动
+- 目标文件：`services/verifier/nonce-registry.ts`
+- 动作：
+  - 引入按 epoch/天分段文件。
+  - 增加最大保留期和启动时增量加载策略。
+
+### P2：监控闭环与策略自动化（持续）
+
+1. 统一安全观测
+- 目标文件：`node/src/rpc.ts`
+- 动作：
+  - 在 `coc_getNetworkStats` 暴露 `rateLimited/authMissing/authInvalid/authRejected` 等计数。
+  - 增加 discovery 隔离池规模与 DHT 验签失败计数。
+
+2. 策略联动
+- 目标文件：`node/src/peer-scoring.ts`、`node/src/health.ts`
+- 动作：
+  - 将鉴权失败率、重放命中率接入封禁评分与健康降级信号。
+
+## 验收标准（建议）
+
+1. 攻击回归测试
+- 新增：
+  - `node/src/pose-http-auth.test.ts`
+  - `node/src/discovery-sybil.test.ts`
+  - `node/src/p2p-replay-persistence.test.ts`
+
+2. 指标验收
+- 在压测下，`authRejectedRequests` 与限流命中率可观测；误杀率在可控阈值内。
+
+3. 灰度验收
+- `monitor -> enforce` 切换期间无大面积合法流量中断，且回退机制可用。
+
 ## 测试覆盖（本轮）
 
 - 已通过：
   - `node/src/config.test.ts`
+  - `node/src/pose-auth.test.ts`
+  - `node/src/dht-network.test.ts`
   - `node/src/pose-engine.test.ts`
   - `node/src/peer-discovery.test.ts`
   - `node/src/p2p-auth.test.ts`

--- a/node/src/config.test.ts
+++ b/node/src/config.test.ts
@@ -39,6 +39,9 @@ describe("validateConfig", () => {
     assert.ok(validateConfig({ p2pRequireInboundAuth: "true" as any }).length > 0)
     assert.ok(validateConfig({ p2pInboundAuthMode: "strict" as any }).length > 0)
     assert.ok(validateConfig({ p2pAuthMaxClockSkewMs: 999 }).length > 0)
+    assert.ok(validateConfig({ p2pAuthNonceRegistryPath: "" }).length > 0)
+    assert.ok(validateConfig({ p2pAuthNonceTtlMs: 59_999 }).length > 0)
+    assert.ok(validateConfig({ p2pAuthNonceMaxEntries: 0 }).length > 0)
     assert.equal(
       validateConfig({
         p2pMaxPeers: 50,
@@ -48,6 +51,26 @@ describe("validateConfig", () => {
         p2pRequireInboundAuth: true,
         p2pInboundAuthMode: "enforce",
         p2pAuthMaxClockSkewMs: 120_000,
+        p2pAuthNonceRegistryPath: "/tmp/p2p-auth-nonce.log",
+        p2pAuthNonceTtlMs: 86_400_000,
+        p2pAuthNonceMaxEntries: 100_000,
+      }).length,
+      0,
+    )
+  })
+
+  it("validates pose route auth settings", () => {
+    assert.ok(validateConfig({ poseRequireInboundAuth: "true" as any }).length > 0)
+    assert.ok(validateConfig({ poseInboundAuthMode: "strict" as any }).length > 0)
+    assert.ok(validateConfig({ poseAuthMaxClockSkewMs: 999 }).length > 0)
+    assert.ok(validateConfig({ poseAllowedChallengers: "0x1234" as any }).length > 0)
+    assert.ok(validateConfig({ poseAllowedChallengers: ["0x1234"] }).length > 0)
+    assert.equal(
+      validateConfig({
+        poseRequireInboundAuth: true,
+        poseInboundAuthMode: "enforce",
+        poseAuthMaxClockSkewMs: 120_000,
+        poseAllowedChallengers: ["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"],
       }).length,
       0,
     )

--- a/node/src/pose-auth.test.ts
+++ b/node/src/pose-auth.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { createNodeSigner } from "./crypto/signer.ts"
+import { buildSignedPosePayload, verifySignedPosePayload } from "./pose-http.ts"
+
+const TEST_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+class ReplayTracker {
+  private readonly used = new Set<string>()
+
+  has(value: string): boolean {
+    return this.used.has(value)
+  }
+
+  add(value: string): void {
+    this.used.add(value)
+  }
+}
+
+describe("pose auth envelope", () => {
+  it("accepts valid signed payload", () => {
+    const signer = createNodeSigner(TEST_KEY)
+    const payload = buildSignedPosePayload("/pose/challenge", {
+      nodeId: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }, signer, 1000)
+    const check = verifySignedPosePayload("/pose/challenge", payload, signer, { nowMs: 1000 })
+    assert.equal(check.ok, true)
+  })
+
+  it("rejects tampered payload body", () => {
+    const signer = createNodeSigner(TEST_KEY)
+    const signed = buildSignedPosePayload("/pose/challenge", {
+      nodeId: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }, signer, 1000)
+    const tampered = { ...signed, nodeId: "0x1111111111111111111111111111111111111111111111111111111111111111" }
+    const check = verifySignedPosePayload("/pose/challenge", tampered, signer, { nowMs: 1000 })
+    assert.equal(check.ok, false)
+    if (!check.ok) {
+      assert.match(check.reason, /invalid auth signature/)
+    }
+  })
+
+  it("rejects stale timestamp", () => {
+    const signer = createNodeSigner(TEST_KEY)
+    const payload = buildSignedPosePayload("/pose/challenge", {
+      nodeId: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }, signer, 1000)
+    const check = verifySignedPosePayload("/pose/challenge", payload, signer, {
+      nowMs: 5000,
+      maxClockSkewMs: 1000,
+    })
+    assert.equal(check.ok, false)
+    if (!check.ok) {
+      assert.match(check.reason, /timestamp out of range/)
+    }
+  })
+
+  it("rejects nonce replay", () => {
+    const signer = createNodeSigner(TEST_KEY)
+    const payload = buildSignedPosePayload("/pose/challenge", {
+      nodeId: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    }, signer, 1000)
+    const tracker = new ReplayTracker()
+    const first = verifySignedPosePayload("/pose/challenge", payload, signer, { nowMs: 1000, nonceTracker: tracker })
+    const second = verifySignedPosePayload("/pose/challenge", payload, signer, { nowMs: 1000, nonceTracker: tracker })
+    assert.equal(first.ok, true)
+    assert.equal(second.ok, false)
+    if (!second.ok) {
+      assert.match(second.reason, /nonce replay detected/)
+    }
+  })
+})

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -7,6 +7,7 @@ import type { Hex, PendingFilter } from "./blockchain-types.ts"
 import type { P2PNode } from "./p2p.ts"
 import type { PoSeEngine } from "./pose-engine.ts"
 import { registerPoseRoutes, handlePoseRequest } from "./pose-http.ts"
+import type { PoseInboundAuthOptions } from "./pose-http.ts"
 import { keccak256Hex } from "../../services/relayer/keccak256.ts"
 import { calculateBaseFee, genesisBaseFee } from "./base-fee.ts"
 import { traceTransaction, traceBlockByNumber, traceTransactionCalls } from "./debug-trace.ts"
@@ -109,7 +110,18 @@ interface JsonRpcResponse {
   error?: { message: string }
 }
 
-export function startRpcServer(bind: string, port: number, chainId: number, evm: EvmChain, chain: IChainEngine, p2p: P2PNode, pose?: PoSeEngine, bftCoordinator?: BftCoordinator, nodeId?: string) {
+export function startRpcServer(
+  bind: string,
+  port: number,
+  chainId: number,
+  evm: EvmChain,
+  chain: IChainEngine,
+  p2p: P2PNode,
+  pose?: PoSeEngine,
+  bftCoordinator?: BftCoordinator,
+  nodeId?: string,
+  poseAuthOptions?: PoseInboundAuthOptions,
+) {
   if (DEV_ACCOUNTS_ENABLED) {
     initializeTestAccounts()
   }
@@ -138,7 +150,7 @@ export function startRpcServer(bind: string, port: number, chainId: number, evm:
     }
 
     // Handle PoSe routes first
-    if (pose && handlePoseRequest(poseRoutes, req, res)) {
+    if (pose && handlePoseRequest(poseRoutes, req, res, poseAuthOptions)) {
       return
     }
 

--- a/runtime/lib/config.ts
+++ b/runtime/lib/config.ts
@@ -22,6 +22,7 @@ export interface CocRuntimeConfig {
   nodeIds?: string[];
   rewardPoolWei?: string;
   slasherPrivateKey?: string;
+  endpointFingerprintMode?: "strict" | "legacy";
 }
 
 export function resolveDataDir(): string {


### PR DESCRIPTION
## Summary
- add PoSe HTTP inbound auth envelope verification (off/monitor/enforce), challenger allowlist, and strict hex32 validation
- switch P2P inbound auth default to enforce and add persistent nonce replay tracker with TTL/compaction
- harden peer discovery and DHT verification with identity quarantine + authenticated wire handshake probing
- update runtime agent to send signed PoSe payloads and add strict endpoint fingerprint mode by default
- update config/docs/tests for new anti-sybil and replay-defense controls

## Testing
- pnpm -C "node" exec node --experimental-strip-types --test "src/config.test.ts" "src/pose-auth.test.ts" "src/pose-http.test.ts" "src/p2p-auth.test.ts" "src/peer-discovery.test.ts" "src/dht-network.test.ts"