### PR TITLE
fix(rpc): validate value/gas/gasPrice/data shape on call-style RPCs (#148)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1001,7 +1001,6 @@ test("RPC Extended Methods", async (t) => {
       const j = await probeError("coc_dhtFindProviders", params)
       assert.ok(j.error, `coc_dhtFindProviders(${JSON.stringify(params)}) must error, got result=${JSON.stringify(j.result)}`)
       assert.equal(j.error!.code, -32602)
-      // The error must NOT live inside the result body anymore.
       assert.equal(j.result, undefined, "errors must be in error field, not result body")
     }
     // (b) coc_ipfsFetchBlockFromPeer same shape
@@ -1018,6 +1017,38 @@ test("RPC Extended Methods", async (t) => {
       assert.ok(j.error)
       assert.equal(j.error!.code, -32601, `${method} must be -32601 when not configured, got ${j.error!.code}`)
     }
+  })
+
+  await t.test("#148: eth_call / estimateGas / sendTransaction / createAccessList validate value/gas/data shape", async () => {
+    // Pre-fix `eth_estimateGas({value:"not-hex"})` returned a clean gas
+    // estimate — the EVM silently treated non-hex value as 0, masking
+    // client typos. `eth_call({data:"not-hex"})` surfaced as -32603 with
+    // the V8 message leaking ("Input must be a 0x-prefixed...").
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const badShapes = [
+      { value: "not-hex" }, { value: "100" }, { value: "0xZZ" },
+      { gas: "not-hex" }, { gasPrice: "100" },
+      { data: "not-hex" }, { data: "0xZ" }, { data: "0x123" }, // odd-length data
+    ]
+    for (const method of ["eth_call", "eth_estimateGas", "eth_createAccessList"]) {
+      for (const bad of badShapes) {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method,
+            params: [{ to: validAddr, from: validAddr, ...bad }],
+          }),
+        })
+        const json = await r.json() as { result?: unknown; error?: { code: number; message: string } }
+        assert.ok(json.error, `${method}(${JSON.stringify(bad)}) must reject, got result=${JSON.stringify(json.result)}`)
+        assert.equal(json.error!.code, -32602, `${method}(${JSON.stringify(bad)}) must be -32602, got ${json.error!.code}`)
+        assert.match(json.error!.message, /invalid (value|gas|gasPrice|data)/, "message must name the bad field")
+      }
+    }
+    // Sanity: clean values pass through.
+    const ok = await rpcCall(port, "eth_estimateGas", [{ from: validAddr, to: validAddr, value: "0x1000", data: "0x" }])
+    assert.match(ok as string, /^0x[0-9a-f]+$/i)
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -118,6 +118,31 @@ function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   return value as Hex
 }
 
