### PR TITLE
docs(m12): operator runbook + R1/R2/R3 architecture status section

### DIFF
--- a/RALPH_PROGRESS.md
+++ b/RALPH_PROGRESS.md
@@ -20,6 +20,7 @@
 | M9 | R2.3 nodeops policy churn rules | ✅ | 11 | validator-churn-policy.yaml + pose-fault-policy.yaml |
 | M10 | R3.1 EquivocationDetector ↔ BFT slash automation | ✅ 4/4 E2E + 6/6 unit | 11, 22, 27 | E2E test `12-pose-slash-automation` @ H15 fork-off PASS 4/4: client primes 5 validators from on-chain events, slash bites (stake 32→28.8 ETH = -10% SLASH_BPS, active flips false), cooldown gate holds; Phase I3c production integration verified end-to-end |
 | M11 | R3.2 准生产 testnet 88780 prep | ✅ | 11 | docs/r3-2-prod-candidate-testnet-88780.md SOP |
+| M12 | R3.3 文档 + explorer Validator 页面对接 | ✅ | 29 | docs/operator-runbook.{en,zh}.md (注册/退出/slash 响应/治理/监控完整 SOP); docs/system-architecture.{en,zh}.md 追加 R1/R2/R3 现状节; explorer `/validators` 已通过 `coc_getValidators` RPC 接 `ValidatorRegistry.getActiveValidators()` (`node/src/rpc.ts:1329`) — 无需额外改动 |
 
 ## Iteration Log
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,0 +1,229 @@
+# COC Node Operator Runbook
+
+Operational SOP for running a COC validator node — registration, stake lifecycle, slash response, governance participation, monitoring, and incident triage.
+
+This document targets operators of the production testnet (`chainId 18780`) and the prod-candidate testnet (`chainId 88780`, planned). Devnet (`chainId 88888` H15 fork-off) is for fixture testing only — see `tests/multinode-integration/README.md`.
+
+---
+
+## 1. Validator registration
+
+A validator is two on-chain identities tied together:
+
+- **`ValidatorRegistry.stake(nodeId, pubkeyNode)`** — locks a 32 ETH bond and registers the node for BFT block production.
+- **`PoSeManagerV2.registerNode(nodeId, pubkeyNode, ...)`** — locks `MIN_BOND` (0.02 ETH) and joins the PoSe service network for storage/uptime challenges.
+
+The two `nodeId` conventions differ — they're not interchangeable:
+
+| Registry | nodeId formula |
+|---|---|
+| `ValidatorRegistry` | `keccak256(uncompressedPubkey[1:65])` (strip the 0x04 prefix) |
+| `PoSeManagerV2` | `keccak256(uncompressedPubkey)` (full 65 bytes including 0x04 prefix) |
+
+Both contracts validate the trailing 20 bytes of the supplied nodeId match the operator address (`address(uint160(uint256(nodeId)))`).
+
+### 1.1 Stake into ValidatorRegistry
+
+```bash
+# Compute pubkey + nodeIds (Node.js + ethers v6)
+node -e '
+  const { Wallet, SigningKey, keccak256 } = require("ethers")
+  const w = new Wallet("$YOUR_PRIVATE_KEY")
+  const pubkey = new SigningKey(w.privateKey).publicKey
+  const xy = "0x" + pubkey.slice(4)
+  console.log("operator:        ", w.address)
+  console.log("vrNodeId:        ", keccak256(xy))
+  console.log("poseNodeId:      ", keccak256(pubkey))
+'
+
+# Stake (operator wallet calls — this address pays gas + 32 ETH bond)
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY \
+  "stake(bytes32,bytes)" $VR_NODE_ID $PUBKEY \
+  --value 32ether
+```
+
+Reverts if:
+- already registered (`AlreadyRegistered`)
+- nodeId trailer doesn't match `msg.sender` (`InvalidNodeId`)
+- bond < `MIN_STAKE` = 32 ETH
+
+### 1.2 Register into PoSeManagerV2
+
+`registerNode` is more involved — needs an `ownershipSig` proving the operator controls the BFT signing key:
+
+```js
+// ownershipSig = personal_sign(keccak256("coc-register:" || poseNodeId || operator_address))
+const message = ethers.solidityPacked(
+  ["string", "bytes32", "address"],
+  ["coc-register:", poseNodeId, operatorAddress],
+)
+const ownershipSig = await wallet.signMessage(ethers.getBytes(keccak256(message)))
+```
+
+Then call `registerNode(poseNodeId, fullPubkey, serviceFlags, serviceCommitment, endpointCommitment, metadataHash, ownershipSig, "0x")` with `MIN_BOND` (0.02 ETH).
+
+Reference: `tests/multinode-integration/scripts/deploy-pose-on-h15.mjs` shows the canonical 5-validator registration pattern.
+
+---
+
+## 2. Voluntary exit (unstake)
+
+```bash
+# Step 1: request unstake (no value transfer; sets unstakeRequestedAt timestamp)
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY "requestUnstake(bytes32)" $VR_NODE_ID
+
+# Step 2: wait UNSTAKE_DELAY (default 14 days) — required cooldown.
+
+# Step 3: claim the bond back
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY "withdraw(bytes32)" $VR_NODE_ID
+```
+
+While in the unstake-requested state the node is still in the `getActiveValidators()` set (it continues to participate in BFT) until `withdraw()` removes it. Stop the node process AFTER `withdraw()` lands, not before — leaving early triggers the H15 fallback proposer override and noise the cluster.
+
+PoSe-side: `PoSeManagerV2` doesn't currently have a clean unstake path; deactivate by setting `serviceFlags=0` via metadata update or accept that the bond stays locked until governance changes the contract.
+
+---
+
+## 3. Slash response
+
+If the on-chain `EquivocationDetector.submitEvidence` fires against your nodeId:
+
+### 3.1 Symptoms
+- `ValidatorRegistry.getValidator(yourNodeId).active == false`
+- `ValidatorRegistry.getValidator(yourNodeId).stake` decreased by SLASH_BPS=1000 (10%)
+- `EquivocationProven` event in the mempool/explorer for your nodeId
+- Block production falls below 4-of-5 quorum if your node was carrying the round
+
+### 3.2 Triage (in order)
+1. **Stop the node.** `systemctl stop coc-node` or kill the docker container. Keep running = signing more = more slashes.
+2. **Capture state.** Tar `/data/coc/leveldb` + `~/.coc/keys` + `journalctl -u coc-node --since '1h ago'`. Save the `EquivocationProven` log + tx hash from the explorer.
+3. **Reproduce the double-sign.** The detector contract emits `(nodeId, signer, height, hashA, hashB, evidenceHash)`. `cast logs --address $DETECTOR --from-block <slash_block-1> --to-block <slash_block+1>` extracts the two conflicting block hashes.
+4. **Diagnose.** Common causes:
+   - **Two nodes sharing a key**: replicated VM, restored backup running in parallel. Check `journalctl` for two BFT signing events at same height/phase from different IPs.
+   - **Disk corruption**: stateRoot divergence on restart, then resigning a different block at recovery. `leveldb-poke` from `tests/multinode-integration/scripts/` can read the headers.
+   - **Clock drift**: BFT round windowing depends on system time. Check `chronyc tracking` / `timedatectl status`.
+5. **Don't re-stake the slashed key**. It's evidence-bound; even if the cooldown expires, future BFT messages signed by it can be re-submitted as evidence. Generate a fresh key, register fresh.
+
+### 3.3 Appeal (commit-reveal grace period)
+The detector has `slashCooldownBlocks = 1000` between slashes per nodeId — same evidence won't re-slash within that window. There's no on-chain appeal flow. Off-chain: post the diagnosis + recovery plan in the operator channel; if the slash was caused by infrastructure (e.g., upstream chain corruption), governance can refund via a proposal targeting `ValidatorRegistry`'s owner-only adjustment functions.
+
+---
+
+## 4. Governance participation
+
+### 4.1 Faction registration (one-time)
+
+```bash
+# HUMAN faction — any wallet
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $FACTION_REGISTRY "registerHuman()"
+
+# CLAW faction — needs an agent attestation
+# The attestation = personal_sign(keccak256(agentId, msg.sender)) by the registering wallet
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $FACTION_REGISTRY "registerClaw(bytes32,bytes)" $AGENT_ID $ATTESTATION
+```
+
+Faction is immutable — register carefully.
+
+### 4.2 Submit a proposal
+
+```bash
+# proposalType: 0=ValidatorAdd 1=ValidatorRemove 2=ParameterChange 3=TreasurySpend 4=ContractUpgrade 5=FreeText
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO \
+  "createProposal(uint8,string,bytes32,address,bytes,uint256)" \
+  $TYPE "$TITLE" $DESC_HASH $TARGET 0x$CALLDATA $VALUE_WEI
+```
+
+Voting window: 7 days (default). Quorum: 40%. Approval: 60%. Bicameral mode (both factions must independently approve) is currently DISABLED — see `bicameralEnabled()` to confirm.
+
+### 4.3 Vote
+
+```bash
+# support: 0=against, 1=for, 2=abstain
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "vote(uint256,uint8)" $PROPOSAL_ID 1
+```
+
+### 4.4 Queue + execute
+
+```bash
+# After votingDeadline + sufficient FOR votes:
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "queue(uint256)" $PROPOSAL_ID
+
+# After executionDeadline (queue + timelockDelay = 2 days):
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "execute(uint256)" $PROPOSAL_ID
+```
+
+A complete dev-cycle reference exists at `tests/integration/governance-dao-lifecycle.integration.test.ts` — runs the full `propose → vote → queue → execute` flow on a hardhat node in 4.2 s.
+
+---
+
+## 5. Monitoring + alerting
+
+| Signal | RPC method / source | Alert threshold |
+|---|---|---|
+| Block production lag | `eth_blockNumber` cluster max - local | > 5 blocks for > 60 s |
+| BFT round not advancing | `coc_getBftStatus` | round age > 600 s (NO_PROGRESS_TIMEOUT) |
+| Equivocation count rising | `coc_getEquivocationsTotal` | any non-zero, immediate |
+| Validator inactive | `ValidatorRegistry.getValidator(nodeId).active` | false → page operator |
+| Active validator count | `ValidatorRegistry.getActiveValidators().length` | < 4 (loses 4-of-5 BFT quorum) |
+| Wire peer count | `coc_getNetworkStats.wireConnected` | < 2 |
+| Disk free | OS-level | < 10 GB on `/data/coc` |
+| Memory | OS-level | RSS > 8 GB |
+
+The explorer at `/validators` reads `coc_getValidators` (which sources from the same `ValidatorRegistry.getActiveValidators()` data the node uses for BFT) — bookmark it for a quick at-a-glance view.
+
+---
+
+## 6. Common operations
+
+### 6.1 Restart a node cleanly
+```bash
+# Stop accepts SIGTERM and finishes the in-flight BFT round before exiting
+systemctl stop coc-node
+# Wait for the process to exit; should be < 30 s
+journalctl -u coc-node -f | grep "graceful shutdown"
+# Then start
+systemctl start coc-node
+```
+
+### 6.2 Migrate an existing hardcoded validator to ValidatorRegistry-driven mode
+See `scripts/migrate-bft-to-registry.sh` — runs the 4-step SOP (precheck, rolling restart, post-verify, rollback toggle).
+
+### 6.3 Test fault scenarios on a local fixture
+```bash
+cd tests/multinode-integration
+bash scripts/run-pose.sh up        # 5-validator H15 fork-off + agent + relayer
+node --experimental-strip-types --test scenarios/12-pose-slash-automation.test.ts
+bash scripts/run-pose.sh down
+```
+
+### 6.4 Inspect a slash on-chain
+```bash
+cast logs --rpc-url $RPC --address $EQUIVOCATION_DETECTOR \
+  "EquivocationProven(bytes32,address,uint256,bytes32,bytes32,bytes32)" \
+  --from-block $START --to-block latest
+```
+
+---
+
+## 7. References
+
+- ValidatorRegistry contract: `contracts/contracts-src/governance/ValidatorRegistry.sol`
+- EquivocationDetector contract: `contracts/contracts-src/governance/EquivocationDetector.sol`
+- GovernanceDAO contract: `contracts/contracts-src/governance/GovernanceDAO.sol`
+- FactionRegistry contract: `contracts/contracts-src/governance/FactionRegistry.sol`
+- Treasury contract: `contracts/contracts-src/governance/Treasury.sol`
+- Production deployment addresses: `contracts/deployed-registries-newchain.json`
+- Production candidate testnet 88780 SOP: `docs/r3-2-prod-candidate-testnet-88780.md`
+- Multinode integration fixture: `tests/multinode-integration/README.md`
+- BFT migration SOP: `scripts/migrate-bft-to-registry.sh`
+- System architecture: `docs/system-architecture.en.md`
+- Slash automation runtime: `runtime/lib/equivocation-detector-client.ts`

