### PR TITLE
fix(ws-rpc): structured -32602/-32005 for invalid subscribe params and max-subscriptions (#130)

### DIFF
--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -284,4 +284,60 @@ describe("WebSocket RPC", () => {
 
     assert.equal(server.getClientCount(), 0)
   })
+
+  // #130: structured JSON-RPC error helper — sendRpc rejects with just
+  // the message, losing the code. This variant returns the full error.
+  async function sendRpcExpectError(ws: WebSocket, method: string, params: unknown[] = []): Promise<{ code: number; message: string }> {
+    const id = Math.floor(Math.random() * 100000)
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("timeout")), 5000)
+      const handler = (data: Buffer | string) => {
+        const msg = JSON.parse(data.toString())
+        if (msg.id === id) {
+          ws.removeListener("message", handler)
+          clearTimeout(timeout)
+          if (msg.error) resolve(msg.error)
+          else reject(new Error(`expected error but got result: ${JSON.stringify(msg.result)}`))
+        }
+      }
+      ws.on("message", handler)
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }))
+    })
+  }
+
+  it("#130: eth_subscribe with bogus type returns -32602 (not -32603)", async () => {
+    const ws = await connectWs(WS_PORT)
+    try {
+      const err = await sendRpcExpectError(ws, "eth_subscribe", ["bogusType"])
+      assert.equal(err.code, -32602, `expected -32602 invalid params, got ${err.code} (${err.message})`)
+      assert.match(err.message, /unsupported subscription type/)
+    } finally {
+      ws.close()
+    }
+  })
+
+  it("#130: eth_subscribe with no params returns -32602", async () => {
+    const ws = await connectWs(WS_PORT)
+    try {
+      const err = await sendRpcExpectError(ws, "eth_subscribe", [])
+      assert.equal(err.code, -32602, `expected -32602 invalid params, got ${err.code}`)
+    } finally {
+      ws.close()
+    }
+  })
+
+  it("#130: 11th subscription on one client returns -32005 (not -32603)", async () => {
+    const ws = await connectWs(WS_PORT)
+    try {
+      // MAX_SUBSCRIPTIONS_PER_CLIENT = 10 — fill the cap with newHeads.
+      for (let i = 0; i < 10; i++) {
+        await sendRpc(ws, "eth_subscribe", ["newHeads"])
+      }
+      const err = await sendRpcExpectError(ws, "eth_subscribe", ["newHeads"])
+      assert.equal(err.code, -32005, `expected -32005 resource limit, got ${err.code} (${err.message})`)
+      assert.match(err.message, /max subscriptions per client/)
+    } finally {
+      ws.close()
+    }
+  })
 })

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -372,16 +372,18 @@ export class WsRpcServer {
 
   private handleSubscribe(ws: WebSocket, params: unknown[]): string {
     if (ws.readyState !== WebSocket.OPEN) {
-      throw new Error("connection not open")
+      // #130: prefer JSON-RPC structured errors so the dispatcher
+      // returns the right code instead of falling back to -32603.
+      throw { code: -32004, message: "connection not open" }
     }
     const type = String(params[0] ?? "")
     const subId = generateSubscriptionId()
 
     const client = this.clients.get(ws)
-    if (!client) throw new Error("client not found")
+    if (!client) throw { code: -32603, message: "client not found" }
 
     if (client.subscriptions.size >= MAX_SUBSCRIPTIONS_PER_CLIENT) {
-      throw new Error(`max subscriptions per client reached (${MAX_SUBSCRIPTIONS_PER_CLIENT})`)
+      throw { code: -32005, message: `max subscriptions per client reached (${MAX_SUBSCRIPTIONS_PER_CLIENT})` }
     }
 
     switch (type) {
@@ -429,7 +431,9 @@ export class WsRpcServer {
         break
       }
       default:
-        throw new Error(`unsupported subscription type: ${type}`)
+        // #130: invalid params → -32602 per JSON-RPC §5.1 instead of
+        // the previous -32603 internal-error fallback.
+        throw { code: -32602, message: `unsupported subscription type: ${type}` }
     }
 
     log.info("subscription created", { type, subId })


### PR DESCRIPTION
Closes #130.

handleSubscribe() threw plain `Error` objects, which the dispatcher serialized as -32603 internal-error instead of the JSON-RPC §5.1 client-error codes for user-input failures.

## Fix

- `"unsupported subscription type"` → -32602 invalid params
- `"max subscriptions per client reached"` → -32005 resource limit
- `"connection not open"` → -32004 method not available

Dispatcher already passes through structured throws verbatim (`websocket-rpc.ts` L325-340), so this is just swapping `new Error(...)` for `{ code, message }`.

## Test plan

- [x] `eth_subscribe("bogusType")` → -32602
- [x] `eth_subscribe()` with no params → -32602
- [x] 11th subscription on one client (MAX_SUBSCRIPTIONS_PER_CLIENT=10) → -32005
- [x] 8/8 websocket-rpc tests pass locally