+/**
+ * #148: validate the numeric/data fields of an eth_call / estimateGas /
+ * sendTransaction-shaped object. Pre-fix, malformed `value`/`gas`/etc
+ * either flowed through to the EVM (which silently treated non-hex as
+ * 0) or surfaced as -32603 internal-error with the V8 message leaked.
+ * Rejects each field at the boundary with -32602.
+ */
+const HEX_QUANTITY_RE = /^0x[0-9a-fA-F]+$/
+const HEX_DATA_RE = /^0x([0-9a-fA-F]{2})*$/
+function validateTxCallFields(callParams: Record<string, unknown>): void {
+  for (const field of ["value", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas"] as const) {
+    const v = callParams[field]
+    if (v === undefined || v === null || v === "") continue
+    if (typeof v !== "string" || !HEX_QUANTITY_RE.test(v)) {
+      throw { code: -32602, message: `invalid ${field}: must match /^0x[0-9a-fA-F]+$/` }
+    }
+  }
+  const data = callParams.data
+  if (data !== undefined && data !== null && data !== "") {
+    if (typeof data !== "string" || !HEX_DATA_RE.test(data)) {
+      throw { code: -32602, message: "invalid data: must match /^0x([0-9a-fA-F]{2})*$/" }
+    }
+  }
+}
+
 const MAX_RPC_BODY = 1024 * 1024 // 1 MB max request body for RPC
 const rateLimiter = new RateLimiter()
 // Cleanup expired buckets every 5 minutes
@@ -667,6 +692,10 @@ async function handleRpc(
       if (estParams.from && !/^0x[0-9a-fA-F]{40}$/.test(estParams.from)) {
         throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
       }
+      // #148: validate value/gas/data shape — pre-fix the EVM silently
+      // treated non-hex as 0, so {value:"not-hex"} gave a clean gas
+      // estimate that ignored the value transfer.
+      validateTxCallFields(estParams)
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
@@ -697,6 +726,10 @@ async function handleRpc(
       if (callParams.from && !/^0x[0-9a-fA-F]{40}$/.test(callParams.from)) {
         throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
       }
+      // #148: validate value/gas/data shape before reaching the EVM,
+      // where malformed input either silently becomes 0 (value) or
+      // surfaces as -32603 with V8 message leak (data).
+      validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
       const callResult = await evm.callRaw({
         from: callParams.from,
@@ -915,10 +948,18 @@ async function handleRpc(
     case "eth_sendTransaction": {
       const txParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
       const from = txParams.from?.toLowerCase()
-      if (!from) throw new Error("missing from address")
+      if (!from) throw { code: -32602, message: "missing from address" }
+      if (!/^0x[0-9a-fA-F]{40}$/.test(from)) {
+        throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      if (txParams.to && !/^0x[0-9a-fA-F]{40}$/.test(txParams.to)) {
+        throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      // #148: validate value/gas/data shape before reaching the mempool.
+      validateTxCallFields(txParams)
 
       const account = testAccounts.get(from)
-      if (!account) throw new Error(`account not found: ${from}. Use eth_accounts to list available test accounts.`)
+      if (!account) throw { code: -32004, message: `account not found: ${from}. Use eth_accounts to list available test accounts.` }
 
       // Serialize per-account to prevent concurrent nonce collision
       const prev = sendTxLocks.get(from) ?? Promise.resolve()
@@ -990,6 +1031,14 @@ async function handleRpc(
     }
     case "eth_createAccessList": {
       const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #148: validate address + value/gas/data shape upfront.
+      if (callParams.to && !/^0x[0-9a-fA-F]{40}$/.test(callParams.to)) {
+        throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      if (callParams.from && !/^0x[0-9a-fA-F]{40}$/.test(callParams.from)) {
+        throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
       const result = await evm.traceCall({
         from: callParams.from,
@@ -1006,6 +1055,14 @@ async function handleRpc(
     case "debug_traceCall": {
       if (!DEBUG_RPC_ENABLED) throw { code: -32601, message: "debug methods disabled (set COC_DEBUG_RPC=1)" }
       const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #148: validate shape — same as eth_call.
+      if (callParams.to && !/^0x[0-9a-fA-F]{40}$/.test(callParams.to)) {
+        throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      if (callParams.from && !/^0x[0-9a-fA-F]{40}$/.test(callParams.from)) {
+        throw { code: -32602, message: "invalid from address: must match /^0x[0-9a-fA-F]{40}$/" }
+      }
+      validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
       const traceOpts = ((payload.params ?? [])[2] ?? {}) as Record<string, unknown>
       const result = await evm.traceCall({


### PR DESCRIPTION
Closes #148.

Live testnet probe — `eth_estimateGas({value:"not-hex"})` silently returned a clean gas estimate (the EVM treated non-hex value as 0). `eth_call({data:"not-hex"})` instead surfaced as -32603 with V8 ethers internals leaked.

## Fix

`validateTxCallFields()` helper rejects malformed numeric/data fields at the RPC boundary:
- `/^0x[0-9a-fA-F]+$/` for value/gas/gasPrice/maxFeePerGas/maxPriorityFeePerGas
- `/^0x([0-9a-fA-F]{2})*$/` for data (even-length hex; "0x" empty ok)

Applied to `eth_call`, `eth_estimateGas`, `eth_sendTransaction`, `eth_createAccessList`, `debug_traceCall`.

Bonus: `eth_sendTransaction` 3 internal errors upgraded to spec codes (`missing from` → -32602, `account not found` → -32004 resource-not-available, malformed from/to rejected upfront).

## Test plan

- [x] 24 malformed shapes across 3 methods → all -32602
- [x] Clean value+data still passes through
- [x] 128/128 rpc tests pass locally