### PR TITLE
fix(ws-rpc): notifications (no id) get no response per JSON-RPC §4.1 (#144)

### DIFF
--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -340,4 +340,28 @@ describe("WebSocket RPC", () => {
       ws.close()
     }
   })
+
+  it("#144: WS notification (no id) gets no response (JSON-RPC §4.1)", async () => {
+    const ws = await connectWs(WS_PORT)
+    try {
+      // Send a notification — no id field. Wait briefly to confirm no
+      // message arrives. Pre-fix the server replied with {id:null,result}.
+      let received: unknown = null
+      const handler = (data: Buffer | string) => {
+        received = JSON.parse(data.toString())
+      }
+      ws.on("message", handler)
+      ws.send(JSON.stringify({ jsonrpc: "2.0", method: "eth_chainId", params: [] }))
+      // Give the server 500ms to (incorrectly) respond.
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      ws.removeListener("message", handler)
+      assert.equal(received, null, `WS server must NOT respond to notification, got: ${JSON.stringify(received)}`)
+
+      // Sanity: a normal request after the notification still works.
+      const result = await sendRpc(ws, "eth_chainId")
+      assert.equal(result, `0x${CHAIN_ID.toString(16)}`, "subsequent request must still work")
+    } finally {
+      ws.close()
+    }
+  })
 })

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -315,14 +315,20 @@ export class WsRpcServer {
       return
     }
 
+    // #144: §4.1 — a request without an `id` field is a Notification;
+    // server MUST NOT reply. Same fix as #140 for HTTP RPC.
+    const isNotification = !("id" in payload)
+
     try {
       const result = await this.dispatch(ws, payload.method, payload.params ?? [])
+      if (isNotification) return
       this.send(ws, {
         jsonrpc: "2.0",
         id: payload.id ?? null,
         result,
       })
     } catch (err) {
+      if (isNotification) return
       // Support structured RPC errors (e.g. { code, message } from dispatch/handleRpcMethod)
       if (err && typeof err === "object" && "code" in err && "message" in err) {
         const rpcErr = err as { code: number; message: string }


### PR DESCRIPTION
Closes #144.

Follow-up to #140 (HTTP RPC notification fix). WebSocket RPC had the same bug — `handleMessage` always called `this.send()` after dispatch, ignoring the notification semantic.

Per §4.1, a request without an `id` field is a Notification; the server MUST NOT reply.

## Fix

Same as #140: detect `!("id" in payload)` after the dispatch and skip the response (both success and error paths).

## Test plan

- [x] Send notification → wait 500ms → assert no message received
- [x] Subsequent normal request still works
- [x] 9/9 ws-rpc tests pass locally