### PR TITLE
fix(rpc): eth_newFilter validates address and topic shape with -32602 (#142)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -952,6 +952,37 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(mixedJson[0].id, 42)
   })
 
+  await t.test("#142: eth_newFilter validates address and topic shape (rejects with -32602)", async () => {
+    // Pre-fix any string was accepted for address/topics. Malformed
+    // filters consumed MAX_FILTERS slots while matching 0 logs forever,
+    // and clients couldn't distinguish typo'd filters from "no events".
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const validTopic = "0x" + "a".repeat(64)
+    const cases: Array<{ params: unknown; what: string }> = [
+      { params: [{ address: "not-an-address" }], what: "address non-hex" },
+      { params: [{ address: "0x123" }], what: "address short hex" },
+      { params: [{ address: ["0x" + "f".repeat(40), "0xbad"] }], what: "address array with bad index" },
+      { params: [{ topics: ["not-hex"] }], what: "topic non-hex" },
+      { params: [{ topics: ["0x1"] }], what: "topic too short" },
+      { params: [{ topics: [null, "0xbad"] }], what: "topic null+bad" },
+      { params: [{ topics: [["0x" + "a".repeat(64), "0xbad"]] }], what: "topic OR-array with bad index" },
+    ]
+    for (const { params, what } of cases) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_newFilter", params }),
+      })
+      const json = await r.json() as { result?: string; error?: { code: number; message: string } }
+      assert.ok(json.error, `eth_newFilter(${what}) must reject, got result=${json.result}`)
+      assert.equal(json.error!.code, -32602, `eth_newFilter(${what}) must be -32602, got ${json.error!.code}`)
+      assert.match(json.error!.message, /invalid filter (address|topic)/, `error message for ${what}`)
+    }
+    // Sanity: a fully valid filter spec creates a filter.
+    const okId = await rpcCall(port, "eth_newFilter", [{ address: validAddr, topics: [validTopic, null] }])
+    assert.match(okId as string, /^0x[0-9a-f]+$/i, "valid filter must return id")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -801,6 +801,19 @@ async function handleRpc(
       const newFilterHeight = await Promise.resolve(chain.getHeight())
       const fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
       const toBlock = query.toBlock !== undefined ? parseBlockTag(query.toBlock, newFilterHeight) : undefined
+      // #142: validate address + topic shape so malformed inputs reject
+      // at the boundary instead of silently consuming a filter slot.
+      // Pre-fix `eth_newFilter({address:"0x123"})` succeeded and returned
+      // a filter id; the filter then matched zero logs forever, while
+      // the slot counted against MAX_FILTERS.
+      const FILTER_ADDR_RE = /^0x[0-9a-fA-F]{40}$/
+      const FILTER_TOPIC_RE = /^0x[0-9a-fA-F]{64}$/
+      const validateFilterAddr = (raw: unknown, idx: number): Hex => {
+        if (typeof raw !== "string" || !FILTER_ADDR_RE.test(raw)) {
+          throw { code: -32602, message: `invalid filter address at index ${idx}: must match /^0x[0-9a-fA-F]{40}$/` }
+        }
+        return raw.toLowerCase() as Hex
+      }
       // Normalize address: support both single string and array of addresses
       let filterAddress: Hex | undefined
       let filterAddresses: Hex[] | undefined
@@ -810,11 +823,32 @@ async function handleRpc(
           if (query.address.length > MAX_FILTER_ADDRESSES) {
             throw { code: -32602, message: `address array too large: ${query.address.length} > ${MAX_FILTER_ADDRESSES}` }
           }
-          filterAddresses = (query.address as string[]).map((a) => String(a).toLowerCase() as Hex)
+          filterAddresses = (query.address as unknown[]).map((a, i) => validateFilterAddr(a, i))
           filterAddress = filterAddresses.length > 0 ? filterAddresses[0] : undefined
         } else {
-          filterAddress = String(query.address).toLowerCase() as Hex
+          filterAddress = validateFilterAddr(query.address, 0)
         }
+      }
+      // Each topic position can be: null (wildcard), a 32-byte hex
+      // string, or a non-empty array of 32-byte hex strings (OR
+      // semantics) per the Ethereum JSON-RPC spec.
+      let normalizedTopics: Array<Hex | Hex[] | null> | undefined
+      if (Array.isArray(query.topics)) {
+        normalizedTopics = query.topics.map((t, i) => {
+          if (t === null || t === undefined) return null
+          if (Array.isArray(t)) {
+            return t.map((tt, j) => {
+              if (typeof tt !== "string" || !FILTER_TOPIC_RE.test(tt)) {
+                throw { code: -32602, message: `invalid filter topic at index ${i}[${j}]: must match /^0x[0-9a-fA-F]{64}$/ or null` }
+              }
+              return tt as Hex
+            })
+          }
+          if (typeof t !== "string" || !FILTER_TOPIC_RE.test(t)) {
+            throw { code: -32602, message: `invalid filter topic at index ${i}: must match /^0x[0-9a-fA-F]{64}$/ or null` }
+          }
+          return t as Hex
+        })
       }
       const filter: PendingFilter = {
         id,
@@ -823,7 +857,7 @@ async function handleRpc(
         toBlock,
         address: filterAddress,
         addresses: filterAddresses,
-        topics: Array.isArray(query.topics) ? query.topics.map((t) => (t ? String(t) as Hex : null)) : undefined,
+        topics: normalizedTopics as Array<Hex | null> | undefined,
         lastCursor: fromBlock > 0n ? fromBlock - 1n : 0n,
         createdAtMs: Date.now(),
       }


### PR DESCRIPTION
Closes #142.

Live testnet probe — `eth_newFilter` accepted any string for address/topics:

```bash
# All three return a filter id (incorrectly):
eth_newFilter({address:"not-an-address"})
eth_newFilter({address:"0x123"})
eth_newFilter({topics:["not-hex"]})
```

The bogus filters match zero logs forever while consuming MAX_FILTERS slots. Clients can't distinguish typo'd filters from "no events".

## Fix

Validate each field at the RPC boundary:
- `address`: must match `/^0x[0-9a-fA-F]{40}$/`
- `topic`: null OR `/^0x[0-9a-fA-F]{64}$/` OR an OR-array of 32-byte hex strings

Same class as #122/#124/#128 — strict validation at the filter creation point.

## Test plan

- [x] 7 malformed cases (address non-hex, short, mixed-array; topic non-hex, short, null+bad, OR-array bad) → all -32602
- [x] Sanity: valid filter still accepted
- [x] 126/126 rpc tests pass locally