### PR TITLE
docs(rpc): #108 part-3 — fix doc drift on contract-registry RPC name (coc_getContractsByPage → coc_getContracts)

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -364,7 +364,7 @@ Implemented:
 - **Phase 25**: Global search bar (address/tx hash/block number)
 - **Phase 25**: Address-to-transaction index in BlockIndex (backend)
 - **Phase 25**: `coc_getTransactionsByAddress` custom RPC method
-- **Phase 27**: Contract registry index with `coc_getContractsByPage` RPC
+- **Phase 27**: Contract registry index with `coc_getContracts` RPC (paginated via `{offset, limit, reverse}`)
 - **Phase 27**: Contract call history component (incoming transactions to contract)
 - **Phase 27**: Address tx history with operation type classification (transfer/contract_call/contract_creation/token_transfer)
 - **Phase 27**: Contract deployment metadata on address page
@@ -671,7 +671,7 @@ Tests (49 new tests):
 - Snapshot JSON import validation (rejects malformed/missing-field JSON)
 
 ### 27.5 Explorer Enhancement
-- Contract registry index with `coc_getContractsByPage` RPC method
+- Contract registry index with `coc_getContracts` RPC (paginated via `{offset, limit, reverse}`) method
 - Contract call history component
 - Address tx history with operation type classification
 - Contract deployment metadata display


### PR DESCRIPTION
Part 3 of #108. Pure doc drift fix.

## Summary
- docs/implementation-status.md referenced \`coc_getContractsByPage\` in 2 places; the actual method is \`coc_getContracts\` with \`{offset, limit, reverse}\` pagination params.
- Explorer (\`explorer/src/app/contracts/page.tsx:98\`) already calls the correct \`coc_getContracts\` — only the docs were stale.

## Test plan
- [x] grep verification: no remaining \`coc_getContractsByPage\` in docs/.
- No code changes → no test runs needed; CI's docs gate covers markdown.

## Remaining in #108
- coc_poseStatus / coc_validatorActivity (separate PRs).