### PR TITLE
fix(rpc): #112 synthesise genesis block for eth_getBlockByNumber("earliest")

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -549,6 +549,23 @@ test("RPC Extended Methods", async (t) => {
     ])
   })
 
+  await t.test("#112: eth_getBlockByNumber(\"earliest\") returns a synthesised genesis block (not null)", async () => {
+    // Pre-fix: returned null because chain.getBlockByNumber(0n) was missing.
+    // Required for ethers/viem/hardhat fork-detection code paths.
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block on the chain so height ≥ 1")
+    const earliest = await rpcCall(port, "eth_getBlockByNumber", ["earliest", false]) as Record<string, unknown> | null
+    assert.ok(earliest !== null, "earliest must not be null")
+    assert.equal(earliest!.number, "0x0", "earliest.number must be 0x0")
+    assert.equal(earliest!.hash, "0x" + "0".repeat(64), "earliest.hash must be all zeros (block-1's parentHash)")
+    assert.equal(earliest!.parentHash, "0x" + "0".repeat(64))
+    assert.equal(earliest!.timestamp, "0x0")
+    assert.deepEqual(earliest!.transactions, [])
+    // Same response for the explicit "0x0" tag
+    const zeroTag = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
+    assert.equal(zeroTag.hash, earliest!.hash)
+  })
+
   await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
     const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
     assert.ok(Array.isArray(peers), "must return an array")

--- a/node/src/rpc-semantic-compat.test.ts
+++ b/node/src/rpc-semantic-compat.test.ts
@@ -154,10 +154,15 @@ describe("RPC semantic compatibility: block tags + pending nonce", () => {
       await engine.addRawTx(tx as Hex)
       await engine.proposeNextBlock()
 
-      // PersistentChainEngine starts at block 1, no block 0 exists.
-      // "earliest" should resolve to block 0, which returns null (no genesis block in persistent engine).
+      // PersistentChainEngine starts at block 1, no real block 0 exists.
+      // Per #112, "earliest" now returns a synthesised genesis block (number=0x0,
+      // hash=0x000…000) matching block-1's parentHash, so standard tooling
+      // (ethers/viem/hardhat fork detection) sees a non-null response.
       const earliest = await rpcCall(rpcPort, "eth_getBlockByNumber", ["earliest", false]) as any
-      assert.equal(earliest, null, "earliest (block 0) returns null when chain starts at block 1")
+      assert.ok(earliest, "earliest must not be null (synthesised genesis block)")
+      assert.equal(earliest.number, "0x0", "earliest.number must be 0x0")
+      assert.equal(earliest.hash, "0x" + "0".repeat(64), "synthesised genesis has all-zero hash")
+      assert.deepEqual(earliest.transactions, [], "synthesised genesis has no transactions")
 
       // Verify block 1 exists
       const block1 = await rpcCall(rpcPort, "eth_getBlockByNumber", ["0x1", false]) as any
@@ -199,10 +204,13 @@ describe("RPC semantic compatibility: block tags + pending nonce", () => {
         await engine.proposeNextBlock()
       }
 
-      // Finalized height resolves to 0 when height < finalityDepth.
-      // Block 0 does not exist in PersistentChainEngine (starts at block 1), so returns null.
+      // Finalized height resolves to 0 when height < finalityDepth. Per #112,
+      // block 0 now returns the synthesised genesis (not null) so clients
+      // querying the finalized tag in a very young chain still get a header.
       const finalized = await rpcCall(rpcPort, "eth_getBlockByNumber", ["finalized", false]) as any
-      assert.equal(finalized, null, "finalized should return null when clamped to block 0 (no genesis)")
+      assert.ok(finalized, "finalized must not be null — clamps to synthesised genesis")
+      assert.equal(finalized.number, "0x0", "clamped genesis has number 0x0")
+      assert.equal(finalized.hash, "0x" + "0".repeat(64))
 
       // With enough blocks, finalized should return a real block
       for (let i = 2; i < 7; i++) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -552,6 +552,17 @@ async function handleRpc(
       const includeTx = Boolean((payload.params ?? [])[1])
       const number = await resolveBlockNumber(tag, chain)
       const block = await Promise.resolve(chain.getBlockByNumber(number))
+      // #112: synthesise a genesis block when block 0 is missing. The
+      // chain starts producing at height 1, so resolveBlockNumber("earliest")
+      // → 0n → null. Standard Ethereum tooling expects "earliest" to return
+      // *something*. Match block-1's parentHash (all zeros) + timestamp 0,
+      // matching the convention already on the wire.
+      if (!block && number === 0n) {
+        const height = await Promise.resolve(chain.getHeight())
+        if (height >= 1n) {
+          return formatGenesisBlock(includeTx)
+        }
+      }
       return formatBlock(block, includeTx, chain, evm)
     }
     case "eth_getBlockByHash": {
@@ -2805,6 +2816,41 @@ async function formatPersistentReceipt(
     effectiveGasPrice: String((parsed as Record<string, unknown>).gasPrice ?? "0x0"),
     contractAddress,
     type: String((parsed as Record<string, unknown>).type ?? "0x0"),
+  }
+}
+
+/**
+ * #112: synthesise a genesis block (block 0) for `eth_getBlockByNumber("earliest")`
+ * when the chain didn't store block 0 explicitly. Match the convention block 1
+ * already uses on the wire (parentHash = 0x000…000, timestamp = 0). Empty txs,
+ * empty proposer, default 30M gasLimit. Hash is all-zeros — the same value
+ * block 1 carries as parentHash, so chain integrity checks line up.
+ */
+function formatGenesisBlock(includeTx: boolean) {
+  const ZERO_HASH = `0x${"0".repeat(64)}`
+  const ZERO_ADDR = `0x${"0".repeat(40)}`
+  return {
+    number: "0x0",
+    hash: ZERO_HASH,
+    parentHash: ZERO_HASH,
+    nonce: "0x0000000000000000",
+    sha3Uncles: ZERO_HASH,
+    logsBloom: `0x${"0".repeat(512)}`,
+    transactionsRoot: ZERO_HASH,
+    stateRoot: ZERO_HASH,
+    receiptsRoot: ZERO_HASH,
+    miner: ZERO_ADDR,
+    difficulty: "0x0",
+    totalDifficulty: "0x0",
+    extraData: "0x",
+    size: "0x0",
+    gasLimit: "0x1c9c380",
+    gasUsed: "0x0",
+    timestamp: "0x0",
+    transactions: includeTx ? [] : [],
+    uncles: [],
+    mixHash: ZERO_HASH,
+    baseFeePerGas: "0x0",
   }
 }
 


### PR DESCRIPTION
Closes #112.

## Summary
- Add `formatGenesisBlock(includeTx)` helper returning a minimal all-zeros genesis header (matching block-1's parentHash + timestamp=0).
- `eth_getBlockByNumber` synthesises this when `resolveBlockNumber(tag) === 0n && height >= 1n && getBlockByNumber(0n) === null`. Otherwise unchanged.
- Update 2 pre-existing `rpc-semantic-compat.test.ts` assertions that codified the old null-return behaviour. Their boundary-clamp intent is preserved.

## Test plan
- [x] New regression: `eth_getBlockByNumber("earliest", false)` after proposing 1 block returns synthesised genesis (number=0x0, hash=zeros, empty txs).
- [x] `eth_getBlockByNumber("0x0", false)` returns the same header.
- [x] `node --test node/src/rpc*.test.ts` → 116/116 pass.