### PR TITLE
fix(chain-engine): case-insensitive proposer check in verifyBlockChain

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -1359,14 +1359,20 @@ export class PersistentChainEngine {
         return false
       }
 
-      // Verify proposer is in validator set (skip for SnapSync — historical validators may differ)
-      if (!skipProposerCheck && validators.length > 0 && !validators.includes(block.proposer)) {
-        log.warn("verifyBlockChain failed: proposer not in validator set", {
-          index: i,
-          number: String(block.number),
-          proposer: block.proposer,
-        })
-        return false
+      // Verify proposer is in validator set (skip for SnapSync — historical validators may differ).
+      // Phase X1.6 (2026-05-08): case-insensitive — block.proposer arrives in mixed
+      // case from remote signers but `validators` may be lowercased by config.
+      if (!skipProposerCheck && validators.length > 0) {
+        const proposerLc = block.proposer.toLowerCase()
+        const matched = validators.some((v) => v.toLowerCase() === proposerLc)
+        if (!matched) {
+          log.warn("verifyBlockChain failed: proposer not in validator set", {
+            index: i,
+            number: String(block.number),
+            proposer: block.proposer,
+          })
+          return false
+        }
       }
 
       // Verify proposer signature if verifier available


### PR DESCRIPTION
## Summary

Phase X1.6 follow-up — completes the case-insensitive proposer normalization that was previously applied at `chain-engine.ts:293` and `chain-engine-persistent.ts:750` but missed at `chain-engine-persistent.ts:1363`.

## The bug

`PersistentChainEngine.verifyBlockChain` validates each block's `proposer` against the configured `validators[]` set with a strict string match:

```ts
// before
if (!skipProposerCheck && validators.length > 0 && !validators.includes(block.proposer)) {
  log.warn("verifyBlockChain failed: proposer not in validator set", ...)
  return false
}
```

`block.proposer` arrives in mixed case from remote signers (e.g. `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`, EIP-55 checksum), but `validators[]` is typically lowercased by config (see existing native template `docker/systemd/native-configs/node-1.json` which stores all validator addresses in lowercase). `Array.prototype.includes` is a strict comparison, so the match fails.

## Repro

A fresh fullnode (observer or new validator) attempting to join an existing multi-validator testnet stalls indefinitely at the first remote block. Symptom in the journal:

```
warn: verifyBlockChain failed: proposer not in validator set
      proposer: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
info: block-level snapshot adoption result {"ok":false,"localHeightBefore":"25328","localHeightAfter":"25328"}
info: fork choice: switching to remote chain {"reason":"longer-chain"}
warn: verifyBlockChain failed: proposer not in validator set ...
```

The `localHeightBefore == localHeightAfter` loop continues forever — every fork-choice attempt fails verification, so no new blocks are adopted.

## Fix

Mirror the existing `.toLowerCase()` pattern at lines 293 and 750:

```ts
// after
if (!skipProposerCheck && validators.length > 0) {
  const proposerLc = block.proposer.toLowerCase()
  const matched = validators.some((v) => v.toLowerCase() === proposerLc)
  if (!matched) {
    log.warn("verifyBlockChain failed: proposer not in validator set", ...)
    return false
  }
}
```

## Verification

Live-tested on a 5-fullnode gcloud deployment (us-central1 / asia-east1 / europe-west1 / us-west1 / asia-southeast1) joining the production testnet (chainId 18780, height ~26000). Without this patch all 5 nodes stalled at their initial snap-sync import boundary; with this patch all 5 caught up to the chain head and continued tracking it correctly.

## Test plan

- [x] Apply patch to a fresh fullnode joining the testnet — syncs past the snap-sync boundary
- [x] No `verifyBlockChain failed` warnings in 1000-line journal sample after applying
- [ ] (suggested) Add a unit test in `chain-engine-persistent.test.ts` covering verifyBlockChain with mixed-case `block.proposer` vs lowercase `validators[]` — left to reviewer to scope alongside any consolidation of normalization helpers