### PR TITLE
fix(rpc): #108 part-2 — implement coc_getPeers RPC

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -53,7 +53,12 @@ test("RPC Extended Methods", async (t) => {
       discoveryPendingPeers: 0,
       discoveryIdentityFailures: 0,
     }),
-  } as P2PNode
+    // Stub for #108: coc_getPeers exposes the same shape as admin_peers.
+    getPeers: () => [
+      { id: "node-2", url: "http://10.0.0.2:29780" },
+      { id: "node-3", url: "http://10.0.0.3:29780", advertisedUrl: "http://203.0.113.3:29780" },
+    ],
+  } as unknown as P2PNode
   const port = 18790 + Math.floor(Math.random() * 100)
 
   const server: http.Server = startRpcServer("127.0.0.1", port, chainId, evm, chain, p2p, undefined, undefined, undefined, undefined, {
@@ -542,6 +547,19 @@ test("RPC Extended Methods", async (t) => {
         type: "bft-equivocation",
       },
     ])
+  })
+
+  await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
+    const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
+    assert.ok(Array.isArray(peers), "must return an array")
+    assert.equal(peers.length, 2)
+    // Second peer in the stub has advertisedUrl — it should win over url
+    const node3 = peers.find(p => p.id === "node-3")
+    assert.ok(node3, "node-3 must be present")
+    assert.equal(node3!.url, "http://203.0.113.3:29780", "advertisedUrl must take precedence over internal url")
+    const node2 = peers.find(p => p.id === "node-2")
+    assert.ok(node2, "node-2 must be present")
+    assert.equal(node2!.url, "http://10.0.0.2:29780", "url falls back when no advertisedUrl")
   })
 
   await t.test("#108: coc_erasureStatus bridges the existing /api/v0/erasure/status path to RPC", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1411,6 +1411,17 @@ async function handleRpc(
       }
       return { latestBlock: 0, pruningHeight: 0, retainedBlocks: 0 }
     }
+    case "coc_getPeers": {
+      // #108: doc-referenced in docs/runbooks/phase-q-erasure-coding.md:204
+      // ("peers should appear in `coc_getPeers` output"). Public (non-admin)
+      // peer list — only exposes the per-peer { id, url } fields already
+      // visible in P2P gossip traffic; no sensitive routing/auth state.
+      const peers = p2p.getPeers?.() ?? p2p.discovery?.getActivePeers?.() ?? []
+      return peers.map((peer: { id: string; url?: string; advertisedUrl?: string }) => ({
+        id: peer.id,
+        url: peer.advertisedUrl ?? peer.url ?? "unknown",
+      }))
+    }
     case "coc_getValidators": {
       if (hasGovernance(chain)) {
         const validators = chain.governance.getActiveValidators()


### PR DESCRIPTION
Part 2 of #108. Implements the public peer-list RPC referenced by the phase-q runbook.

## Summary
- Add `coc_getPeers` returning `{ id, url }[]`. Prefers `advertisedUrl` over `url`, matching the existing P2P dedup.
- Non-admin-gated since the same data is already in P2P gossip.

## Test plan
- [x] Regression: stubbed peer list with mixed advertised/internal URLs — assertions on shape + url selection.
- [x] `node --test node/src/rpc-extended.test.ts` → 49/49.
- [x] `node --test node/src/rpc*.test.ts` → 115/115.

## Remaining in #108
- coc_getContractsByPage / coc_poseStatus / coc_validatorActivity (separate PRs).