### PR TITLE
feat: add on-chain challenger auth and composite inbound scoring

### DIFF
--- a/docs/architecture-zh.md
+++ b/docs/architecture-zh.md
@@ -1,7 +1,7 @@
 # COC (ChainOfClaw) 技术架构文档
 
 > **版本**: v1.2.0
-> **更新日期**: 2026-02-15
+> **更新日期**: 2026-02-16
 > **状态**: 生产就绪（190 测试通过）
 
 ---
@@ -465,8 +465,9 @@ class NonceRegistry {
 ### 4.7 网络入口与发现层加固（新增）
 
 - PoSe HTTP 入站鉴权支持 `off/monitor/enforce`，并可通过 `challengerAuthorizer` 扩展为动态角色校验（含缓存）。
+  - 动态源支持治理活跃集，以及 PoSeManager `operatorNodeCount(address)` 的 on-chain 授权检查。
 - DHT peer 验证默认 `fail-closed`：当握手鉴权不可用时拒绝 peer，仅在显式关闭开关时才允许 TCP fallback。
-- P2P 入站来源接入 `PeerScoring`，鉴权失败/限流命中可触发临时封禁；discovery 身份失败联动惩罚打分。
+- P2P 入站来源接入 `PeerScoring`，鉴权失败/限流命中可触发临时封禁；来源识别使用 `IP + senderId` 复合键，discovery 身份失败联动惩罚打分。
 
 ---
 

--- a/node/src/config.test.ts
+++ b/node/src/config.test.ts
@@ -69,6 +69,13 @@ describe("validateConfig", () => {
     assert.ok(validateConfig({ poseAllowedChallengers: "0x1234" as any }).length > 0)
     assert.ok(validateConfig({ poseAllowedChallengers: ["0x1234"] }).length > 0)
     assert.ok(validateConfig({ poseUseGovernanceChallengerAuth: "true" as any }).length > 0)
+    assert.ok(validateConfig({ poseUseOnchainChallengerAuth: "true" as any }).length > 0)
+    assert.ok(validateConfig({ poseOnchainAuthRpcUrl: 123 as any }).length > 0)
+    assert.ok(validateConfig({ poseOnchainAuthPoseManagerAddress: "0x1234" }).length > 0)
+    assert.ok(validateConfig({ poseOnchainAuthMinOperatorNodes: 0 }).length > 0)
+    assert.ok(validateConfig({ poseOnchainAuthTimeoutMs: 99 }).length > 0)
+    assert.ok(validateConfig({ poseOnchainAuthFailOpen: "true" as any }).length > 0)
+    assert.ok(validateConfig({ poseUseOnchainChallengerAuth: true }).length > 0)
     assert.ok(validateConfig({ poseChallengerAuthCacheTtlMs: 999 }).length > 0)
     assert.equal(
       validateConfig({
@@ -80,6 +87,12 @@ describe("validateConfig", () => {
         poseAuthNonceMaxEntries: 100_000,
         poseAllowedChallengers: ["0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"],
         poseUseGovernanceChallengerAuth: true,
+        poseUseOnchainChallengerAuth: true,
+        poseOnchainAuthRpcUrl: "http://127.0.0.1:8545",
+        poseOnchainAuthPoseManagerAddress: "0x1111111111111111111111111111111111111111",
+        poseOnchainAuthMinOperatorNodes: 1,
+        poseOnchainAuthTimeoutMs: 3000,
+        poseOnchainAuthFailOpen: false,
         poseChallengerAuthCacheTtlMs: 30_000,
       }).length,
       0,

--- a/node/src/pose-onchain-authorizer.test.ts
+++ b/node/src/pose-onchain-authorizer.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { createOnchainOperatorResolver } from "./pose-onchain-authorizer.ts"
+
+test("returns false for invalid senderId without querying contract", async () => {
+  let calls = 0
+  const resolver = createOnchainOperatorResolver({
+    rpcUrl: "http://unused",
+    poseManagerAddress: "0x0000000000000000000000000000000000000001",
+    operatorNodeCountFn: async () => {
+      calls += 1
+      return 1
+    },
+  })
+  assert.equal(await resolver("not-an-address"), false)
+  assert.equal(calls, 0)
+})
+
+test("accepts operator when on-chain operatorNodeCount >= threshold", async () => {
+  const resolver = createOnchainOperatorResolver({
+    rpcUrl: "http://unused",
+    poseManagerAddress: "0x0000000000000000000000000000000000000001",
+    minOperatorNodes: 1,
+    operatorNodeCountFn: async () => 2,
+  })
+  assert.equal(await resolver("0x0000000000000000000000000000000000000002"), true)
+})
+
+test("rejects operator when operatorNodeCount below threshold", async () => {
+  const resolver = createOnchainOperatorResolver({
+    rpcUrl: "http://unused",
+    poseManagerAddress: "0x0000000000000000000000000000000000000001",
+    minOperatorNodes: 2,
+    operatorNodeCountFn: async () => 1,
+  })
+  assert.equal(await resolver("0x0000000000000000000000000000000000000002"), false)
+})
+
+test("throws on invalid resolver config", async () => {
+  assert.throws(() => {
+    createOnchainOperatorResolver({
+      rpcUrl: "",
+      poseManagerAddress: "0x0000000000000000000000000000000000000001",
+    })
+  }, /missing rpcUrl|invalid rpcUrl/)
+
+  assert.throws(() => {
+    createOnchainOperatorResolver({
+      rpcUrl: "http://unused",
+      poseManagerAddress: "not-an-address",
+    })
+  }, /invalid poseManagerAddress/)
+})
+
+test("times out long on-chain queries", async () => {
+  const resolver = createOnchainOperatorResolver({
+    rpcUrl: "http://unused",
+    poseManagerAddress: "0x0000000000000000000000000000000000000001",
+    timeoutMs: 100,
+    operatorNodeCountFn: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      return 1
+    },
+  })
+
+  await assert.rejects(async () => {
+    await resolver("0x0000000000000000000000000000000000000002")
+  }, /timeout/)
+})

--- a/node/src/pose-onchain-authorizer.ts
+++ b/node/src/pose-onchain-authorizer.ts
@@ -1,0 +1,83 @@
+import { Contract, JsonRpcProvider, isAddress } from "ethers"
+import { createLogger } from "./logger.ts"
+
+const log = createLogger("pose-onchain-authorizer")
+
+const POSE_MANAGER_ABI = [
+  "function operatorNodeCount(address) view returns (uint8)",
+] as const
+
+export interface OnchainOperatorResolverOptions {
+  rpcUrl: string
+  poseManagerAddress: string
+  minOperatorNodes?: number
+  timeoutMs?: number
+  operatorNodeCountFn?: (operator: string) => Promise<number | bigint>
+}
+
+const DEFAULT_TIMEOUT_MS = 3_000
+
+export function createOnchainOperatorResolver(
+  options: OnchainOperatorResolverOptions,
+): (senderId: string) => Promise<boolean> {
+  const minOperatorNodes = options.minOperatorNodes ?? 1
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  if (!Number.isInteger(minOperatorNodes) || minOperatorNodes < 1) {
+    throw new Error("invalid minOperatorNodes")
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 100) {
+    throw new Error("invalid timeoutMs")
+  }
+
+  let operatorNodeCountFn = options.operatorNodeCountFn
+  if (!operatorNodeCountFn) {
+    if (!options.rpcUrl || options.rpcUrl.trim().length === 0) {
+      throw new Error("missing rpcUrl for on-chain challenger authorizer")
+    }
+    if (!isAddress(options.poseManagerAddress)) {
+      throw new Error("invalid poseManagerAddress for on-chain challenger authorizer")
+    }
+    const provider = new JsonRpcProvider(options.rpcUrl)
+    const contract = new Contract(options.poseManagerAddress, POSE_MANAGER_ABI, provider)
+    operatorNodeCountFn = async (operator: string): Promise<number | bigint> => {
+      return await contract.operatorNodeCount(operator)
+    }
+  }
+
+  return async (senderId: string): Promise<boolean> => {
+    if (!isAddress(senderId)) return false
+
+    try {
+      const rawCount = await withTimeout(operatorNodeCountFn!(senderId), timeoutMs)
+      const count = Number(rawCount)
+      if (!Number.isFinite(count) || count < 0) return false
+      return count >= minOperatorNodes
+    } catch (error) {
+      log.warn("on-chain operator authorization query failed", {
+        senderId,
+        error: String(error),
+      })
+      throw error
+    }
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("on-chain operator authorization timeout"))
+    }, timeoutMs)
+
+    promise.then(
+      (result) => {
+        clearTimeout(timer)
+        resolve(result)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}


### PR DESCRIPTION
## 目标
继续强化系统抗女巫能力与入口安全，完成链上 challenger 授权联动与复合来源封禁策略。

## 主要改动
- 新增 `node/src/pose-onchain-authorizer.ts`
  - 通过 `PoSeManager.operatorNodeCount(address)` 做 on-chain challenger 授权校验
  - 支持最小节点数阈值、调用超时控制、参数校验
- 扩展 `node/src/config.ts`
  - 新增 on-chain 授权配置：
    - `poseUseOnchainChallengerAuth`
    - `poseOnchainAuthRpcUrl`
    - `poseOnchainAuthPoseManagerAddress`
    - `poseOnchainAuthMinOperatorNodes`
    - `poseOnchainAuthTimeoutMs`
    - `poseOnchainAuthFailOpen`
  - 增加 on-chain 模式必填校验（RPC + 合约地址）
- 更新 `node/src/index.ts`
  - challenger 动态授权改为“on-chain 优先，governance 兜底”
  - on-chain 初始化失败时采用 deny-all 安全回退，避免误放行
- 强化 `node/src/p2p.ts`
  - 入站安全评分由“仅 IP”升级为“IP + senderId 复合来源键”
  - 认证成功/失败在双键上记分，提高对换 IP 绕过的抑制能力
- 文档更新
  - `docs/phase-24-plan.zh.md`
  - `docs/architecture-zh.md`

## 测试
已通过：
- `pnpm -C node exec node --experimental-strip-types --test src/config.test.ts src/pose-authorizer.test.ts src/pose-onchain-authorizer.test.ts src/p2p-auth.test.ts src/dht-network.test.ts src/pose-engine.test.ts`

说明：
- 当前沙箱环境仍受 `listen EPERM` 限制，未在本次执行中运行依赖监听端口的测试（如 `pose-http.test.ts`、`p2p.test.ts`）。
