### PR TITLE
chore(r3-2): VM bootstrap script + observer config template

### DIFF
--- a/configs/r3-2-candidate/observer-config-template.json
+++ b/configs/r3-2-candidate/observer-config-template.json
@@ -1,0 +1,59 @@
+{
+  "_comment_template": "Observer fullnode for chainId 88780. Does NOT participate in BFT (enableBft=false), nodeId is a generated random key per host (NOT in validators[]). Replace ${...} placeholders before deploy.",
+  "_comment_keys": "Set COC_NODE_KEY env to a freshly-generated random hex (NOT one of the 5 validator keys). bash scripts/generate-validator-keys.sh 1 ~/.coc/keys/88780-observer-N/ produces a usable key file (rename validator-1 → observer-N).",
+  "dataDir": "/var/lib/coc/node-1",
+  "nodeId": "${OBSERVER_NODE_ID}",
+  "chainId": 88780,
+  "rpcBind": "0.0.0.0",
+  "rpcPort": 28780,
+  "p2pBind": "0.0.0.0",
+  "p2pPort": 29780,
+  "wsBind": "0.0.0.0",
+  "wsPort": 28790,
+  "ipfsBind": "0.0.0.0",
+  "ipfsPort": 28800,
+  "wireBind": "0.0.0.0",
+  "wirePort": 29781,
+  "advertisedP2pUrl": "http://${SELF_HOST}:29780",
+  "peers": [
+    { "id": "0xde4e7889aa9007318ff261b1ee675f1305153590", "url": "http://${V1_HOST}:29780" },
+    { "id": "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9", "url": "http://${V2_HOST}:29780" },
+    { "id": "0xdefc8430388093fdfacb0a929fedc14d2e631d19", "url": "http://${V3_HOST}:29780" },
+    { "id": "0xcc64096600c1759d7aaea91166837a5873175867", "url": "http://${V4_HOST}:29780" },
+    { "id": "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae", "url": "http://${V5_HOST}:29780" }
+  ],
+  "dhtBootstrapPeers": [
+    { "id": "0xde4e7889aa9007318ff261b1ee675f1305153590", "address": "${V1_HOST}", "port": 29781 },
+    { "id": "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9", "address": "${V2_HOST}", "port": 29781 },
+    { "id": "0xdefc8430388093fdfacb0a929fedc14d2e631d19", "address": "${V3_HOST}", "port": 29781 },
+    { "id": "0xcc64096600c1759d7aaea91166837a5873175867", "address": "${V4_HOST}", "port": 29781 },
+    { "id": "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae", "address": "${V5_HOST}", "port": 29781 }
+  ],
+  "validators": [
+    "0xde4e7889aa9007318ff261b1ee675f1305153590",
+    "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9",
+    "0xdefc8430388093fdfacb0a929fedc14d2e631d19",
+    "0xcc64096600c1759d7aaea91166837a5873175867",
+    "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae"
+  ],
+  "validatorStakes": [
+    { "id": "0xde4e7889aa9007318ff261b1ee675f1305153590", "address": "0xde4e7889aa9007318ff261b1ee675f1305153590", "stake": "32000000000000000000" },
+    { "id": "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9", "address": "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9", "stake": "32000000000000000000" },
+    { "id": "0xdefc8430388093fdfacb0a929fedc14d2e631d19", "address": "0xdefc8430388093fdfacb0a929fedc14d2e631d19", "stake": "32000000000000000000" },
+    { "id": "0xcc64096600c1759d7aaea91166837a5873175867", "address": "0xcc64096600c1759d7aaea91166837a5873175867", "stake": "32000000000000000000" },
+    { "id": "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae", "address": "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae", "stake": "32000000000000000000" }
+  ],
+  "blockTimeMs": 3000,
+  "syncIntervalMs": 5000,
+  "finalityDepth": 3,
+  "maxTxPerBlock": 100,
+  "minGasPriceWei": "1",
+  "poseEpochMs": 3600000,
+  "enableBft": false,
+  "enableWireProtocol": true,
+  "enableDht": true,
+  "enableSnapSync": true,
+  "snapSyncThreshold": 100,
+  "p2pInboundAuthMode": "enforce",
+  "poseInboundAuthMode": "enforce"
+}

