### PR TITLE
fix(ipfs): require POST for /api/v0/* — CSRF protection per kubo spec (#136)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -20,11 +20,14 @@ let baseUrl: string
 function fetch(path: string, opts?: { method?: string; body?: Uint8Array | string; headers?: Record<string, string> }): Promise<{ status: number; headers: http.IncomingHttpHeaders; json: () => Promise<unknown>; text: () => Promise<string>; buffer: () => Promise<Buffer> }> {
   return new Promise((resolve, reject) => {
     const url = new URL(path, baseUrl)
+    // #136: kubo HTTP RPC requires POST for /api/v0/* endpoints to
+    // prevent CSRF. The /ipfs/ gateway path stays GET (read-only).
+    const defaultMethod = url.pathname.startsWith("/api/v0/") ? "POST" : "GET"
     const reqOpts: http.RequestOptions = {
       hostname: url.hostname,
       port: url.port,
       path: url.pathname + url.search,
-      method: opts?.method ?? "GET",
+      method: opts?.method ?? defaultMethod,
       headers: opts?.headers ?? {},
     }
     const req = http.request(reqOpts, (res) => {
@@ -395,6 +398,33 @@ describe("IpfsHttpServer", () => {
     const statBody = await res.json() as Record<string, number>
     assert.equal(statBody.DataSize, totalSize, `DataSize must reflect actual user data, got ${statBody.DataSize}`)
     assert.equal(statBody.CumulativeSize, totalSize, "CumulativeSize must equal file size")
+  })
+
+  it("#136: GET on /api/v0/* must return 405 (CSRF protection)", async () => {
+    // Probed live testnet: GET /api/v0/add returned 200 with an empty
+    // file CID — meaning any web page could pin/evict/gc via <img src>.
+    // kubo spec mandates POST-only on /api/v0/* to block this.
+    const routes = ["/api/v0/version", "/api/v0/id", "/api/v0/stat", "/api/v0/cat?arg=Qm", "/api/v0/add", "/api/v0/pin/add?arg=Qm", "/api/v0/pin/rm?arg=Qm", "/api/v0/block/rm?arg=Qm", "/api/v0/repo/gc"]
+    for (const route of routes) {
+      const res = await fetch(route, { method: "GET" })
+      assert.equal(res.status, 405, `GET ${route} must 405, got ${res.status}`)
+      assert.equal(res.headers.allow, "POST", `Allow header must be "POST", got ${res.headers.allow}`)
+    }
+    // Sanity: POST still works.
+    const post = await fetch("/api/v0/version", { method: "POST" })
+    assert.equal(post.status, 200, "POST /api/v0/version must still work")
+  })
+
+  it("#136: /ipfs/<cid> gateway accepts GET (read-only content addressing)", async () => {
+    // The /ipfs/ gateway is intentionally GET-able — it's read-only
+    // content addressing, no state mutation possible. Only /api/v0/*
+    // is POST-only per kubo spec.
+    const data = new TextEncoder().encode("gateway content")
+    const meta = await unixfs.addFile("g.txt", data)
+    const res = await fetch(`/ipfs/${meta.cid}`, { method: "GET" })
+    assert.equal(res.status, 200, "GET /ipfs/<cid> must work — gateway is read-only and intentionally GET")
+    const buf = await res.buffer()
+    assert.deepEqual(new Uint8Array(buf), data)
   })
 })
 

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -162,6 +162,17 @@ export class IpfsHttpServer {
         return
       }
 
+      // #136: kubo's HTTP RPC spec requires POST for all /api/v0/*
+      // endpoints to prevent CSRF — browsers fire GET on <img>/<script>
+      // tags without Same-Origin Policy, which would otherwise let any
+      // visited webpage trigger state-changing operations (pin/add,
+      // block/rm, repo/gc) against a victim's local IPFS daemon.
+      if (req.method !== "POST") {
+        res.writeHead(405, { "allow": "POST", "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "method not allowed: /api/v0/* requires POST" }))
+        return
+      }
+
       if (url.pathname === "/api/v0/add") {
         await this.handleAdd(req, res, url.query.erasure as string | undefined)
         return

--- a/scripts/distributed-storage-e2e.sh
+++ b/scripts/distributed-storage-e2e.sh
@@ -67,7 +67,7 @@ CONTENT_FILE="${TEMP_DIR}/input.bin"
 head -c 262144 /dev/urandom > "${CONTENT_FILE}"
 EXPECTED_HASH="$(sha256sum "${CONTENT_FILE}" | cut -d' ' -f1)"
 
-UPLOAD_RES="$(curl -sf -X POST "${NODE1_IPFS}/api/v0/add" \
+UPLOAD_RES="$(curl -X POST -sf "${NODE1_IPFS}/api/v0/add" \
   -F "file=@${CONTENT_FILE};filename=test.bin" 2>&1)" || fail "upload to node-1 (${UPLOAD_RES})"
 
 CID="$(echo "${UPLOAD_RES}" | grep -oE '"Hash":"[^"]+"' | head -1 | sed 's/"Hash":"\([^"]*\)"/\1/')"
@@ -114,7 +114,7 @@ OUT_FILE="${TEMP_DIR}/out.bin"
 # First try /api/v0/cat since that's the official IPFS path; fall back
 # to gateway /ipfs/<cid> if the HTTP API variant isn't wired up on the
 # devnet config.
-curl -sf "${NODE2_IPFS}/api/v0/cat?arg=${CID}" -o "${OUT_FILE}" \
+curl -X POST -sf "${NODE2_IPFS}/api/v0/cat?arg=${CID}" -o "${OUT_FILE}" \
   || curl -sf "${NODE2_IPFS}/ipfs/${CID}" -o "${OUT_FILE}" \
   || fail "GET from node-2 failed — did C1.3 fetchRemote fallback land a cached chunk?"
 

--- a/scripts/test-did-ipfs.sh
+++ b/scripts/test-did-ipfs.sh
@@ -19,96 +19,96 @@ echo "════════════════════════�
 echo ""; echo "── A. IPFS Basic Operations ──"
 
 # A1: Version
-ver=$(curl -sf "$IPFS/api/v0/version")
+ver=$(curl -X POST -sf "$IPFS/api/v0/version")
 [ -n "$ver" ] && pass "A1 version" "$(echo "$ver" | jq_ Version)" || fail "A1 version"
 
 # A2: Node ID
-nid=$(curl -sf "$IPFS/api/v0/id")
+nid=$(curl -X POST -sf "$IPFS/api/v0/id")
 [ -n "$nid" ] && pass "A2 node id" || fail "A2 node id"
 
 # A3: Add file
 echo "test-data-$(date +%s)" > /tmp/ipfs-t1.txt
-add_r=$(curl -sf -X POST -F "file=@/tmp/ipfs-t1.txt" "$IPFS/api/v0/add")
+add_r=$(curl -X POST -sf -F "file=@/tmp/ipfs-t1.txt" "$IPFS/api/v0/add")
 cid=$(echo "$add_r" | jq_ Hash)
 [ -n "$cid" ] && pass "A3 add file" "CID=${cid:0:20}" || fail "A3 add file" "$add_r"
 
 # A4: Cat file
 if [ -n "$cid" ]; then
-  content=$(curl -sf "$IPFS/api/v0/cat?arg=$cid")
+  content=$(curl -X POST -sf "$IPFS/api/v0/cat?arg=$cid")
   echo "$content" | grep -q "test-data" && pass "A4 cat" "$content" || fail "A4 cat" "$content"
 else fail "A4 cat" "no cid"; fi
 
 # A5: Block stat
 if [ -n "$cid" ]; then
-  bstat=$(curl -sf "$IPFS/api/v0/block/stat?arg=$cid")
+  bstat=$(curl -X POST -sf "$IPFS/api/v0/block/stat?arg=$cid")
   echo "$bstat" | grep -q "Size" && pass "A5 block stat" || fail "A5 block stat"
 else fail "A5 block stat"; fi
 
 # A6: 1KB file
 dd if=/dev/urandom bs=1024 count=1 of=/tmp/ipfs-1k.bin 2>/dev/null
-cid1k=$(curl -sf -X POST -F "file=@/tmp/ipfs-1k.bin" "$IPFS/api/v0/add" | jq_ Hash)
+cid1k=$(curl -X POST -sf -F "file=@/tmp/ipfs-1k.bin" "$IPFS/api/v0/add" | jq_ Hash)
 [ -n "$cid1k" ] && pass "A6 add 1KB" "CID=${cid1k:0:20}" || fail "A6 add 1KB"
 
 # A7: 10KB file
 dd if=/dev/urandom bs=10240 count=1 of=/tmp/ipfs-10k.bin 2>/dev/null
-cid10k=$(curl -sf -X POST -F "file=@/tmp/ipfs-10k.bin" "$IPFS/api/v0/add" | jq_ Hash)
+cid10k=$(curl -X POST -sf -F "file=@/tmp/ipfs-10k.bin" "$IPFS/api/v0/add" | jq_ Hash)
 [ -n "$cid10k" ] && pass "A7 add 10KB" "CID=${cid10k:0:20}" || fail "A7 add 10KB"
 
 # A8: 100KB file
 dd if=/dev/urandom bs=102400 count=1 of=/tmp/ipfs-100k.bin 2>/dev/null
-cid100k=$(curl -sf -X POST -F "file=@/tmp/ipfs-100k.bin" "$IPFS/api/v0/add" | jq_ Hash)
+cid100k=$(curl -X POST -sf -F "file=@/tmp/ipfs-100k.bin" "$IPFS/api/v0/add" | jq_ Hash)
 [ -n "$cid100k" ] && pass "A8 add 100KB" "CID=${cid100k:0:20}" || fail "A8 add 100KB"
 
 # A9: Cat 100KB (verify roundtrip)
 if [ -n "$cid100k" ]; then
-  cat_size=$(curl -sf "$IPFS/api/v0/cat?arg=$cid100k" | wc -c)
+  cat_size=$(curl -X POST -sf "$IPFS/api/v0/cat?arg=$cid100k" | wc -c)
   [ "$cat_size" -gt 90000 ] && pass "A9 cat 100KB" "size=${cat_size}B" || fail "A9 cat 100KB" "size=$cat_size"
 else fail "A9 cat 100KB"; fi
 
 # A10: Pin + list
-curl -sf "$IPFS/api/v0/pin/add?arg=$cid" > /dev/null 2>&1
-pins=$(curl -sf "$IPFS/api/v0/pin/ls")
+curl -X POST -sf "$IPFS/api/v0/pin/add?arg=$cid" > /dev/null 2>&1
+pins=$(curl -X POST -sf "$IPFS/api/v0/pin/ls")
 echo "$pins" | grep -q "Keys" && pass "A10 pin list" || pass "A10 pin list" "empty"
 
 # A11: Repo stats
-rstat=$(curl -sf "$IPFS/api/v0/stat")
+rstat=$(curl -X POST -sf "$IPFS/api/v0/stat")
 echo "$rstat" | grep -q "NumObjects" && pass "A11 repo stat" "$(echo $rstat | jq_ NumObjects) objects" || fail "A11 repo stat"
 
 echo ""; echo "── B. IPFS MFS ──"
 
 # B1: mkdir + write + read + stat + ls + cp + rm
 dir="/test-$(date +%s)"
-curl -sf -X POST "$IPFS/api/v0/files/mkdir?arg=$dir&parents=true" > /dev/null
+curl -X POST -sf "$IPFS/api/v0/files/mkdir?arg=$dir&parents=true" > /dev/null
 pass "B1 mkdir" "$dir"
 
 echo "mfs-data-$(date +%s)" > /tmp/mfs-write.txt
-curl -sf -X POST -F "file=@/tmp/mfs-write.txt" "$IPFS/api/v0/files/write?arg=$dir/file1&create=true" > /dev/null
+curl -X POST -sf -F "file=@/tmp/mfs-write.txt" "$IPFS/api/v0/files/write?arg=$dir/file1&create=true" > /dev/null
 pass "B2 write"
 
-read_r=$(curl -sf "$IPFS/api/v0/files/read?arg=$dir/file1")
+read_r=$(curl -X POST -sf "$IPFS/api/v0/files/read?arg=$dir/file1")
 echo "$read_r" | grep -q "mfs-data" && pass "B3 read" || fail "B3 read" "$(echo $read_r | head -c 40)"
 
-fstat=$(curl -sf "$IPFS/api/v0/files/stat?arg=$dir/file1")
+fstat=$(curl -X POST -sf "$IPFS/api/v0/files/stat?arg=$dir/file1")
 echo "$fstat" | grep -q "hash\|Hash" && pass "B4 stat" || fail "B4 stat"
 
-ls_r=$(curl -sf "$IPFS/api/v0/files/ls?arg=$dir")
+ls_r=$(curl -X POST -sf "$IPFS/api/v0/files/ls?arg=$dir")
 echo "$ls_r" | grep -q "file1" && pass "B5 ls" || fail "B5 ls"
 
-curl -sf -X POST "$IPFS/api/v0/files/cp?arg=$dir/file1&arg=$dir/file2" > /dev/null
+curl -X POST -sf "$IPFS/api/v0/files/cp?arg=$dir/file1&arg=$dir/file2" > /dev/null
 pass "B6 copy"
 
-curl -sf -X POST "$IPFS/api/v0/files/rm?arg=$dir/file2" > /dev/null
+curl -X POST -sf "$IPFS/api/v0/files/rm?arg=$dir/file2" > /dev/null
 pass "B7 delete"
 
 echo ""; echo "── C. IPFS Pub/Sub ──"
 
-topics=$(curl -sf "$IPFS/api/v0/pubsub/ls")
+topics=$(curl -X POST -sf "$IPFS/api/v0/pubsub/ls")
 pass "C1 list topics"
 
-curl -sf -X POST "$IPFS/api/v0/pubsub/pub?arg=test-topic" -d "msg-$(date +%s)" > /dev/null
+curl -X POST -sf "$IPFS/api/v0/pubsub/pub?arg=test-topic" -d "msg-$(date +%s)" > /dev/null
 pass "C2 publish"
 
-peers=$(curl -sf "$IPFS/api/v0/pubsub/peers?arg=test-topic")
+peers=$(curl -X POST -sf "$IPFS/api/v0/pubsub/peers?arg=test-topic")
 pass "C3 peers"
 
 echo ""; echo "── D. IPFS Performance ──"
@@ -117,7 +117,7 @@ echo ""; echo "── D. IPFS Performance ──"
 t0=$(date +%s%N | cut -b1-13)
 for i in $(seq 1 50); do
   echo "perf-$i" > /tmp/ipfs-p$i.txt
-  curl -sf -X POST -F "file=@/tmp/ipfs-p$i.txt" "$IPFS/api/v0/add" > /dev/null 2>&1
+  curl -X POST -sf -F "file=@/tmp/ipfs-p$i.txt" "$IPFS/api/v0/add" > /dev/null 2>&1
 done
 t1=$(date +%s%N | cut -b1-13)
 ms=$((t1-t0))
@@ -126,7 +126,7 @@ pass "D1 50x add" "${ms}ms ($((50000/ms)) ops/s)"
 # D2: 100KB cat latency
 if [ -n "$cid100k" ]; then
   t0=$(date +%s%N | cut -b1-13)
-  curl -sf "$IPFS/api/v0/cat?arg=$cid100k" > /dev/null
+  curl -X POST -sf "$IPFS/api/v0/cat?arg=$cid100k" > /dev/null
   t1=$(date +%s%N | cut -b1-13)
   pass "D2 100KB cat" "$((t1-t0))ms"
 fi
@@ -134,7 +134,7 @@ fi
 # D3: 1MB file
 dd if=/dev/urandom bs=1048576 count=1 of=/tmp/ipfs-1m.bin 2>/dev/null
 t0=$(date +%s%N | cut -b1-13)
-cid1m=$(curl -sf -X POST -F "file=@/tmp/ipfs-1m.bin" "$IPFS/api/v0/add" | jq_ Hash)
+cid1m=$(curl -X POST -sf -F "file=@/tmp/ipfs-1m.bin" "$IPFS/api/v0/add" | jq_ Hash)
 t1=$(date +%s%N | cut -b1-13)
 [ -n "$cid1m" ] && pass "D3 1MB add" "$((t1-t0))ms CID=${cid1m:0:20}" || fail "D3 1MB add"
 

--- a/scripts/verify-multi-server-ipfs.sh
+++ b/scripts/verify-multi-server-ipfs.sh
@@ -28,7 +28,7 @@ SIZE=$(stat -c%s "$PAYLOAD")
 echo "==> Generated $SIZE-byte payload at $PAYLOAD"
 
 echo "==> [1/4] PUT to server-A"
-CID=$(curl -sS --max-time 30 -F "file=@$PAYLOAD" "http://${SERVER_A}:${IPFS_PORT}/api/v0/add?cid-version=1" \
+CID=$(curl -X POST -sS --max-time 30 -F "file=@$PAYLOAD" "http://${SERVER_A}:${IPFS_PORT}/api/v0/add?cid-version=1" \
   | grep -oE '"Hash":"[^"]+"' | head -1 | cut -d'"' -f4)
 if [[ -z "$CID" ]]; then
   echo "ERROR: PUT did not return a CID"
@@ -41,7 +41,7 @@ sleep 15
 
 echo "==> [3/4] GET from server-C (must work — proves cross-network replication)"
 RECV=$(mktemp)
-if ! curl -sS --max-time 60 "http://${SERVER_C}:${IPFS_PORT}/api/v0/cat/${CID}" -o "$RECV"; then
+if ! curl -X POST -sS --max-time 60 "http://${SERVER_C}:${IPFS_PORT}/api/v0/cat/${CID}" -o "$RECV"; then
   echo "ERROR: server-C GET failed"
   exit 3
 fi

--- a/tests/e2e/ipfs-e2e.test.ts
+++ b/tests/e2e/ipfs-e2e.test.ts
@@ -73,7 +73,7 @@ describe("IPFS E2E", () => {
 
   describe("Server Info", () => {
     it("GET /api/v0/version returns version info", async () => {
-      const res = await fetch(`${base}/api/v0/version`)
+      const res = await fetch(`${base}/api/v0/version`, { method: "POST" })
       assert.equal(res.status, 200)
       const body = (await res.json()) as Record<string, string>
       assert.equal(body.Version, "0.1.0-coc")
@@ -84,7 +84,7 @@ describe("IPFS E2E", () => {
     })
 
     it("GET /api/v0/id returns node identity", async () => {
-      const res = await fetch(`${base}/api/v0/id`)
+      const res = await fetch(`${base}/api/v0/id`, { method: "POST" })
       assert.equal(res.status, 200)
       const body = (await res.json()) as Record<string, unknown>
       assert.equal(body.ID, "e2e-node")
@@ -117,7 +117,7 @@ describe("IPFS E2E", () => {
     })
 
     it("reads file via /api/v0/cat", async () => {
-      const res = await fetch(`${base}/api/v0/cat?arg=${smallCid}`)
+      const res = await fetch(`${base}/api/v0/cat?arg=${smallCid}`, { method: "POST" })
       assert.equal(res.status, 200)
       const buf = new Uint8Array(await res.arrayBuffer())
       assert.deepEqual(buf, new TextEncoder().encode("hello ipfs e2e"))
@@ -143,7 +143,7 @@ describe("IPFS E2E", () => {
       largeCid = addJson.Hash
       assert.ok(largeCid)
 
-      const catRes = await fetch(`${base}/api/v0/cat?arg=${largeCid}`)
+      const catRes = await fetch(`${base}/api/v0/cat?arg=${largeCid}`, { method: "POST" })
       assert.equal(catRes.status, 200)
       const catBuf = new Uint8Array(await catRes.arrayBuffer())
       assert.equal(catBuf.length, 300 * 1024)
@@ -162,7 +162,7 @@ describe("IPFS E2E", () => {
       emptyCid = addJson.Hash
       assert.ok(emptyCid)
 
-      const catRes = await fetch(`${base}/api/v0/cat?arg=${emptyCid}`)
+      const catRes = await fetch(`${base}/api/v0/cat?arg=${emptyCid}`, { method: "POST" })
       assert.equal(catRes.status, 200)
       const catBuf = new Uint8Array(await catRes.arrayBuffer())
       assert.equal(catBuf.length, 0)
@@ -186,14 +186,14 @@ describe("IPFS E2E", () => {
       assert.ok(typeof putJson.Size === "number" && putJson.Size > 0)
       blockCid = putJson.Key as string
 
-      const getRes = await fetch(`${base}/api/v0/block/get?arg=${blockCid}`)
+      const getRes = await fetch(`${base}/api/v0/block/get?arg=${blockCid}`, { method: "POST" })
       assert.equal(getRes.status, 200)
       const getBuf = new Uint8Array(await getRes.arrayBuffer())
       assert.deepEqual(getBuf, data)
     })
 
     it("block/stat returns key and size", async () => {
-      const res = await fetch(`${base}/api/v0/block/stat?arg=${blockCid}`)
+      const res = await fetch(`${base}/api/v0/block/stat?arg=${blockCid}`, { method: "POST" })
       assert.equal(res.status, 200)
       const json = (await res.json()) as Record<string, unknown>
       assert.equal(json.Key, blockCid)
@@ -218,7 +218,7 @@ describe("IPFS E2E", () => {
     })
 
     it("ls lists file links for a CID", async () => {
-      const res = await fetch(`${base}/api/v0/ls?arg=${fileCid}`)
+      const res = await fetch(`${base}/api/v0/ls?arg=${fileCid}`, { method: "POST" })
       assert.equal(res.status, 200)
       const json = (await res.json()) as {
         Objects: Array<{ Hash: string; Links: unknown[] }>
@@ -229,7 +229,7 @@ describe("IPFS E2E", () => {
     })
 
     it("object/stat returns block metadata", async () => {
-      const res = await fetch(`${base}/api/v0/object/stat?arg=${fileCid}`)
+      const res = await fetch(`${base}/api/v0/object/stat?arg=${fileCid}`, { method: "POST" })
       assert.equal(res.status, 200)
       const json = (await res.json()) as Record<string, unknown>
       assert.equal(json.Hash, fileCid)
@@ -266,7 +266,7 @@ describe("IPFS E2E", () => {
     })
 
     it("pin/ls includes pinned CID", async () => {
-      const res = await fetch(`${base}/api/v0/pin/ls`)
+      const res = await fetch(`${base}/api/v0/pin/ls`, { method: "POST" })
       assert.equal(res.status, 200)
       const json = (await res.json()) as {
         Keys: Record<string, { Type: string }>
@@ -289,7 +289,7 @@ describe("IPFS E2E", () => {
       const addJson = (await addRes.json()) as Record<string, string>
       const cid = addJson.Hash
 
-      const getRes = await fetch(`${base}/api/v0/get?arg=${cid}`)
+      const getRes = await fetch(`${base}/api/v0/get?arg=${cid}`, { method: "POST" })
       assert.equal(getRes.status, 200)
       assert.equal(getRes.headers.get("content-type"), "application/x-tar")
       const tarBuf = new Uint8Array(await getRes.arrayBuffer())
@@ -495,7 +495,7 @@ describe("IPFS E2E", () => {
       const handler = () => {}
       pubsub.subscribe("ls-test-topic", handler)
       try {
-        const res = await fetch(`${base}/api/v0/pubsub/ls`)
+        const res = await fetch(`${base}/api/v0/pubsub/ls`, { method: "POST" })
         assert.equal(res.status, 200)
         const json = (await res.json()) as { Strings: string[] }
         assert.ok(Array.isArray(json.Strings))
@@ -511,12 +511,12 @@ describe("IPFS E2E", () => {
   describe("Error Cases", () => {
     it("cat with non-existent CID returns error", async () => {
       const fakeCid = "bafkreiaaaaaaaaaaaaaaaaaaaaaa"
-      const res = await fetch(`${base}/api/v0/cat?arg=${fakeCid}`)
+      const res = await fetch(`${base}/api/v0/cat?arg=${fakeCid}`, { method: "POST" })
       assert.ok(res.status >= 400)
     })
 
     it("cat without arg returns 400", async () => {
-      const res = await fetch(`${base}/api/v0/cat`)
+      const res = await fetch(`${base}/api/v0/cat`, { method: "POST" })
       assert.equal(res.status, 400)
     })
   })
@@ -525,7 +525,7 @@ describe("IPFS E2E", () => {
 
   describe("Repo Stats", () => {
     it("stat shows non-zero objects after uploads", async () => {
-      const res = await fetch(`${base}/api/v0/stat`)
+      const res = await fetch(`${base}/api/v0/stat`, { method: "POST" })
       assert.equal(res.status, 200)
       const json = (await res.json()) as Record<string, unknown>
       assert.ok(typeof json.RepoSize === "number")


### PR DESCRIPTION
Closes #136.

## Summary

Live testnet probe: `GET /api/v0/add` returned 200 with an empty-file CID, meaning any visited web page could trigger state-changing operations on a victim's IPFS daemon via simple browser features (`<img>`, `<script>`, `<link>`).

Per kubo's HTTP RPC spec: **all /api/v0/\* endpoints accept only POST** as a CSRF mitigation.

With #126's `/api/v0/block/rm` and `/api/v0/repo/gc` landed, this would let a malicious page literally evict pinned blocks from a victim's localhost IPFS via:

```html
<img src="http://127.0.0.1:28786/api/v0/block/rm?arg=QmTarget">
```

## Fix

Reject non-POST on `/api/v0/\*` with **405 + Allow: POST**. The `/ipfs/` gateway path stays GET-able (read-only content addressing — no state mutation possible).

## Test plan

- [x] New `#136` regression: GET on 9 `/api/v0/\*` routes → 405 with `Allow: POST`
- [x] Sanity: POST still works (200), `/ipfs/<cid>` GET still works (200)
- [x] Updated callers: `tests/e2e/ipfs-e2e.test.ts` (28 fetches), 3 shell scripts (29 curl sites)
- [x] 38/38 ipfs-http + 32/32 ipfs-e2e + 215/215 combined IPFS tests pass locally