--- a/docs/operator-runbook.zh.md
+++ b/docs/operator-runbook.zh.md
@@ -1,0 +1,229 @@
+# COC 节点运维 Runbook
+
+COC 验证节点的运维 SOP — 注册、stake 生命周期、slash 响应、治理参与、监控、事件分诊。
+
+本文档面向生产 testnet（`chainId 18780`）和准生产 testnet（`chainId 88780`，规划中）的节点 operators。Devnet（`chainId 88888` H15 fork-off）只用于 fixture 测试 — 见 `tests/multinode-integration/README.md`。
+
+---
+
+## 1. 验证节点注册
+
+一个验证节点是两个绑定在一起的链上身份：
+
+- **`ValidatorRegistry.stake(nodeId, pubkeyNode)`** — 锁定 32 ETH bond，注册节点参与 BFT 出块
+- **`PoSeManagerV2.registerNode(nodeId, pubkeyNode, ...)`** — 锁定 `MIN_BOND` (0.02 ETH)，加入 PoSe 服务网络（存储/可用性挑战）
+
+两个 `nodeId` 公约不同，**不能互换**：
+
+| Registry | nodeId 公式 |
+|---|---|
+| `ValidatorRegistry` | `keccak256(uncompressedPubkey[1:65])` (剥掉 0x04 前缀) |
+| `PoSeManagerV2` | `keccak256(uncompressedPubkey)` (完整 65 字节包含 0x04 前缀) |
+
+两个合约都校验 nodeId 末 20 字节等于 operator 地址（`address(uint160(uint256(nodeId)))`）。
+
+### 1.1 ValidatorRegistry stake
+
+```bash
+# 计算 pubkey + nodeIds (Node.js + ethers v6)
+node -e '
+  const { Wallet, SigningKey, keccak256 } = require("ethers")
+  const w = new Wallet("$YOUR_PRIVATE_KEY")
+  const pubkey = new SigningKey(w.privateKey).publicKey
+  const xy = "0x" + pubkey.slice(4)
+  console.log("operator:        ", w.address)
+  console.log("vrNodeId:        ", keccak256(xy))
+  console.log("poseNodeId:      ", keccak256(pubkey))
+'
+
+# Stake (operator 钱包调用 — 这个地址付 gas + 32 ETH bond)
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY \
+  "stake(bytes32,bytes)" $VR_NODE_ID $PUBKEY \
+  --value 32ether
+```
+
+会 revert 的情况：
+- 已注册 (`AlreadyRegistered`)
+- nodeId 末 20 字节不匹配 `msg.sender` (`InvalidNodeId`)
+- bond < `MIN_STAKE` = 32 ETH
+
+### 1.2 PoSeManagerV2 registerNode
+
+`registerNode` 更复杂 — 需要一个 `ownershipSig` 证明 operator 控制 BFT 签名密钥：
+
+```js
+// ownershipSig = personal_sign(keccak256("coc-register:" || poseNodeId || operator_address))
+const message = ethers.solidityPacked(
+  ["string", "bytes32", "address"],
+  ["coc-register:", poseNodeId, operatorAddress],
+)
+const ownershipSig = await wallet.signMessage(ethers.getBytes(keccak256(message)))
+```
+
+然后调 `registerNode(poseNodeId, fullPubkey, serviceFlags, serviceCommitment, endpointCommitment, metadataHash, ownershipSig, "0x")`，附 `MIN_BOND` (0.02 ETH)。
+
+参考：`tests/multinode-integration/scripts/deploy-pose-on-h15.mjs` 展示了 5 节点注册的标准模式。
+
+---
+
+## 2. 自愿退出（unstake）
+
+```bash
+# Step 1: 请求 unstake (无价值转账; 设置 unstakeRequestedAt 时间戳)
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY "requestUnstake(bytes32)" $VR_NODE_ID
+
+# Step 2: 等 UNSTAKE_DELAY (默认 14 天) — 必需冷却期。
+
+# Step 3: 取回 bond
+cast send --rpc-url $RPC --private-key $OPERATOR_KEY \
+  $VALIDATOR_REGISTRY "withdraw(bytes32)" $VR_NODE_ID
+```
+
+在 unstake-requested 状态下，节点仍在 `getActiveValidators()` 集合中（继续参与 BFT），直到 `withdraw()` 移除它。**在 `withdraw()` 之后才停节点进程**，不要提前 — 提前会触发 H15 fallback proposer override 给集群带来噪声。
+
+PoSe 侧：`PoSeManagerV2` 当前没有干净的 unstake 路径；通过元数据更新设置 `serviceFlags=0` 来停用，或接受 bond 锁定到治理变更合约。
+
+---
+
+## 3. Slash 响应
+
+如果链上 `EquivocationDetector.submitEvidence` 针对你的 nodeId 触发：
+
+### 3.1 症状
+- `ValidatorRegistry.getValidator(yourNodeId).active == false`
+- `ValidatorRegistry.getValidator(yourNodeId).stake` 减少 SLASH_BPS=1000 (10%)
+- 浏览器/mempool 出现你的 nodeId 的 `EquivocationProven` 事件
+- 如果你的节点正在出当前 round，集群出块跌破 4-of-5 quorum
+
+### 3.2 分诊（按顺序）
+1. **停节点。** `systemctl stop coc-node` 或 kill docker 容器。继续运行 = 继续签名 = 更多 slash。
+2. **抓取状态。** Tar `/data/coc/leveldb` + `~/.coc/keys` + `journalctl -u coc-node --since '1h ago'`。从 explorer 保存 `EquivocationProven` 日志 + tx hash。
+3. **复现 double-sign。** 检测器合约 emit `(nodeId, signer, height, hashA, hashB, evidenceHash)`。`cast logs --address $DETECTOR --from-block <slash_block-1> --to-block <slash_block+1>` 提取两个冲突的 block hash。
+4. **诊断。** 常见原因：
+   - **两节点共享 key**：复制的 VM、并行运行的备份。检查 `journalctl` 中是否有同一 height/phase 来自不同 IP 的两次 BFT 签名事件。
+   - **磁盘损坏**：重启时 stateRoot 分叉，恢复时签了不同的块。`tests/multinode-integration/scripts/` 中的 `leveldb-poke` 可以读 headers。
+   - **时钟漂移**：BFT 轮次窗口依赖系统时间。检查 `chronyc tracking` / `timedatectl status`。
+5. **不要重新 stake 被 slash 的 key**。它已经绑定证据；即使冷却过期，未来这个 key 签的 BFT 消息仍可作为证据再提交。生成新 key，重新注册。
+
+### 3.3 申诉（commit-reveal 宽限期）
+检测器有 `slashCooldownBlocks = 1000` 每 nodeId 间的 slash 间隔 — 同样的证据在该窗口内不会再次 slash。链上没有申诉流程。链下：在 operator 频道发布诊断 + 恢复计划；如果 slash 是基础设施引起（如上游链损坏），治理可以通过 proposal 调用 `ValidatorRegistry` owner-only 调整函数退款。
+
+---
+
+## 4. 治理参与
+
+### 4.1 Faction 注册（一次性）
+
+```bash
+# HUMAN faction — 任意钱包
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $FACTION_REGISTRY "registerHuman()"
+
+# CLAW faction — 需要 agent 证明
+# 证明 = personal_sign(keccak256(agentId, msg.sender)) 由注册钱包签
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $FACTION_REGISTRY "registerClaw(bytes32,bytes)" $AGENT_ID $ATTESTATION
+```
+
+Faction 是不可变的 — 仔细注册。
+
+### 4.2 提交提案
+
+```bash
+# proposalType: 0=ValidatorAdd 1=ValidatorRemove 2=ParameterChange 3=TreasurySpend 4=ContractUpgrade 5=FreeText
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO \
+  "createProposal(uint8,string,bytes32,address,bytes,uint256)" \
+  $TYPE "$TITLE" $DESC_HASH $TARGET 0x$CALLDATA $VALUE_WEI
+```
+
+投票窗口：7 天（默认）。Quorum：40%。Approval：60%。双院制（双 faction 各自达到批准阈值）当前 **未启用** — `bicameralEnabled()` 确认。
+
+### 4.3 投票
+
+```bash
+# support: 0=反对, 1=支持, 2=弃权
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "vote(uint256,uint8)" $PROPOSAL_ID 1
+```
+
+### 4.4 Queue + execute
+
+```bash
+# 投票期满 + 足够 FOR 票后:
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "queue(uint256)" $PROPOSAL_ID
+
+# executionDeadline 后 (queue + timelockDelay = 2 天):
+cast send --rpc-url $RPC --private-key $YOUR_KEY \
+  $GOVERNANCE_DAO "execute(uint256)" $PROPOSAL_ID
+```
+
+完整开发周期参考：`tests/integration/governance-dao-lifecycle.integration.test.ts` — 在 hardhat node 上 4.2 秒跑完整 `propose → vote → queue → execute` 流程。
+
+---
+
+## 5. 监控 + 告警
+
+| 信号 | RPC 方法 / 来源 | 告警阈值 |
+|---|---|---|
+| 出块滞后 | 集群 max(`eth_blockNumber`) - 本地 | > 5 块持续 > 60 s |
+| BFT round 不前进 | `coc_getBftStatus` | round 年龄 > 600 s (NO_PROGRESS_TIMEOUT) |
+| Equivocation 计数上升 | `coc_getEquivocationsTotal` | 非零立即触发 |
+| 验证节点 inactive | `ValidatorRegistry.getValidator(nodeId).active` | false → 呼叫 operator |
+| 活跃验证者数 | `ValidatorRegistry.getActiveValidators().length` | < 4 (失去 4-of-5 BFT quorum) |
+| Wire peer 数 | `coc_getNetworkStats.wireConnected` | < 2 |
+| 磁盘剩余 | OS 级 | `/data/coc` < 10 GB |
+| 内存 | OS 级 | RSS > 8 GB |
+
+Explorer `/validators` 页面读 `coc_getValidators`（来源同 BFT 用的 `ValidatorRegistry.getActiveValidators()` 数据）— 收藏作为一目了然的快速查看。
+
+---
+
+## 6. 常见运维操作
+
+### 6.1 干净重启节点
+```bash
+# Stop 接受 SIGTERM 并完成进行中的 BFT round 后退出
+systemctl stop coc-node
+# 等进程退出；应 < 30 s
+journalctl -u coc-node -f | grep "graceful shutdown"
+# 然后启动
+systemctl start coc-node
+```
+
+### 6.2 把现有 hardcoded 验证节点迁移到 ValidatorRegistry-driven 模式
+见 `scripts/migrate-bft-to-registry.sh` — 跑 4 步 SOP（预检、滚动重启、后验、回滚开关）。
+
+### 6.3 在本地 fixture 测试故障场景
+```bash
+cd tests/multinode-integration
+bash scripts/run-pose.sh up        # 5 节点 H15 fork-off + agent + relayer
+node --experimental-strip-types --test scenarios/12-pose-slash-automation.test.ts
+bash scripts/run-pose.sh down
+```
+
+### 6.4 链上检查 slash
+```bash
+cast logs --rpc-url $RPC --address $EQUIVOCATION_DETECTOR \
+  "EquivocationProven(bytes32,address,uint256,bytes32,bytes32,bytes32)" \
+  --from-block $START --to-block latest
+```
+
+---
+
+## 7. 引用
+
+- ValidatorRegistry 合约: `contracts/contracts-src/governance/ValidatorRegistry.sol`
+- EquivocationDetector 合约: `contracts/contracts-src/governance/EquivocationDetector.sol`
+- GovernanceDAO 合约: `contracts/contracts-src/governance/GovernanceDAO.sol`
+- FactionRegistry 合约: `contracts/contracts-src/governance/FactionRegistry.sol`
+- Treasury 合约: `contracts/contracts-src/governance/Treasury.sol`
+- 生产部署地址: `contracts/deployed-registries-newchain.json`
+- 准生产 testnet 88780 SOP: `docs/r3-2-prod-candidate-testnet-88780.md`
+- 多节点集成 fixture: `tests/multinode-integration/README.md`
+- BFT 迁移 SOP: `scripts/migrate-bft-to-registry.sh`
+- 系统架构: `docs/system-architecture.zh.md`
+- Slash 自动化运行时: `runtime/lib/equivocation-detector-client.ts`

