### PR TITLE
fix(ipfs): #90 serialize pin() writes to fix concurrent /api/v0/add HTTP 500s

### DIFF
--- a/node/src/ipfs-blockstore.test.ts
+++ b/node/src/ipfs-blockstore.test.ts
@@ -77,6 +77,19 @@ describe("IpfsBlockstore", () => {
     assert.equal(pins.length, 1)
   })
 
+  it("concurrent pins are serialized without ENOENT or lost-updates", async () => {
+    // Pre-fix bug: pins.json used a shared `pins.json.tmp` path + no lock,
+    // so N parallel pin() calls raced the rename — second rename hit
+    // ENOENT, and the read-modify-write window lost some adds.
+    const N = 20
+    const cids: CidString[] = Array.from({ length: N }, (_, i) => `QmConc${i.toString().padStart(2, "0")}` as CidString)
+    const results = await Promise.allSettled(cids.map((c) => store.pin(c)))
+    for (const r of results) assert.equal(r.status, "fulfilled", `pin rejected: ${(r as PromiseRejectedResult).reason}`)
+    const pins = await store.listPins()
+    assert.equal(pins.length, N, "every concurrent pin should be persisted")
+    for (const c of cids) assert.ok(pins.includes(c), `missing pin ${c}`)
+  })
+
   it("stat returns correct counts and size", async () => {
     await store.put(makeBlock("QmS1", "abc"))
     await store.put(makeBlock("QmS2", "defgh"))

--- a/node/src/ipfs-blockstore.ts
+++ b/node/src/ipfs-blockstore.ts
@@ -89,6 +89,17 @@ export class IpfsBlockstore {
   private currentBytes = 0
   private accessSeqCounter = 0
   private metaLoaded = false
+  // Serializes the read-modify-write cycle on pins.json. Two concurrent
+  // pin() calls would otherwise:
+  //   (a) both write to the same `pins.json.tmp` then race the rename —
+  //       the second rename hits ENOENT because the first already moved
+  //       the tmp file → HTTP 500 surfaces to the caller.
+  //   (b) lost-update each other's added CID, because both read the same
+  //       on-disk snapshot before either write lands.
+  // Chaining writes through this promise gives every pin() a single
+  // serialized critical section.
+  private pinsLock: Promise<unknown> = Promise.resolve()
+  private pinsTmpCounter = 0
 
   constructor(root: string, hooks?: IpfsBlockstoreHooks, opts?: IpfsBlockstoreOpts) {
     this.root = root
@@ -305,9 +316,13 @@ export class IpfsBlockstore {
   }
 
   async pin(cid: CidString): Promise<void> {
-    const pins = await this.readPins()
-    pins.add(cid)
-    await this.writePins(pins)
+    const next = this.pinsLock.then(async () => {
+      const pins = await this.readPins()
+      pins.add(cid)
+      await this.writePins(pins)
+    })
+    this.pinsLock = next.catch(() => {})
+    await next
   }
 
   async listPins(): Promise<CidString[]> {
@@ -379,8 +394,11 @@ export class IpfsBlockstore {
 
   private async writePins(pins: Set<CidString>): Promise<void> {
     await mkdir(this.root, { recursive: true })
-    // Atomic write: write to temp file then rename to prevent corruption on crash
-    const tmpPath = this.pinsPath() + ".tmp"
+    // Atomic write: write to a per-call unique temp file then rename. The
+    // unique suffix is defence-in-depth against any path that bypasses
+    // pinsLock (e.g. multiple IpfsBlockstore instances sharing the same
+    // root, or future call sites that mutate pins.json directly).
+    const tmpPath = `${this.pinsPath()}.${process.pid}.${++this.pinsTmpCounter}.tmp`
     await writeFile(tmpPath, JSON.stringify({ pins: [...pins] }, null, 2))
     await rename(tmpPath, this.pinsPath())
   }


### PR DESCRIPTION
Closes #90.

## Summary
- Add `pinsLock` promise chain to serialize `pin()` read-modify-write
- Generate per-call unique tmp filenames as defence-in-depth
- New regression test fires 20 concurrent pins and asserts they all persist

## Test plan
- [x] `node --experimental-strip-types --test node/src/ipfs-blockstore.test.ts` → 28/28 PASS (new test included)
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 30/30 PASS
- [x] Local repro of #90 against an `IpfsHttpServer` instance:
  - Before fix: 9 of 10 concurrent uploads → HTTP 500 with `ENOENT: pins.json.tmp -> pins.json`
  - After fix: 50 of 50 concurrent uploads → HTTP 200
- [x] Live testnet repro (server-1 `chainId 18780`, port 28786) — also pre-fix, will retest the next time the node binary is redeployed