### PR TITLE
fix(rpc): #106 implement coc_getEquivocationsTotal referenced by operator runbook

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -528,6 +528,16 @@ test("RPC Extended Methods", async (t) => {
     ])
   })
 
+  await t.test("#106: coc_getEquivocationsTotal returns the count of all evidence entries", async () => {
+    // The operator runbook tells operators to alert on this metric, but
+    // pre-fix the method threw "method not supported". The fixture
+    // injects one mock equivocation via getBftEquivocations, so the count
+    // should be 1.
+    const result = await rpcCall(port, "coc_getEquivocationsTotal")
+    assert.equal(typeof result, "number", `coc_getEquivocationsTotal must return a number, got ${typeof result}`)
+    assert.equal(result, 1, "fixture has exactly one mock equivocation, so total must be 1")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1767,6 +1767,16 @@ async function handleRpc(
       }
       return null
     }
+    case "coc_getEquivocationsTotal": {
+      // Cheap counter for ops monitoring. The operator runbook
+      // (docs/operator-runbook.{en,zh}.md section 5) instructs operators
+      // to alert when this rises above zero, so the method must exist as
+      // a first-class endpoint instead of forcing callers to fetch the
+      // full evidence array via coc_getEquivocations and count it.
+      const totalGetter = (opts as RpcRuntimeOptions | undefined)?.getBftEquivocations
+      if (!totalGetter) return 0
+      return totalGetter(0).length
+    }
     case "coc_getEquivocations": {
       const sinceMs = Number((payload.params ?? [])[0] ?? 0)
       const getter = (opts as RpcRuntimeOptions | undefined)?.getBftEquivocations


### PR DESCRIPTION
Closes #106.

## Summary
- Add `coc_getEquivocationsTotal` — thin handler returning `getBftEquivocations(0).length`. Same data source as `coc_getEquivocations`; lets ops scrapers poll just the count.

## Test plan
- [x] Regression: fixture injects 1 evidence entry → method returns 1.
- [x] `node --test node/src/rpc-extended.test.ts` → 46/46 pass.