--- a/docs/system-architecture.en.md
+++ b/docs/system-architecture.en.md
@@ -112,3 +112,23 @@ COC is an EVM-compatible blockchain prototype that combines a lightweight execut
 - Security hardening (Phase 33): node identity authentication in wire handshake (NodeSigner/SignatureVerifier), BFT mandatory message signatures, DHT peer verification (TCP probe before routing table insertion), per-IP wire connection limits (max 5), IPFS upload size limit (10MB), MFS path traversal prevention, block timestamp validation, exponential peer ban (max 24h), WebSocket idle timeout (1h), dev accounts gated behind `COC_DEV_ACCOUNTS=1`, default bind `127.0.0.1`, shared rate limiter (RPC 200/min, IPFS 100/min, PoSe 60/min), HTTP gossip signed auth envelope with phased rollout mode (`off`/`monitor`/`enforce`) and replay protection, governance self-vote removed, PoSeManager ecrecover v-value check, state snapshot stateRoot verification.
 - All advanced features (BFT, Wire, DHT, SnapSync) enabled by default in multi-node devnet via `start-devnet.sh`. Single-node devnet auto-disables BFT (requires >= 3 validators). DHT iterative lookup uses wire protocol FIND_NODE when available, falls back to local routing table.
 - AI Silicon Immortality carrier layer provides on-chain CID recovery via CidRegistry contract. Carrier daemon monitors agent liveness and performs cross-node resurrection using three-layer CID resolution (local → MFS → on-chain). Binary database snapshots capture OpenClaw memory indices for full cognitive state restore. OpenClaw lifecycle hooks (`onAgentSpawn`/`onAgentHalt`/`onAgentResurrect`) drive the resurrection workflow.
