### PR TITLE
fix(rpc): #122 strict address validation for eth_getBalance / eth_getTransactionCount / coc_getContractInfo

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -336,6 +336,37 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(receipts, null)
   })
 
+  await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
+    // Pre-fix bugs:
+    //   - eth_getBalance returned -32603 with the raw input echoed back
+    //     ("Invalid address input=not-an-address")
+    //   - eth_getTransactionCount accepted short-hex like "0x123" and
+    //     forwarded to evm (similar input leak)
+    //   - coc_getContractInfo returned null for any malformed input,
+    //     indistinguishable from "no deployed contract"
+    const bads = ["not-an-address", "0x", "0x123", "0x" + "g".repeat(40), "0x" + "f".repeat(41)]
+    for (const method of ["eth_getBalance", "eth_getTransactionCount", "coc_getContractInfo"]) {
+      for (const badAddr of bads) {
+        const params = method.startsWith("eth_") ? [badAddr, "latest"] : [badAddr]
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        const json = await r.json() as { error?: { code: number; message: string } }
+        assert.ok(json.error, `expected error for ${method}(${JSON.stringify(badAddr)})`)
+        assert.equal(json.error!.code, -32602, `${method}(${JSON.stringify(badAddr)}) must be -32602, got ${json.error!.code}`)
+        assert.match(json.error!.message, /invalid address/i, `error message for ${method} should mention "invalid address"`)
+      }
+    }
+    // Sanity: valid address still works for getBalance/getTransactionCount.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const bal = await rpcCall(port, "eth_getBalance", [validAddr, "latest"])
+    assert.match(bal as string, /^0x[0-9a-f]+$/i, "valid eth_getBalance must return hex")
+    const nonce = await rpcCall(port, "eth_getTransactionCount", [validAddr, "latest"])
+    assert.match(nonce as string, /^0x[0-9a-f]+$/i, "valid eth_getTransactionCount must return hex")
+  })
+
   await t.test("#120: coc_getTransactionsByAddress rejects malformed addresses with -32602", async () => {
     // Pre-fix: typo or junk address silently returned [] (it just missed
     // the per-address index), masking client mistakes as "no transactions".

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -92,6 +92,24 @@ function requireHexParam(params: unknown[], index: number, name: string): Hex {
   return value as Hex
 }
 
+/**
+ * #122: strict 20-byte address validator. requireHexParam accepts any
+ * hex up to 66 chars, so "0x123" slipped through and downstream code
+ * either echoed back the raw input (eth_getBalance) or silently missed
+ * the index (coc_getContractInfo). Use this at the RPC boundary for
+ * methods whose param is documented as an Ethereum address.
+ */
+function requireAddressParam(params: unknown[], index: number, name = "address"): Hex {
+  const value = (params ?? [])[index]
+  if (typeof value !== "string") {
+    throw { code: -32602, message: `invalid ${name}: expected string` }
+  }
+  if (!/^0x[0-9a-fA-F]{40}$/.test(value)) {
+    throw { code: -32602, message: `invalid ${name}: must match /^0x[0-9a-fA-F]{40}$/` }
+  }
+  return value as Hex
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -490,13 +508,17 @@ async function handleRpc(
       return `0x${height.toString(16)}`
     }
     case "eth_getBalance": {
-      const address = String((payload.params ?? [])[0] ?? "")
+      // #122: validate at the boundary so a typo gives -32602 instead of
+      // -32603 with the raw input echoed back from the EVM.
+      const address = requireAddressParam(payload.params ?? [], 0)
       const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[1], chain)
       const balance = await evm.getBalance(address, stateRoot)
       return `0x${balance.toString(16)}`
     }
     case "eth_getTransactionCount": {
-      const address = String((payload.params ?? [])[0] ?? "")
+      // #122: same boundary check as eth_getBalance so address typos
+      // surface consistently across read-state RPCs.
+      const address = requireAddressParam(payload.params ?? [], 0)
       const tag = (payload.params ?? [])[1]
       if (tag === "pending") {
         const onchainNonce = await evm.getNonce(address)
@@ -1815,8 +1837,10 @@ async function handleRpc(
       return { enabled: hasBlockIndex(chain) }
     }
     case "coc_getContractInfo": {
-      const addr = (payload.params ?? [])[0] as string
-      if (!addr) throw new Error("address required")
+      // #122: stricter validation so typos return -32602 instead of
+      // silently null (indistinguishable from "this address has no
+      // deployed contract"). Mirrors the #120 fix for getTransactionsByAddress.
+      const addr = requireAddressParam(payload.params ?? [], 0)
       if (hasBlockIndex(chain)) {
         const info = await chain.blockIndex.getContractInfo(addr as Hex)
         if (!info) return null


### PR DESCRIPTION
Closes #122. Continues the boundary-validation theme from #120.

## Summary
- Add a shared `requireAddressParam` helper (`/^0x[0-9a-fA-F]{40}$/`) — stricter than `requireHexParam` which let 5-char hex like "0x123" slip through.
- Apply to: `eth_getBalance`, `eth_getTransactionCount`, `coc_getContractInfo`.
- Pre-fix: each returned either -32603 with raw input echoed (info leak), or silent null (UX failure).

## Test plan
- [x] 3 methods × 5 malformed shapes → -32602 with /invalid address/ message.
- [x] Valid address sanity: `eth_getBalance` + `eth_getTransactionCount` still return hex.
- [x] `node --test node/src/rpc*.test.ts` → 121/121 pass.