### PR TITLE
fix(rpc): structured -32602/-32005/-32601 for block-range, filter-limit, unknown-method errors (#132)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -819,6 +819,54 @@ test("RPC Extended Methods", async (t) => {
     assert.match(result as string, /^0x[0-9a-f]+$/i)
   })
 
+  await t.test("#132: structured error codes for block range, unknown method, legacy compile", async () => {
+    // (a) eth_getLogs over a range > MAX_LOG_BLOCK_RANGE (=10000) → -32602
+    const tooWide = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_getLogs",
+        params: [{ fromBlock: "0x0", toBlock: "0x4000" }],
+      }),
+    })
+    const tooWideJson = await tooWide.json() as { error?: { code: number; message: string } }
+    assert.ok(tooWideJson.error)
+    assert.equal(tooWideJson.error!.code, -32602, `too-wide range must be -32602, got ${tooWideJson.error!.code}`)
+    assert.match(tooWideJson.error!.message, /block range too large/)
+
+    // (b) eth_getLogs with fromBlock > toBlock → -32602
+    const swapped = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_getLogs",
+        params: [{ fromBlock: "0xa", toBlock: "0x5" }],
+      }),
+    })
+    const swappedJson = await swapped.json() as { error?: { code: number; message: string } }
+    assert.equal(swappedJson.error!.code, -32602, `swapped range must be -32602, got ${swappedJson.error!.code}`)
+    assert.match(swappedJson.error!.message, /invalid block range/)
+
+    // (c) unknown method → -32601 method not found
+    const unknown = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "foo_bar_baz", params: [] }),
+    })
+    const unknownJson = await unknown.json() as { error?: { code: number; message: string } }
+    assert.equal(unknownJson.error!.code, -32601, `unknown method must be -32601, got ${unknownJson.error!.code}`)
+    assert.match(unknownJson.error!.message, /method not supported/)
+
+    // (d) eth_compileLLL / eth_compileSerpent → -32601 (legacy)
+    const compileLll = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_compileLLL", params: ["foo"] }),
+    })
+    const compileLllJson = await compileLll.json() as { error?: { code: number; message: string } }
+    assert.equal(compileLllJson.error!.code, -32601, `eth_compileLLL must be -32601`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -739,7 +739,7 @@ async function handleRpc(
     case "eth_newFilter": {
       if (filters.size >= MAX_FILTERS) {
         cleanupExpiredFilters(filters)
-        if (filters.size >= MAX_FILTERS) throw new Error("filter limit exceeded")
+        if (filters.size >= MAX_FILTERS) throw { code: -32005, message: "filter limit exceeded" }
       }
       const query = ((payload.params ?? [])[0] ?? {}) as Record<string, unknown>
       const id = `0x${randomBytes(16).toString("hex")}`
@@ -1224,7 +1224,7 @@ async function handleRpc(
     case "eth_newBlockFilter": {
       if (filters.size >= MAX_FILTERS) {
         cleanupExpiredFilters(filters)
-        if (filters.size >= MAX_FILTERS) throw new Error("filter limit exceeded")
+        if (filters.size >= MAX_FILTERS) throw { code: -32005, message: "filter limit exceeded" }
       }
       const id = `0x${randomBytes(16).toString("hex")}`
       const height = await Promise.resolve(chain.getHeight())
@@ -1241,7 +1241,7 @@ async function handleRpc(
     case "eth_newPendingTransactionFilter": {
       if (filters.size >= MAX_FILTERS) {
         cleanupExpiredFilters(filters)
-        if (filters.size >= MAX_FILTERS) throw new Error("filter limit exceeded")
+        if (filters.size >= MAX_FILTERS) throw { code: -32005, message: "filter limit exceeded" }
       }
       const id = `0x${randomBytes(16).toString("hex")}`
       // Pre-populate seenPendingTxs with everything already in the mempool
@@ -1275,7 +1275,7 @@ async function handleRpc(
       const height = await Promise.resolve(chain.getHeight())
       const end = filter.toBlock ?? height
       if (end - filter.fromBlock > MAX_LOG_BLOCK_RANGE) {
-        throw new Error(`block range too large: max ${MAX_LOG_BLOCK_RANGE} blocks`)
+        throw { code: -32602, message: `block range too large: max ${MAX_LOG_BLOCK_RANGE} blocks` }
       }
       return collectLogs(chain, filter.fromBlock, end, filter)
     }
@@ -1312,7 +1312,10 @@ async function handleRpc(
     }
     case "eth_compileLLL":
     case "eth_compileSerpent":
-      throw new Error(`${payload.method} is not supported`)
+      // #132: -32601 method not found per JSON-RPC §5.1 (these were
+      // deprecated in geth long ago; clients should treat as "doesn't
+      // exist" rather than a generic internal failure).
+      throw { code: -32601, message: `${payload.method} is not supported` }
     case "eth_getBlockReceipts": {
       // #114: per-receipt shape must match eth_getTransactionReceipt exactly.
       // Pre-fix this returned a custom subset missing contractAddress,
@@ -2078,7 +2081,10 @@ async function handleRpc(
       return didProvider.getCredentialAnchor(credentialId)
     }
     default:
-      throw new Error("method not supported")
+      // #132: -32601 method not found per JSON-RPC §5.1. Pre-fix this
+      // surfaced as -32603 internal-error, which made unknown-method
+      // probes look like server-side faults to monitoring tools.
+      throw { code: -32601, message: `method not supported: ${payload.method}` }
   }
 }
 
@@ -2985,11 +2991,11 @@ async function queryLogs(chain: IChainEngine, query: Record<string, unknown>, re
 
   // Reject invalid range where fromBlock > toBlock
   if (fromBlock > toBlock) {
-    throw new Error(`invalid block range: fromBlock ${fromBlock} > toBlock ${toBlock}`)
+    throw { code: -32602, message: `invalid block range: fromBlock ${fromBlock} > toBlock ${toBlock}` }
   }
   // Enforce block range limit to prevent resource exhaustion
   if (toBlock - fromBlock > MAX_LOG_BLOCK_RANGE) {
-    throw new Error(`block range too large: max ${MAX_LOG_BLOCK_RANGE} blocks, got ${toBlock - fromBlock}`)
+    throw { code: -32602, message: `block range too large: max ${MAX_LOG_BLOCK_RANGE} blocks, got ${toBlock - fromBlock}` }
   }
 
   // Normalize address filter: single string or array of strings
@@ -3042,10 +3048,10 @@ async function queryTraceFilter(chain: IChainEngine, evm: EvmChain, query: Recor
   const fromBlock = parseBlockTag(query.fromBlock ?? "earliest", height, finalizedHeight)
   const toBlock = parseBlockTag(query.toBlock ?? "latest", height, finalizedHeight)
   if (fromBlock > toBlock) {
-    throw new Error(`invalid block range: fromBlock ${fromBlock} > toBlock ${toBlock}`)
+    throw { code: -32602, message: `invalid block range: fromBlock ${fromBlock} > toBlock ${toBlock}` }
   }
   if (toBlock - fromBlock > MAX_TRACE_BLOCK_RANGE) {
-    throw new Error(`trace block range too large: max ${MAX_TRACE_BLOCK_RANGE} blocks, got ${toBlock - fromBlock}`)
+    throw { code: -32602, message: `trace block range too large: max ${MAX_TRACE_BLOCK_RANGE} blocks, got ${toBlock - fromBlock}` }
   }
 
   const fromAddresses = normalizeTraceAddressFilter(query.fromAddress)


### PR DESCRIPTION
Closes #132.

Following #104, #128, #130, this sweep replaces the remaining `throw new Error(...)` sites in rpc.ts that surfaced as -32603 internal-error for what are actually client-input or method-shape failures.

## Fix

| Path | Old code | New code |
|---|---|---|
| filter-limit cap (×3) | -32603 `filter limit exceeded` | -32005 |
| oversized block range (eth_getLogs, eth_getFilterChanges, debug_traceBlock) | -32603 | -32602 |
| swapped block range (fromBlock > toBlock) | -32603 | -32602 |
| eth_compileLLL / eth_compileSerpent (legacy) | -32603 | -32601 |
| catch-all unknown method | -32603 | -32601 |

The dispatcher already passes structured throws verbatim, so this is just `throw new Error(...)` → `throw { code, message }`. Message strings unchanged for unknown-method (now `method not supported: <name>`).

## Test plan

- [x] `#132` test exercises eth_getLogs oversized + swapped ranges (-32602), `foo_bar_baz` (-32601), `eth_compileLLL` (-32601)
- [x] 58/58 rpc-extended + 124/124 rpc*.test.ts pass locally