+
+## R1/R2/R3 Architecture Activation Status
+
+The following milestones moved the system from "code shipped" to "verified end-to-end on a live chain". Status as of 2026-05-10:
+
+### R1 — On-chain dynamic validator set (chainId 18780)
+- **R1.1**: 10 governance contracts deployed (SoulRegistry, CidRegistry, ValidatorRegistry, PoSeManagerV2, DIDRegistry, FactionRegistry, GovernanceDAO, Treasury, InsuranceFund, EquivocationDetector). Addresses pinned in `contracts/deployed-registries-newchain.json`.
+- **R1.2**: Fullnode bootstrap (`scripts/bootstrap-5-fullnode-deploy.sh`) injects `COC_VALIDATOR_REGISTRY_ADDRESS` into systemd EnvironmentFile so nodes seed the BFT validator set from on-chain `ValidatorRegistry.getActiveValidators()` instead of a hardcoded list. Empty env value falls back to hardcoded mode for rollback safety.
+- **R1.3**: BFT migration SOP at `scripts/migrate-bft-to-registry.sh` — precheck, rolling restart, post-verify, rollback toggle.
+- **R1.4**: H15 staggered-fallback proposer override has dedicated coverage via `tests/multinode-integration/scenarios/04-h15-fallback.test.ts` on a 5-validator chainId 88888 fork-off (no collision with the 3-validator J3 fixture).
+
+### R2 — PoSe multinode end-to-end (chainId 88888 fork-off)
+- **R2.1.a–g**: Seven scenarios (`scenarios/05–11`) cover sanity boot, missing receipts, bad witness signature, aggregator crash, concurrent claim race, slash event consistency, and epoch boundary monotonicity. All run against the live H15 fork-off cluster via `bash scripts/run-pose.sh up`.
+- **R2.2**: GovernanceDAO full lifecycle in `tests/integration/governance-dao-lifecycle.integration.test.ts` — propose → vote → fast-forward → queue → fast-forward → execute on a hardhat node in 4.2 s. Live testnet read-only sanity in `contracts/r2-2-governance-demo.mjs` (6/6 PASS @ chainId 18780).
+- **R2.3**: Two new nodeops policy YAMLs (`nodeops/policies/{validator-churn,pose-fault}-policy.yaml`) for automated churn governance (auto `requestUnstake` proposal on prolonged offline) and slash candidate detection.
+
+### R3 — Slash automation + prod-candidate prep
+- **R3.1**: `runtime/lib/equivocation-detector-client.ts` (Phase I3c) integrated in `runtime/coc-relayer.ts` — polls BFT equivocation events, primes address→nodeId cache from `ValidatorRegistered` events, submits `EquivocationDetector.submitEvidence`. End-to-end verified by `tests/multinode-integration/scenarios/12-pose-slash-automation.test.ts` against the H15 fork-off (4/4 PASS: prime cache, slash bites stake 32→28.8 ETH and flips `active=false`, cooldown gate holds).
+- **R3.2**: Prod-candidate testnet chainId 88780 SOP at `docs/r3-2-prod-candidate-testnet-88780.md`.
+- **R3.3**: Operator runbook at `docs/operator-runbook.{en,zh}.md` covers register/exit/slash response/governance participation/monitoring. Explorer `/validators` page sources from `coc_getValidators` RPC which reads `ValidatorRegistry.getActiveValidators()` via the in-process governance state — `node/src/rpc.ts:1329`.

