### PR TITLE
fix(ipfs): pushToK skip stale + duplicate peers, add per-peer reason log

### DIFF
--- a/node/src/coc-ipfs-wiring.ts
+++ b/node/src/coc-ipfs-wiring.ts
@@ -238,17 +238,41 @@ export function buildCocIpfsWiring(cfg: CocIpfsWiringConfig): {
   }
 
   const pushToK = async (cid: string, bytes: Uint8Array): Promise<PushToKResult> => {
-    // findClosest on the routing table is O(peers). Caps at K-bucket size
-    // (20) per bucket so the walk is cheap even at high peer counts. We
-    // ask for `replicationFactor + 1` so we can skip the local node if
-    // it lands in its own table — defensive, since DhtNetwork.announce()
-    // intentionally self-FindNodes and some implementations may mirror
-    // us back.
-    const candidates = cfg.dht.routingTable.findClosest(cidToRoutingKey(cid), replicationFactor + 1)
-    const targets = candidates
-      .map((p) => p.id)
-      .filter((id) => id.toLowerCase() !== cfg.localNodeId.toLowerCase())
-      .slice(0, replicationFactor)
+    // Phase Q.5 follow-up (2026-05-08): pull a wider candidate pool and
+    // filter out peers that have no live wire connection. Without this,
+    // a single TERMINATED peer that the DHT routing table hasn't pruned
+    // yet occupies one of the K replication slots and silently degrades
+    // the effective replication factor. Diagnostic data showed 4-node
+    // mesh with 1 stale peer routinely landing pushToK at 2/3 succeeded
+    // even though all 5 reachable peers had healthy wire connections.
+    //
+    // We mirror pushStripe's SPREAD_CANDIDATE_POOL sizing (K*4) so that a
+    // routing table polluted with up to 3K stale entries still finds K
+    // healthy targets.
+    const POOL_SIZE = Math.max(replicationFactor * 4, 8)
+    const candidates = cfg.dht.routingTable.findClosest(cidToRoutingKey(cid), POOL_SIZE)
+    const targets: string[] = []
+    const seenLc = new Set<string>([cfg.localNodeId.toLowerCase()])
+    let staleSkipped = 0
+    let dupSkipped = 0
+    for (const p of candidates) {
+      const idLc = p.id.toLowerCase()
+      if (seenLc.has(idLc)) {
+        // Either local-node skip or DHT duplicate entry (mixed/lower case
+        // for the same address — Phase X1.6 follow-up).
+        if (idLc !== cfg.localNodeId.toLowerCase()) dupSkipped++
+        continue
+      }
+      const client = cfg.connMgr.findByNodeId(p.id)
+      if (!client || !client.isConnected()) {
+        staleSkipped++
+        seenLc.add(idLc)
+        continue
+      }
+      targets.push(p.id)
+      seenLc.add(idLc)
+      if (targets.length >= replicationFactor) break
+    }
 
     // Clamp: if we have fewer potential peers than the replication target,
     // accept the deficit rather than block the PUT. We also skip entirely
@@ -262,6 +286,7 @@ export function buildCocIpfsWiring(cfg: CocIpfsWiringConfig): {
           cid,
           replicationFactor,
           peersInTable: candidates.length,
+          staleSkipped,
         })
         lastLowPeerWarnMs = now
       }