--- a/scripts/r3-2-bootstrap.sh
+++ b/scripts/r3-2-bootstrap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# r3-2-bootstrap.sh — Idempotent host-side setup script for an r3-2
+# fullnode VM (Debian 12). Installs Node 22, clones COC, copies the
+# pre-rendered config + key into /etc/coc, installs systemd unit, starts
+# the service.
+#
+# Usage on the VM (after scp + chmod):
+#   sudo bash /tmp/r3-2-bootstrap.sh <git-rev>
+#
+# Caller (operator workstation) is responsible for placing these files
+# before invoking this script:
+#   /tmp/node-1.json   — pre-rendered per-host node config (this script
+#                        copies to /etc/coc/node-1.json, mode 644, root)
+#   /tmp/node-1.env    — COC_NODE_KEY=... (this script copies to
+#                        /etc/coc/node-1.env, mode 600, root)
+set -euo pipefail
+
+GIT_REV="${1:-main}"
+COC_REPO="${COC_REPO:-https://github.com/chainofclaw/COC.git}"
+INSTALL_DIR=/opt/coc
+DATA_DIR=/var/lib/coc/node-1
+LOG_DIR=/var/log/coc
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "must run as root" >&2
+  exit 1
+fi
+
+if [[ ! -f /tmp/node-1.json || ! -f /tmp/node-1.env ]]; then
+  echo "missing /tmp/node-1.json or /tmp/node-1.env" >&2
+  echo "scp them in before running this script" >&2
+  exit 1
+fi
+
+echo "=== Step 1: install Node 22 + git + build tools ==="
+apt-get update -qq
+apt-get install -y -qq curl git ca-certificates gnupg build-essential
+if ! command -v node >/dev/null 2>&1 || [[ "$(node -v 2>/dev/null | cut -dv -f2 | cut -d. -f1)" != "22" ]]; then
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y -qq nodejs
+fi
+echo "node version: $(node --version)"
+echo "npm version: $(npm --version)"
+
+echo "=== Step 2: clone or update COC repo at ${INSTALL_DIR} ==="
+if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
+  git clone --depth 50 "$COC_REPO" "$INSTALL_DIR"
+else
+  git -C "$INSTALL_DIR" fetch origin
+fi
+git -C "$INSTALL_DIR" checkout "$GIT_REV"
+git -C "$INSTALL_DIR" pull --ff-only || true
+
+echo "=== Step 3: install dependencies ==="
+cd "$INSTALL_DIR/node"
+npm install --no-audit --no-fund
+
+echo "=== Step 4: prepare data + log dirs ==="
+mkdir -p /etc/coc "$DATA_DIR" "$LOG_DIR"
+useradd --system --home-dir "$DATA_DIR" --shell /usr/sbin/nologin coc 2>/dev/null || true
+chown -R coc:coc "$DATA_DIR" "$LOG_DIR"
+
+echo "=== Step 5: install config + key ==="
+install -o root -g root -m 644 /tmp/node-1.json /etc/coc/node-1.json
+install -o root -g root -m 600 /tmp/node-1.env /etc/coc/node-1.env
+shred -u /tmp/node-1.env  # don't leave the key in /tmp
+
+echo "=== Step 6: install systemd unit ==="
+cat > /etc/systemd/system/coc-node@.service <<'UNIT'
+[Unit]
+Description=COC node instance %i
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=coc
+Group=coc
+EnvironmentFile=/etc/coc/node-%i.env
+Environment=COC_NODE_CONFIG=/etc/coc/node-%i.json
+Environment=COC_METRICS_PORT=28810
+WorkingDirectory=/opt/coc
+ExecStart=/usr/bin/node --experimental-strip-types /opt/coc/node/src/index.ts
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/coc/node-%i.log
+StandardError=append:/var/log/coc/node-%i.log
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable coc-node@1
+systemctl restart coc-node@1
+
+echo "=== Step 7: verify ==="
+sleep 3
+systemctl is-active coc-node@1 && echo "service active"
+echo "tail of log:"
+tail -20 "$LOG_DIR/node-1.log" 2>/dev/null || echo "(log not yet populated)"
+
+echo "=== bootstrap complete ==="
+echo "RPC: curl -X POST http://$(curl -sS ifconfig.me):28780 -H 'content-type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_blockNumber\",\"params\":[]}'"


