### PR TITLE
fix(rpc): #104 coerce non-numeric error codes to -32603 (JSON-RPC 2.0 §5.1)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -457,6 +457,42 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(result, false)
   })
 
+  await t.test("#104: malformed eth_sendRawTransaction returns integer error.code (not ethers string code)", async () => {
+    // Pre-fix bug: ethers errors thrown from the rawtx parse path carried
+    // `code: "INVALID_ARGUMENT"` (a string), which the RPC catch passed
+    // through verbatim — violating JSON-RPC 2.0 §5.1 (error.code MUST be
+    // an integer) and leaking the ethers library version on every
+    // response.
+    for (const badRaw of ["0xnothex", "", "0xdeadbeef"]) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [badRaw] }),
+      })
+      const json = await r.json() as { error?: { code: unknown; message: unknown } }
+      assert.ok(json.error, `expected error for raw="${badRaw}"`)
+      assert.equal(typeof json.error!.code, "number", `error.code must be a number for raw="${badRaw}", got ${typeof json.error!.code}: ${String(json.error!.code)}`)
+      assert.ok(Number.isInteger(json.error!.code as number), `error.code must be integer, got ${json.error!.code}`)
+      assert.equal(typeof json.error!.message, "string", "error.message must be a string")
+    }
+  })
+
+  await t.test("#104: structured RPC errors with numeric code are preserved", async () => {
+    // Regression check: legitimate handlers throw { code: -32602, message }
+    // for invalid params. Those should NOT be coerced to -32603; only
+    // non-numeric codes are coerced. eth_estimateGas with an invalid `to`
+    // address throws { code: -32602, message: "invalid to address" }.
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_estimateGas", params: [{ to: "not-a-hex-address" }] }),
+    })
+    const json = await r.json() as { error?: { code: unknown; message: unknown } }
+    assert.ok(json.error)
+    assert.equal(json.error!.code, -32602, "structured -32602 must be preserved verbatim")
+    assert.equal(json.error!.message, "invalid to address")
+  })
+
   await t.test("#100: coc_getValidators returns an array (not a single string) without governance", async () => {
     // This RPC test fixture builds a ChainEngine without on-chain governance,
     // so we exercise the fallback path. Pre-fix, the fallback returned

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -396,8 +396,17 @@ async function handleOne(
   } catch (error: unknown) {
     // Support structured RPC errors (e.g. { code, message } from param validation)
     if (error && typeof error === "object" && "code" in error && "message" in error) {
-      const rpcErr = error as { code: number; message: string }
-      return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: rpcErr.code, message: rpcErr.message } }
+      const rpcErr = error as { code: unknown; message: unknown }
+      // JSON-RPC 2.0 §5.1 requires error.code to be a number. Our internal
+      // handlers throw { code: -32xxx, ... } objects (legitimate), but
+      // downstream libraries like ethers throw errors with string codes
+      // ("INVALID_ARGUMENT", "BUFFER_OVERRUN"). Coerce non-integer codes
+      // to -32603 (Internal error) so the response stays spec-compliant
+      // and clients aren't forced to handle the union type.
+      const numericCode =
+        typeof rpcErr.code === "number" && Number.isInteger(rpcErr.code) ? rpcErr.code : -32603
+      const message = typeof rpcErr.message === "string" ? rpcErr.message : "internal error"
+      return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: numericCode, message } }
     }
     return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: -32603, message: error instanceof Error ? error.message : "internal error" } }
   }


### PR DESCRIPTION
Closes #104.

## Summary
- Validate that error.code is a finite integer before passing it through; otherwise coerce to -32603 with a string-message fallback.
- Structured handler throws like `{ code: -32602, message: ... }` are preserved verbatim — only upstream library codes (ethers' `INVALID_ARGUMENT`, `BUFFER_OVERRUN`) are coerced.

## Test plan
- [x] New regression: malformed eth_sendRawTransaction inputs (3 shapes) — `error.code` is integer, `error.message` is string.
- [x] New regression: invalid eth_estimateGas params preserves -32602.
- [x] `node --test node/src/rpc-extended.test.ts` → 45/45 pass.
- [x] `node --test node/src/rpc*.test.ts` → 109/109 pass.

## Coordination
Branched off main parallel to PR #103 (#102 filter TTL fix). Both touch `rpc.ts` + `rpc-extended.test.ts`; will rebase if conflict arises after #103 merges.