@@ -272,34 +297,54 @@ export function buildCocIpfsWiring(cfg: CocIpfsWiringConfig): {
     // buffers. Per-peer we fully serialize via `sendThroughPeer` to keep
     // in-flight bytes bounded. The bytes ride base64 in a single frame
     // (Phase C1.2's design note on pushBlock).
+    //
+    // Phase Q.5 follow-up (2026-05-08): pushBlock collapses 5 distinct
+    // failure modes (no-client / not-connected / queue-full / timeout /
+    // null-ack) into a single boolean. Capture the per-peer reason here
+    // so partial replication is diagnosable from the info-level log.
     const results = await Promise.all(targets.map(async (peerId) => {
       const client = cfg.connMgr.findByNodeId(peerId)
       if (!client) {
-        log.debug("pushToK: no client for peerId", { peerId, cid })
-        return { peerId, ok: false }
+        return { peerId, ok: false, reason: "no-client-for-peerId" }
       }
-      const ok = await sendThroughPeer(peerId, async () => {
+      const outcome = await sendThroughPeer(peerId, async () => {
+        if (!client.isConnected()) {
+          return { ok: false, reason: "wire-not-connected" }
+        }
         try {
-          return await client.pushBlock(cid, bytes, pushTimeoutMs)
+          const ok = await client.pushBlock(cid, bytes, pushTimeoutMs)
+          return { ok, reason: ok ? "ok" : "pushBlock-returned-false" }
         } catch (err) {
-          log.debug("pushToK: peer pushBlock threw", { peerId, cid, error: String(err) })
-          return false
+          return { ok: false, reason: `pushBlock-threw: ${String(err)}` }
         }
       })
-      return { peerId, ok }
+      return { peerId, ok: outcome.ok, reason: outcome.reason }
     }))
 
     const succeeded = results.filter((r) => r.ok).map((r) => r.peerId)
     const failed = results.filter((r) => !r.ok).map((r) => r.peerId)
     if (failed.length > 0) {
+      const failedDetail = results
+        .filter((r) => !r.ok)
+        .map((r) => ({ peerId: r.peerId, reason: r.reason }))
       log.info("pushToK: partial replication", {
         cid,
         attempted: targets.length,
-        succeeded: succeeded.length,
-        failed: failed.length,
+        succeededCount: succeeded.length,
+        failedCount: failed.length,
+        succeededPeers: succeeded,
+        failedDetail,
+        staleSkipped,
+        dupSkipped,
       })
     } else {
-      log.debug("pushToK: full replication", { cid, attempted: targets.length })
+      log.info("pushToK: full replication", {
+        cid,
+        attempted: targets.length,
+        succeededPeers: succeeded,
+        staleSkipped,
+        dupSkipped,
+      })
     }
     return { cid, attempted: targets.length, succeeded, failed, skippedLowPeers: false }
   }


### PR DESCRIPTION
## Summary

Phase Q.5 follow-up. The `pushToK` function silently degrades replication when the DHT routing table contains stale or duplicate peer entries — both happen routinely in production.

## The bug

A live 5-fullnode gcloud testbed joining the production testnet (chainId 18780) was producing only `attempted=3 succeeded=1 failed=2` for every chunk of every UnixFS file, even though all peers had healthy wire connections and DHT advertise was working. The 50 MB test file ended up with each chunk on only one other peer, and the upstream validators (which the test was designed to exercise as eventual replicas) returned HTTP 404 for the file CID.

Two compounding issues in `findClosest` → `targets.slice(0, K)`:

### 1. Stale entries

When a peer (e.g. a TERMINATED VM) drops its connection, `DhtNetwork.routingTable` retains its (id, contact) record. `findClosest(K+1)` returns 3 candidates including the dead peer, the loop calls `cfg.connMgr.findByNodeId(deadPeer)` → `undefined`, and the slot is consumed but no data goes anywhere. The per-peer reason was logged at `log.debug` so operators couldn't see why.

### 2. Mixed/lower-case duplicates

The same address ends up in the routing table twice — once as the EIP-55 mixed-case form a remote peer advertised, once as the lowercase form generated locally. The DHT's `id` comparator treats them as distinct entries:

```
"succeededPeers":[
  "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
  "0xF7B71E59d625fa8E540FF48A4fFCcaD1D777Df78",
  "0xf7b71e59d625fa8e540ff48a4ffccad1d777df78"   ← same address, different case
]
```

Both pushes "succeed", but to the same node — silently halving distinct replicas.

## Repro

Boot any fullnode joining a >3-peer multi-validator testnet, run a few `IPFS add` operations, then `journalctl -u coc-node@1 | grep "partial replication"`. The repro is deterministic — every UnixFS chunk above ~256 KB hits the same path.

## Fix

- **Wider candidate pool.** Pull `max(K*4, 8)` from the routing table (mirrors `pushStripe`'s `SPREAD_CANDIDATE_POOL`). Headroom to skip stale/duplicate entries without falling below K healthy targets.
- **Skip stale.** Before adding a candidate to `targets`, look up its `WireClient` and require `client.isConnected()`. Count skips as `staleSkipped`.
- **Dedupe case-insensitively.** Track lower-cased peer ids in a `Set` alongside the local node id so `findClosest` returning both `0xABC...` and `0xabc...` collapses to one slot. Count duplicates as `dupSkipped`.
- **Per-peer failure reason at info-level.** Capture the actual failure reason (`no-client-for-peerId` / `wire-not-connected` / `pushBlock-returned-false` / `pushBlock-threw: <err>`) and surface it in the `partial replication` log. Promote `full replication` from debug to info so operators can audit successful distribution.

## Verification

Live-tested on a 4-peer gcloud mesh (us-central1 / asia-east1 / europe-west1 / us-west1) joining the production testnet, with the upstream 3-validator set in each node's `peers[]`.

**Before this fix:**
- 50 MB upload to anchor-2 → all 200+ chunks log `attempted=3 succeeded=1 failed=2`
- Upstream validators all HTTP 404 for the file CID
- Only one gcloud peer (us-west1) had a complete copy

**After this fix:**
- 50 MB upload → 0 partial replications, 201 full replications, all `succeededPeers` lists are 3 distinct nodes
- All 3 upstream validators GET the 50 MB file in 14-30 s, sha256 matches the original
- Stopped **all 5** gcloud test nodes and re-tested — upstream validators still serve the file:
  ```
  validator-1  HTTP=200  17s 52428800B OK
  validator-2  HTTP=200  14s 52428800B OK
  validator-3  HTTP=200  28s 52428800B OK
  ```
  This is the persistence property the `pushToK` design promised but the routing-table dedup hole prevented.

Sample post-fix log:
```
"pushToK: full replication","data":{"cid":"bafy...",
  "succeededPeers":["0x70997970...c8","0x3c44cd...bc","0x38C440De..."],
  "staleSkipped":1,"dupSkipped":1}
```

## Companion PR

This pairs with #74 (`fix(chain-engine): case-insensitive proposer check`) which is the same case-insensitivity gap on the BFT side. Both surfaced from the same gcloud testbed run.

## Test plan

- [x] Apply patch to a fullnode joining a multi-peer testnet → pushToK achieves K=3 distinct replication on every chunk
- [x] Upstream validators GET the CID while all replicas online
- [x] Stop every gcloud peer, upstream validators still GET the CID → **persistence achieved**
- [ ] (suggested) Unit test in `coc-ipfs-wiring.test.ts` covering pushToK with (a) stale routing entry whose connMgr lookup returns undefined, (b) routing entry with `client.isConnected() = false`, (c) duplicate mixed-case + lowercase entries for the same address — left to reviewer to scope, may be combined with broader routing-table dedup work.