### PR TITLE
fix(bft): PR-1F — gate onProposerStuck on prepare-phase silent-proposer only

### DIFF
--- a/node/src/bft-coordinator.test.ts
+++ b/node/src/bft-coordinator.test.ts
@@ -818,4 +818,107 @@ describe("BftCoordinator", () => {
     await coord.startRound(block)
     assert.equal(broadcasted.length, 1, "fallback path still broadcasts prepare")
   })
+
+  it("PR-1F: onProposerStuck fires only on prepare-phase timeout with NO peer prepares", async () => {
+    // 88780 Day 1 drill fingerprint: a force-proposer's round reaches commit
+    // phase with 4-of-5 prepares but only 3-of-5 commits → round times out.
+    // Old PR-1A marked the proposer as unreachable, leading to a different
+    // fallback re-proposing a fresh block hash, which Phase R then refused
+    // as self-equivocation → chain deadlock.
+    //
+    // PR-1F: only signal proposer-stuck when round timed out in PREPARE
+    // phase AND no peer prepare votes arrived (only our self-vote).
+    const stuckCalls: Array<{ proposerId: string; height: bigint }> = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      broadcastMessage: async () => {},
+      onFinalized: async () => {},
+      prepareTimeoutMs: 50, // short so test doesn't hang
+      commitTimeoutMs: 50,
+      onProposerStuck: (proposerId, height) => stuckCalls.push({ proposerId, height }),
+    })
+
+    // Round proposed by v2 (peer). Local v1 broadcasts its own prepare.
+    const block = makeBlock(1n, "v2")
+    await coord.startRound(block)
+
+    // Drive the round to commit phase: receive prepares from v2 + v3 →
+    // quorum-of-prepares reached. Local v1 then broadcasts commit.
+    await coord.handleMessage(bftMsg("prepare", 1n, block.hash, "v2"))
+    await coord.handleMessage(bftMsg("prepare", 1n, block.hash, "v3"))
+
+    // Confirm we're in commit phase (round didn't finalize yet — need a peer commit).
+    assert.equal(coord.getRoundState().phase, "commit", "round transitioned to commit")
+
+    // Now let the round time out without further commit votes.
+    await new Promise<void>((resolve) => setTimeout(resolve, 120))
+
+    // PR-1F: should NOT have marked v2 unreachable — the round was in commit
+    // phase, meaning v2 successfully proposed and collected peer prepares.
+    assert.equal(stuckCalls.length, 0, "no onProposerStuck on commit-phase timeout")
+    assert.equal(coord.getRoundState().active, false, "round was cleared")
+  })
+
+  it("PR-1F: onProposerStuck DOES fire on prepare-phase timeout with no peer prepares (regression)", async () => {
+    // The "proposer is silent" case: local node received the proposed block
+    // (likely via gossip relay) and broadcast its own prepare, but no peer
+    // prepares arrived → round times out in prepare phase with only the
+    // self-vote. This is the original PR-1A signal we DO want to preserve.
+    const stuckCalls: Array<{ proposerId: string; height: bigint }> = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      broadcastMessage: async () => {},
+      onFinalized: async () => {},
+      prepareTimeoutMs: 50,
+      commitTimeoutMs: 50,
+      onProposerStuck: (proposerId, height) => stuckCalls.push({ proposerId, height }),
+    })
+
+    const block = makeBlock(1n, "v2")
+    await coord.startRound(block)
+
+    // No peer prepares — let the round time out in prepare phase.
+    await new Promise<void>((resolve) => setTimeout(resolve, 120))
+
+    assert.equal(stuckCalls.length, 1, "onProposerStuck fired for silent proposer")
+    assert.equal(stuckCalls[0].proposerId, "v2")
+    assert.equal(stuckCalls[0].height, 1n)
+  })
+
+  it("PR-1F: prepare-phase timeout with PEER prepare (but quorum miss) does NOT mark stuck", async () => {
+    // Adjacent case: 1 peer prepare arrived (so the proposer IS talking to
+    // someone), but quorum wasn't reached before timeout. Proposer is alive
+    // and broadcasting — should not be marked unreachable.
+    const stuckCalls: Array<{ proposerId: string; height: bigint }> = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators: [
+        { id: "v1", stake: 100n },
+        { id: "v2", stake: 100n },
+        { id: "v3", stake: 100n },
+        { id: "v4", stake: 100n },
+        { id: "v5", stake: 100n },
+      ],
+      broadcastMessage: async () => {},
+      onFinalized: async () => {},
+      prepareTimeoutMs: 50,
+      commitTimeoutMs: 50,
+      onProposerStuck: (proposerId, height) => stuckCalls.push({ proposerId, height }),
+    })
+
+    const block = makeBlock(1n, "v2")
+    await coord.startRound(block)
+
+    // 1 peer prepare from v3 (proposer's reach is partial) — total 2-of-5,
+    // below quorum (needs 4 with N=5, strict 2/3+1).
+    await coord.handleMessage(bftMsg("prepare", 1n, block.hash, "v3"))
+    assert.equal(coord.getRoundState().phase, "prepare", "still in prepare phase")
+
+    // Time out.
+    await new Promise<void>((resolve) => setTimeout(resolve, 120))
+
+    assert.equal(stuckCalls.length, 0, "proposer with at least 1 peer prepare is NOT stuck")
+  })
 })

