### PR TITLE
fix(bft): N=5 fault-tolerance — 5 PR series resolves #85

### DIFF
--- a/docs/n5-fault-tolerance-fix-2026-05-10.md
+++ b/docs/n5-fault-tolerance-fix-2026-05-10.md
@@ -1,0 +1,168 @@
+# N=5 Fault-Tolerance Fix Series — 2026-05-10
+
+## Context
+
+The 2026-05-10 N=5 attempt #2 (`docs/n5-attempt-2-2026-05-10.md`) revealed
+that BFT freezes immediately on any single validator unavailability —
+same as N=3, regardless of N. Five distinct bugs combined to produce a
+~1 hour cumulative chain freeze; recovery required manual rsync.
+
+Branch: `fix/bft-n5-fault-tolerance`
+
+## The 5 PRs
+
+| PR | Subject | Files |
+|----|---------|-------|
+| **1A** | Fast-path proposer skip when slot is unreachable | `consensus.ts`, `bft-coordinator.ts`, `index.ts`, `bft-proposer-skip.test.ts` |
+| **1B** | Invalidate `lastProposed` cache on validator set change | `consensus.ts`, `bft-coordinator.ts`, `index.ts`, `consensus-validator-set-change.test.ts` |
+| **1C** | Sliding-window evidence cap + monitoring + recency prune | `bft.ts`, `bft-evidence-eviction.test.ts` |
+| **1D** | Self-heal tip pointer desync at init | `chain-engine-persistent.ts`, `storage/block-index.ts`, `chain-engine-tip-sync.test.ts` |
+| **1E** | Snap-sync per-peer fetch instrumentation + diagnostics | `p2p.ts`, `consensus.ts`, `p2p-snapshot-provider.test.ts` |
+
+### PR-1A — fast-path proposer skip
+
+Old behavior: when the slot proposer was unreachable, BFT round timeouts
+fired every 4s but the round-robin kept selecting the dead validator;
+chain only progressed via the H15 600s `NO_PROGRESS_TIMEOUT_MS` watchdog.
+Producing N blocks where N validators were dead in any window required
+N × 600s of waiting.
+
+New behavior: `BftCoordinator.onProposerStuck` callback fires when a
+non-self proposer's round times out, marking that validator unreachable
+in `ConsensusEngine` for 60s TTL. Plus `reachabilityProvider` exposes
+wire-connection-manager's connected peer set as a second evidence source.
+When `checkNoProgressWatchdog` sees an unreachable stuck proposer, it
+arms the same H15 override at `PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS=15s`
+instead of 600s. Rotation stagger preserved (no equivocation storm).
+`notifyBftProgress` clears all unreachable marks on each successful
+finalize.
+
+### PR-1B — `lastProposed` cache invalidation
+
+Old behavior: `BftCoordinator.updateValidators` only updated the stake
+distribution; cache fields (`localPreparedAt`, `localCommittedAt`,
+`localPreparedBlock`, `pendingMessages`) survived across membership
+changes. The 2026-05-09 attempt #1 fingerprint was a reader-driven
+N=3→N=8 change leaving `consensus.lastProposedBlock` pointing at a block
+whose proposer was assigned by the OLD rotation; round-timeout re-broadcast
+replayed that stale block; Phase R refused as self-equivocation; chain
+stalled ~7h.
+
+New behavior: `updateValidators` diffs membership (lowercased,
+order-insensitive). On real change, clears all local-state caches and
+force-clears the active round (its quorum was snapshotted from old
+stakes). `ConsensusEngine.onValidatorSetChange` is a single entry point
+that calls `clearLastProposed` AND routes through
+`bft.updateValidators`. All 3 reader/governance update sites in
+`index.ts` use it. Stake-only rebalancing (non-disruptive) preserves
+caches.
+
+### PR-1C — sliding-window evidence cap
+
+Old behavior: `EquivocationDetector` per-validator cap (default 100)
+silently dropped NEW evidence when reached. During chain freeze,
+`clearEvidenceBefore` (Phase H16) is never called (no finalize). One
+validator's cache fills to 100; subsequent rounds' evidence is lost;
+slashing decisions on recovery use stale evidence.
+
+New behavior: at cap, evict the OLDEST entry of the same validator and
+push the new one (sliding window). Recent evidence is strictly more
+useful for slashing than ancient evidence about the same actor. New
+`pruneByMaxHeight(keep)` retains only the `keep` most-recent heights
+(usable from a watchdog as a recency-based bound when finalize hasn't
+advanced). New `getStats()` exposes counters for Prometheus.
+
+### PR-1D — tip pointer self-heal
+
+Old behavior: server-1 (N=5 attempt #2) reported h=71448 via RPC but
+`eth_getBlockByNumber("0x116ba"=71450)` returned a valid block whose
+stateRoot matched server-2/3. Disk had `b:71450` written, but
+`m:latest-block` (LATEST) stayed at 71448. Recovery required manual
+rsync of leveldb-chain. Atomicity of `buildBlockOps` should have
+prevented this — but somehow it desynced. Most plausible vector:
+snap-sync's per-block `putBlock` loop rewinds LATEST without deleting
+stale `b:>peerTip` entries from a prior run.
+
+New behavior: `BlockIndex.repairLatestPointer()` scans `b:` prefix,
+parses BigInt suffixes, finds numerically-highest stored block, and
+promotes LATEST if it lags. `PersistentChainEngine.init()` invokes the
+repair on every boot. A desynced node self-aligns on restart.
+
+### PR-1E — snap-sync diagnostics
+
+Old behavior: `forceSnapSync` repeatedly logged "no peer snapshot
+available" with no per-peer attribution. The N=5 attempt #2 cluster
+burned 30+ minutes in this state without operators being able to
+diagnose whether peers were unreachable, returning 429s, returning empty
+bodies, or hitting the 15s aggregate timeout.
+
+New behavior: `P2PNode.fetchSnapshots` tracks per-call counters
+(attempts, successes, errors, timeouts, emptyResults) and per-peer-URL
+last-failure-reason map. Aggregate timeout marks all peers as
+timed-out. fetchSnapshots logs structured warn with first-5 sample
+failure reasons whenever the round produced 0 successes. New
+`getSnapshotFetchStats()` exposes counters. `consensus.forceSnapSync`'s
+"no peer snapshot available" log now includes the stats snapshot.
+
+## Test results
+
+All unit tests passing on this branch:
+
+```
+node --experimental-strip-types --test \
+  node/src/bft-proposer-skip.test.ts \
+  node/src/consensus-validator-set-change.test.ts \
+  node/src/bft-evidence-eviction.test.ts \
+  node/src/chain-engine-tip-sync.test.ts \
+  node/src/p2p-snapshot-provider.test.ts \
+  node/src/bft.test.ts \
+  node/src/bft-coordinator.test.ts \
+  node/src/consensus.test.ts \
+  node/src/p2p.test.ts
+# 126/126 pass (PR-1A: 7, PR-1B: 7, PR-1C: 7, PR-1D: 5, PR-1E: 3, regression: 97)
+```
+
+Storage + persistent engine layer regression also clean:
+`node/src/storage/*.test.ts` 106/106 pass.
+
+## Devnet drill caveat (2026-05-10 local run)
+
+A local `bash scripts/start-devnet.sh 5 18780` reproduced an
+**unrelated environmental issue**: 5 nodes sharing `127.0.0.1` exhaust
+each others' peer-scoring quotas, getting `HTTP 429 peer temporarily
+banned` on `/p2p/chain-snapshot` polls. BFT messages are exempt from
+ban-checks (`p2p.ts:494`), but the polling pressure plus IP-shared
+scoring still degrades cluster behavior on a single host. PR-1E's
+instrumentation immediately surfaced the cause — a concrete win for
+diagnostic value.
+
+For end-to-end N=5 chaos validation use one of:
+- gcloud 5-node cluster (different IPs per node — no scoring collision)
+- 5 separate VMs / containers with distinct hostnames
+- chainId 88780 R3.2 prod-candidate per `docs/r3-2-prod-candidate-testnet-88780.md`
+
+The local `scripts/start-devnet.sh 5 [chainId]` is fine for **single-node
+restart** drills (T2/T4 single-validator stop) when started with
+`COC_DEVNET_CHAIN_ID=...` parameterization, but not for sustained N=5
+chaos sequences.
+
+## What's next (Phase 2 → Phase 4)
+
+| Phase | Status |
+|-------|--------|
+| Phase 1: 5 BFT bug PRs + tests | ✅ done (this commit series) |
+| Phase 2: cloud / multi-host N=5 chaos drill | ⏳ pending — local devnet caveat above |
+| Phase 3: chainId 88780 R3.2 prep (keys, genesis, contracts) | ⏳ pending |
+| Phase 4: 88780 deploy + 30-day soak | ⏳ pending |
+
+The 5 PRs are independently mergeable to `main`. Phase 2 cloud drill
+becomes the gate for Phase 3 deployment.
+
+## Helper scripts added
+
+- `scripts/start-devnet.sh` — chainId now parameterized via `$2` or
+  `COC_DEVNET_CHAIN_ID` env (default 18780 preserved).
+- `scripts/stop-devnet-node.sh <total-nodes> <node-id>` — stop a single
+  node from a running cluster (T2/T4 chaos helper).
+- `scripts/start-devnet-node.sh <total-nodes> <node-id>` — restart a
+  single stopped node, preserving its leveldb + config.

--- a/node/src/bft-coordinator.ts
+++ b/node/src/bft-coordinator.ts
@@ -115,6 +115,17 @@ export interface BftCoordinatorConfig {
    * When omitted, only the legacy `lastFinalizedHeight` guard applies.
    */
   getChainHeight?: () => bigint | Promise<bigint>
+  /**
+   * PR-1A (2026-05-10): callback fired when a BFT round times out and the
+   * round's proposer was *not* the local node. The parent (consensus engine)
+   * uses this signal to mark the proposer unreachable, which arms the fast-
+   * path H15 fallback (~15s) instead of waiting for the conservative 600s
+   * timeout. Repeat callbacks for the same proposer refresh the TTL,
+   * keeping a persistently-down validator marked across many rounds.
+   *
+   * Optional — when omitted, only the slow 600s path applies.
+   */
+  onProposerStuck?: (proposerId: string, height: bigint) => void
 }
 
 /**
@@ -972,6 +983,20 @@ export class BftCoordinator {
               })
             } catch (err) {
               log.warn("BFT onPersistentDivergence callback threw", { error: String(err) })
+            }
+          }
+        }
+
+        // PR-1A: notify parent that this round's proposer is likely unreachable.
+        // Skip when the proposer was local — `onProposerStuck` is for *peer*
+        // unreachability evidence; self-stuck has its own J2.2 path.
+        if (this.cfg.onProposerStuck && this.activeRound) {
+          const proposerId = this.activeRound.state.proposedBlock?.proposer
+          if (proposerId && proposerId.toLowerCase() !== this.cfg.localId.toLowerCase()) {
+            try {
+              this.cfg.onProposerStuck(proposerId, this.activeRound.state.height)
+            } catch (err) {
+              log.warn("BFT onProposerStuck callback threw", { error: String(err) })
             }
           }
         }

--- a/node/src/bft-coordinator.ts
+++ b/node/src/bft-coordinator.ts
@@ -614,12 +614,55 @@ export class BftCoordinator {
 
   /**
    * Update the validator set (e.g., after governance changes).
+   *
+   * PR-1B (2026-05-10): when membership *changes* (validators added or
+   * removed, not just stake reweighted), force-clear local-state caches.
+   * Carrying localPreparedAt / localCommittedAt / localPreparedBlock /
+   * pendingMessages across a membership change can replay stale blocks
+   * whose proposer was assigned by the OLD rotation — Phase R then refuses
+   * a re-prepare of the new rotation's block as self-equivocation, and
+   * the chain stalls (2026-05-09 reader-driven N=3→N=8 attempt #1, ~7h).
+   *
+   * Stake-only updates (re-balancing without membership churn) are
+   * non-disruptive and DO preserve the local state.
    */
   updateValidators(validators: Array<{ id: string; stake: bigint }>): void {
-    // Defensive copy to prevent external mutation of the active validator set.
-    // Without this, the caller could modify the array after passing it, potentially
-    // corrupting quorum calculations in an active BFT round.
+    const oldIds = new Set(this.cfg.validators.map(v => v.id.toLowerCase()))
+    const newIds = new Set(validators.map(v => v.id.toLowerCase()))
+    const membershipChanged = oldIds.size !== newIds.size
+      || [...newIds].some(id => !oldIds.has(id))
+      || [...oldIds].some(id => !newIds.has(id))
+
+    // Defensive copy — caller could mutate the array after passing it.
     this.cfg.validators = validators.map(v => ({ id: v.id, stake: v.stake }))
+
+    if (!membershipChanged) return
+
+    log.info("BFT validator set membership changed — clearing local state caches", {
+      added: [...newIds].filter(id => !oldIds.has(id)),
+      removed: [...oldIds].filter(id => !newIds.has(id)),
+    })
+    // Self-vote ledger: drop entirely. Heights below currentHeight are
+    // already finalized so the entries are dead weight; heights at-or-above
+    // were voted under stale rotation and must be redone under the new set.
+    this.localPreparedAt.clear()
+    this.localCommittedAt.clear()
+    this.localPreparedBlock.clear()
+    // Pending messages may carry senderIds that are no longer validators;
+    // drop them so handleMessage doesn't reject them one-by-one (and so
+    // a removed peer's stale prepare can't influence quorum after they're out).
+    this.pendingMessages.length = 0
+    // Active round held the OLD validator stake snapshot — quorum would
+    // be computed against stale distribution. Clean break: drop it; next
+    // propose / received block will start a fresh round under the new set.
+    if (this.activeRound) {
+      log.warn("BFT clearing active round due to validator set change", {
+        height: this.activeRound.state.height.toString(),
+        phase: this.activeRound.state.phase,
+      })
+      this.clearRound()
+    }
+    this.deferredBlock = null
   }
 
   /**

--- a/node/src/bft-evidence-eviction.test.ts
+++ b/node/src/bft-evidence-eviction.test.ts
@@ -1,0 +1,153 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { EquivocationDetector } from "./bft.ts"
+import type { Hex } from "./blockchain-types.ts"
+
+/**
+ * PR-1C: Equivocation evidence cache 自清 + sliding-window
+ *
+ * 2026-05-10 N=5 attempt #2 fingerprint: during chain freeze, clearEvidenceBefore
+ * is never called (no finalize). A single validator's evidence array fills to
+ * the per-validator cap=100, after which new evidence is silently NOT pushed
+ * (kept in `evidence` array). The validator's cap stays full forever; later
+ * recovery's evidence cleanup only frees the slot when finalize advances past
+ * the height — but because the freeze stopped finalization, that doesn't happen.
+ *
+ * Fix:
+ *   1. When per-validator cap reached, evict the OLDEST entry from the same
+ *      validator and push the new one (sliding window). Recent evidence is
+ *      strictly more useful than ancient evidence for slashing decisions.
+ *   2. Add `getStats()` for monitoring (size, dropCount, perValidator counts).
+ *   3. Add `pruneByMaxHeight(maxHeight, keep)` that retains only the `keep`
+ *      most-recent heights — usable by external watchdogs to bound memory
+ *      even when finalize hasn't advanced.
+ */
+
+function mkHash(suffix: number): Hex {
+  return ("0x" + suffix.toString(16).padStart(64, "0")) as Hex
+}
+
+test("PR-1C: per-validator cap evicts OLDEST entry of same validator (sliding window)", () => {
+  // Cap of 3 for testability. Push 5 conflicting votes for the same validator.
+  // Old behavior: first 3 stored, last 2 dropped → array stays at the OLDEST 3.
+  // PR-1C behavior: array slides → keeps the NEWEST 3 (most recent are most useful).
+  const det = new EquivocationDetector(100, 1000, 3)
+  const v = "0xvalidator1"
+
+  // Generate 5 equivocation events at different heights for the same validator
+  for (let h = 1; h <= 5; h++) {
+    det.recordVote(v, BigInt(h), "prepare", mkHash(h * 10), ("0xsig" + h) as Hex)
+    det.recordVote(v, BigInt(h), "prepare", mkHash(h * 10 + 1), ("0xsig" + h + "b") as Hex)
+  }
+
+  const ev = det.getEvidenceFor(v)
+  assert.equal(ev.length, 3, "per-validator cap respected")
+  // Sliding window keeps the NEWEST: heights 3, 4, 5 (not 1, 2, 3)
+  const heights = ev.map((e) => e.height).sort((a, b) => Number(a - b))
+  assert.deepEqual(heights, [3n, 4n, 5n], "newest entries retained")
+})
+
+test("PR-1C: getStats exposes size + per-validator counts", () => {
+  const det = new EquivocationDetector(100, 1000, 100)
+
+  // Two validators, two evicocations each
+  for (const v of ["0xa", "0xb"]) {
+    det.recordVote(v, 10n, "prepare", mkHash(1))
+    det.recordVote(v, 10n, "prepare", mkHash(2))
+    det.recordVote(v, 11n, "commit", mkHash(3))
+    det.recordVote(v, 11n, "commit", mkHash(4))
+  }
+
+  const stats = det.getStats()
+  assert.equal(stats.totalEvidence, 4, "4 total evidence entries")
+  assert.equal(stats.uniqueValidators, 2)
+  assert.equal(stats.perValidator["0xa"], 2)
+  assert.equal(stats.perValidator["0xb"], 2)
+})
+
+test("PR-1C: pruneByMaxHeight retains only `keep` most-recent heights", () => {
+  const det = new EquivocationDetector(100, 1000, 100)
+  const v = "0xv1"
+
+  // Conflicting votes at heights 1..10
+  for (let h = 1; h <= 10; h++) {
+    det.recordVote(v, BigInt(h), "prepare", mkHash(h * 10))
+    det.recordVote(v, BigInt(h), "prepare", mkHash(h * 10 + 1))
+  }
+  assert.equal(det.getEvidence().length, 10, "10 evidence entries before prune")
+
+  // Keep only the 3 most-recent heights worth of evidence
+  const removed = det.pruneByMaxHeight(3)
+  assert.equal(removed, 7, "7 entries pruned (10 - 3)")
+
+  const remaining = det.getEvidence()
+  assert.equal(remaining.length, 3)
+  const heights = remaining.map((e) => e.height).sort((a, b) => Number(a - b))
+  assert.deepEqual(heights, [8n, 9n, 10n], "newest 3 heights retained")
+})
+
+test("PR-1C: pruneByMaxHeight is a no-op when total <= keep", () => {
+  const det = new EquivocationDetector(100, 1000, 100)
+  det.recordVote("0xv", 1n, "prepare", mkHash(1))
+  det.recordVote("0xv", 1n, "prepare", mkHash(2))
+  det.recordVote("0xv", 2n, "prepare", mkHash(3))
+  det.recordVote("0xv", 2n, "prepare", mkHash(4))
+
+  const removed = det.pruneByMaxHeight(10)
+  assert.equal(removed, 0)
+  assert.equal(det.getEvidence().length, 2)
+})
+
+test("PR-1C: long-running stress — 1000 conflicting votes settle into bounded cache", () => {
+  // Simulate a multi-hour run with hostile validators repeatedly equivocating.
+  // Without PR-1C: array grows past cap, oldest-from-most-active stays evicted,
+  // memory & CPU stable but old evidence pinned.
+  // With PR-1C: sliding-window means newest evidence always wins.
+  const det = new EquivocationDetector(100, 1000, 50)
+
+  for (let h = 1; h <= 1000; h++) {
+    det.recordVote("0xattacker", BigInt(h), "prepare", mkHash(h * 10))
+    det.recordVote("0xattacker", BigInt(h), "prepare", mkHash(h * 10 + 1))
+  }
+
+  const ev = det.getEvidenceFor("0xattacker")
+  assert.equal(ev.length, 50, "respects per-validator cap of 50")
+  // Should be the NEWEST 50 heights (951..1000)
+  const heights = ev.map((e) => Number(e.height))
+  assert.equal(Math.min(...heights), 951, "oldest retained = h-49")
+  assert.equal(Math.max(...heights), 1000, "newest retained = h")
+})
+
+test("PR-1C: clearEvidenceBefore still works as before (regression check)", () => {
+  // Existing semantics preserved: clearEvidenceBefore removes evidence
+  // with height < threshold and keeps the rest. Used by Phase H16 on every
+  // finalize. PR-1C does NOT change this method.
+  const det = new EquivocationDetector(100, 1000, 100)
+  det.recordVote("0xv1", 5n, "prepare", mkHash(1))
+  det.recordVote("0xv1", 5n, "prepare", mkHash(2))
+  det.recordVote("0xv1", 8n, "commit", mkHash(3))
+  det.recordVote("0xv1", 8n, "commit", mkHash(4))
+
+  const removed = det.clearEvidenceBefore(7n)
+  assert.equal(removed, 1, "h=5 evidence removed")
+  assert.equal(det.getEvidenceFor("0xv1").length, 1)
+  assert.equal(det.getEvidenceFor("0xv1")[0].height, 8n)
+})
+
+test("PR-1C: getStats droppedTotal counts incoming votes silently dropped pre-cap", () => {
+  // Before PR-1C, hitting per-validator cap silently dropped new evidence
+  // (logged a warn but no metric). PR-1C: cap-eviction means we never DROP
+  // legitimate evidence — droppedTotal stays at 0 in normal operation.
+  const det = new EquivocationDetector(100, 1000, 5)
+
+  for (let h = 1; h <= 20; h++) {
+    det.recordVote("0xv", BigInt(h), "prepare", mkHash(h * 10))
+    det.recordVote("0xv", BigInt(h), "prepare", mkHash(h * 10 + 1))
+  }
+
+  const stats = det.getStats()
+  // With sliding window, no drops: every conflict either was added or
+  // evicted an older entry. Total entries = cap (5).
+  assert.equal(stats.totalEvidence, 5)
+  assert.equal(stats.droppedTotal, 0, "no legitimate evidence is dropped")
+})

--- a/node/src/bft-proposer-skip.test.ts
+++ b/node/src/bft-proposer-skip.test.ts
@@ -1,0 +1,229 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import {
+  ConsensusEngine,
+  NO_PROGRESS_TIMEOUT_MS,
+  NO_PROGRESS_STAGGER_MS,
+  PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS,
+  PROPOSER_UNREACHABLE_TTL_MS,
+} from "./consensus.ts"
+
+/**
+ * PR-1A: Proposer slot skip 机制
+ *
+ * 2026-05-10 N=5 attempt #2 实测发现:N=5 BFT 在单 validator 不可达时立即冻结链,
+ * 与 N 无关。根因是 expectedProposer() 用 (height-1) % N 选 proposer,无 skip 机制;
+ * round timeout 后只清理不推进高度;只能等 H15 600s NO_PROGRESS_TIMEOUT_MS 兜底。
+ *
+ * 修复:
+ *   1. 新增 markProposerUnreachable(id) — 由 BFT round timeout 调用
+ *   2. 新增 reachabilityProvider opt — 暴露 wire-connection-manager 已连接 peer 集合
+ *   3. checkNoProgressWatchdog 当 stuck proposer 不可达时,fast-path 用
+ *      PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS (15s) 替代 600s 触发 fallback
+ *   4. unreachable 标记 60s TTL,持续 unreachable 期间会被 BFT timeout / wire 事件刷新
+ */
+
+const VALIDATORS_5 = ["node-1", "node-2", "node-3", "node-4", "node-5"]
+
+function mkMockChain(validators: string[]): any {
+  return {
+    getHeight: async () => 0n,
+    getTip: async () => null,
+    expectedProposer: (h: bigint) =>
+      validators[Number((h - 1n) % BigInt(validators.length))],
+    mempool: { getPendingTxs: () => [] },
+    events: { on: () => {}, off: () => {} },
+  }
+}
+
+const mkMockP2p = (): any => ({
+  fetchSnapshots: async () => [],
+  receiveBlock: async () => {},
+})
+
+const mkMockBft = (): any => ({
+  getRoundState: () => ({ active: false }),
+  stop: () => {},
+})
+
+test("PR-1A: markProposerUnreachable records id with TTL", () => {
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-2" },
+  )
+
+  c.markProposerUnreachable("node-1")
+  assert.equal((c as any).isProposerUnreachable("node-1"), true)
+  assert.equal((c as any).isProposerUnreachable("NODE-1"), true, "case-insensitive")
+  assert.equal((c as any).isProposerUnreachable("node-3"), false)
+
+  // After expiry the entry should be cleared on next query
+  ;(c as any).unreachableProposers.set("node-1", Date.now() - 1)
+  assert.equal((c as any).isProposerUnreachable("node-1"), false)
+  assert.equal(
+    (c as any).unreachableProposers.has("node-1"),
+    false,
+    "expired entries are pruned on read",
+  )
+})
+
+test("PR-1A: reachabilityProvider drives isProposerUnreachable for non-self ids", () => {
+  const reachable = new Set<string>()
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    {
+      bft: mkMockBft(),
+      nodeId: "node-2",
+      reachabilityProvider: () => reachable,
+    },
+  )
+
+  // Empty reachable set → all peers (except self) are considered unreachable
+  assert.equal((c as any).isProposerUnreachable("node-1"), true, "missing-from-reachable counts as unreachable")
+  // Self is never marked unreachable by the reachability provider
+  assert.equal((c as any).isProposerUnreachable("node-2"), false, "self is always reachable")
+
+  reachable.add("node-1")
+  assert.equal((c as any).isProposerUnreachable("node-1"), false, "now reachable")
+})
+
+test("PR-1A: fast watchdog fires at 15s when stuck proposer marked unreachable", async () => {
+  // N=5 chain. expectedProposer(1) = node-1 (stuck). Local = node-2 (offset 1 fallback).
+  // With unreachable evidence, override should arm at PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS,
+  // not at NO_PROGRESS_TIMEOUT_MS (600s).
+  const mockChain = mkMockChain(VALIDATORS_5)
+  const mockP2p = mkMockP2p()
+  const mockBft = mkMockBft()
+
+  const c = new ConsensusEngine(
+    mockChain,
+    mockP2p,
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mockBft, nodeId: "node-2" },
+  )
+
+  c.markProposerUnreachable("node-1")
+
+  // Below fast threshold → no arming
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS - 2_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).noProgressProposerOverride, false, "below fast threshold: no arm")
+
+  // Above fast threshold and well below H15 → arms
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS + 2_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).noProgressProposerOverride, true, "fast watchdog arms when proposer unreachable")
+})
+
+test("PR-1A: without unreachable evidence, slow path (600s) governs", async () => {
+  const mockChain = mkMockChain(VALIDATORS_5)
+  const c = new ConsensusEngine(
+    mockChain,
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-2" },
+  )
+
+  // No markProposerUnreachable call. Even at 30s elapsed (well past fast threshold),
+  // the override must NOT arm — without evidence we keep the conservative behaviour.
+  ;(c as any).lastBftProgressAtMs = Date.now() - 30_000
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).noProgressProposerOverride, false, "no evidence: slow path")
+
+  // Slow path eventually fires at NO_PROGRESS_TIMEOUT_MS as before
+  ;(c as any).lastBftProgressAtMs = Date.now() - (NO_PROGRESS_TIMEOUT_MS + 5_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).noProgressProposerOverride, true, "slow path still works")
+})
+
+test("PR-1A: fast path respects rotation stagger across multiple fallbacks", async () => {
+  // 2026-05-02 regression: ALL nodes armed override simultaneously → equivocation storm.
+  // Same protection must hold on the fast path.
+  // Setup: stuck = node-1 (offset 0). Primary fallback = node-2 (offset 1).
+  // Secondary = node-3 (offset 2). Tertiary = node-4 (offset 3) ...
+
+  async function fires(localId: string, elapsedMs: number): Promise<boolean> {
+    const c = new ConsensusEngine(
+      mkMockChain(VALIDATORS_5),
+      mkMockP2p(),
+      { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+      { bft: mkMockBft(), nodeId: localId },
+    )
+    c.markProposerUnreachable("node-1")
+    ;(c as any).lastBftProgressAtMs = Date.now() - elapsedMs
+    await (c as any).checkNoProgressWatchdog()
+    return (c as any).noProgressProposerOverride === true
+  }
+
+  const FAST = PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS
+  const STAG = NO_PROGRESS_STAGGER_MS
+
+  // Stuck proposer (node-1) NEVER arms (its own slot)
+  assert.equal(await fires("node-1", FAST + 5 * STAG), false, "stuck proposer never arms")
+
+  // Primary fallback fires at FAST
+  assert.equal(await fires("node-2", FAST - 2_000), false, "node-2 below fast threshold")
+  assert.equal(await fires("node-2", FAST + 2_000), true, "node-2 arms at fast threshold")
+
+  // Secondary fallback fires at FAST + STAG
+  assert.equal(await fires("node-3", FAST + 2_000), false, "node-3 below secondary threshold")
+  assert.equal(await fires("node-3", FAST + STAG + 2_000), true, "node-3 arms at secondary threshold")
+
+  // Tertiary fallback fires at FAST + 2*STAG
+  assert.equal(
+    await fires("node-4", FAST + STAG + 2_000),
+    false,
+    "node-4 below tertiary threshold",
+  )
+  assert.equal(
+    await fires("node-4", FAST + 2 * STAG + 2_000),
+    true,
+    "node-4 arms at tertiary threshold",
+  )
+})
+
+test("PR-1A: notifyBftProgress clears unreachable mark for stuck proposer", () => {
+  // When the stuck proposer recovers and successfully finalizes a block,
+  // notifyBftProgress should clear all unreachable marks so the next slot
+  // tick goes back to the normal round-robin path.
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-2" },
+  )
+
+  c.markProposerUnreachable("node-1")
+  c.markProposerUnreachable("node-3")
+  assert.equal((c as any).unreachableProposers.size, 2)
+
+  c.notifyBftProgress()
+  assert.equal(
+    (c as any).unreachableProposers.size,
+    0,
+    "successful finalize clears all unreachable marks",
+  )
+})
+
+test("PR-1A: TTL constant is reasonable", () => {
+  // Sanity check the constants relate sensibly:
+  //   FAST < TTL  (a single round must not expire its own evidence mid-flight)
+  //   FAST < NO_PROGRESS_TIMEOUT_MS (fast path must beat slow path)
+  //   TTL <= NO_PROGRESS_TIMEOUT_MS (don't keep stale evidence past slow-path window)
+  assert.ok(
+    PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS < PROPOSER_UNREACHABLE_TTL_MS,
+    "fast timeout < TTL",
+  )
+  assert.ok(
+    PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS < NO_PROGRESS_TIMEOUT_MS,
+    "fast timeout < slow timeout",
+  )
+  assert.ok(
+    PROPOSER_UNREACHABLE_TTL_MS <= NO_PROGRESS_TIMEOUT_MS,
+    "TTL <= slow timeout",
+  )
+})

--- a/node/src/bft.ts
+++ b/node/src/bft.ts
@@ -463,6 +463,9 @@ export class EquivocationDetector {
   private readonly maxTrackedHeights: number
   private readonly maxEvidence: number
   private readonly maxEvidencePerValidator: number
+  // PR-1C: monitoring counter — only increments on rare desync repair paths,
+  // not on routine sliding-window evictions. Stays at 0 in normal operation.
+  private droppedTotal = 0
 
   constructor(maxTrackedHeights = 100, maxEvidence = 1000, maxEvidencePerValidator = 100) {
     this.maxTrackedHeights = maxTrackedHeights
@@ -511,29 +514,54 @@ export class EquivocationDetector {
         ...(existing?.signature ? { signature1: existing.signature } : {}),
         ...(signature ? { signature2: signature } : {}),
       }
-      // Per-validator evidence cap: prevent one attacker from flushing another validator's evidence
+      // PR-1C (2026-05-10): sliding-window per-validator cap.
+      // Old behavior dropped NEW evidence when a validator hit cap,
+      // pinning ancient evidence in the array forever during a chain
+      // freeze (clearEvidenceBefore wasn't called). Sliding-window
+      // evicts the OLDEST entry from the same validator and pushes the
+      // new one — recent evidence is strictly more useful for slashing
+      // than ancient evidence about the same actor.
       const validatorCount = this.evidenceCountByValidator.get(normalizedId) ?? 0
       if (validatorCount >= this.maxEvidencePerValidator) {
-        // This validator already has max evidence; log but don't store to prevent flush attack
-        log.warn("equivocation evidence cap reached for validator", { validator: normalizedId, cap: this.maxEvidencePerValidator })
-      } else {
-        // Global cap with per-validator fairness: evict oldest from the SAME validator if global is full
-        if (this.evidence.length >= this.maxEvidence) {
-          // Find and remove oldest evidence from the validator with the most entries
-          let maxValidator = normalizedId
-          let maxCount = validatorCount
-          for (const [vid, cnt] of this.evidenceCountByValidator) {
-            if (cnt > maxCount) { maxValidator = vid; maxCount = cnt }
-          }
-          const evictIdx = this.evidence.findIndex((e) => e.validatorId === maxValidator)
-          if (evictIdx >= 0) {
-            this.evidence.splice(evictIdx, 1)
-            this.evidenceCountByValidator.set(maxValidator, (this.evidenceCountByValidator.get(maxValidator) ?? 1) - 1)
-          }
+        const oldestIdx = this.evidence.findIndex((e) => e.validatorId === normalizedId)
+        if (oldestIdx >= 0) {
+          this.evidence.splice(oldestIdx, 1)
+          // Counter unchanged — we evicted 1 of this validator's entries
+          // and are about to push 1 new one.
+        } else {
+          // Counter desync — defensive: rebuild from array and bail.
+          this.evidenceCountByValidator.set(normalizedId, 0)
+          this.droppedTotal += 1
+          log.warn("equivocation evidence counter desync — repaired", {
+            validator: normalizedId,
+          })
         }
-        this.evidence.push(ev)
-        this.evidenceCountByValidator.set(normalizedId, validatorCount + 1)
       }
+      // Global cap with per-validator fairness: evict oldest from the SAME
+      // validator-with-most-entries if global is full.
+      if (this.evidence.length >= this.maxEvidence) {
+        let maxValidator = normalizedId
+        let maxCount = this.evidenceCountByValidator.get(normalizedId) ?? 0
+        for (const [vid, cnt] of this.evidenceCountByValidator) {
+          if (cnt > maxCount) { maxValidator = vid; maxCount = cnt }
+        }
+        const evictIdx = this.evidence.findIndex((e) => e.validatorId === maxValidator)
+        if (evictIdx >= 0) {
+          this.evidence.splice(evictIdx, 1)
+          this.evidenceCountByValidator.set(
+            maxValidator,
+            (this.evidenceCountByValidator.get(maxValidator) ?? 1) - 1,
+          )
+        }
+      }
+      this.evidence.push(ev)
+      this.evidenceCountByValidator.set(
+        normalizedId,
+        Math.min(
+          this.maxEvidencePerValidator,
+          (this.evidenceCountByValidator.get(normalizedId) ?? 0) + 1,
+        ),
+      )
       log.warn("equivocation detected!", {
         validator: validatorId,
         height: height.toString(),
@@ -589,5 +617,59 @@ export class EquivocationDetector {
     for (let i = 0; i < toRemove; i++) {
       this.votes.delete(heights[i].toString())
     }
+  }
+
+  /**
+   * PR-1C (2026-05-10): monitoring snapshot. Plumbed into Prometheus metrics
+   * so an operator can alert on cache pressure (`totalEvidence > 0.8 *
+   * maxEvidence`) before the global cap fires; without this, the existing
+   * "evidence cap reached" log is the only signal and easy to miss.
+   */
+  getStats(): {
+    totalEvidence: number
+    maxEvidence: number
+    maxEvidencePerValidator: number
+    uniqueValidators: number
+    perValidator: Record<string, number>
+    trackedHeights: number
+    droppedTotal: number
+  } {
+    const perValidator: Record<string, number> = {}
+    for (const [id, cnt] of this.evidenceCountByValidator) perValidator[id] = cnt
+    return {
+      totalEvidence: this.evidence.length,
+      maxEvidence: this.maxEvidence,
+      maxEvidencePerValidator: this.maxEvidencePerValidator,
+      uniqueValidators: this.evidenceCountByValidator.size,
+      perValidator,
+      trackedHeights: this.votes.size,
+      droppedTotal: this.droppedTotal,
+    }
+  }
+
+  /**
+   * PR-1C (2026-05-10): retain only evidence at the `keep` highest heights
+   * still present, dropping the rest. Complement to `clearEvidenceBefore`
+   * (which trims by absolute height): this method bounds memory by recency
+   * count, usable from a periodic watchdog when finalize hasn't advanced for
+   * a long time (chain freeze) and the threshold-based prune doesn't fire.
+   *
+   * Returns the number of entries removed.
+   */
+  pruneByMaxHeight(keep: number): number {
+    if (keep <= 0) {
+      const removed = this.evidence.length
+      this.evidence.length = 0
+      this.evidenceCountByValidator.clear()
+      return removed
+    }
+    const uniqueHeights = new Set<bigint>()
+    for (const e of this.evidence) uniqueHeights.add(e.height)
+    if (uniqueHeights.size <= keep) return 0
+
+    // Sorted descending by height — the first `keep` are the survivors.
+    const sorted = [...uniqueHeights].sort((a, b) => (a > b ? -1 : a < b ? 1 : 0))
+    const cutoff = sorted[keep - 1] // smallest height that survives
+    return this.clearEvidenceBefore(cutoff)
   }
 }

--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -171,6 +171,22 @@ export class PersistentChainEngine {
   async init(): Promise<void> {
     await this.db.open()
 
+    // PR-1D (2026-05-10): self-heal tip-pointer desync. The N=5 attempt #2
+    // observed disk holding b:71450 with consistent stateRoot but LATEST
+    // pointer at 71448 — most plausibly because snap-sync rewinds LATEST
+    // without deleting stale b:>peerTip entries from a prior run. Without
+    // this repair, the node would have to wait for cluster gossip to push
+    // it forward (slow) or be manually rsync'd. With it, every restart
+    // self-aligns LATEST with the highest stored block.
+    const repair = await this.blockIndex.repairLatestPointer()
+    if (repair.repaired) {
+      log.warn("PR-1D: tip pointer desync detected — repaired on init", {
+        latestBefore: repair.latestBefore?.toString() ?? "<none>",
+        latestAfter: repair.latestAfter?.toString() ?? "<none>",
+        highestStored: repair.highestStored?.toString() ?? "<none>",
+      })
+    }
+
     // Load latest block first to decide whether this is a genesis boot or a restart.
     const latestBlock = await this.blockIndex.getLatestBlock()
 

--- a/node/src/chain-engine-tip-sync.test.ts
+++ b/node/src/chain-engine-tip-sync.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { BlockIndex } from "./storage/block-index.ts"
+import { MemoryDatabase } from "./storage/db.ts"
+import type { ChainBlock, Hex } from "./blockchain-types.ts"
+
+/**
+ * PR-1D: tip pointer atomicity invariant + auto-repair.
+ *
+ * 2026-05-10 N=5 attempt #2 fingerprint: server-1 RPC reported h=71448 but
+ * eth_getBlockByNumber("0x116ba"=71450) returned a valid block whose
+ * stateRoot matched server-2/3. "chain data 写到 disk 但 head pointer 没
+ * 更新." The atomic batch in BlockIndex.buildBlockOps writes b:N AND
+ * LATEST_BLOCK_KEY together, so the pointer should never lag behind the
+ * highest stored block — but in practice it did. Most plausible vector:
+ * snap-sync's per-block putBlock loop does not delete b:>peerTip entries
+ * left over from a prior run; LATEST gets rewound, but stale b:N>tip
+ * remain on disk.
+ *
+ * Fix: BlockIndex.repairLatestPointer() scans the `b:` prefix, finds
+ * the highest block number actually stored, and promotes LATEST_BLOCK_KEY
+ * to match if it lags. PersistentChainEngine.init() runs this on every
+ * boot so a desync recovers automatically without manual rsync.
+ */
+
+function mkBlock(number: number): ChainBlock {
+  const hash = ("0x" + number.toString(16).padStart(64, "0")) as Hex
+  const parent = number > 0
+    ? ("0x" + (number - 1).toString(16).padStart(64, "0"))
+    : "0x" + "0".repeat(64)
+  return {
+    number: BigInt(number),
+    hash,
+    parentHash: parent as Hex,
+    proposer: "0xproposer",
+    timestampMs: Date.now(),
+    txs: [],
+    stateRoot: ("0xst" + number.toString(16).padStart(62, "0")) as Hex,
+  } as unknown as ChainBlock
+}
+
+test("PR-1D: repairLatestPointer is a no-op when LATEST already matches highest stored", async () => {
+  const db = new MemoryDatabase()
+  const idx = new BlockIndex(db)
+
+  await idx.putBlock(mkBlock(1))
+  await idx.putBlock(mkBlock(2))
+  await idx.putBlock(mkBlock(3))
+
+  const result = await idx.repairLatestPointer()
+  assert.equal(result.repaired, false)
+  assert.equal(result.latestBefore, 3n)
+  assert.equal(result.highestStored, 3n)
+  const latest = await idx.getLatestBlock()
+  assert.equal(latest?.number, 3n)
+})
+
+test("PR-1D: repairLatestPointer promotes LATEST when stale block exists above tip", async () => {
+  // Reproduce the N=5 attempt #2 desync: b:71450 exists, LATEST=71448.
+  const db = new MemoryDatabase()
+  const idx = new BlockIndex(db)
+
+  // Put 1..5 normally
+  for (let n = 1; n <= 5; n++) await idx.putBlock(mkBlock(n))
+  // Force LATEST back to b:3 via direct put (bypass putBlock's atomicity).
+  // This is the symptom we're recovering from, not a normal write path.
+  await idx.putBlock(mkBlock(3))
+  // ... but b:4 and b:5 still exist on disk
+  const stale4 = await idx.getBlockByNumber(4n)
+  const stale5 = await idx.getBlockByNumber(5n)
+  assert.ok(stale4 && stale5, "stale higher blocks still present on disk")
+  const beforeLatest = await idx.getLatestBlock()
+  assert.equal(beforeLatest?.number, 3n, "LATEST stale at 3")
+
+  const result = await idx.repairLatestPointer()
+  assert.equal(result.repaired, true)
+  assert.equal(result.latestBefore, 3n)
+  assert.equal(result.highestStored, 5n)
+  assert.equal(result.latestAfter, 5n)
+
+  const latest = await idx.getLatestBlock()
+  assert.equal(latest?.number, 5n, "LATEST promoted to 5")
+})
+
+test("PR-1D: repairLatestPointer with empty db returns null state", async () => {
+  const db = new MemoryDatabase()
+  const idx = new BlockIndex(db)
+
+  const result = await idx.repairLatestPointer()
+  assert.equal(result.repaired, false)
+  assert.equal(result.latestBefore, null)
+  assert.equal(result.highestStored, null)
+})
+
+test("PR-1D: repairLatestPointer handles many blocks correctly (lexicographic-vs-numeric)", async () => {
+  // Lexicographic key sort places "b:9" > "b:10" > "b:71450". Naive key-based
+  // max would mis-rank. The repair must parse numbers and use BigInt comparison.
+  const db = new MemoryDatabase()
+  const idx = new BlockIndex(db)
+
+  for (const n of [1, 9, 10, 71450, 71449, 71448]) {
+    await idx.putBlock(mkBlock(n))
+  }
+  // After loop, LATEST = the LAST putBlock's data → b:71448 (the last call).
+  const before = await idx.getLatestBlock()
+  assert.equal(before?.number, 71448n, "LATEST at last-written block")
+
+  const result = await idx.repairLatestPointer()
+  assert.equal(result.repaired, true)
+  assert.equal(result.highestStored, 71450n, "BigInt-correct max")
+
+  const after = await idx.getLatestBlock()
+  assert.equal(after?.number, 71450n, "LATEST promoted to numeric max")
+})
+
+test("PR-1D: repairLatestPointer is idempotent across repeated calls", async () => {
+  const db = new MemoryDatabase()
+  const idx = new BlockIndex(db)
+
+  for (let n = 1; n <= 10; n++) await idx.putBlock(mkBlock(n))
+  await idx.putBlock(mkBlock(5)) // rewind LATEST → 5
+
+  const r1 = await idx.repairLatestPointer()
+  assert.equal(r1.repaired, true)
+  assert.equal(r1.latestAfter, 10n)
+
+  const r2 = await idx.repairLatestPointer()
+  assert.equal(r2.repaired, false, "second call no-op")
+  assert.equal((await idx.getLatestBlock())?.number, 10n)
+})

--- a/node/src/consensus-validator-set-change.test.ts
+++ b/node/src/consensus-validator-set-change.test.ts
@@ -1,0 +1,203 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { ConsensusEngine } from "./consensus.ts"
+import { BftCoordinator } from "./bft-coordinator.ts"
+import type { BftMessage } from "./bft.ts"
+import type { ChainBlock } from "./blockchain-types.ts"
+
+/**
+ * PR-1B: lastProposed cache + BFT local state must be invalidated when the
+ * validator set membership changes (ValidatorRegistry reader detects an
+ * add/remove between polls).
+ *
+ * 2026-05-09 attempt #1 fingerprint: reader-driven set switch from N=3 to N=8
+ * silently kept consensus.lastProposedBlock pointing at a block whose proposer
+ * was assigned by the OLD rotation. Re-broadcast on round timeout replayed the
+ * stale block, peers' Phase R refused self-equivocation, chain stalled 7 hours.
+ *
+ * Fix: BftCoordinator.updateValidators detects membership change and clears
+ * localPreparedAt / localCommittedAt / localPreparedBlock / pendingMessages
+ * (and force-clears any active round). ConsensusEngine.clearLastProposed()
+ * resets the lastProposedHeight/Block fields.  index.ts wires the reader's
+ * applyActiveSet callback to call both.
+ */
+
+const VALIDATORS_3 = [
+  { id: "node-1", stake: 32n },
+  { id: "node-2", stake: 32n },
+  { id: "node-3", stake: 32n },
+]
+const VALIDATORS_5 = [
+  ...VALIDATORS_3,
+  { id: "node-4", stake: 32n },
+  { id: "node-5", stake: 32n },
+]
+const VALIDATORS_3_RESTAKED = [
+  { id: "node-1", stake: 64n },
+  { id: "node-2", stake: 32n },
+  { id: "node-3", stake: 32n },
+]
+
+function mkBft(): BftCoordinator {
+  return new BftCoordinator({
+    localId: "node-1",
+    validators: [...VALIDATORS_3],
+    broadcastMessage: async () => {},
+    onFinalized: async () => {},
+  })
+}
+
+const mkMockChain = (validators: Array<{ id: string; stake: bigint }>): any => ({
+  getHeight: async () => 0n,
+  getTip: async () => null,
+  expectedProposer: (h: bigint) =>
+    validators[Number((h - 1n) % BigInt(validators.length))].id,
+  mempool: { getPendingTxs: () => [] },
+  events: { on: () => {}, off: () => {} },
+})
+
+const mkMockP2p = (): any => ({
+  fetchSnapshots: async () => [],
+  receiveBlock: async () => {},
+})
+
+test("PR-1B: BftCoordinator.updateValidators clears local state on membership add", () => {
+  const bft = mkBft()
+  // Seed local state caches as if we'd voted at heights 5/6/7
+  ;(bft as any).localPreparedAt.set(5n, "0xaa")
+  ;(bft as any).localCommittedAt.set(5n, "0xaa")
+  ;(bft as any).localPreparedBlock.set(5n, { number: 5n, hash: "0xaa" } as ChainBlock)
+  ;(bft as any).pendingMessages.push({
+    type: "prepare",
+    height: 6n,
+    blockHash: "0xbb",
+    senderId: "node-2",
+  } as BftMessage)
+
+  // Add 2 new validators: membership changed
+  bft.updateValidators(VALIDATORS_5)
+
+  assert.equal((bft as any).localPreparedAt.size, 0, "localPreparedAt cleared")
+  assert.equal((bft as any).localCommittedAt.size, 0, "localCommittedAt cleared")
+  assert.equal((bft as any).localPreparedBlock.size, 0, "localPreparedBlock cleared")
+  assert.equal((bft as any).pendingMessages.length, 0, "pendingMessages cleared")
+})
+
+test("PR-1B: BftCoordinator.updateValidators clears local state on membership remove", () => {
+  const bft = new BftCoordinator({
+    localId: "node-1",
+    validators: [...VALIDATORS_5],
+    broadcastMessage: async () => {},
+    onFinalized: async () => {},
+  })
+
+  ;(bft as any).localPreparedAt.set(10n, "0xab")
+  ;(bft as any).pendingMessages.push({
+    type: "commit",
+    height: 11n,
+    blockHash: "0xcd",
+    senderId: "node-5",
+  } as BftMessage)
+
+  // Remove 2 validators
+  bft.updateValidators(VALIDATORS_3)
+
+  assert.equal((bft as any).localPreparedAt.size, 0)
+  assert.equal((bft as any).pendingMessages.length, 0)
+})
+
+test("PR-1B: BftCoordinator.updateValidators preserves caches on stake-only change", () => {
+  // Stake update without membership change is a regular governance event;
+  // running BFT rounds must continue undisturbed.
+  const bft = mkBft()
+  ;(bft as any).localPreparedAt.set(5n, "0xaa")
+  ;(bft as any).localPreparedBlock.set(5n, { number: 5n, hash: "0xaa" } as ChainBlock)
+  ;(bft as any).pendingMessages.push({
+    type: "prepare",
+    height: 6n,
+    blockHash: "0xbb",
+    senderId: "node-2",
+  } as BftMessage)
+
+  bft.updateValidators(VALIDATORS_3_RESTAKED)
+
+  assert.equal((bft as any).localPreparedAt.size, 1, "preserve on stake-only change")
+  assert.equal((bft as any).localPreparedBlock.size, 1)
+  assert.equal((bft as any).pendingMessages.length, 1)
+  // Stakes were updated though
+  assert.equal((bft as any).cfg.validators[0].stake, 64n)
+})
+
+test("PR-1B: BftCoordinator.updateValidators is case-insensitive for membership comparison", () => {
+  // Reader returns lowercase, hardcoded config may be EIP-55 mixed-case.
+  // Treat them as the same set so casing churn doesn't trigger spurious clears.
+  const bft = new BftCoordinator({
+    localId: "node-1",
+    validators: [
+      { id: "0xAaBb", stake: 32n },
+      { id: "0xCcDd", stake: 32n },
+    ],
+    broadcastMessage: async () => {},
+    onFinalized: async () => {},
+  })
+  ;(bft as any).localPreparedAt.set(5n, "0xff")
+
+  bft.updateValidators([
+    { id: "0xaabb", stake: 32n },
+    { id: "0xccdd", stake: 32n },
+  ])
+
+  assert.equal((bft as any).localPreparedAt.size, 1, "case difference is not membership change")
+})
+
+test("PR-1B: ConsensusEngine.clearLastProposed resets cached block + height", () => {
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_3),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { nodeId: "node-1" },
+  )
+  ;(c as any).lastProposedHeight = 17n
+  ;(c as any).lastProposedBlock = { number: 17n, hash: "0xab" }
+
+  c.clearLastProposed()
+
+  assert.equal((c as any).lastProposedHeight, undefined)
+  assert.equal((c as any).lastProposedBlock, undefined)
+})
+
+test("PR-1B: ConsensusEngine.onValidatorSetChange clears caches AND calls bft.updateValidators", () => {
+  const bft = mkBft()
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft, nodeId: "node-1" },
+  )
+  ;(c as any).lastProposedHeight = 5n
+  ;(c as any).lastProposedBlock = { number: 5n, hash: "0xff" }
+  ;(bft as any).localPreparedAt.set(5n, "0xff")
+
+  c.onValidatorSetChange(VALIDATORS_5)
+
+  assert.equal((c as any).lastProposedHeight, undefined, "lastProposed cleared")
+  assert.equal((c as any).lastProposedBlock, undefined)
+  assert.equal((bft as any).localPreparedAt.size, 0, "BFT local state cleared")
+  assert.equal((bft as any).cfg.validators.length, 5, "BFT validators updated")
+})
+
+test("PR-1B: BftCoordinator.updateValidators force-clears active round on membership change", async () => {
+  // If we hold an active round during a membership change, the round was
+  // started under stake-snapshot from the OLD set. Continuing under it
+  // would compute quorum against stale stake distribution and could leave
+  // votes unfulfilled. Cleaner to drop and let the next propose start fresh.
+  const bft = mkBft()
+  // Inject a fake active round
+  ;(bft as any).activeRound = {
+    state: { height: 5n, phase: "prepare", prepareVotes: new Map(), commitVotes: new Map() },
+  }
+  // Trigger membership change
+  bft.updateValidators(VALIDATORS_5)
+
+  assert.equal((bft as any).activeRound, null, "active round cleared on membership change")
+})

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -852,7 +852,15 @@ export class ConsensusEngine {
         }
       }
       if (!best) {
-        log.warn("forceSnapSync: no peer snapshot available")
+        // PR-1E: pull P2P-layer fetch stats into the failure log so operators
+        // can tell apart "peers unreachable" from "all peers returning 429"
+        // from "aggregate timeout fired". Pre-PR-1E this was a single-line
+        // warn with no per-peer attribution — the N=5 attempt #2 cluster
+        // burned 30+ minutes in this state with no actionable diagnostic.
+        const stats = (this.p2p as unknown as { getSnapshotFetchStats?: () => unknown }).getSnapshotFetchStats?.()
+        log.warn("forceSnapSync: no peer snapshot available", {
+          stats: stats ?? "<unavailable>",
+        })
         return false
       }
       log.warn("forceSnapSync: starting state-snapshot import from peers", {

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -779,6 +779,35 @@ export class ConsensusEngine {
   }
 
   /**
+   * PR-1B (2026-05-10): drop the cached `lastProposedBlock` / `lastProposedHeight`
+   * so the BFT-timeout re-broadcast path (in tryPropose) does not replay a
+   * stale block whose proposer was assigned by an old rotation. Called by
+   * onValidatorSetChange and exposed publicly so the validator-registry
+   * reader (or any other set-mutating actor) can invoke it directly.
+   */
+  clearLastProposed(): void {
+    this.lastProposedHeight = undefined
+    this.lastProposedBlock = undefined
+  }
+
+  /**
+   * PR-1B (2026-05-10): single entry point for "the active validator set has
+   * changed; clean up cross-cutting state". Performs:
+   *   1. clearLastProposed — drop the consensus-layer re-broadcast cache
+   *   2. bft.updateValidators(newSet) — push the new set to the BFT
+   *      coordinator, which itself decides whether membership changed and
+   *      clears its own local-state caches if so.
+   *
+   * Wired into `validator-registry-reader.on("validatorAdded"/"validatorRemoved")`
+   * by index.ts so reader-driven set transitions cannot leave stale rotation
+   * caches behind.
+   */
+  onValidatorSetChange(validators: Array<{ id: string; stake: bigint }>): void {
+    this.clearLastProposed()
+    this.bft?.updateValidators(validators)
+  }
+
+  /**
    * Phase H5: Force a state-snapshot import from peers, bypassing the
    * usual gap-based heuristics. Used when the BFT layer has detected
    * persistent divergence — i.e. snap-sync wouldn't trigger via

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -73,6 +73,22 @@ export const NO_PROGRESS_TIMEOUT_MS = 600_000
 export const NO_PROGRESS_STAGGER_MS = 30_000
 const NO_PROGRESS_MAX_VALIDATORS = 10
 
+// PR-1A (2026-05-10): fast-path fallback when we have *direct evidence* the
+// stuck proposer is unreachable — either because BFT round timed out at their
+// slot, or wire-connection-manager reports their socket is closed. The 600s
+// H15 timeout is appropriate when we don't know *why* progress halted (could
+// be slow network, GC pause, etc.), but when reachability is observable,
+// waiting 10 minutes per dead validator wastes liveness. N=5 attempt 2026-05-10
+// observed: H15 fired, override armed → 14 blocks produced → next slot rotated
+// back to dead validator → another 600s wait. Fast timeout + persistent
+// unreachable marks (refreshed by repeated round timeouts) eliminate the
+// re-freeze cycle.
+//
+// FAST < SLOW so the fast path beats H15 when evidence is present;
+// FAST < TTL so a single round does not expire its own evidence mid-flight.
+export const PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS = 15_000
+export const PROPOSER_UNREACHABLE_TTL_MS = 60_000
+
 /** Race a promise against a timeout. Throws on timeout, otherwise returns the value. */
 async function withSyncTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -220,11 +236,29 @@ export class ConsensusEngine {
   // we occupy so only the designated fallback proposer arms the override.
   private readonly nodeId: string | null
 
+  // PR-1A: validators (lowercased) marked as unreachable with absolute
+  // expiry timestamp. Refreshed by BFT round timeouts (proposer-stuck callback)
+  // or by reachability provider returning a set that excludes them. Drives the
+  // fast-path fallback in checkNoProgressWatchdog.
+  private unreachableProposers = new Map<string, number>()
+
+  // PR-1A: optional injection of wire-layer reachability. When provided,
+  // returns the lowercased set of validator IDs the local node currently has
+  // a wire connection to. Validators NOT in this set (excluding self) are
+  // treated as unreachable for fast-fallback purposes.
+  private readonly reachabilityProvider: (() => Set<string>) | null
+
   constructor(
     chain: IChainEngine,
     p2p: P2PNode,
     cfg: ConsensusConfig,
-    opts?: { bft?: BftCoordinator; snapSync?: SnapSyncProvider; wireBroadcast?: (block: ChainBlock) => void; nodeId?: string },
+    opts?: {
+      bft?: BftCoordinator
+      snapSync?: SnapSyncProvider
+      wireBroadcast?: (block: ChainBlock) => void
+      nodeId?: string
+      reachabilityProvider?: () => Set<string>
+    },
   ) {
     this.chain = chain
     this.p2p = p2p
@@ -233,6 +267,50 @@ export class ConsensusEngine {
     this.snapSync = opts?.snapSync ?? null
     this.wireBroadcast = opts?.wireBroadcast ?? null
     this.nodeId = opts?.nodeId ?? null
+    this.reachabilityProvider = opts?.reachabilityProvider ?? null
+  }
+
+  /**
+   * PR-1A: mark a validator as unreachable for `ttlMs` (default 60s).
+   * Called by the BFT coordinator's round-timeout handler when the round's
+   * proposer was not the local node — strong evidence the slot proposer is
+   * offline, partitioned, or otherwise unable to drive their round.
+   *
+   * Repeat marks refresh the TTL, so a persistently dead validator stays
+   * marked across many rounds without the slow path's 600s wait.
+   */
+  markProposerUnreachable(proposerId: string, ttlMs: number = PROPOSER_UNREACHABLE_TTL_MS): void {
+    const id = proposerId.toLowerCase()
+    if (id === (this.nodeId?.toLowerCase() ?? "")) return // never mark self
+    this.unreachableProposers.set(id, Date.now() + ttlMs)
+  }
+
+  /**
+   * PR-1A: probe whether `proposerId` is currently believed unreachable.
+   * Sources of evidence (any positive => unreachable):
+   *   1. Active mark from markProposerUnreachable still in TTL
+   *   2. reachabilityProvider returns a set that excludes them
+   * Self is never reported unreachable. Expired marks are pruned on read.
+   */
+  private isProposerUnreachable(proposerId: string): boolean {
+    const id = proposerId.toLowerCase()
+    if (id === (this.nodeId?.toLowerCase() ?? "")) return false
+
+    const exp = this.unreachableProposers.get(id)
+    if (exp !== undefined) {
+      if (Date.now() < exp) return true
+      this.unreachableProposers.delete(id)
+    }
+
+    if (this.reachabilityProvider) {
+      try {
+        const reachable = this.reachabilityProvider()
+        if (reachable && !reachable.has(id)) return true
+      } catch {
+        // Provider failure is non-fatal — fall through to slow path
+      }
+    }
+    return false
   }
 
   start(): void {
@@ -290,7 +368,6 @@ export class ConsensusEngine {
     if (this.syncInFlight) return
     if (!this.bft) return
     const elapsed = Date.now() - this.lastBftProgressAtMs
-    if (elapsed <= NO_PROGRESS_TIMEOUT_MS) return
 
     if (!this.nodeId) {
       // Cannot determine fallback proposer identity — skip to avoid storm
@@ -308,6 +385,18 @@ export class ConsensusEngine {
     // but a node's nodeId may be EIP-55 checksummed).
     const stuckProposerId = this.chain.expectedProposer(stuckHeight).toLowerCase()
     const localNodeId = this.nodeId?.toLowerCase()
+
+    // PR-1A: if we have direct evidence the stuck proposer is unreachable
+    // (recent BFT round timed out at their slot, or wire socket is closed),
+    // bypass the conservative 600s H15 timeout. The fast path keeps the same
+    // rotation-stagger logic so only one fallback fires per tick — preventing
+    // the 2026-05-02 equivocation storm — but with FAST=15s as the base
+    // threshold instead of SLOW=600s. Falls through to slow path otherwise.
+    const stuckUnreachable = this.isProposerUnreachable(stuckProposerId)
+    const baseTimeoutMs = stuckUnreachable
+      ? PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS
+      : NO_PROGRESS_TIMEOUT_MS
+    if (elapsed <= baseTimeoutMs) return
 
     // Phase J2.2: when we are the stuck proposer AND we hold an active
     // round whose state is internally deadlocked (no peers responding,
@@ -360,7 +449,11 @@ export class ConsensusEngine {
 
     // Primary fallback fires at base timeout; each subsequent fallback adds
     // one stagger interval so at most one node fires per tick.
-    const activationThresholdMs = NO_PROGRESS_TIMEOUT_MS + (rotationOffset - 1) * NO_PROGRESS_STAGGER_MS
+    // PR-1A: when the stuck proposer is known unreachable, baseTimeoutMs is
+    // the fast threshold (15s) so secondary/tertiary fallbacks proportionally
+    // shift down too — but stagger interval stays at NO_PROGRESS_STAGGER_MS
+    // to keep the equivocation-storm protection intact.
+    const activationThresholdMs = baseTimeoutMs + (rotationOffset - 1) * NO_PROGRESS_STAGGER_MS
     if (elapsed < activationThresholdMs) return
 
     log.error("Phase H15: no BFT progress — enabling proposer override (fallback proposer)", {
@@ -370,6 +463,8 @@ export class ConsensusEngine {
       stuckHeight: stuckHeight.toString(),
       stuckProposerId,
       localNodeId: this.nodeId,
+      stuckUnreachable,
+      path: stuckUnreachable ? "fast" : "slow",
     })
     this.noProgressProposerOverride = true
   }
@@ -676,6 +771,11 @@ export class ConsensusEngine {
   notifyBftProgress(): void {
     this.lastBftProgressAtMs = Date.now()
     this.noProgressProposerOverride = false
+    // PR-1A: a successful finalize is the strongest "the cluster is healthy"
+    // signal we have. Clear all unreachable marks so the next rotation slot
+    // is evaluated on fresh evidence rather than stale BFT timeouts from
+    // before the cluster recovered.
+    this.unreachableProposers.clear()
   }
 
   /**

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -606,10 +606,18 @@ if (bftEnabled) {
       log.info("BFT finalized block", { height: block.number.toString(), hash: block.hash })
       // Phase H15: reset the no-progress watchdog baseline on every successful finalize
       consensus?.notifyBftProgress()
-      // Sync BFT validator set with governance after each finalized block
+      // Sync BFT validator set with governance after each finalized block.
+      // PR-1B: route through onValidatorSetChange so consensus also clears
+      // its lastProposed cache when membership changes — preventing stale
+      // re-broadcast on round timeout against the new rotation.
       if (hasGovernance(chain)) {
         const active = chain.governance.getActiveValidators()
-        bftCoordinator?.updateValidators(active.map((v) => ({ id: v.id, stake: v.stake })))
+        const next = active.map((v) => ({ id: v.id, stake: v.stake }))
+        if (consensus) {
+          consensus.onValidatorSetChange(next)
+        } else {
+          bftCoordinator?.updateValidators(next)
+        }
       }
       } // end of work()
       // Wall-clock timeout around the entire work() body. Observed on testnet:
@@ -890,7 +898,17 @@ if (bftEnabled) {
         id: ("0x" + e.nodeId.slice(-40)).toLowerCase(),
         stake: e.stake,
       }))
-      bftCoordinator?.updateValidators(next)
+      // PR-1B (2026-05-10): route through consensus.onValidatorSetChange so
+      // the lastProposed cache is invalidated alongside the BFT cache. The
+      // 2026-05-09 attempt #1 fingerprint was reader-driven N=3→N=8 keeping
+      // a stale cached block in consensus, which Phase R then refused as
+      // self-equivocation. Falls back to direct BFT update if consensus
+      // hasn't been constructed yet (only happens during init race).
+      if (consensus) {
+        consensus.onValidatorSetChange(next)
+      } else {
+        bftCoordinator?.updateValidators(next)
+      }
       log.info("BFT validator set updated from ValidatorRegistry", {
         count: next.length,
         ids: next.map((v) => v.id),
@@ -1061,10 +1079,16 @@ if (stateTrie && config.enableSnapSync) {
         (chain.governance as { initGenesis(v: Array<{ id: string; address: string; stake: bigint }>): void }).initGenesis(validators)
         log.info("governance validators restored from snap sync", { count: validators.length })
       }
-      // Sync BFT coordinator validator set with restored governance
+      // Sync BFT coordinator validator set with restored governance.
+      // PR-1B: also invalidate consensus.lastProposed if consensus exists.
       if (bftCoordinator) {
         const activeValidators = validators.filter((v) => v.active)
-        bftCoordinator.updateValidators(activeValidators.map((v) => ({ id: v.id, stake: v.stake })))
+        const next = activeValidators.map((v) => ({ id: v.id, stake: v.stake }))
+        if (consensus) {
+          consensus.onValidatorSetChange(next)
+        } else {
+          bftCoordinator.updateValidators(next)
+        }
         log.info("BFT coordinator validators synced after governance restore", { count: activeValidators.length })
       }
     },

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -407,6 +407,17 @@ if (bftEnabled) {
     // proposals (height ≤ chain tip). `lastFinalizedHeight` alone misses
     // gossip-block catch-up after a restart; this closes the gap.
     getChainHeight: () => chain.getHeight(),
+    // PR-1A (2026-05-10): when a BFT round times out at a peer's slot, mark
+    // that proposer unreachable so consensus.checkNoProgressWatchdog's fast
+    // path (~15s) takes over from the conservative 600s H15 timeout.
+    onProposerStuck: (proposerId: string, height: bigint) => {
+      if (!consensus) return
+      log.warn("PR-1A: BFT round timed out — marking proposer unreachable", {
+        proposerId,
+        height: height.toString(),
+      })
+      consensus.markProposerUnreachable(proposerId)
+    },
     onEquivocation: (evidence: EquivocationEvidence) => {
       log.warn("BFT equivocation detected", {
         validator: evidence.validatorId,
@@ -1080,6 +1091,21 @@ const consensus = new ConsensusEngine(chain, p2p, {
   snapSync: snapSyncProvider,
   wireBroadcast: (block) => wireBroadcastFn?.(block),
   nodeId: config.nodeId,
+  // PR-1A (2026-05-10): expose wire-layer reachability so
+  // checkNoProgressWatchdog can detect a disconnected proposer immediately
+  // (rather than waiting for the 600s H15 timeout). `wireClients` is
+  // populated when the wire layer initialises later in this module — the
+  // closure captures the array reference, so this provider works as soon
+  // as the wire connections come up.
+  reachabilityProvider: (): Set<string> => {
+    const set = new Set<string>()
+    for (const c of wireClients) {
+      if (!c.isConnected()) continue
+      const id = c.getRemoteNodeId()
+      if (id) set.add(id.toLowerCase())
+    }
+    return set
+  },
 })
 consensus.start()
 

--- a/node/src/p2p-snapshot-provider.test.ts
+++ b/node/src/p2p-snapshot-provider.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { P2PNode } from "./p2p.ts"
+
+/**
+ * PR-1E: Snap-sync provider instrumentation + fallback diagnostics.
+ *
+ * 2026-05-10 N=5 attempt #2 fingerprint: forceSnapSync repeatedly logged
+ * "no peer snapshot available" while server-2 / server-3 should have been
+ * serving snapshots. Pre-PR-1E, fetchSnapshots silently dropped failed/
+ * timed-out peers — operators had no per-peer telemetry to diagnose
+ * whether peers were unreachable, returning 429s, returning empty bodies,
+ * or hitting the 15s aggregate timeout.
+ *
+ * Fix:
+ *   1. P2PNode tracks per-peer snapshot fetch outcomes (success | error |
+ *      timeout | empty) plus aggregate counters.
+ *   2. New `getSnapshotFetchStats()` method exposes the counters for
+ *      Prometheus / log diagnostics.
+ *   3. fetchSnapshots logs a warn-level summary when ALL peers failed
+ *      (zero successes) so an operator looking at logs sees the cause.
+ */
+
+function mkNode(opts?: { peers?: Array<{ id: string; url: string }> }): P2PNode {
+  return new P2PNode(
+    {
+      port: 0,
+      peers: opts?.peers ?? [],
+      enableDiscovery: false,
+    } as any,
+    {
+      onSnapshotRequest: async () => ({ blocks: [], updatedAtMs: Date.now() }),
+    } as any,
+  )
+}
+
+test("PR-1E: getSnapshotFetchStats returns zero state on a fresh node", () => {
+  const node = mkNode()
+  const stats = node.getSnapshotFetchStats()
+  assert.equal(stats.attempts, 0)
+  assert.equal(stats.successes, 0)
+  assert.equal(stats.errors, 0)
+  assert.equal(stats.timeouts, 0)
+  assert.equal(stats.emptyResults, 0)
+  assert.deepEqual(stats.lastFailureReasons, {})
+})
+
+test("PR-1E: fetchSnapshots reports zero-success outcome when no peers configured", async () => {
+  const node = mkNode()
+  const result = await node.fetchSnapshots()
+  assert.deepEqual(result, [])
+
+  const stats = node.getSnapshotFetchStats()
+  assert.equal(stats.attempts, 1)
+  assert.equal(stats.successes, 0)
+  // No peers → no per-peer attempts → totals stay at 0 except attempts
+  assert.equal(stats.errors, 0)
+  assert.equal(stats.emptyResults, 1, "an empty peer list counts as an empty fetch round")
+})
+
+test("PR-1E: fetchSnapshots records error per unreachable peer", async () => {
+  // Use a deliberately invalid url scheme so requestJson rejects fast.
+  const node = mkNode({
+    peers: [
+      { id: "peer-1", url: "http://127.0.0.1:1" }, // refused, fast fail
+      { id: "peer-2", url: "http://127.0.0.1:2" },
+    ],
+  })
+  const result = await node.fetchSnapshots()
+  assert.deepEqual(result, [], "no successful snapshots from unreachable peers")
+
+  const stats = node.getSnapshotFetchStats()
+  assert.equal(stats.attempts, 1)
+  assert.equal(stats.successes, 0)
+  // Both peers should have produced an error outcome
+  assert.ok(stats.errors >= 1, "at least one peer error recorded")
+  // Some failure reason key should be present
+  assert.ok(Object.keys(stats.lastFailureReasons).length > 0)
+})

--- a/node/src/p2p.ts
+++ b/node/src/p2p.ts
@@ -388,6 +388,17 @@ export class P2PNode {
   private bytesReceived = 0
   private bytesSent = 0
   private startedAtMs = 0
+  // PR-1E (2026-05-10): per-call instrumentation of /p2p/chain-snapshot
+  // fetches. Plumbed into Prometheus + diagnostic logs so operators can see
+  // *why* forceSnapSync reports "no peer snapshot available" — distinguishing
+  // unreachable peers from rate-limited (429) from auth-failed from empty
+  // bodies from the 15s aggregate timeout.
+  private snapshotFetchAttempts = 0
+  private snapshotFetchSuccesses = 0
+  private snapshotFetchErrors = 0
+  private snapshotFetchTimeouts = 0
+  private snapshotFetchEmptyResults = 0
+  private snapshotFetchLastFailureReasons = new Map<string, string>()
   readonly scoring: PeerScoring
   readonly discovery: PeerDiscovery
   private pubsubHandler: ((topic: string, message: unknown) => void) | null = null
@@ -864,8 +875,18 @@ export class P2PNode {
       }
     }
 
+    this.snapshotFetchAttempts += 1
+    // PR-1E: empty peer list is itself diagnostic — operators should see
+    // immediately that the node has no peer URLs configured / discovered.
+    if (allPeers.length === 0) {
+      this.snapshotFetchEmptyResults += 1
+      log.warn("fetchSnapshots: no peers to query (empty peer list)")
+      return []
+    }
+
     // Parallel fetch with total timeout to prevent slow peers from blocking sync
     const FETCH_TOTAL_TIMEOUT_MS = 15_000
+    let timedOut = false
     const settled = await Promise.race([
       Promise.allSettled(
         allPeers.map((peer) => {
@@ -877,14 +898,89 @@ export class P2PNode {
         })
       ),
       new Promise<PromiseSettledResult<ChainSnapshot>[]>((resolve) =>
-        setTimeout(() => resolve([]), FETCH_TOTAL_TIMEOUT_MS)
+        setTimeout(() => { timedOut = true; resolve([]) }, FETCH_TOTAL_TIMEOUT_MS)
       ),
     ])
+
+    if (timedOut) {
+      this.snapshotFetchTimeouts += 1
+      log.warn("fetchSnapshots: aggregate timeout — peers may be slow or unreachable", {
+        peerCount: allPeers.length,
+        timeoutMs: FETCH_TOTAL_TIMEOUT_MS,
+      })
+    }
+
     const results: ChainSnapshot[] = []
-    for (const r of settled) {
-      if (r.status === "fulfilled") results.push(r.value)
+    let perPeerErrors = 0
+    let perPeerEmpties = 0
+    // PR-1E: per-peer outcome attribution. settled[] aligns 1:1 with allPeers
+    // when timedOut=false; on timeout it's [] and we mark all peers as timed
+    // out below.
+    if (!timedOut) {
+      for (let i = 0; i < settled.length; i++) {
+        const r = settled[i]
+        const peerUrl = allPeers[i].url
+        if (r.status === "fulfilled") {
+          if (r.value && Array.isArray((r.value as ChainSnapshot).blocks) && (r.value as ChainSnapshot).blocks.length > 0) {
+            results.push(r.value)
+          } else {
+            perPeerEmpties += 1
+            this.snapshotFetchLastFailureReasons.set(peerUrl, "empty-response")
+          }
+        } else {
+          perPeerErrors += 1
+          const reason = String(r.reason ?? "unknown").slice(0, 200)
+          this.snapshotFetchLastFailureReasons.set(peerUrl, reason)
+        }
+      }
+    } else {
+      // All peers slipped past the 15s deadline → mark as timed-out.
+      for (const peer of allPeers) {
+        this.snapshotFetchLastFailureReasons.set(peer.url, "aggregate-timeout")
+      }
+      perPeerErrors = allPeers.length
+    }
+
+    this.snapshotFetchErrors += perPeerErrors
+    this.snapshotFetchEmptyResults += perPeerEmpties
+    if (results.length > 0) {
+      this.snapshotFetchSuccesses += 1
+    } else {
+      log.warn("fetchSnapshots: no successful snapshot fetched", {
+        peerCount: allPeers.length,
+        errors: perPeerErrors,
+        empty: perPeerEmpties,
+        timedOut,
+        // Cap at first 5 peers to keep log entry bounded
+        sampleFailures: [...this.snapshotFetchLastFailureReasons.entries()].slice(0, 5),
+      })
     }
     return results
+  }
+
+  /**
+   * PR-1E (2026-05-10): structured snapshot of fetch-snapshot health for
+   * Prometheus / diagnostic logs. forceSnapSync's "no peer snapshot
+   * available" was previously a single-line warn with no per-peer
+   * attribution; this exposes the underlying counters so operators can
+   * tell apart "all peers timing out" from "all peers returning 429" etc.
+   */
+  getSnapshotFetchStats(): {
+    attempts: number
+    successes: number
+    errors: number
+    timeouts: number
+    emptyResults: number
+    lastFailureReasons: Record<string, string>
+  } {
+    return {
+      attempts: this.snapshotFetchAttempts,
+      successes: this.snapshotFetchSuccesses,
+      errors: this.snapshotFetchErrors,
+      timeouts: this.snapshotFetchTimeouts,
+      emptyResults: this.snapshotFetchEmptyResults,
+      lastFailureReasons: Object.fromEntries(this.snapshotFetchLastFailureReasons),
+    }
   }
 
   getPeers(): NodePeer[] {

--- a/node/src/storage/block-index.ts
+++ b/node/src/storage/block-index.ts
@@ -208,6 +208,88 @@ export class BlockIndex implements IBlockIndex {
     return block
   }
 
+  /**
+   * PR-1D (2026-05-10): scan `b:` prefix, find the numerically-highest block
+   * actually stored, and promote LATEST_BLOCK_KEY if it lags behind. Returns
+   * a structured result rather than throwing so callers can log + continue.
+   *
+   * 2026-05-10 N=5 attempt #2 fingerprint: server-1 RPC reported h=71448
+   * but eth_getBlockByNumber("0x116ba"=71450) returned a valid block. The
+   * atomic batch in `buildBlockOps` writes b:N AND LATEST together, so a
+   * desync should be impossible — yet it happened, most plausibly because
+   * snap-sync's per-block putBlock loop rewinds LATEST without deleting
+   * stale b:>peerTip entries left from a prior run.
+   *
+   * This method recovers from any such desync. Called from
+   * PersistentChainEngine.init() so every restart self-heals — no more
+   * manual rsync recovery for tip-pointer-only corruption.
+   */
+  async repairLatestPointer(): Promise<{
+    repaired: boolean
+    latestBefore: bigint | null
+    latestAfter: bigint | null
+    highestStored: bigint | null
+  }> {
+    const before = await this.getLatestBlock()
+    const beforeNum = before?.number ?? null
+
+    // Scan b: prefix; parse numeric suffix; track BigInt max.
+    const keys = await this.db.getKeysWithPrefix(BLOCK_BY_NUMBER_PREFIX, { limit: -1 })
+    let highest: bigint | null = null
+    for (const k of keys) {
+      const suffix = k.slice(BLOCK_BY_NUMBER_PREFIX.length)
+      let n: bigint
+      try {
+        n = BigInt(suffix)
+      } catch {
+        continue // skip malformed key
+      }
+      if (highest === null || n > highest) highest = n
+    }
+
+    // No data on disk at all
+    if (highest === null) {
+      return {
+        repaired: false,
+        latestBefore: beforeNum,
+        latestAfter: beforeNum,
+        highestStored: null,
+      }
+    }
+
+    // LATEST already matches (or exceeds) highest stored
+    if (beforeNum !== null && beforeNum >= highest) {
+      return {
+        repaired: false,
+        latestBefore: beforeNum,
+        latestAfter: beforeNum,
+        highestStored: highest,
+      }
+    }
+
+    // LATEST lags — promote it to the highest stored block. Re-write
+    // LATEST_BLOCK_KEY only (b:N already present, no need to re-batch).
+    const newLatest = await this.getBlockByNumber(highest)
+    if (!newLatest) {
+      // Highest scanned key but block parse failed — leave alone.
+      return {
+        repaired: false,
+        latestBefore: beforeNum,
+        latestAfter: beforeNum,
+        highestStored: highest,
+      }
+    }
+    const blockData = encoder.encode(serializeJSON(newLatest))
+    await this.db.batch([{ type: "put", key: LATEST_BLOCK_KEY, value: blockData }])
+
+    return {
+      repaired: true,
+      latestBefore: beforeNum,
+      latestAfter: highest,
+      highestStored: highest,
+    }
+  }
+
   buildTransactionOps(txHash: Hex, tx: TxWithReceipt): BatchOp[] {
     const key = TX_BY_HASH_PREFIX + txHash
     const txData = encoder.encode(serializeJSON(tx))

--- a/scripts/start-devnet-node.sh
+++ b/scripts/start-devnet-node.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# start-devnet-node.sh — restart a single node within an existing devnet
+# cluster (preserving its leveldb + config). Use after stop-devnet-node.sh
+# to simulate a validator coming back online during chaos drills (T2/T4
+# recovery).
+#
+# Usage: bash scripts/start-devnet-node.sh <total-nodes> <node-id>
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NODES="${1:?usage: $0 <total-nodes> <node-id>}"
+NODE_ID_ARG="${2:?usage: $0 <total-nodes> <node-id>}"
+RUN_DIR="${ROOT}/.run/devnet-${NODES}"
+DATA_DIR="${RUN_DIR}/node-${NODE_ID_ARG}"
+CONFIG="${DATA_DIR}/node-config.json"
+PIDFILE="${RUN_DIR}/node-${NODE_ID_ARG}.pid"
+LOG_FILE="${RUN_DIR}/node-${NODE_ID_ARG}.log"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "config not found: ${CONFIG}" >&2
+  echo "(was the devnet started with this NODES count?)" >&2
+  exit 1
+fi
+if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+  echo "node-${NODE_ID_ARG} is already running (pid $(cat "$PIDFILE"))" >&2
+  exit 1
+fi
+
+# Re-derive anvil key by index (same table as start-devnet.sh)
+IDX=$((NODE_ID_ARG - 1))
+ANVIL_KEYS=(
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+  "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6"
+  "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
+  "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+  "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"
+)
+NODE_KEY="${ANVIL_KEYS[$IDX]}"
+METRICS_PORT=$((28810 + IDX))
+
+env \
+  COC_METRICS_PORT="${METRICS_PORT}" \
+  COC_NODE_KEY="${NODE_KEY}" \
+  COC_NODE_CONFIG="${CONFIG}" \
+  node --experimental-strip-types "${ROOT}/node/src/index.ts" >>"${LOG_FILE}" 2>&1 &
+PID=$!
+echo "$PID" > "$PIDFILE"
+echo "started node-${NODE_ID_ARG} (pid ${PID}); log: ${LOG_FILE}"

--- a/scripts/start-devnet.sh
+++ b/scripts/start-devnet.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 NODES="${1:-3}"
+# PR-1B preparatory: chainId is now optional second arg / env var
+# (default 18780 keeps existing scripts working). Phase 2 chaos drill
+# scripts pass 88780 here for fresh-chain dry runs.
+CHAIN_ID="${2:-${COC_DEVNET_CHAIN_ID:-18780}}"
 if [[ "$NODES" != "3" && "$NODES" != "5" && "$NODES" != "7" ]]; then
-  echo "usage: $0 <3|5|7>"
+  echo "usage: $0 <3|5|7> [chainId]"
+  echo "       env: COC_DEVNET_CHAIN_ID=<id>"
   exit 1
 fi
 
@@ -115,7 +120,7 @@ for i in $(seq 1 "$NODES"); do
 {
   "dataDir": "${DATA_DIR}",
   "nodeId": "${NODE_ID}",
-  "chainId": 18780,
+  "chainId": ${CHAIN_ID},
   "rpcBind": "127.0.0.1",
   "rpcPort": ${RPC_PORT},
   "p2pBind": "127.0.0.1",

--- a/scripts/stop-devnet-node.sh
+++ b/scripts/stop-devnet-node.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# stop-devnet-node.sh — stop a single node from a running devnet cluster.
+# Usage: bash scripts/stop-devnet-node.sh <total-nodes> <node-id>
+#
+# PR-1A chaos drill helper. Used by docs/n5-devnet-drill.md to simulate a
+# single validator going offline (T2) without tearing down the rest of the
+# cluster. Counterpart: scripts/start-devnet-node.sh restarts a single node.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NODES="${1:?usage: $0 <total-nodes> <node-id>}"
+NODE_ID="${2:?usage: $0 <total-nodes> <node-id>}"
+RUN_DIR="${ROOT}/.run/devnet-${NODES}"
+
+if [[ ! -d "$RUN_DIR" ]]; then
+  echo "run dir not found: ${RUN_DIR}" >&2
+  exit 1
+fi
+
+PIDFILE="${RUN_DIR}/node-${NODE_ID}.pid"
+if [[ ! -f "$PIDFILE" ]]; then
+  echo "pidfile not found: ${PIDFILE} (node-${NODE_ID} not running)" >&2
+  exit 1
+fi
+
+PID="$(cat "$PIDFILE")"
+if ! kill -0 "$PID" >/dev/null 2>&1; then
+  echo "pid ${PID} already dead; cleaning up pidfile"
+  rm -f "$PIDFILE"
+  exit 0
+fi
+
+kill "$PID"
+for _ in $(seq 1 100); do
+  kill -0 "$PID" 2>/dev/null || break
+  sleep 0.1
+done
+if kill -0 "$PID" 2>/dev/null; then
+  echo "pid ${PID} still alive after 10s, sending SIGKILL"
+  kill -9 "$PID" || true
+fi
+rm -f "$PIDFILE"
+echo "stopped node-${NODE_ID} (pid ${PID})"


### PR DESCRIPTION
## Summary

Resolves #85. The 2026-05-10 N=5 in-place upgrade attempt #2
(`docs/n5-attempt-2-2026-05-10.md`) revealed that BFT freezes immediately on
any single validator unavailability — same as N=3, regardless of N. Root
cause was a cluster of 5 distinct bugs interacting; recovery required
manual rsync of leveldb-chain.

This branch lands 5 independent fixes as one bundled series. Each commit is
self-contained (separate test files, no cross-dependencies) and could be
cherry-picked individually if reviewers prefer.

## Commits

| PR | Subject | Files | Tests |
|----|---------|-------|-------|
| **1A** | `fix(bft): fast-path proposer skip when slot is unreachable` | `consensus.ts`, `bft-coordinator.ts`, `index.ts` | 7/7 |
| **1B** | `fix(bft): invalidate lastProposed cache on validator set change` | `consensus.ts`, `bft-coordinator.ts`, `index.ts` | 7/7 |
| **1C** | `fix(bft): sliding-window evidence cap + monitoring + recency prune` | `bft.ts` | 7/7 |
| **1D** | `fix(chain): self-heal tip pointer desync at init` | `chain-engine-persistent.ts`, `storage/block-index.ts` | 5/5 |
| **1E** | `fix(p2p): snap-sync per-peer fetch instrumentation + diagnostics` | `p2p.ts`, `consensus.ts` | 3/3 |
| chore | `chore(devnet): chainId param + per-node start/stop helpers + summary` | `scripts/*.sh`, `docs/n5-fault-tolerance-fix-2026-05-10.md` | — |

## Bug map (each PR addresses one symptom from #85)

### 1A — fast-path proposer skip
Old: dead validator's slot waited 600s `NO_PROGRESS_TIMEOUT_MS` for H15 fallback. Fast path arms the same H15 override at `PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS=15s` when there's *direct evidence* (BFT round timeout at peer's slot, or wire-connection-manager reports them disconnected). Rotation stagger preserved → no equivocation storm. `notifyBftProgress` clears all unreachable marks on each successful finalize, so transient blips don't poison the cache.

### 1B — `lastProposed` cache invalidation
Old: 2026-05-09 attempt #1 fingerprint — reader-driven N=3→N=8 left `consensus.lastProposedBlock` pointing at a block whose proposer was assigned by the OLD rotation; round-timeout re-broadcast replayed it; Phase R refused as self-equivocation; chain stalled ~7h. New: `BftCoordinator.updateValidators` diffs membership and clears local-state caches + active round on real change. Stake-only updates preserve caches (non-disruptive). All 3 reader/governance call sites in `index.ts` route through `consensus.onValidatorSetChange`.

### 1C — evidence cache sliding window
Old: per-validator cap=100 silently dropped NEW evidence when reached. Long-running clusters (and frozen ones, where `clearEvidenceBefore` doesn't fire) accumulated stale evidence forever. New: at cap, evict OLDEST entry of the same validator and push the new one. Plus `pruneByMaxHeight(keep)` (recency-bounded prune for watchdog use) and `getStats()` (Prometheus-able cache pressure metric).

### 1D — tip pointer self-heal
Old: 2026-05-10 N=5 attempt — server-1 reported h=71448 via RPC but `eth_getBlockByNumber("0x116ba"=71450)` returned a valid block whose stateRoot matched server-2/3. Recovery required manual rsync. Most plausible root: snap-sync's per-block `putBlock` rewinds LATEST without deleting stale `b:>peerTip` entries from a prior run. New: `BlockIndex.repairLatestPointer()` scans `b:` prefix, parses BigInt suffixes, promotes LATEST to highest stored block. `PersistentChainEngine.init()` invokes on every boot.

### 1E — snap-sync diagnostics
Old: `forceSnapSync` repeatedly logged `"no peer snapshot available"` with no per-peer attribution. The N=5 attempt cluster burned 30+ minutes here without operators being able to tell apart unreachable / 429 / auth-failed / empty / timeout. New: per-call counters, per-peer last-failure-reason map, `getSnapshotFetchStats()` for Prometheus, structured warn log with sample failures whenever a round produces 0 successes.

## Test plan

- [x] `node --experimental-strip-types --test $(find node/src -name '*.test.ts' -type f | sort)` — **1363/1363 pass** (29 new + 1334 regression). One transient flake on the throughput benchmark recovered on re-run; not related to this branch.
- [x] `node --experimental-strip-types --test $(find node/src/storage -name '*.test.ts' -type f)` — 106/106 pass.
- [x] Each PR test file runs cleanly in isolation (`bft-proposer-skip.test.ts`, `consensus-validator-set-change.test.ts`, `bft-evidence-eviction.test.ts`, `chain-engine-tip-sync.test.ts`, `p2p-snapshot-provider.test.ts`).
- [x] `node --experimental-strip-types --check node/src/index.ts node/src/p2p.ts node/src/consensus.ts node/src/bft-coordinator.ts node/src/bft.ts node/src/chain-engine-persistent.ts node/src/storage/block-index.ts` — clean.
- [ ] **Cloud N=5 chaos drill** (gcloud or multi-host): T2 single-validator stop → verify chain progresses ≤10s (not 600s). Local 5-node devnet shares 127.0.0.1 and triggers an unrelated peer-scoring rate-limit issue — see caveat in `docs/n5-fault-tolerance-fix-2026-05-10.md`. PR-1E's instrumentation surfaced the cause immediately, which is itself the kind of diagnostic value the PR was after.
- [ ] Stage on chainId 88780 R3.2 prod-candidate per `docs/r3-2-prod-candidate-testnet-88780.md` after CI green.

## Devnet helpers added

- `scripts/start-devnet.sh <N> <chainId?>` — chainId now parameterized (default 18780 preserved).
- `scripts/stop-devnet-node.sh <N> <id>`, `scripts/start-devnet-node.sh <N> <id>` — single-node lifecycle for chaos drills.
- `docs/n5-fault-tolerance-fix-2026-05-10.md` — full PR series rationale + Phase 2-4 path forward.

## Risks

- 1A's `unreachableProposers` map could over-mark a slow-but-alive peer. TTL=60s + heartbeat-driven `reachabilityProvider` give multiple paths back to "reachable"; `notifyBftProgress` clears the entire map on each successful finalize so transient state can't accumulate.
- 1B's "membership change → clear active round" is an explicit liveness sacrifice for safety. The round was started against the old stake snapshot; continuing under it could finalize against a quorum the new set wouldn't recognize. Trade-off explicit in the comment.
- 1D's `repairLatestPointer` only promotes LATEST; never demotes. Stale `b:N>tip` entries are harmless reads but could be cleaned by a separate prune utility (out of scope here — recovering liveness was the priority).