### PR TITLE
fix(rpc): #118 eth_getStorageAt validates slot before forwarding to evm

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -336,6 +336,30 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(receipts, null)
   })
 
+  await t.test("#118: eth_getStorageAt rejects malformed slots with -32602", async () => {
+    // Pre-fix: invalid slots either leaked the evm's padded hex back
+    // ("0x000…-1") or silently returned zero. Now each malformed shape
+    // gets a clean -32602.
+    const accounts = await rpcCall(port, "eth_accounts") as string[]
+    const addr = accounts[0]
+    for (const badSlot of ["-1", "", "0x", "0xZZ", "1", "0x" + "f".repeat(65)]) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_getStorageAt",
+          params: [addr, badSlot, "latest"],
+        }),
+      })
+      const json = await r.json() as { error?: { code: number; message: string } }
+      assert.ok(json.error, `expected error for slot=${JSON.stringify(badSlot)}`)
+      assert.equal(json.error!.code, -32602, `slot=${JSON.stringify(badSlot)} must be -32602, got ${json.error!.code}`)
+    }
+    // Sanity: a valid slot still works.
+    const ok = await rpcCall(port, "eth_getStorageAt", [addr, "0x0", "latest"]) as string
+    assert.match(ok, /^0x[0-9a-f]{64}$/, "valid slot must return a 32-byte hex word")
+  })
+
   await t.test("#116: eth_getLogs rejects blockHash + fromBlock combo with -32602", async () => {
     // EIP-234: blockHash is mutually exclusive with fromBlock/toBlock.
     // Pre-fix the implementation silently processed the range and surfaced

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -623,7 +623,19 @@ async function handleRpc(
     }
     case "eth_getStorageAt": {
       const storageAddr = requireHexParam(payload.params, 0, "address")
-      const storageSlot = String((payload.params ?? [])[1] ?? "0x0")
+      // #118: validate the slot before forwarding to evm. Pre-fix, an
+      // unsanitised slot like "-1" or unprefixed "1" was concatenated +
+      // padded inside the EVM layer, surfacing either as -32603 with a
+      // leaked padded-hex string ("0x000…-1") or as silent zero returns
+      // that masked the underlying input bug.
+      const slotRaw = (payload.params ?? [])[1]
+      if (typeof slotRaw !== "string" || slotRaw.length === 0) {
+        throw { code: -32602, message: "invalid storage slot: expected non-empty 0x-prefixed hex string" }
+      }
+      const storageSlot = slotRaw
+      if (!/^0x[0-9a-fA-F]{1,64}$/.test(storageSlot)) {
+        throw { code: -32602, message: `invalid storage slot: must match /^0x[0-9a-fA-F]{1,64}$/` }
+      }
       const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[2], chain)
       return await evm.getStorageAt(storageAddr, storageSlot, stateRoot)
     }


### PR DESCRIPTION
Closes #118.

## Summary
- Reject malformed storage slots at the RPC boundary with -32602 instead of forwarding to the EVM (which leaked the padded hex internal representation in the error message).
- Validates against `/^0x[0-9a-fA-F]{1,64}$/`.

## Test plan
- [x] 6 malformed shapes → -32602.
- [x] Valid "0x0" still returns 32-byte hex.
- [x] `node --test node/src/rpc*.test.ts` → 119/119 pass.