### PR TITLE
fix(rpc): #100 coc_getValidators returns array consistently (was single string in fallback)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -457,6 +457,25 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(result, false)
   })
 
+  await t.test("#100: coc_getValidators returns an array (not a single string) without governance", async () => {
+    // This RPC test fixture builds a ChainEngine without on-chain governance,
+    // so we exercise the fallback path. Pre-fix, the fallback returned
+    // `chain.expectedProposer(height + 1n)` — a single string — which
+    // contradicted the method's name and broke array-shaped client code.
+    const result = await rpcCall(port, "coc_getValidators") as unknown
+    assert.ok(Array.isArray(result), `coc_getValidators must return an array, got: ${typeof result}`)
+    // Every entry should be an object with at least an `id` field.
+    const arr = result as Array<Record<string, unknown>>
+    for (const v of arr) {
+      assert.equal(typeof v, "object", "validator entry should be an object")
+      assert.ok(typeof v.id === "string" && v.id.length > 0, `validator entry missing id: ${JSON.stringify(v)}`)
+    }
+    // The chain in this test fixture was constructed with `validators: ["node-1"]`,
+    // so the fallback should expose exactly that.
+    assert.equal(arr.length, 1, "fallback should return all hardcoded validators")
+    assert.equal(arr[0].id, "node-1")
+  })
+
   await t.test("coc_getEquivocations maps persisted BFT evidence fields", async () => {
     const result = await rpcCall(port, "coc_getEquivocations", [0])
     assert.ok(Array.isArray(result))

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1379,9 +1379,17 @@ async function handleRpc(
           joinedAtEpoch: `0x${v.joinedAtEpoch.toString(16)}`,
         }))
       }
-      // Fallback: return basic validator info from round-robin
-      const height = await Promise.resolve(chain.getHeight())
-      return chain.expectedProposer(height + 1n)
+      // Fallback (no on-chain governance): expose the hardcoded validator
+      // set as an array so the return type stays a collection, consistent
+      // with the governance-enabled branch above. Pre-fix this returned a
+      // single string (the next-block proposer), which contradicted the
+      // method name and broke any client treating it as an array.
+      const cfgValidators = hasConfig(chain) ? chain.cfg.validators : []
+      return cfgValidators.map((v) => ({
+        id: v,
+        address: v,
+        active: true,
+      }))
     }
     case "coc_submitProposal": {
       if (!hasGovernance(chain)) throw new Error("governance not enabled")


### PR DESCRIPTION
Closes #100.

## Summary
- Fallback (governance disabled) returned a single string instead of an array. Now formats `chain.cfg.validators` as `{ id, address, active: true }[]`, matching the governance-enabled branch's array shape.

## Test plan
- [x] New regression test: array shape + entries match fixture validators.
- [x] `node --test node/src/rpc-extended.test.ts` → 43/43 pass.
- [x] `node --test node/src/rpc*.test.ts` → 107/107 pass.