### PR TITLE
fix(ipfs): expose real per-leaf chunk size in /api/v0/ls and DataSize in object/stat (#134)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -337,6 +337,65 @@ describe("IpfsHttpServer", () => {
     assert.ok(json.Hash)
     assert.equal(json.Size, String(payload.length))
   })
+
+  it("#134: /api/v0/ls returns per-leaf chunk size, sum equals file size", async () => {
+    // Upload via /api/v0/add so file-meta.json is populated (the
+    // UnixFsBuilder direct path used in other tests does not write
+    // file meta — only the HTTP add endpoint does). UnixFsBuilder
+    // chunks at 256 KiB; use 700 KB to get a multi-leaf file.
+    const totalSize = 700 * 1024
+    const content = Buffer.alloc(totalSize, 0x37)
+    const boundary = "----LsBoundary134"
+    const head = Buffer.from(
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="multi.bin"\r\n` +
+      "Content-Type: application/octet-stream\r\n\r\n",
+    )
+    const tail = Buffer.from(`\r\n--${boundary}--\r\n`)
+    const body = Buffer.concat([head, content, tail])
+    const addRes = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    assert.equal(addRes.status, 200)
+    const addJson = await addRes.json() as Record<string, string>
+    const cid = addJson.Hash
+    const res = await fetch(`/api/v0/ls?arg=${cid}`)
+    assert.equal(res.status, 200)
+    const lsJson = await res.json() as { Objects: Array<{ Links: Array<{ Name: string; Hash: string; Size: number; Type: number }> }> }
+    const links = lsJson.Objects[0].Links
+    assert.ok(links.length >= 2, `expected multi-chunk file but got ${links.length} leaves`)
+    const sumLeafBytes = links.reduce((acc, l) => acc + l.Size, 0)
+    assert.equal(sumLeafBytes, totalSize, `leaf size sum (${sumLeafBytes}) must equal file size (${totalSize})`)
+    for (const l of links) {
+      assert.ok(l.Size > 0, `leaf ${l.Name} has Size 0 — kubo-spec regression`)
+    }
+  })
+
+  it("#134: /api/v0/object/stat exposes DataSize (not hardcoded 0)", async () => {
+    const totalSize = 5000
+    const content = Buffer.alloc(totalSize, 0x42)
+    const boundary = "----StatBoundary134"
+    const head = Buffer.from(
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="statme.bin"\r\n` +
+      "Content-Type: application/octet-stream\r\n\r\n",
+    )
+    const tail = Buffer.from(`\r\n--${boundary}--\r\n`)
+    const body = Buffer.concat([head, content, tail])
+    const addRes = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    const addJson = await addRes.json() as Record<string, string>
+    const res = await fetch(`/api/v0/object/stat?arg=${addJson.Hash}`)
+    assert.equal(res.status, 200)
+    const statBody = await res.json() as Record<string, number>
+    assert.equal(statBody.DataSize, totalSize, `DataSize must reflect actual user data, got ${statBody.DataSize}`)
+    assert.equal(statBody.CumulativeSize, totalSize, "CumulativeSize must equal file size")
+  })
 })
 
 // Phase Q.4 — Reed-Solomon erasure coding integration tests.

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -488,6 +488,16 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: "file not found" }))
       return
     }
+    // #134: kubo's /api/v0/ls Size field is the cumulative byte size
+    // of the linked DAG. For terminal leaves that's the chunk's data
+    // size, derivable from file.blockSize without extra block IO:
+    //   leaves[0..n-1) each have `blockSize` bytes
+    //   leaves[n-1] (last) has the remainder: size - blockSize*(n-1)
+    // Pre-fix every leaf was hardcoded Size:0, breaking kubo client
+    // progress accounting and Pinata/Web3.storage SDK size summation.
+    const totalSize = file.size
+    const chunkSize = file.blockSize
+    const leafCount = file.leaves.length
     res.writeHead(200, { "content-type": "application/json" })
     res.end(JSON.stringify({
       Objects: [
@@ -496,7 +506,9 @@ export class IpfsHttpServer {
           Links: file.leaves.map((leaf, index) => ({
             Name: String(index),
             Hash: leaf,
-            Size: 0,
+            Size: leafCount > 0 && index === leafCount - 1
+              ? totalSize - chunkSize * (leafCount - 1)
+              : chunkSize,
             Type: 2,
           })),
         }
@@ -513,13 +525,20 @@ export class IpfsHttpServer {
     const block = await this.store.get(cid)
     const meta = await this.readFileMeta()
     const file = meta[cid]
+    // #134: DataSize and LinksSize were hardcoded to 0. For UnixFS
+    // files, DataSize is the user-data byte count exposed by `ls`;
+    // LinksSize is a rough estimate of CID-reference bytes. The
+    // important field for clients summing file sizes is DataSize.
+    const numLinks = file?.leaves.length ?? 0
+    const linksSize = numLinks > 0 ? Math.min(numLinks * 36, block.bytes.length) : 0
+    const dataSize = file?.size ?? Math.max(block.bytes.length - linksSize, 0)
     res.writeHead(200, { "content-type": "application/json" })
     res.end(JSON.stringify({
       Hash: cid,
-      NumLinks: file?.leaves.length ?? 0,
+      NumLinks: numLinks,
       BlockSize: block.bytes.length,
-      LinksSize: 0,
-      DataSize: 0,
+      LinksSize: linksSize,
+      DataSize: dataSize,
       CumulativeSize: file?.size ?? block.bytes.length,
     }))
   }


### PR DESCRIPTION
Closes #134.

Probed the live testnet — `/api/v0/ls` returns `Size: 0` for every leaf link. Per kubo's spec the Size field is the cumulative byte size of the linked DAG; for terminal leaves that's the chunk's data bytes.

## Impact

- `ipfs-http-client.ls()` returns 0 for every chunk → progress reporting / size summation breaks
- Pinata / Web3.storage SDKs that sum link sizes see total=0
- Wallet/extension file pre-download size estimates show "0 bytes"

## Fix

`handleLs` derives per-leaf size from `UnixFsFileMeta.size + blockSize` (no extra block IO):
- leaves[0..n-1) each have `blockSize`
- leaves[n-1] has the remainder: `size - blockSize*(n-1)`

`handleObjectStat` now exposes `DataSize = file.size` and a rough `LinksSize` estimate.

## Test plan

- [x] Multi-chunk upload (700KB → 3 leaves) — sum of leaf Sizes must equal file size, no leaf may be 0
- [x] 5KB upload — `object/stat.DataSize` must equal 5000
- [x] 38/38 ipfs-http + 183/183 all-ipfs tests pass locally