### PR TITLE
fix(rpc): JSON-RPC 2.0 §4.1 notifications get no response; §6 empty batch errors (#140)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -903,6 +903,55 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(strJson.error!.code, -32600, `string-payload must include code -32600, got ${strJson.error?.code}`)
   })
 
+  await t.test("#140: JSON-RPC 2.0 §4.1 notifications get no response; §6 empty batch errors", async () => {
+    // (a) Single notification (no `id` field) → HTTP 204 no-body
+    const notify = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", params: [] }),
+    })
+    assert.equal(notify.status, 204, `notification must HTTP 204 no-body, got ${notify.status}`)
+    const notifyBody = await notify.text()
+    assert.equal(notifyBody, "", "notification body must be empty")
+
+    // (b) Empty batch [] → single Invalid Request -32600 (not [])
+    const emptyBatch = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "[]",
+    })
+    assert.equal(emptyBatch.status, 200)
+    const emptyJson = await emptyBatch.json() as { error?: { code: number; message: string } } | unknown[]
+    assert.ok(!Array.isArray(emptyJson), "empty batch must return single object, not []")
+    assert.equal((emptyJson as { error: { code: number } }).error.code, -32600, "empty batch error must be -32600")
+
+    // (c) Batch of all notifications → 204 no-body
+    const batchNotify = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "eth_chainId", params: [] },
+        { jsonrpc: "2.0", method: "eth_blockNumber", params: [] },
+      ]),
+    })
+    assert.equal(batchNotify.status, 204, `batch of notifications must HTTP 204, got ${batchNotify.status}`)
+
+    // (d) Mixed batch (1 notification + 1 request) → array with only the request's response
+    const mixed = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "eth_chainId", params: [] }, // notification (no id)
+        { jsonrpc: "2.0", id: 42, method: "eth_blockNumber", params: [] },
+      ]),
+    })
+    assert.equal(mixed.status, 200)
+    const mixedJson = await mixed.json() as Array<{ id: number; result: string }>
+    assert.ok(Array.isArray(mixedJson))
+    assert.equal(mixedJson.length, 1, "notification must be filtered out, leaving only the request's response")
+    assert.equal(mixedJson[0].id, 42)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -415,14 +415,48 @@ export function startRpcServer(
             }
           }
         }
+        // #140: §6 says an empty batch must return a single Invalid
+        // Request error (NOT an empty array).
+        if (Array.isArray(payload) && payload.length === 0) {
+          if (!res.headersSent) {
+            res.writeHead(200, { "content-type": "application/json" })
+          }
+          res.end(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: empty batch" } }))
+          return
+        }
+
         const response = Array.isArray(payload)
           ? await Promise.all(payload.slice(0, MAX_BATCH_SIZE).map((item) => handleOne(item, chainId, evm, chain, p2p, filters, bftCoordinator, scopedOpts)))
           : await handleOne(payload, chainId, evm, chain, p2p, filters, bftCoordinator, scopedOpts)
 
+        // #140: §4.1 server MUST NOT reply to notifications (requests
+        // without "id"). handleOne returns null for notifications;
+        // strip nulls here. If everything was a notification (single
+        // or batch), respond with HTTP 204 no-body.
+        if (response === null) {
+          if (!res.headersSent) {
+            res.writeHead(204)
+          }
+          res.end()
+          return
+        }
+        let finalResponse: unknown = response
+        if (Array.isArray(response)) {
+          const filtered = response.filter((r) => r !== null)
+          if (filtered.length === 0) {
+            if (!res.headersSent) {
+              res.writeHead(204)
+            }
+            res.end()
+            return
+          }
+          finalResponse = filtered
+        }
+
         if (!res.headersSent) {
           res.writeHead(200, { "content-type": "application/json" })
         }
-        res.end(jsonStringify(response))
+        res.end(jsonStringify(finalResponse))
       } catch (error) {
         sendError(res, null, error instanceof Error ? error.message : "internal error")
       }
@@ -444,7 +478,7 @@ async function handleOne(
   filters: Map<string, PendingFilter>,
   bftCoordinator?: BftCoordinator,
   opts?: Record<string, unknown>,
-): Promise<JsonRpcResponse> {
+): Promise<JsonRpcResponse | null> {
   if (!payload || typeof payload !== "object" || !payload.method) {
     // #138: per JSON-RPC §5.1 invalid-request must carry code -32600.
     // Pre-fix this returned only { message }, which clients couldn't
@@ -452,10 +486,17 @@ async function handleOne(
     return { jsonrpc: "2.0", id: payload?.id ?? null, error: { code: -32600, message: "invalid request" } }
   }
 
+  // #140: §4.1 — a request without an `id` field is a Notification.
+  // The server processes it but MUST NOT respond. Return null and let
+  // the dispatcher omit the response from the wire.
+  const isNotification = !("id" in payload)
+
   try {
     const result = await handleRpc(payload, chainId, evm, chain, p2p, filters, bftCoordinator, opts)
+    if (isNotification) return null
     return { jsonrpc: "2.0", id: payload.id ?? null, result }
   } catch (error: unknown) {
+    if (isNotification) return null
     // Support structured RPC errors (e.g. { code, message } from param validation)
     if (error && typeof error === "object" && "code" in error && "message" in error) {
       const rpcErr = error as { code: unknown; message: unknown }


### PR DESCRIPTION
Closes #140.

Live testnet probe found two §4 / §6 spec violations:

1. **§4.1**: a request without an `id` is a Notification — server MUST NOT respond. Pre-fix the server returned a full `{id:null,result}` response, hanging clients (web3.py, ethers, viem) that expect silence.
2. **§6**: empty batch `[]` MUST return a single Invalid Request error. Pre-fix the server returned an empty array, indistinguishable from "batch processed successfully with 0 results".

## Fix

- `handleOne` returns `null` when payload has no `id` field
- Outer dispatcher filters nulls from batch responses; if everything was a notification, responds with HTTP 204 no-body
- Empty batch short-circuits to single `-32600` error before dispatching

## Test plan

- [x] Single notification → 204 + empty body
- [x] Empty batch → single -32600 object, not `[]`
- [x] Batch of all notifications → 204
- [x] Mixed batch (notification + request) → array with only the request's response
- [x] 125/125 rpc tests pass locally