### PR TITLE
fix(ipfs): #92 parse multipart bodies on files/write, block/put, pubsub/pub

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -150,6 +150,37 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(new Uint8Array(buf), data)
   })
 
+  it("#92: POST /api/v0/block/put extracts file bytes from kubo-style multipart", async () => {
+    // Pre-fix bug: the entire multipart envelope (boundary, headers,
+    // closing boundary) was stored as block bytes — incompatible with the
+    // kubo CLI / js-ipfs which always send multipart.
+    const boundary = "----BlockPutMpBoundary"
+    const content = "raw bytes inside multipart"
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="data"; filename="b.bin"',
+      "Content-Type: application/octet-stream",
+      "",
+      content,
+      `--${boundary}--`,
+      "",
+    ].join("\r\n")
+    const putRes = await fetch("/api/v0/block/put", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    assert.equal(putRes.status, 200)
+    const putBody = await putRes.json() as Record<string, unknown>
+    assert.ok(putBody.Key)
+    assert.equal(putBody.Size, Buffer.byteLength(content), "stored block must be the inner file bytes, not the multipart envelope")
+
+    const getRes = await fetch(`/api/v0/block/get?arg=${putBody.Key}`)
+    assert.equal(getRes.status, 200)
+    const buf = await getRes.buffer()
+    assert.equal(new TextDecoder().decode(buf), content)
+  })
+
   it("GET /api/v0/pin/ls returns pins list", async () => {
     const res = await fetch("/api/v0/pin/ls")
     assert.equal(res.status, 200)

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -608,7 +608,12 @@ export class IpfsHttpServer {
   }
 
   private async handleBlockPut(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-    const body = await readBody(req)
+    // Use readMultipartFile so kubo-standard multipart uploads
+    // (Content-Type: multipart/form-data; boundary=...) get parsed —
+    // otherwise the entire envelope is stored as block bytes. The helper
+    // falls back to readBody for raw-body POSTs, so existing callers that
+    // PUT plain bytes keep working.
+    const { bytes: body } = await readMultipartFile(req)
     const block = await storeRawBlock(this.store, body)
     res.writeHead(200, { "content-type": "application/json" })
     res.end(JSON.stringify({ Key: block.cid, Size: block.bytes.length }))
@@ -733,7 +738,11 @@ export class IpfsHttpServer {
           break
         }
         case "write": {
-          const body = await readBody(req)
+          // kubo CLI + js-ipfs send file content as multipart/form-data; raw
+          // body uploads (Uint8Array POSTs) also need to work. readMultipartFile
+          // handles both: it extracts the file bytes from multipart, or returns
+          // raw bytes when the request has no boundary in Content-Type.
+          const { bytes: body } = await readMultipartFile(req)
           await this.mfs.write(arg, body, {
             create: url.query?.create === "true",
             truncate: url.query?.truncate === "true",
@@ -837,7 +846,11 @@ export class IpfsHttpServer {
             res.end(JSON.stringify({ error: "missing topic" }))
             break
           }
-          const body = await readBody(req)
+          // kubo's pubsub/pub accepts the message body as multipart/form-data;
+          // raw-body POSTs (e2e tests, simple curl --data-binary) still work
+          // because readMultipartFile falls back to raw bytes when there's no
+          // boundary in Content-Type.
+          const { bytes: body } = await readMultipartFile(req)
           await this.pubsub.publish(topic, body)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))

--- a/tests/e2e/ipfs-e2e.test.ts
+++ b/tests/e2e/ipfs-e2e.test.ts
@@ -326,6 +326,31 @@ describe("IPFS E2E", () => {
       assert.deepEqual(buf, new TextEncoder().encode("hello mfs"))
     })
 
+    it("#92: files/write extracts file bytes from kubo-style multipart upload", async () => {
+      // Pre-fix bug: the entire multipart envelope (boundary, headers,
+      // file content, closing boundary) was stored as the file content.
+      // kubo CLI's `ipfs files write` always uses multipart/form-data, so
+      // any standard IPFS client previously corrupted the file.
+      const { body, contentType } = multipart("mp.txt", "hello multipart write")
+      const writeRes = await fetch(
+        `${base}/api/v0/files/write?arg=/test-dir/mp.txt&create=true&truncate=true`,
+        { method: "POST", headers: { "content-type": contentType }, body },
+      )
+      assert.equal(writeRes.status, 200)
+      try {
+        const readRes = await fetch(
+          `${base}/api/v0/files/read?arg=/test-dir/mp.txt`,
+          { method: "POST" },
+        )
+        assert.equal(readRes.status, 200)
+        const got = await readRes.text()
+        assert.equal(got, "hello multipart write", "files/write must extract file bytes, not store envelope")
+      } finally {
+        // Clean up so the subsequent rm-empties-the-directory test still sees only hello.txt
+        await fetch(`${base}/api/v0/files/rm?arg=/test-dir/mp.txt`, { method: "POST" })
+      }
+    })
+
     it("ls lists directory entries", async () => {
       const res = await fetch(`${base}/api/v0/files/ls?arg=/test-dir`, {
         method: "POST",
@@ -379,6 +404,29 @@ describe("IPFS E2E", () => {
       assert.equal(res.status, 200)
       const json = (await res.json()) as { ok: boolean }
       assert.equal(json.ok, true)
+    })
+
+    it("#92: pubsub/pub delivers inner bytes from kubo-style multipart message", async () => {
+      // Pre-fix bug: publish() received the full multipart envelope as the
+      // message body. Subscribers then got the envelope instead of the
+      // intended payload.
+      const received: Uint8Array[] = []
+      pubsub.subscribe("mp-topic", (msg) => { received.push(msg.data) })
+      try {
+        const { body, contentType } = multipart("msg.bin", "hello mp message")
+        const res = await fetch(`${base}/api/v0/pubsub/pub?arg=mp-topic`, {
+          method: "POST",
+          headers: { "content-type": contentType },
+          body,
+        })
+        assert.equal(res.status, 200)
+        // Subscribers run synchronously inside publish() in this impl, so
+        // we don't need to await dispatch.
+        assert.equal(received.length, 1, "exactly one message delivered")
+        assert.equal(new TextDecoder().decode(received[0]), "hello mp message")
+      } finally {
+        pubsub.unsubscribe("mp-topic")
+      }
     })
 
     it("ls lists subscribed topics", async () => {


### PR DESCRIPTION
Closes #92.

## Summary
- Switch `/api/v0/files/write`, `/api/v0/block/put`, `/api/v0/pubsub/pub` to `readMultipartFile(req)` — kubo CLI / js-ipfs send multipart, raw-body uploads still work via the helper's fallback.
- Add regression tests (block/put + files/write + pubsub/pub) verifying inner-bytes extraction.

## Test plan
- [x] `node --test node/src/ipfs-*.test.ts` → 173/173 PASS (includes the new block/put multipart regression)
- [x] `node --test tests/e2e/ipfs-e2e.test.ts` → 27/27 PASS (includes new files/write + pubsub/pub regressions)
- [x] Manual repro pre-fix:
  - kubo-style multipart `files/write` → stored multipart envelope as file content
  - kubo-style multipart `block/put` → returned a CID for the envelope
  Both fixed after this PR.