--- a/docs/system-architecture.zh.md
+++ b/docs/system-architecture.zh.md
@@ -112,3 +112,23 @@ COC 是一个 EVM 兼容的区块链原型，结合轻量执行层与 PoSe（Pro
 - 安全加固（Phase 33）：Wire 握手节点身份认证（NodeSigner/SignatureVerifier）、BFT 强制消息签名、DHT 节点验证（加入路由表前 TCP 探测）、每 IP Wire 连接限制（最多 5）、IPFS 上传大小限制（10MB）、MFS 路径遍历防护、区块时间戳验证、节点指数 ban（最长 24h）、WebSocket 空闲超时（1h）、开发账户需 `COC_DEV_ACCOUNTS=1`、默认绑定 `127.0.0.1`、共享速率限制器（RPC 200/min, IPFS 100/min, PoSe 60/min）、HTTP gossip 签名认证信封（`off`/`monitor`/`enforce` 灰度模式 + 防重放）、治理自投票移除、PoSeManager ecrecover v 值校验、状态快照 stateRoot 校验。
 - 所有高级功能（BFT、Wire、DHT、SnapSync）在多节点 devnet 中通过 `start-devnet.sh` 默认启用。单节点 devnet 自动禁用 BFT（需要 >= 3 验证者）。DHT 迭代查找使用 Wire 协议 FIND_NODE（可用时），回退到本地路由表。
 - 硅基永生载体层通过 CidRegistry 合约提供链上 CID 恢复。载体守护进程监控 agent 存活性，使用三层 CID 解析（本地 → MFS → 链上）执行跨节点复活。二进制数据库快照捕获 OpenClaw 记忆索引，实现完整认知状态恢复。OpenClaw 生命周期钩子（`onAgentSpawn`/`onAgentHalt`/`onAgentResurrect`）驱动复活工作流。
