### PR TITLE
fix(rpc): #116 eth_getLogs rejects blockHash + fromBlock per EIP-234

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -336,6 +336,24 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(receipts, null)
   })
 
+  await t.test("#116: eth_getLogs rejects blockHash + fromBlock combo with -32602", async () => {
+    // EIP-234: blockHash is mutually exclusive with fromBlock/toBlock.
+    // Pre-fix the implementation silently processed the range and surfaced
+    // a misleading "block range too large" error referencing the chain height.
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_getLogs",
+        params: [{ blockHash: "0x" + "00".repeat(32), fromBlock: "0x0" }],
+      }),
+    })
+    const json = await r.json() as { error?: { code: number; message: string } }
+    assert.ok(json.error, "must surface an error")
+    assert.equal(json.error!.code, -32602, "must be -32602 invalid params")
+    assert.match(json.error!.message, /mutually exclusive/i, "message must mention the mutual-exclusivity rule")
+  })
+
   await t.test("#114: eth_getBlockReceipts shape matches eth_getTransactionReceipt", async () => {
     // Pre-fix bug: getBlockReceipts returned a stripped-down 9-field shape
     // (no contractAddress / cumulativeGasUsed / effectiveGasPrice / logsBloom

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -684,6 +684,12 @@ async function handleRpc(
     }
     case "eth_getLogs": {
       const query = ((payload.params ?? [])[0] ?? {}) as Record<string, unknown>
+      // EIP-234: blockHash is mutually exclusive with fromBlock/toBlock.
+      // Pre-fix this silently processed the range and surfaced a confusing
+      // "block range too large" error referencing the full chain height.
+      if (query.blockHash !== undefined && (query.fromBlock !== undefined || query.toBlock !== undefined)) {
+        throw { code: -32602, message: "eth_getLogs: blockHash is mutually exclusive with fromBlock/toBlock" }
+      }
       const logsHeight = await Promise.resolve(chain.getHeight())
       return await queryLogs(chain, query, logsHeight)
     }


### PR DESCRIPTION
Closes #116.

## Summary
- Validate param shape: if \`blockHash\` is set together with \`fromBlock\`/\`toBlock\`, throw -32602 "mutually exclusive" rather than silently processing the range and emitting the misleading "block range too large" error.

## Test plan
- [x] Regression: call with both blockHash + fromBlock → -32602 with /mutually exclusive/i message.
- [x] All 52 rpc-extended pass.
- [x] All 118 rpc*.test.ts pass.