### PR TITLE
fix(rpc): #102 filter TTL uses last-access (not creation) time

### DIFF
--- a/node/src/blockchain-types.ts
+++ b/node/src/blockchain-types.ts
@@ -72,6 +72,12 @@ export interface PendingFilter {
   topics?: Array<Hex | null>
   lastCursor: bigint
   createdAtMs?: number
+  // Last time the filter was polled via eth_getFilterChanges /
+  // eth_getFilterLogs. The cleanup pass uses this (not createdAtMs) to
+  // decide whether a filter has been idle long enough to reap, so
+  // long-lived polling subscribers don't get GC'd out from under
+  // themselves after FILTER_TTL_MS since creation.
+  lastAccessedAtMs?: number
   // pendingTx-only: set of tx hashes already returned to this filter, so
   // a second poll only sees newly-arrived hashes. Kept per filter so two
   // independent pendingTx subscribers each get their own diff.

--- a/node/src/rpc-filter-ttl.test.ts
+++ b/node/src/rpc-filter-ttl.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { cleanupExpiredFilters, FILTER_TTL_MS } from "./rpc.ts"
+import type { PendingFilter } from "./blockchain-types.ts"
+
+test("#102: cleanupExpiredFilters preserves filters whose lastAccessedAtMs is fresh, even if createdAtMs is stale", () => {
+  const filters = new Map<string, PendingFilter>()
+  const now = Date.now()
+  const wayBack = now - FILTER_TTL_MS - 60_000 // 6 min ago — well past TTL
+
+  // Pre-fix bug: cleanup looked only at createdAtMs, so this filter
+  // would be deleted even though the client polled it 10s ago.
+  filters.set("0xactive", {
+    id: "0xactive",
+    kind: "block",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: wayBack,
+    lastAccessedAtMs: now - 10_000, // just polled 10s ago
+  })
+
+  // Genuinely idle filter — created and last polled long ago. Must be reaped.
+  filters.set("0xidle", {
+    id: "0xidle",
+    kind: "log",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: wayBack,
+    lastAccessedAtMs: wayBack,
+  })
+
+  // No lastAccessedAtMs set (older code path) — falls back to createdAtMs.
+  // Stale createdAtMs → should reap.
+  filters.set("0xlegacy-stale", {
+    id: "0xlegacy-stale",
+    kind: "log",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: wayBack,
+  })
+
+  // No lastAccessedAtMs, fresh createdAtMs → kept.
+  filters.set("0xlegacy-fresh", {
+    id: "0xlegacy-fresh",
+    kind: "log",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: now - 30_000,
+  })
+
+  cleanupExpiredFilters(filters, { force: true })
+
+  assert.equal(filters.has("0xactive"), true, "actively polled filter must survive")
+  assert.equal(filters.has("0xidle"), false, "idle filter must be reaped")
+  assert.equal(filters.has("0xlegacy-stale"), false, "legacy filter with stale createdAt must be reaped")
+  assert.equal(filters.has("0xlegacy-fresh"), true, "legacy filter with fresh createdAt must survive")
+})
+
+test("#102: cleanup throttles non-forced calls", () => {
+  const filters = new Map<string, PendingFilter>()
+  const now = Date.now()
+  const wayBack = now - FILTER_TTL_MS - 60_000
+  filters.set("0xs", {
+    id: "0xs",
+    kind: "log",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: wayBack,
+    lastAccessedAtMs: wayBack,
+  })
+
+  // Force-call first to set lastFilterCleanupMs to "now", reaping the entry.
+  cleanupExpiredFilters(filters, { force: true })
+  assert.equal(filters.has("0xs"), false)
+
+  // Re-add a stale filter and call without force — should be throttled
+  // (skipped because last cleanup happened a few microseconds ago).
+  filters.set("0xs2", {
+    id: "0xs2",
+    kind: "log",
+    fromBlock: 0n,
+    lastCursor: 0n,
+    createdAtMs: wayBack,
+    lastAccessedAtMs: wayBack,
+  })
+  cleanupExpiredFilters(filters)
+  assert.equal(filters.has("0xs2"), true, "throttled non-forced cleanup should skip work")
+})

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -28,7 +28,7 @@ const log = createLogger("rpc")
 const sendTxLocks = new Map<string, Promise<unknown>>()
 
 const MAX_FILTERS = 1000
-const FILTER_TTL_MS = 5 * 60 * 1000 // 5 minutes
+export const FILTER_TTL_MS = 5 * 60 * 1000 // 5 minutes
 const CHAIN_STATS_CACHE_TTL_MS = 5_000
 let chainStatsCache: { result: unknown; height: bigint; cachedAtMs: number } | null = null
 let chainStatsComputing: Promise<unknown> | null = null
@@ -39,12 +39,18 @@ let lastFilterCleanupMs = 0
 
 const feeOracle = new FeeOracle()
 
-function cleanupExpiredFilters(filters: Map<string, PendingFilter>): void {
+export function cleanupExpiredFilters(filters: Map<string, PendingFilter>, opts?: { force?: boolean }): void {
   const now = Date.now()
-  if (now - lastFilterCleanupMs < FILTER_CLEANUP_THROTTLE_MS) return
+  if (!opts?.force && now - lastFilterCleanupMs < FILTER_CLEANUP_THROTTLE_MS) return
   lastFilterCleanupMs = now
   for (const [id, filter] of filters) {
-    if (filter.createdAtMs && now - filter.createdAtMs > FILTER_TTL_MS) {
+    // Use last-poll time (falling back to creation time) so actively
+    // polled filters don't get reaped from under their subscribers.
+    // Polling-based clients (the standard fallback when WebSocket isn't
+    // available) often live for hours and call getFilterChanges every
+    // few seconds; using createdAtMs killed those after 5 min.
+    const lastSeen = filter.lastAccessedAtMs ?? filter.createdAtMs
+    if (lastSeen && now - lastSeen > FILTER_TTL_MS) {
       filters.delete(id)
     }
   }
@@ -680,6 +686,9 @@ async function handleRpc(
       const id = String((payload.params ?? [])[0] ?? "")
       const filter = filters.get(id)
       if (!filter) return []
+      // Refresh the filter's last-access timestamp so cleanupExpiredFilters
+      // doesn't reap an actively polled subscriber.
+      filter.lastAccessedAtMs = Date.now()
       // pendingTx filter: return mempool tx hashes that haven't been
       // returned to this filter yet, then record them so the next poll
       // only sees newly-arrived hashes.
@@ -1163,6 +1172,8 @@ async function handleRpc(
       const id = String((payload.params ?? [])[0] ?? "")
       const filter = filters.get(id)
       if (!filter) return []
+      // Refresh last-access time so active polls keep the filter alive.
+      filter.lastAccessedAtMs = Date.now()
       // getFilterLogs is a log-filter-only method: block and pendingTx
       // filters have no historical "logs" to return. Match the kubo/geth
       // behaviour of returning [] rather than confusing the caller with


### PR DESCRIPTION
Closes #102.

## Summary
- Add `lastAccessedAtMs` to `PendingFilter`, stamp on every `getFilterChanges`/`getFilterLogs`.
- `cleanupExpiredFilters` checks `lastAccessedAtMs ?? createdAtMs` so active polling clients aren't reaped after 5 min.
- Export `cleanupExpiredFilters` + `FILTER_TTL_MS` with a `force` option for deterministic unit tests.

## Test plan
- [x] New `node/src/rpc-filter-ttl.test.ts`: 4-case matrix (active/idle × with/without lastAccessedAtMs) + throttle behaviour.
- [x] `node --test node/src/rpc*.test.ts` → 109/109 pass.