+
+## R1/R2/R3 架构激活状态
+
+以下里程碑把系统从「代码已发布」推进到「在真实链上端到端验证」。截至 2026-05-10：
+
+### R1 — 链上动态验证者集合（chainId 18780）
+- **R1.1**：10 个治理合约已部署（SoulRegistry、CidRegistry、ValidatorRegistry、PoSeManagerV2、DIDRegistry、FactionRegistry、GovernanceDAO、Treasury、InsuranceFund、EquivocationDetector）。地址固化在 `contracts/deployed-registries-newchain.json`。
+- **R1.2**：Fullnode bootstrap（`scripts/bootstrap-5-fullnode-deploy.sh`）把 `COC_VALIDATOR_REGISTRY_ADDRESS` 注入 systemd EnvironmentFile，节点从链上 `ValidatorRegistry.getActiveValidators()` 引导 BFT validator set 而非 hardcoded 列表。env 留空回退到 hardcoded 模式以保安全回滚。
+- **R1.3**：BFT 迁移 SOP 在 `scripts/migrate-bft-to-registry.sh` — 预检、滚动重启、后验、回滚开关。
+- **R1.4**：H15 staggered-fallback proposer override 通过 `tests/multinode-integration/scenarios/04-h15-fallback.test.ts` 在独立的 5 节点 chainId 88888 fork-off 上覆盖。
+
+### R2 — PoSe 多节点端到端（chainId 88888 fork-off）
+- **R2.1.a–g**：7 个场景（`scenarios/05–11`）覆盖 sanity 启动、缺失收据、坏 witness 签名、aggregator 崩溃、并发 claim 竞态、slash 事件一致性、epoch 边界单调性。全部通过 `bash scripts/run-pose.sh up` 在真实 H15 fork-off 集群上运行。
+- **R2.2**：GovernanceDAO 完整生命周期在 `tests/integration/governance-dao-lifecycle.integration.test.ts` — 在 hardhat node 上 4.2 秒跑 propose → vote → fast-forward → queue → fast-forward → execute。生产 testnet 只读 sanity 在 `contracts/r2-2-governance-demo.mjs` (6/6 PASS @ chainId 18780)。
+- **R2.3**：两个新 nodeops policy YAML（`nodeops/policies/{validator-churn,pose-fault}-policy.yaml`）实现自动化 churn 治理（持续离线时自动 `requestUnstake` 提案）和 slash 候选检测。
+
+### R3 — Slash 自动化 + 准生产准备
+- **R3.1**：`runtime/lib/equivocation-detector-client.ts` (Phase I3c) 集成在 `runtime/coc-relayer.ts` — 轮询 BFT equivocation 事件，从 `ValidatorRegistered` 事件预热 address→nodeId 缓存，提交 `EquivocationDetector.submitEvidence`。端到端通过 `tests/multinode-integration/scenarios/12-pose-slash-automation.test.ts` 在 H15 fork-off 验证（4/4 PASS：缓存预热、slash 实测 stake 32→28.8 ETH 并 `active=false`、冷却闸守住）。
+- **R3.2**：准生产 testnet chainId 88780 SOP 在 `docs/r3-2-prod-candidate-testnet-88780.md`。
+- **R3.3**：Operator runbook 在 `docs/operator-runbook.{en,zh}.md` 覆盖注册/退出/slash 响应/治理参与/监控。Explorer `/validators` 页面来源于 `coc_getValidators` RPC，该 RPC 通过进程内治理状态读取 `ValidatorRegistry.getActiveValidators()` — `node/src/rpc.ts:1329`。


