### PR TITLE
fix(rpc): strict 32-byte tx-hash validation for eth_getTransactionByHash / Receipt (#150)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1051,6 +1051,42 @@ test("RPC Extended Methods", async (t) => {
     assert.match(ok as string, /^0x[0-9a-f]+$/i)
   })
 
+  await t.test("#150: eth_getTransactionByHash / eth_getTransactionReceipt reject short tx hashes with -32602", async () => {
+    // Pre-fix the loose requireHexParam accepted any 0x-prefixed hex up
+    // to 64 chars. `"0x123"` slipped through and the tx-lookup returned
+    // null ("not found") — clients couldn't tell a typo from a missing
+    // tx, so receipt pollers waited forever on bad hashes.
+    // Probe a few representative shapes; full panel covered in the
+    // #122/#124 address-validation tests. (Kept short to stay under
+    // the per-IP rate-limit shared with other tests in this fixture.)
+    const cases = [
+      { method: "eth_getTransactionByHash", hash: "0x123" },
+      { method: "eth_getTransactionByHash", hash: "0x" + "f".repeat(63) },
+      { method: "eth_getTransactionReceipt", hash: "0x" + "g".repeat(64) },
+    ]
+    for (const { method, hash } of cases) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [hash] }),
+      })
+      const json = await r.json() as { result?: unknown; error?: { code: number; message: string } }
+      assert.ok(json.error, `${method}(${JSON.stringify(hash)}) must error, got result=${JSON.stringify(json.result)}`)
+      assert.equal(json.error!.code, -32602, `${method}(${JSON.stringify(hash)}) must be -32602, got ${json.error!.code}`)
+      assert.match(json.error!.message, /invalid transaction hash/, "error must name the field")
+    }
+    // Sanity: a valid (but non-existent) hash returns null, not error.
+    const validButMissing = "0x" + "a".repeat(64)
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionByHash", params: [validButMissing] }),
+    })
+    const json = await r.json() as { result: unknown; error?: unknown }
+    assert.equal(json.error, undefined, "valid-shape but non-existent hash must NOT error")
+    assert.equal(json.result, null, "valid-shape but non-existent hash returns null")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -110,6 +110,24 @@ function requireAddressParam(params: unknown[], index: number, name = "address")
   return value as Hex
 }
 
+/**
+ * #150: strict 32-byte (64 hex chars) tx-hash validator. The loose
+ * requireHexParam accepts 0x-prefixed hex up to 66 chars, so a typo
+ * like "0x123" slipped through and the downstream tx lookup returned
+ * null ("tx not found"). Clients couldn't distinguish a typo from a
+ * tx that doesn't exist on-chain.
+ */
+function requireTxHashParam(params: unknown[], index: number, name = "transaction hash"): Hex {
+  const value = (params ?? [])[index]
+  if (typeof value !== "string") {
+    throw { code: -32602, message: `invalid ${name}: expected string` }
+  }
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    throw { code: -32602, message: `invalid ${name}: must match /^0x[0-9a-fA-F]{64}$/` }
+  }
+  return value as Hex
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -610,7 +628,7 @@ async function handleRpc(
       return `0x${nonce.toString(16)}`
     }
     case "eth_getTransactionReceipt": {
-      const hash = requireHexParam(payload.params ?? [], 0, "transaction hash")
+      const hash = requireTxHashParam(payload.params ?? [], 0)
       // Try persistent index first, then fall back to EVM memory
       if (typeof chain.getTransactionByHash === "function") {
         const tx = await chain.getTransactionByHash(hash as Hex)
@@ -621,7 +639,7 @@ async function handleRpc(
       return evm.getReceipt(hash)
     }
     case "eth_getTransactionByHash": {
-      const hash = requireHexParam(payload.params ?? [], 0, "transaction hash")
+      const hash = requireTxHashParam(payload.params ?? [], 0)
       // Try persistent index first, then fall back to EVM memory
       if (typeof chain.getTransactionByHash === "function") {
         const tx = await chain.getTransactionByHash(hash as Hex)


### PR DESCRIPTION
Closes #150.

Live testnet probe — `eth_getTransactionByHash("0x123")` returned `{result: null}` ("tx not found") instead of `-32602`. The loose `requireHexParam` accepted any 0x-prefixed hex up to 64 chars, so typo'd hashes silently masqueraded as "tx doesn't exist". Receipt pollers waited forever.

## Fix

New `requireTxHashParam` helper requires `/^0x[0-9a-fA-F]{64}$/` (32 bytes). Applied to `eth_getTransactionByHash` and `eth_getTransactionReceipt`.

Same class as #122/#124 fixes for address validation, but for tx hashes.

## Test plan

- [x] Malformed hashes (short, 63-char, non-hex 64-char) → -32602
- [x] Valid-but-missing 64-char hash → null (not error)
- [x] 130/130 rpc tests pass locally