### PR TITLE
feat: strengthen sybil resistance and authenticated peer verification

### DIFF
--- a/node/src/config.test.ts
+++ b/node/src/config.test.ts
@@ -68,6 +68,8 @@ describe("validateConfig", () => {
     assert.ok(validateConfig({ poseAuthNonceMaxEntries: 0 }).length > 0)
     assert.ok(validateConfig({ poseAllowedChallengers: "0x1234" as any }).length > 0)
     assert.ok(validateConfig({ poseAllowedChallengers: ["0x1234"] }).length > 0)
+    assert.ok(validateConfig({ poseUseGovernanceChallengerAuth: "true" as any }).length > 0)
+    assert.ok(validateConfig({ poseChallengerAuthCacheTtlMs: 999 }).length > 0)
     assert.equal(
       validateConfig({
         poseRequireInboundAuth: true,
@@ -77,9 +79,17 @@ describe("validateConfig", () => {
         poseAuthNonceTtlMs: 86_400_000,
         poseAuthNonceMaxEntries: 100_000,
         poseAllowedChallengers: ["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"],
+        poseUseGovernanceChallengerAuth: true,
+        poseChallengerAuthCacheTtlMs: 30_000,
       }).length,
       0,
     )
+  })
+
+  it("validates dht authenticated verify setting", () => {
+    assert.ok(validateConfig({ dhtRequireAuthenticatedVerify: "true" as any }).length > 0)
+    assert.equal(validateConfig({ dhtRequireAuthenticatedVerify: true }).length, 0)
+    assert.equal(validateConfig({ dhtRequireAuthenticatedVerify: false }).length, 0)
   })
 
   it("accepts valid port range", () => {

--- a/node/src/dht-network.test.ts
+++ b/node/src/dht-network.test.ts
@@ -359,4 +359,46 @@ describe("DhtNetwork", () => {
 
     assert.equal(ok, false)
   })
+
+  it("should reject peers when authenticated verify is required but handshake config is unavailable", async () => {
+    const network = new DhtNetwork({
+      localId: "0xaaa",
+      bootstrapPeers: [],
+      wireClients: [],
+      onPeerDiscovered: () => {},
+      requireAuthenticatedVerify: true,
+    })
+
+    const ok = await network.verifyPeer({
+      id: "0xbbb",
+      address: "127.0.0.1:19781",
+      lastSeenMs: Date.now(),
+    })
+    const stats = network.getStats()
+
+    assert.equal(ok, false)
+    assert.equal(stats.verifyFailures, 1)
+    assert.equal(stats.verifyFallbackTcpAttempts, 0)
+  })
+
+  it("should attempt TCP fallback when authenticated verify is disabled", async () => {
+    const network = new DhtNetwork({
+      localId: "0xaaa",
+      bootstrapPeers: [],
+      wireClients: [],
+      onPeerDiscovered: () => {},
+      requireAuthenticatedVerify: false,
+    })
+
+    const ok = await network.verifyPeer({
+      id: "0xbbb",
+      address: "127.0.0.1:1",
+      lastSeenMs: Date.now(),
+    })
+    const stats = network.getStats()
+
+    assert.equal(ok, false)
+    assert.equal(stats.verifyFallbackTcpAttempts, 1)
+    assert.equal(stats.verifyFallbackTcpFailures, 1)
+  })
 })

--- a/node/src/pose-authorizer.test.ts
+++ b/node/src/pose-authorizer.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { CachedPoseChallengerAuthorizer } from "./pose-authorizer.ts"
+
+test("allows static allowlist match and rejects non-match when no dynamic resolver", async () => {
+  const authorizer = new CachedPoseChallengerAuthorizer({
+    staticAllowlist: ["0xabc"],
+  })
+
+  assert.equal(await authorizer.isAllowed("0xAbC"), true)
+  assert.equal(await authorizer.isAllowed("0xdef"), false)
+})
+
+test("empty static allowlist without dynamic resolver remains allow-all", async () => {
+  const authorizer = new CachedPoseChallengerAuthorizer()
+  assert.equal(await authorizer.isAllowed("0xabc"), true)
+})
+
+test("caches dynamic resolver result by senderId", async () => {
+  let calls = 0
+  const authorizer = new CachedPoseChallengerAuthorizer({
+    cacheTtlMs: 30_000,
+    dynamicResolver: async (senderId) => {
+      calls += 1
+      return senderId === "0xabc"
+    },
+  })
+
+  assert.equal(await authorizer.isAllowed("0xabc"), true)
+  assert.equal(await authorizer.isAllowed("0xabc"), true)
+  assert.equal(calls, 1)
+})
+
+test("supports fail-open mode when dynamic resolver throws", async () => {
+  const strict = new CachedPoseChallengerAuthorizer({
+    dynamicResolver: async () => {
+      throw new Error("boom")
+    },
+  })
+  const failOpen = new CachedPoseChallengerAuthorizer({
+    failOpen: true,
+    dynamicResolver: async () => {
+      throw new Error("boom")
+    },
+  })
+
+  assert.equal(await strict.isAllowed("0xabc"), false)
+  assert.equal(await failOpen.isAllowed("0xabc"), true)
+})

--- a/node/src/pose-authorizer.ts
+++ b/node/src/pose-authorizer.ts
@@ -1,0 +1,67 @@
+export interface PoseChallengerAuthorizer {
+  isAllowed(senderId: string): Promise<boolean>
+}
+
+export interface CachedPoseChallengerAuthorizerOptions {
+  staticAllowlist?: string[]
+  cacheTtlMs?: number
+  failOpen?: boolean
+  dynamicResolver?: (senderId: string) => Promise<boolean>
+}
+
+interface CacheEntry {
+  allowed: boolean
+  expiresAtMs: number
+}
+
+const DEFAULT_CACHE_TTL_MS = 30_000
+
+export class CachedPoseChallengerAuthorizer implements PoseChallengerAuthorizer {
+  private readonly staticAllowlist: Set<string>
+  private readonly cacheTtlMs: number
+  private readonly failOpen: boolean
+  private readonly dynamicResolver?: (senderId: string) => Promise<boolean>
+  private readonly cache = new Map<string, CacheEntry>()
+
+  constructor(opts: CachedPoseChallengerAuthorizerOptions = {}) {
+    this.staticAllowlist = new Set((opts.staticAllowlist ?? []).map((x) => x.toLowerCase()))
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.failOpen = opts.failOpen === true
+    this.dynamicResolver = opts.dynamicResolver
+  }
+
+  async isAllowed(senderId: string): Promise<boolean> {
+    const key = senderId.trim().toLowerCase()
+    if (!key) return false
+    if (this.staticAllowlist.has(key)) return true
+    if (!this.dynamicResolver) {
+      // Backward compatibility: empty allowlist means no static restriction.
+      return this.staticAllowlist.size === 0
+    }
+
+    const now = Date.now()
+    const cached = this.cache.get(key)
+    if (cached && cached.expiresAtMs >= now) {
+      return cached.allowed
+    }
+
+    let allowed = false
+    try {
+      allowed = await this.dynamicResolver(key)
+    } catch {
+      // Optional fail-open mode for availability-first deployments.
+      allowed = this.failOpen && this.staticAllowlist.size === 0
+    }
+
+    this.cache.set(key, { allowed, expiresAtMs: now + this.cacheTtlMs })
+    return allowed
+  }
+
+  clearCache(): void {
+    this.cache.clear()
+  }
+}
+
+export function createPoseChallengerAuthorizer(opts: CachedPoseChallengerAuthorizerOptions): PoseChallengerAuthorizer {
+  return new CachedPoseChallengerAuthorizer(opts)
+}


### PR DESCRIPTION
## 变更概览
- DHT 新增 `dhtRequireAuthenticatedVerify`（默认开启），握手鉴权不可用时 fail-closed，避免退化到匿名 TCP 探测
- PoSe 入站新增动态 challenger 授权器（`pose-authorizer`），支持静态 allowlist + 动态 resolver + TTL 缓存
- P2P 入站安全事件接入 `PeerScoring`，对鉴权失败/限流来源执行自动临时封禁；discovery 身份失败联动惩罚
- PoSe 挑战发放支持按挑战桶（U/S/R）与信誉层（default/trusted/restricted）分层预算
- 更新中文架构与 Phase 24 计划文档，补充新增安全开关与落地状态

## 关键配置
- `dhtRequireAuthenticatedVerify` / `COC_DHT_REQUIRE_AUTHENTICATED_VERIFY`
- `poseUseGovernanceChallengerAuth` / `COC_POSE_USE_GOVERNANCE_CHALLENGER_AUTH`
- `poseChallengerAuthCacheTtlMs` / `COC_POSE_CHALLENGER_AUTH_CACHE_TTL_MS`

## 测试
- 已通过：
  - `pnpm -C node exec node --experimental-strip-types --test src/config.test.ts src/dht-network.test.ts src/pose-authorizer.test.ts src/pose-engine.test.ts src/p2p-auth.test.ts`
- 受沙箱网络限制（`listen EPERM`）未在当前环境执行：
  - `node/src/pose-http.test.ts`
  - `node/src/p2p.test.ts`