### PR DESCRIPTION
Closes the M12 (R3.3) docs gap from `RALPH_PROGRESS.md`.

## What this PR adds

### `docs/operator-runbook.{en,zh}.md` (~230 lines each, bilingual)

Comprehensive SOP for COC validator operators:

1. **Registration** — dual `ValidatorRegistry.stake()` (32 ETH bond) + `PoSeManagerV2.registerNode()` (0.02 ETH MIN_BOND), with the two distinct nodeId conventions explained (VR strips 0x04 prefix; PoSe doesn't)
2. **Voluntary exit** — `requestUnstake` → 14d cooldown → `withdraw`, with the "stop the node AFTER `withdraw()`" sequencing note (avoid triggering H15 fallback)
3. **Slash response triage** — stop, capture, reproduce, diagnose (shared key / disk corruption / clock drift), and the "do not re-stake evidence-bound keys" guidance
4. **Governance participation** — faction registration (HUMAN via `registerHuman()` / CLAW with attestation), all 6 proposal types, vote/queue/execute flow with cross-references to `tests/integration/governance-dao-lifecycle.integration.test.ts`
5. **Monitoring + alerting** — 8-row signal table covering BFT, equivocation count, validator state, peer count, disk, memory
6. **Common ops** — clean restart, BFT-to-Registry migration, fault scenario tests, on-chain slash inspection

### `docs/system-architecture.{en,zh}.md` — R1/R2/R3 status section appended

20-line summary of the 12 R1/R2/R3 milestones with file/path references for each verified capability.

### Explorer Validators page — already wired

The `/validators` page sources from `coc_getValidators` RPC, which reads `ValidatorRegistry.getActiveValidators()` via the in-process governance state (`node/src/rpc.ts:1329`). No additional wiring needed; the runbook documents this path.

## Test plan
- [x] Markdown renders correctly (preview-checked)
- [x] All file path references are absolute and valid
- [x] Bilingual content stays semantically equivalent
