### PR TITLE
fix(rpc): tighten eth_estimateGas address regex to exactly 40 hex chars (#128)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -648,7 +648,10 @@ test("RPC Extended Methods", async (t) => {
     const json = await r.json() as { error?: { code: unknown; message: unknown } }
     assert.ok(json.error)
     assert.equal(json.error!.code, -32602, "structured -32602 must be preserved verbatim")
-    assert.equal(json.error!.message, "invalid to address")
+    // #128 widened this message to "invalid to address: must match ..."
+    // — assert the prefix instead of an exact match so future refinements
+    // don't keep breaking this regression test.
+    assert.match(json.error!.message as string, /^invalid to address/)
   })
 
   await t.test("#100: coc_getValidators returns an array (not a single string) without governance", async () => {
@@ -787,6 +790,33 @@ test("RPC Extended Methods", async (t) => {
     assert.match(code as string, /^0x[0-9a-f]*$/i)
     const slot = await rpcCall(port, "eth_getStorageAt", [validAddr, "0x0", "latest"])
     assert.match(slot as string, /^0x[0-9a-f]+$/i)
+  })
+
+  await t.test("#128: eth_estimateGas rejects malformed to/from addresses with -32602", async () => {
+    // Follow-up to #124: that PR fixed eth_call's regex but missed
+    // eth_estimateGas which had the same /^0x[0-9a-fA-F]{1,40}$/
+    // copy-paste. An address must be exactly 40 hex chars.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const badAddrs = ["0x", "0x1", "0x" + "f".repeat(39), "0x" + "f".repeat(41), "0x" + "g".repeat(40)]
+    for (const bad of badAddrs) {
+      for (const field of ["to", "from"]) {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method: "eth_estimateGas",
+            params: [{ [field]: bad, ...(field === "to" ? { from: validAddr } : { to: validAddr }) }],
+          }),
+        })
+        const json = await r.json() as { error?: { code: number; message: string } }
+        assert.ok(json.error, `expected error for ${field}=${JSON.stringify(bad)}`)
+        assert.equal(json.error!.code, -32602, `${field}=${JSON.stringify(bad)} must be -32602, got ${json.error!.code}`)
+        assert.match(json.error!.message, new RegExp(`invalid ${field} address`, "i"))
+      }
+    }
+    // Sanity: a valid call still returns a hex gas estimate.
+    const result = await rpcCall(port, "eth_estimateGas", [{ from: validAddr, to: validAddr, value: "0x0" }])
+    assert.match(result as string, /^0x[0-9a-f]+$/i)
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -601,11 +601,16 @@ async function handleRpc(
     }
     case "eth_estimateGas": {
       const estParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
-      if (estParams.to && !/^0x[0-9a-fA-F]{1,40}$/i.test(estParams.to)) {
-        throw { code: -32602, message: "invalid to address" }
+      // #128: pre-fix the regex was /^0x[0-9a-fA-F]{1,40}$/ which
+      // accepted "0x1" or any 1-39 hex chars. Same class as #124 fix
+      // for eth_call but eth_estimateGas was missed in that pass.
+      // Address must be exactly 20 bytes (40 hex chars). Empty `to`
+      // still permitted for contract-creation gas estimates.
+      if (estParams.to && !/^0x[0-9a-fA-F]{40}$/.test(estParams.to)) {
+        throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
       }
-      if (estParams.from && !/^0x[0-9a-fA-F]{1,40}$/i.test(estParams.from)) {
-        throw { code: -32602, message: "invalid from address" }
+      if (estParams.from && !/^0x[0-9a-fA-F]{40}$/.test(estParams.from)) {
+        throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
       }
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"


### PR DESCRIPTION
Closes #128.

Follow-up to #124. eth_call's regex was tightened in that PR but eth_estimateGas had the same loose copy-paste and was missed.

## Fix

`/^0x[0-9a-fA-F]{1,40}$/` → `/^0x[0-9a-fA-F]{40}$/` for both `to` and `from`. Empty `to` still permitted for contract-creation estimates.

## Test plan

- [x] New `#128` regression in `rpc-extended.test.ts` covering both fields × 5 malformed inputs
- [x] Pre-existing `#104` message-shape assertion widened to match prefix instead of exact string
- [x] 57/57 rpc-extended + 123/123 all-rpc tests pass locally