--- a/node/src/bft-coordinator.ts
+++ b/node/src/bft-coordinator.ts
@@ -1033,9 +1033,34 @@ export class BftCoordinator {
         // PR-1A: notify parent that this round's proposer is likely unreachable.
         // Skip when the proposer was local — `onProposerStuck` is for *peer*
         // unreachability evidence; self-stuck has its own J2.2 path.
+        //
+        // PR-1F (2026-05-11): tighten the unreachability signal. 88780 Day 1
+        // drill exposed a false positive: when a force-proposer's round
+        // reaches commit-phase with quorum-of-prepares but only 3/4 commits,
+        // the round still times out — yet the proposer was clearly working
+        // (it proposed AND collected peer prepare votes). Marking it
+        // unreachable here means the NEXT force-propose attempt picks a
+        // different fallback, which generates a fresh block hash, which
+        // Phase R then correctly refuses as self-equivocation → chain
+        // deadlocks at that height.
+        //
+        // Fix: only signal unreachable when (a) round timed out in PREPARE
+        // phase AND (b) no peer prepare votes arrived (only our own self-
+        // vote). That matches the original intent — "the proposer isn't
+        // talking to us" — and excludes the commit-phase case where the
+        // proposer demonstrably did its job.
         if (this.cfg.onProposerStuck && this.activeRound) {
           const proposerId = this.activeRound.state.proposedBlock?.proposer
-          if (proposerId && proposerId.toLowerCase() !== this.cfg.localId.toLowerCase()) {
+          const phase = this.activeRound.state.phase
+          const localIdLower = this.cfg.localId.toLowerCase()
+          const peerPrepareCount = [...this.activeRound.state.prepareVotes.keys()]
+            .filter(id => id !== localIdLower).length
+          const isPrepareTimeoutWithSilentProposer = phase === "prepare" && peerPrepareCount === 0
+          if (
+            proposerId
+            && proposerId.toLowerCase() !== localIdLower
+            && isPrepareTimeoutWithSilentProposer
+          ) {
             try {
               this.cfg.onProposerStuck(proposerId, this.activeRound.state.height)
             } catch (err) {


### PR DESCRIPTION
## Summary

Fixes a false-positive in PR-1A discovered during the 88780 Day 1 chaos drill (2026-05-11).

## Bug

When a force-proposer's round reaches commit phase with quorum-of-prepares
but doesn't gather enough commits (e.g. 4-of-5 prepares + 3-of-5 commits),
the round times out. Old PR-1A marked the proposer as unreachable even
though it was demonstrably working. The next H15 fallback then picked a
different validator → fresh block hash for the same height → Phase R
(self-equivocation guard from PR-1B) correctly refused → **chain deadlock**.

## Fix

Tighten the unreachability signal. `onProposerStuck` now fires only when:
1. Round timed out in **prepare phase** (not commit phase), AND
2. **No peer prepare votes arrived** (only our self-vote)

That matches PR-1A's original intent — "the proposer isn't talking to us" —
and excludes both the commit-phase case (proposer demonstrably did its
job) and the partial-prepare case (proposer is reaching someone, just
not us yet).

| Scenario | Old | New |
|---|---|---|
| Commit-phase timeout, N-1 of N prepares | marks stuck ❌ | not stuck ✓ |
| Prepare-phase timeout, ≥1 peer prepare | marks stuck ❌ | not stuck ✓ |
| Prepare-phase timeout, only self-vote | marks stuck ✓ | marks stuck ✓ |

## Test plan

- [x] 3 new tests in `bft-coordinator.test.ts` covering the three scenarios
- [x] 38/38 bft-coordinator + bft-proposer-skip tests pass
- [x] 119/119 full bft+consensus+storage regression passes
- [ ] Deploy to 88780 validators + retry T2 drill — expect ≤15 s recovery
      via PR-1A fast path (instead of 600 s H15 + deadlock cycle)

## 88780 Day 1 drill fingerprint that prompted this fix

- T+0: validator-3 stopped (T2 setup)
- T+~600 s: H15 fires, validator-5 force-proposes h=3613
- Round: `prepareVotes:4 commitVotes:3 buffered:1` → times out in commit
- Old code marks validator-5 unreachable → next H15 picks validator-4
- validator-4 proposes h=3613 with different tx set (different hash)
- Phase R refuses → chain stuck at h=3613 for ~30 min
- Recovery: only when validator-3 came back online and caught up via
  snap-sync; it then proposed h=3613 with a fresh hash that all 5 voted
  cleanly on, breaking the lock.

Average block time during the drill: ~15 s/block instead of the target
~3 s. PR-1F removes the deadlock cycle so the fast-path actually delivers
its design goal.