### PR TITLE
fix(rpc): #108 part 1 — implement coc_erasureStatus RPC bridge

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1330,6 +1330,26 @@ startRpcServer(
     getBftEquivocations: (sinceMs: number) => bftEvidenceStore.peek().filter(
       (e) => (e.rawEvidence?.detectedAtMs ?? 0) > sinceMs
     ),
+    getErasureStatus: async (cid: string) => {
+      // #108: RPC bridge for the existing /api/v0/erasure/status handler.
+      // Resolve the CID into an ErasureManifest (throws if it's not one
+      // or the blocks are missing), then compute per-stripe availability.
+      const { resolveCid, erasureStatus, ErasureError } = await import("./ipfs-erasure-reader.ts")
+      try {
+        const resolved = await resolveCid(cid, ipfsStore)
+        if (resolved.kind !== "erasure" || !resolved.manifest) {
+          throw { code: -32604, message: `CID ${cid} is not an erasure manifest` }
+        }
+        return await erasureStatus(resolved.manifest, ipfsStore)
+      } catch (err) {
+        if (err instanceof ErasureError) {
+          if (err.code === "invalid_cid") throw { code: -32602, message: err.message }
+          if (err.code === "not_found") throw { code: -32604, message: err.message }
+          throw { code: -32603, message: err.message }
+        }
+        throw err
+      }
+    },
     didResolver: didResolverInstance,
     didDataProvider: didDataProviderInstance,
   },

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -71,6 +71,22 @@ test("RPC Extended Methods", async (t) => {
         },
       },
     ],
+    getErasureStatus: async (cid: string) => {
+      // Stub: returns a deterministic manifest summary so the dispatch
+      // path is exercised end-to-end without spinning up a real
+      // blockstore. The real implementation in index.ts delegates to
+      // resolveCid + erasureStatus.
+      if (cid === "bafy-missing") throw { code: -32604, message: "not_found" }
+      return {
+        fileSize: 1_048_576,
+        scheme: "rs(4+2)",
+        n: 4,
+        m: 2,
+        stripes: [
+          { stripeIndex: 0, dataAvailable: 4, parityAvailable: 2, needsRepair: false },
+        ],
+      }
+    },
   })
   t.after(async () => {
     await new Promise<void>((resolve, reject) => {
@@ -526,6 +542,28 @@ test("RPC Extended Methods", async (t) => {
         type: "bft-equivocation",
       },
     ])
+  })
+
+  await t.test("#108: coc_erasureStatus bridges the existing /api/v0/erasure/status path to RPC", async () => {
+    const result = await rpcCall(port, "coc_erasureStatus", ["bafy-mock-manifest"])
+    assert.ok(typeof result === "object" && result !== null)
+    const status = result as { fileSize: number; scheme: string; n: number; m: number; stripes: unknown[] }
+    assert.equal(status.fileSize, 1_048_576)
+    assert.equal(status.scheme, "rs(4+2)")
+    assert.equal(status.n, 4)
+    assert.equal(status.m, 2)
+    assert.ok(Array.isArray(status.stripes) && status.stripes.length === 1)
+  })
+
+  await t.test("#108: coc_erasureStatus rejects missing CID with -32602", async () => {
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_erasureStatus", params: [""] }),
+    })
+    const json = await r.json() as { error?: { code: number; message: string } }
+    assert.ok(json.error)
+    assert.equal(json.error!.code, -32602)
   })
 
   await t.test("#106: coc_getEquivocationsTotal returns the count of all evidence entries", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -201,6 +201,27 @@ interface RpcRuntimeOptions {
   fetchBlockFromPeer?: (cid: string, excludePeerId?: string) => Promise<Uint8Array | null>
   rewardManifestDir?: string
   getBftEquivocations?: (sinceMs: number) => Array<{ rawEvidence?: Record<string, unknown>; [key: string]: unknown }>
+  /**
+   * Phase Q.4 / #108: expose erasure-coded manifest availability to RPC
+   * clients. The HTTP /api/v0/erasure/status endpoint has had this since
+   * Phase Q but the matching RPC method (which the runbook + skills
+   * spec reference) was never wired. Bridge accepts the manifest CID
+   * and returns per-stripe data/parity availability + total file size.
+   * Throws on invalid_cid / not_a_manifest / not_found so the catch in
+   * handleRpcMethod can surface the appropriate JSON-RPC error.
+   */
+  getErasureStatus?: (cid: string) => Promise<{
+    fileSize: number
+    scheme: string
+    n: number
+    m: number
+    stripes: Array<{
+      stripeIndex: number
+      dataAvailable: number
+      parityAvailable: number
+      needsRepair: boolean
+    }>
+  }>
   getSyncProgress?: () => Promise<{ syncing: boolean; currentHeight: bigint; highestPeerHeight: bigint; startingHeight: bigint }>
   didResolver?: { resolve: (did: string) => Promise<unknown> }
   didDataProvider?: {
@@ -346,6 +367,9 @@ export function startRpcServer(
         }
         if (runtimeOptions?.fetchBlockFromPeer) {
           rpcOpts.fetchBlockFromPeer = runtimeOptions.fetchBlockFromPeer
+        }
+        if (runtimeOptions?.getErasureStatus) {
+          rpcOpts.getErasureStatus = runtimeOptions.getErasureStatus
         }
         const scopedOpts = Object.keys(rpcOpts).length > 0 ? rpcOpts : undefined
         const MAX_BATCH_SIZE = 100
@@ -1766,6 +1790,18 @@ async function handleRpc(
         }
       }
       return null
+    }
+    case "coc_erasureStatus": {
+      // RPC bridge for the existing HTTP /api/v0/erasure/status handler.
+      // Doc-referenced for ops tooling (phase-q-erasure-coding.md:233);
+      // returns per-stripe data/parity availability for a Reed-Solomon
+      // manifest CID. The runtime hook is wired from index.ts using
+      // resolveCid + erasureStatus.
+      const getter = (opts as RpcRuntimeOptions | undefined)?.getErasureStatus
+      if (!getter) throw { code: -32601, message: "erasure status not available on this node" }
+      const cid = String((payload.params ?? [])[0] ?? "")
+      if (!cid) throw { code: -32602, message: "missing manifest CID" }
+      return getter(cid)
     }
     case "coc_getEquivocationsTotal": {
       // Cheap counter for ops monitoring. The operator runbook


### PR DESCRIPTION
Part 1 of #108 (5-method audit). Wires `coc_erasureStatus` to the existing `/api/v0/erasure/status` logic via a new runtime hook.

## Summary
- Add `getErasureStatus(cid)` to `RpcRuntimeOptions`, forward it through the rpcOpts plumb.
- New `coc_erasureStatus` handler: validates CID, maps ErasureError codes to JSON-RPC -32602 / -32604 / -32603.
- Wire the hook in `index.ts` using lazy-import of `resolveCid` + `erasureStatus`.

## Test plan
- [x] Stub-based unit test verifying happy-path response shape.
- [x] Empty CID → -32602.
- [x] `node --test node/src/rpc-extended.test.ts` → 48/48.
- [x] `node --test node/src/rpc*.test.ts` → 114/114.

## Remaining in #108
- coc_getPeers / coc_getContractsByPage / coc_poseStatus / coc_validatorActivity (separate PRs).