### PR TITLE
fix(rpc): #114 eth_getBlockReceipts uses same shape as eth_getTransactionReceipt

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -336,6 +336,47 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(receipts, null)
   })
 
+  await t.test("#114: eth_getBlockReceipts shape matches eth_getTransactionReceipt", async () => {
+    // Pre-fix bug: getBlockReceipts returned a stripped-down 9-field shape
+    // (no contractAddress / cumulativeGasUsed / effectiveGasPrice / logsBloom
+    // / type), incompatible with the per-tx receipt format. Indexers that
+    // batched via this RPC silently lost contract-creation tracking and gas
+    // accounting.
+    //
+    // Send a real tx, mine the block, then compare the key sets of both
+    // receipt RPC responses for the same tx.
+    const accounts = await rpcCall(port, "eth_accounts") as string[]
+    const txHash = await rpcCall(port, "eth_sendTransaction", [{
+      from: accounts[0],
+      to: accounts[1],
+      value: "0x1",
+      gas: "0x5208",
+    }]) as string
+    await chain.proposeNextBlock()
+    const single = await rpcCall(port, "eth_getTransactionReceipt", [txHash]) as Record<string, unknown>
+    assert.ok(single, "single-tx receipt must exist")
+    const blockNum = single.blockNumber as string
+    const batch = await rpcCall(port, "eth_getBlockReceipts", [blockNum]) as Array<Record<string, unknown>>
+    assert.ok(Array.isArray(batch), "batch receipts must be an array")
+    const fromBatch = batch.find(r => r.transactionHash === txHash)
+    assert.ok(fromBatch, "tx must appear in batch receipts")
+    // Key set must match exactly between the two methods so any client
+    // switching between them doesn't silently lose fields. This is the
+    // regression assertion: pre-fix the batch method dropped 5 fields
+    // (contractAddress / cumulativeGasUsed / effectiveGasPrice / logsBloom /
+    // type), and this key-equality check fails on that drift even when
+    // contractAddress itself is null/undefined for a plain transfer.
+    const singleKeys = Object.keys(single).sort()
+    const batchKeys = Object.keys(fromBatch!).sort()
+    assert.deepEqual(batchKeys, singleKeys, "batch receipt keys must match single receipt keys")
+    // Sanity-check the previously-missing fields exist as keys (values may
+    // be null for non-contract-creation txs, but the key itself must be
+    // present so clients can rely on it).
+    for (const required of ["cumulativeGasUsed", "effectiveGasPrice", "logsBloom"]) {
+      assert.ok(required in fromBatch!, `batch receipt must contain ${required}`)
+    }
+  })
+
   await t.test("txpool_status returns pool stats", async () => {
     const status = await rpcCall(port, "txpool_status")
     assert.ok(typeof status === "object")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1265,41 +1265,32 @@ async function handleRpc(
     case "eth_compileSerpent":
       throw new Error(`${payload.method} is not supported`)
     case "eth_getBlockReceipts": {
+      // #114: per-receipt shape must match eth_getTransactionReceipt exactly.
+      // Pre-fix this returned a custom subset missing contractAddress,
+      // cumulativeGasUsed, effectiveGasPrice, logsBloom, and type — breaking
+      // indexers that batch via this method.
+      //
+      // Strategy: walk block.txs, parse each to derive its hash, then route
+      // through the same persistent / evm fallback as eth_getTransactionReceipt
+      // so a single receipt formatter is used for both methods.
       const tag = String((payload.params ?? [])[0] ?? "latest")
       const num = await resolveBlockNumber(tag, chain)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       if (!block) return null
       const receipts: unknown[] = []
-      for (let i = 0; i < block.txs.length; i++) {
+      for (const rawTx of block.txs) {
         try {
-          const parsed = Transaction.from(block.txs[i])
+          const parsed = Transaction.from(rawTx)
+          const hash = parsed.hash as Hex
+          let receipt: unknown = null
           if (typeof chain.getTransactionByHash === "function") {
-            const tx = await chain.getTransactionByHash(parsed.hash as Hex)
-            if (tx?.receipt) {
-              const r = tx.receipt
-              receipts.push({
-                transactionHash: r.transactionHash,
-                transactionIndex: `0x${i.toString(16)}`,
-                blockNumber: `0x${block.number.toString(16)}`,
-                blockHash: block.hash,
-                from: r.from,
-                to: r.to,
-                gasUsed: `0x${r.gasUsed.toString(16)}`,
-                status: r.status === 1n ? "0x1" : "0x0",
-                logs: (r.logs ?? []).map((log: any, idx: number) => ({
-                  address: log.address,
-                  topics: log.topics,
-                  data: log.data,
-                  blockNumber: `0x${block.number.toString(16)}`,
-                  blockHash: block.hash,
-                  transactionHash: r.transactionHash,
-                  transactionIndex: `0x${i.toString(16)}`,
-                  logIndex: `0x${idx.toString(16)}`,
-                  removed: false,
-                })),
-              })
-            }
+            const tx = await chain.getTransactionByHash(hash)
+            if (tx?.receipt) receipt = await formatPersistentReceipt(tx, chain)
           }
+          // Fallback to in-memory EVM receipt for chain engines without
+          // a persistent tx index (matches eth_getTransactionReceipt fallback).
+          if (!receipt) receipt = evm.getReceipt(hash)
+          if (receipt) receipts.push(receipt)
         } catch { /* skip unparseable */ }
       }
       return receipts


### PR DESCRIPTION
Closes #114.

## Summary
- Route `eth_getBlockReceipts` through the same `formatPersistentReceipt` helper used by `eth_getTransactionReceipt`, falling back to `evm.getReceipt` for non-persistent chains.
- Single source of truth → key set identical across both methods.

## Test plan
- [x] New regression: send tx, mine block, fetch single + batch — JSON key set is identical, previously-missing fields present.
- [x] `node --test node/src/rpc-extended.test.ts` → 51/51 pass.
- [x] `node --test node/src/rpc*.test.ts` → 117/117 pass.