### PR DESCRIPTION
## Summary

Phase 4 Day 0 artifacts. Phase 3 prep (#87) handed over a render script
for 5 validator configs but didn't cover observer fullnodes or the
on-VM install path. Adding both makes the Phase 4 SOP turnkey.

## What's in this PR

- `scripts/r3-2-bootstrap.sh` — idempotent host-side setup script run
  as root on each Debian 12 VM. Installs Node 22, clones
  chainofclaw/COC, copies the pre-staged `/tmp/node-1.{json,env}`,
  installs systemd unit at `coc-node@.service`, starts `coc-node@1`.
  Returns the public RPC curl probe so the operator can spot-check
  from outside.
- `configs/r3-2-candidate/observer-config-template.json` — observer
  fullnode template (`enableBft=false`, all 5 validators in
  `peers[]`/`dhtBootstrapPeers[]`, `nodeId` is a fresh random key NOT
  in `validators[]`). Sed-substitutable placeholders:
  `${OBSERVER_NODE_ID}`, `${SELF_HOST}`, `${V1_HOST}..${V5_HOST}`.

## End-to-end deployment summary (2026-05-10)

- 7 e2-medium VMs (5 validator + 2 observer) provisioned across 7
  gcloud regions (us-central1, asia-east1, europe-west1, us-west1,
  asia-southeast1, us-east1, australia-southeast1)
- chainId 88780 LIVE, ~3 s/block, **stateRoot identical 7/7 at h=100**
  (`0x91f620664b8159b38ad264b78b8617a8aee053d6eda8b37f773ce737c8780fe3`)
- Phase 4 Day 0 acceptance ✓

## Environment fix found during deploy

- Firewall rule `coc-testnet-p2p` (28780/29780/29781/28786) was
  attached to network `coc-testnet` (where existing 18780 anchors
  live). New r3-2 VMs were created on the `default` network for
  isolation, so the existing rule didn't apply → cross-VM TCP
  connections to port 29780 silently DROPPED.
- Fix: added `coc-r3-2-p2p` rule on `default` network targeting tag
  `coc-fullnode`, mirroring `coc-testnet-p2p`'s allowed ports.
- PR-1E's per-peer fetch-snapshot diagnostic (#86) immediately
  surfaced the cause via "Error: request timeout after 10000ms" per
  peer, made the misconfig trivial to spot in 2 minutes.

## Test plan

- [x] All 7 VMs RUNNING after `gcloud instances create`
- [x] All 7 nodes pass `systemctl is-active coc-node@1`
- [x] Genesis block produced by validator-1 (h=1, proposer 0xde4e7889…)
- [x] BFT cluster produces blocks at ~3 s/block from h=2 onward
- [x] All 7 nodes report identical stateRoot at h=100
- [x] Observer-1 and observer-2 sync to chain tip via snap-sync (h≈140)
- [ ] Day 1 chaos drill: T2 single-validator stop → verify chain
      progresses ≤15 s (PR-1A fast-path real-network validation)
- [ ] 30-day soak

## Risks

None to existing 18780. New VMs/firewall/rules are isolated on `default`
network; existing 18780 cluster on `coc-testnet` network is unaffected.