### PR TITLE
fix(ipfs): #98 map MFS user-error throws uniformly at the route catch (404/400)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -755,7 +755,9 @@ export class IpfsHttpServer {
         case "read": {
           // Forward offset/count to IpfsMfs.read so partial reads work as
           // kubo CLI + js-ipfs expect. Pre-fix the params were silently
-          // dropped and every read returned the whole file.
+          // dropped and every read returned the whole file. The
+          // route-level catch (below) maps MFS "not found" / "is a
+          // directory" errors to structured 4xx for every MFS endpoint.
           const offsetRaw = url.query?.offset
           const countRaw = url.query?.count
           const opts: { offset?: number; count?: number } = {}
@@ -769,18 +771,7 @@ export class IpfsHttpServer {
             if (!Number.isFinite(n) || n < 0) throw new HttpError(400, "invalid count")
             opts.count = n
           }
-          let data: Uint8Array
-          try {
-            data = await this.mfs.read(arg, opts)
-          } catch (err) {
-            // Map MFS "not found" / "is a directory" errors to the
-            // structured 404 / 400 shape clients expect, instead of the
-            // generic 500 the catch-all would otherwise emit.
-            const msg = err instanceof Error ? err.message : String(err)
-            if (/^not found/.test(msg)) throw new HttpError(404, "not found", msg)
-            if (/^is a directory/.test(msg)) throw new HttpError(400, "is a directory", msg)
-            throw err
-          }
+          const data = await this.mfs.read(arg, opts)
           res.writeHead(200)
           res.end(data)
           break
@@ -840,9 +831,37 @@ export class IpfsHttpServer {
     } catch (err) {
       // Mirror the main catch's HttpError handling so routes can opt into
       // structured 4xx responses (e.g. read of a missing path → 404).
-      const status = err instanceof HttpError ? err.status : 500
-      const code = err instanceof HttpError ? err.code : "internal error"
-      const message = err instanceof HttpError && err.message !== code ? err.message : undefined
+      // For routes that throw a plain Error from IpfsMfs (e.g. "not found:
+      // /x", "is a directory: /y", "parent directory not found: /z"),
+      // promote those well-known message prefixes to 4xx here so every MFS
+      // endpoint is consistent — clients can rely on stat/cp/mv/rm/ls all
+      // emitting 404 for user typos instead of opaque 500s.
+      let httpErr = err instanceof HttpError ? err : null
+      if (!httpErr && err instanceof Error) {
+        const msg = err.message
+        // 404: any error message mentioning "not found" (e.g. "not found:",
+        // "parent directory not found:", "file not found:", "source not
+        // found:", "destination directory not found:").
+        if (/not found/i.test(msg)) {
+          httpErr = new HttpError(404, "not found", msg)
+        } else if (
+          /is a directory/i.test(msg) ||
+          /directory not empty/i.test(msg) ||
+          /^cannot (remove|operate on|copy)/i.test(msg) ||
+          /must be/i.test(msg) ||
+          /^missing /i.test(msg) ||
+          /^write would exceed/i.test(msg) ||
+          /^max mfs depth/i.test(msg) ||
+          /^path too long/i.test(msg) ||
+          /^null byte in path/i.test(msg) ||
+          /^invalid /i.test(msg)
+        ) {
+          httpErr = new HttpError(400, "bad request", msg)
+        }
+      }
+      const status = httpErr ? httpErr.status : 500
+      const code = httpErr ? httpErr.code : "internal error"
+      const message = httpErr && httpErr.message !== code ? httpErr.message : undefined
       if (status >= 500) {
         log.error("MFS route failed", { error: String(err) })
       } else {

--- a/tests/e2e/ipfs-e2e.test.ts
+++ b/tests/e2e/ipfs-e2e.test.ts
@@ -359,6 +359,34 @@ describe("IPFS E2E", () => {
       assert.equal(json.error, "not found")
     })
 
+    it("#98: stat/cp/mv/rm/ls of missing paths return 404 uniformly", async () => {
+      // All MFS routes previously collapsed user-error throws to opaque 500.
+      // Verify each route now emits a structured 404.
+      for (const path of [
+        "/api/v0/files/stat?arg=/no-such-stat.txt",
+        "/api/v0/files/cp?arg=/no-such-cp.txt&dest=/x.txt",
+        "/api/v0/files/mv?arg=/no-such-mv.txt&dest=/y.txt",
+        "/api/v0/files/rm?arg=/no-such-rm.txt",
+        "/api/v0/files/ls?arg=/no-such-dir",
+      ]) {
+        const res = await fetch(`${base}${path}`, { method: "POST" })
+        assert.equal(res.status, 404, `expected 404 for ${path}, got ${res.status}`)
+        const json = (await res.json()) as { error: string }
+        assert.equal(json.error, "not found", `error code mismatch for ${path}`)
+      }
+    })
+
+    it("#98: cp with missing dest returns 400 (not 500)", async () => {
+      // Pre-fix: cp without ?dest threw a plain Error → 500.
+      const res = await fetch(
+        `${base}/api/v0/files/cp?arg=/test-dir/hello.txt`,
+        { method: "POST" },
+      )
+      assert.equal(res.status, 400)
+      const json = (await res.json()) as { error: string }
+      assert.equal(json.error, "bad request")
+    })
+
     it("#92: files/write extracts file bytes from kubo-style multipart upload", async () => {
       // Pre-fix bug: the entire multipart envelope (boundary, headers,
       // file content, closing boundary) was stored as the file content.


### PR DESCRIPTION
Closes #98.

## Summary
- Extend the MFS catch handler to recognize well-known IpfsMfs error message prefixes and emit 404 / 400 instead of opaque 500.
- Strip the per-route try/catch from `read` (the catch now covers it uniformly across stat/cp/mv/rm/ls/mkdir/etc).

## Test plan
- [x] e2e: stat / cp / mv / rm / ls of missing path → 404 `{"error":"not found"}` (5 endpoints in one assertion loop).
- [x] e2e: cp with missing dest → 400 `{"error":"bad request"}`.
- [x] All 30 `tests/e2e/ipfs-e2e.test.ts` pass.
- [x] All 173 `node/src/ipfs-*.test.ts` pass.

## Follow-up note
While probing this surface, two other low-severity issues showed up:
- `eth_getBlockByNumber("earliest")` returns `null` (genesis block isn't stored).
- Empty JSON-RPC batch `[]` returns `[]` instead of the spec-required Invalid Request.
Both are spec-compliance nits; will file as separate issues if they're worth addressing.