### PR TITLE
ci: point setup-node cache at root package-lock.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: node/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - name: Run node tests
         run: |
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: node/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - run: cd runtime && npm install --omit=dev
       - name: Run runtime tests
@@ -68,7 +68,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: node/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - run: npm install --no-save ethers
       - name: Run service tests
@@ -97,7 +97,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: contracts/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd contracts && npm ci
       - run: cd contracts && npm test
       - run: |
@@ -114,7 +114,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: node/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd wallet && npm install --omit=dev
       - name: Run wallet tests
         run: |
@@ -133,7 +133,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: explorer/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd explorer && npm ci
       - name: Run explorer lib tests
         run: |
@@ -156,7 +156,7 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: faucet/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: cd faucet && npm ci
       - name: Run faucet tests
         run: |


### PR DESCRIPTION
## Summary

Fixes CI test workflow failing at the `actions/setup-node@v4` step for every job:

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

The workflow references per-subdir lock files (`node/package-lock.json`,
`contracts/package-lock.json`, `explorer/package-lock.json`, `faucet/package-lock.json`)
that don't exist in this repo — the project uses npm workspaces with a single
root `package-lock.json`. Update all 7 `cache-dependency-path` values to
point at the root lock.

This is a standalone, tiny PR to unblock CI before any other PR can pass.
The same fix is included in #66, but it can't take effect there because
GitHub's `pull_request` event uses the **base branch's** workflow YAML
for cross-fork PRs.

## Test plan

- [ ] CI on this branch runs the full test gate (which it couldn't before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
