### PR TITLE
ci(test): drop broken setup-node cache config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd node && npm ci
+      - run: cd node && npm install --no-audit --no-fund
       - name: Run node tests
         run: |
           cd node
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd node && npm ci
+      - run: cd node && npm install --no-audit --no-fund
       - run: cd runtime && npm install --omit=dev
       - name: Run runtime tests
         run: |
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd node && npm ci
+      - run: cd node && npm install --no-audit --no-fund
       - run: npm install --no-save ethers
       - name: Run service tests
         run: |
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd contracts && npm ci
+      - run: cd contracts && npm install --no-audit --no-fund
       - run: cd contracts && npm test
       - run: |
           node --experimental-default-type=module --experimental-strip-types --test \
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd explorer && npm ci
+      - run: cd explorer && npm install --no-audit --no-fund
       - name: Run explorer lib tests
         run: |
           node --experimental-default-type=module --experimental-strip-types --test \
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - run: cd faucet && npm ci
+      - run: cd faucet && npm install --no-audit --no-fund
       - name: Run faucet tests
         run: |
           node --experimental-strip-types --test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: "22"
       - run: cd node && npm install --no-audit --no-fund
+      - run: cd node && npm install --no-save --no-audit --no-fund solc
       - name: Run node tests
         run: |
           cd node
@@ -65,6 +66,10 @@ jobs:
           node-version: "22"
       - run: cd node && npm install --no-audit --no-fund
       - run: npm install --no-save ethers
+      # Service integration tests load contract artifacts from contracts/artifacts.
+      # Compile them once here so tests/integration/relayer-v2-hardhat-recovery
+      # can read PoSeManagerV2.json etc.
+      - run: cd contracts && npm install --no-audit --no-fund && npm run compile
       - name: Run service tests
         run: |
           node --experimental-strip-types --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=service-results.xml \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
   test-services:
     name: Services + NodeOps + Tests Workspace (337+)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - name: Run node tests
         run: |
@@ -46,8 +44,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - run: cd runtime && npm install --omit=dev
       - name: Run runtime tests
@@ -67,8 +63,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd node && npm ci
       - run: npm install --no-save ethers
       - name: Run service tests
@@ -96,8 +90,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd contracts && npm ci
       - run: cd contracts && npm test
       - run: |
@@ -113,8 +105,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd wallet && npm install --omit=dev
       - name: Run wallet tests
         run: |
@@ -132,8 +122,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd explorer && npm ci
       - name: Run explorer lib tests
         run: |
@@ -155,8 +143,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: package-lock.json
       - run: cd faucet && npm ci
       - name: Run faucet tests
         run: |


### PR DESCRIPTION
## Summary

The `Test` workflow on `main` had been red for 30+ commits with all 7 test jobs failing identically in their `actions/setup-node@v4` prelude. This PR unblocks the CI prelude in 4 layers:

1. **Drop broken cache config** (`63d4e75`) — `cache: npm` + `cache-dependency-path: package-lock.json` was failing because `package-lock.json` is gitignored repo-wide (since initial commit `ad0d09e`). Removed all 7 occurrences.
2. **`npm ci` → `npm install`** (`1cc44aa`) — `npm ci` strictly requires a lockfile. Switched to `npm install --no-audit --no-fund` for the 6 install steps.
3. **Add solc + compile contracts** (`640ce94`) — `node/src/rpc.ts` imports `solc` (only declared in `explorer/package.json`). Added a `npm install --no-save solc` step to test-node. `services` integration tests need pre-built contract artifacts. Added `cd contracts && npm install && npm run compile`.
4. **Bump test-services timeout** (`b9c2d0e`) — hardhat compile pushed Services past 10-min timeout. Bumped to 20 min.

## Result

5 of 7 test jobs now reach actual test execution and PASS:

| Job | Status |
|---|---|
| Runtime Tests (72+) | ✅ SUCCESS |
| Contract Tests + Deploy CLI | ✅ SUCCESS |
| Wallet Tests (8+) | ✅ SUCCESS |
| Explorer Build + Lib Tests (43+) | ✅ SUCCESS |
| Faucet Tests (26+) | ✅ SUCCESS |
| Node Tests (859+) | ❌ FAILURE — pre-existing test bug |
| Services + NodeOps (337+) | ⏰ CANCELLED — pre-existing test bug |

## The 2 remaining failures are pre-existing test bugs, NOT CI infrastructure

**Node Tests:** `Dual-Engine Comparison` test failures (5 subtests at `src/persistent-engine/...`):
- `both engines produce identical results for simple ETH transfer`
- `both engines handle contract deployment identically`
- `both engines handle multiple sequential transactions identically`
- `engine factory creates correct engine types`

These are real test-code or runtime issues in the dual-engine comparison logic. They were hidden behind the broken setup-node prelude for 30+ commits. The diff to fix them is unrelated to CI workflow config.

**Services + NodeOps:** integration test `tests/integration/relayer-v2-hardhat-recovery.integration.test.ts` fails to spin up its hardhat JSON-RPC and leaves a `JsonRpcProvider failed to detect network and cannot start up; retry in 1s` infinite retry loop running for ~13 min, exhausting even the bumped 20-min timeout. The fix is a test-side cleanup (abort the provider on `before`/`after` hook failure), not a workflow change.

## Recommendation

Merge this PR as-is. It:
- Unblocks 5 of 7 test jobs that have been silently broken for 30+ commits
- Surfaces 2 real test bugs that need separate triage
- Trade-off: the `Test Gate` will still report failure until both follow-ups land, but the failure now points at real bugs rather than infrastructure

Follow-ups (open as separate issues, not blockers for this PR):
- [ ] Fix `Dual-Engine Comparison` test failures in Node Tests
- [ ] Fix `relayer-v2-hardhat-recovery` integration test infinite-retry leak
- [ ] (longer term) Decide whether to track `package-lock.json` to enable `npm ci` + dep caching
