### PR TITLE
fix(rpc): JSON-RPC §5.1 codes for parse-error / empty-body / invalid-request (#138)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -867,6 +867,42 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(compileLllJson.error!.code, -32601, `eth_compileLLL must be -32601`)
   })
 
+  await t.test("#138: JSON-RPC §5.1 spec codes for parse-error / empty-body / invalid-request", async () => {
+    // Probed live testnet — each of these returned -32603 (internal error)
+    // pre-fix. The parse path additionally leaked the raw V8 JSON.parse
+    // message ("Expected property name or '}' in JSON at position 1...").
+
+    // (a) Malformed JSON body → -32700 Parse error
+    const parseErr = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not valid json",
+    })
+    const parseJson = await parseErr.json() as { error?: { code: number; message: string } }
+    assert.equal(parseJson.error!.code, -32700, `malformed JSON must be -32700, got ${parseJson.error!.code}`)
+    assert.match(parseJson.error!.message, /parse error/i)
+    // Crucially, the V8 internal phrasing must NOT leak.
+    assert.doesNotMatch(parseJson.error!.message, /position \d+|line \d+ column/i, "V8 JSON.parse internals must not leak")
+
+    // (b) Empty body → -32600 Invalid Request
+    const emptyErr = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "",
+    })
+    const emptyJson = await emptyErr.json() as { error?: { code: number; message: string } }
+    assert.equal(emptyJson.error!.code, -32600, `empty body must be -32600, got ${emptyJson.error!.code}`)
+
+    // (c) String payload (valid JSON, invalid request) → -32600 with code field
+    const strPayload = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '"just a string"',
+    })
+    const strJson = await strPayload.json() as { error?: { code: number; message: string } }
+    assert.equal(strJson.error!.code, -32600, `string-payload must include code -32600, got ${strJson.error?.code}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -337,10 +337,21 @@ export function startRpcServer(
       if (aborted) return
       try {
         if (!body || body.trim().length === 0) {
-          return sendError(res, null, "empty request")
+          // #138: empty body is "Invalid Request" per JSON-RPC §5.1.
+          // Pre-fix this fell through to -32603 internal error.
+          return sendError(res, null, "empty request", -32600)
         }
 
-        const payload = JSON.parse(body)
+        let payload: JsonRpcRequest | JsonRpcRequest[]
+        try {
+          payload = JSON.parse(body)
+        } catch {
+          // #138: malformed JSON is "Parse error" -32700 per §5.1.
+          // Pre-fix the V8 JSON.parse message ("Expected property name
+          // or '}' in JSON at position 1...") leaked through as -32603,
+          // coupling clients to internal Node phrasing.
+          return sendError(res, null, "parse error: invalid JSON", -32700)
+        }
         const rpcOpts: Record<string, unknown> = {}
         if (rpcAuthOptions?.enableAdminRpc) {
           rpcOpts.enableAdminRpc = true
@@ -435,7 +446,10 @@ async function handleOne(
   opts?: Record<string, unknown>,
 ): Promise<JsonRpcResponse> {
   if (!payload || typeof payload !== "object" || !payload.method) {
-    return { jsonrpc: "2.0", id: payload?.id ?? null, error: { message: "invalid request" } }
+    // #138: per JSON-RPC §5.1 invalid-request must carry code -32600.
+    // Pre-fix this returned only { message }, which clients couldn't
+    // distinguish from a malformed response.
+    return { jsonrpc: "2.0", id: payload?.id ?? null, error: { code: -32600, message: "invalid request" } }
   }
 
   try {


### PR DESCRIPTION
Closes #138.

Live testnet probe found three §5.1 spec violations on the JSON-RPC layer:

| Input | Pre-fix | Spec |
|---|---|---|
| Malformed JSON body | -32603 + raw V8 message (`"Expected property name or '}' in JSON at position 1..."`) | -32700 Parse error |
| Empty body | -32603 `"empty request"` | -32600 Invalid Request |
| Non-object payload | `{error:{message}}` no `code` field | -32600 with code |

The parse path was also leaking V8 internals (position/column phrasing) that change across Node versions and break clients that pattern-match.

## Fix

- Wrap JSON.parse in its own try/catch → -32700 with generic `"parse error: invalid JSON"`
- Pass -32600 explicitly to sendError for empty body
- Add `code: -32600` to handleOne's invalid-request return

## Test plan

- [x] `#138` test exercises all three paths, asserts the V8 `position N / line N column M` phrasing does NOT appear in the response
- [x] 125/125 rpc tests pass locally