### PR TITLE
fix(ipfs): #96 forward offset/count to MFS read and map not-found to 404

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -753,7 +753,34 @@ export class IpfsHttpServer {
           break
         }
         case "read": {
-          const data = await this.mfs.read(arg)
+          // Forward offset/count to IpfsMfs.read so partial reads work as
+          // kubo CLI + js-ipfs expect. Pre-fix the params were silently
+          // dropped and every read returned the whole file.
+          const offsetRaw = url.query?.offset
+          const countRaw = url.query?.count
+          const opts: { offset?: number; count?: number } = {}
+          if (offsetRaw !== undefined) {
+            const n = Number(offsetRaw)
+            if (!Number.isFinite(n)) throw new HttpError(400, "invalid offset")
+            opts.offset = n
+          }
+          if (countRaw !== undefined) {
+            const n = Number(countRaw)
+            if (!Number.isFinite(n) || n < 0) throw new HttpError(400, "invalid count")
+            opts.count = n
+          }
+          let data: Uint8Array
+          try {
+            data = await this.mfs.read(arg, opts)
+          } catch (err) {
+            // Map MFS "not found" / "is a directory" errors to the
+            // structured 404 / 400 shape clients expect, instead of the
+            // generic 500 the catch-all would otherwise emit.
+            const msg = err instanceof Error ? err.message : String(err)
+            if (/^not found/.test(msg)) throw new HttpError(404, "not found", msg)
+            if (/^is a directory/.test(msg)) throw new HttpError(400, "is a directory", msg)
+            throw err
+          }
           res.writeHead(200)
           res.end(data)
           break
@@ -811,9 +838,22 @@ export class IpfsHttpServer {
           res.end(JSON.stringify({ error: `unknown MFS command: ${route}` }))
       }
     } catch (err) {
-      log.error("MFS route failed", { error: String(err) })
-      res.writeHead(500, { "content-type": "application/json" })
-      res.end(JSON.stringify({ error: "internal error" }))
+      // Mirror the main catch's HttpError handling so routes can opt into
+      // structured 4xx responses (e.g. read of a missing path → 404).
+      const status = err instanceof HttpError ? err.status : 500
+      const code = err instanceof HttpError ? err.code : "internal error"
+      const message = err instanceof HttpError && err.message !== code ? err.message : undefined
+      if (status >= 500) {
+        log.error("MFS route failed", { error: String(err) })
+      } else {
+        log.warn("MFS request rejected", { status, code })
+      }
+      if (!res.headersSent) {
+        res.writeHead(status, { "content-type": "application/json" })
+      }
+      try {
+        res.end(JSON.stringify(message ? { error: code, message } : { error: code }))
+      } catch { /* connection already closed */ }
     }
   }
 

--- a/tests/e2e/ipfs-e2e.test.ts
+++ b/tests/e2e/ipfs-e2e.test.ts
@@ -326,6 +326,39 @@ describe("IPFS E2E", () => {
       assert.deepEqual(buf, new TextEncoder().encode("hello mfs"))
     })
 
+    it("#96: read respects offset query param", async () => {
+      // Pre-fix bug: HTTP handler ignored offset, always returned full file.
+      // "hello mfs" → offset=6 → "mfs"
+      const res = await fetch(
+        `${base}/api/v0/files/read?arg=/test-dir/hello.txt&offset=6`,
+        { method: "POST" },
+      )
+      assert.equal(res.status, 200)
+      assert.equal(await res.text(), "mfs")
+    })
+
+    it("#96: read respects offset+count query params", async () => {
+      // "hello mfs" → offset=0 count=5 → "hello"
+      const res = await fetch(
+        `${base}/api/v0/files/read?arg=/test-dir/hello.txt&offset=0&count=5`,
+        { method: "POST" },
+      )
+      assert.equal(res.status, 200)
+      assert.equal(await res.text(), "hello")
+    })
+
+    it("#96: read of nonexistent path returns 404 (not 500)", async () => {
+      // Pre-fix bug: MFS "not found" errors leaked through the generic
+      // catch-all as opaque 500 internal-error responses.
+      const res = await fetch(
+        `${base}/api/v0/files/read?arg=/no-such-file.txt`,
+        { method: "POST" },
+      )
+      assert.equal(res.status, 404)
+      const json = (await res.json()) as { error: string }
+      assert.equal(json.error, "not found")
+    })
+
     it("#92: files/write extracts file bytes from kubo-style multipart upload", async () => {
       // Pre-fix bug: the entire multipart envelope (boundary, headers,
       // file content, closing boundary) was stored as the file content.


### PR DESCRIPTION
Closes #96.

## Summary
- Forward `?offset` and `?count` query params from the HTTP handler to `IpfsMfs.read()`.
- Map MFS not-found / is-directory errors to structured 404 / 400 at the route boundary.
- Make the MFS catch handler `HttpError`-aware so routes can emit structured 4xx instead of getting collapsed to 500.

## Test plan
- [x] e2e: `/api/v0/files/read?arg=...&offset=6` returns last 3 bytes of a 9-byte file.
- [x] e2e: `/api/v0/files/read?...&offset=0&count=5` returns the first 5 bytes.
- [x] e2e: read of nonexistent path returns 404 `{"error":"not found"}`.
- [x] `node --test tests/e2e/ipfs-e2e.test.ts` → 30/30 pass.
- [x] `node --test node/src/ipfs-*.test.ts` → 173/173 pass.