### PR TITLE
fix(test): widen wire-server handshake timeout to 5s under CI load (#152)

### DIFF
--- a/node/src/wire-server.test.ts
+++ b/node/src/wire-server.test.ts
@@ -1032,7 +1032,12 @@ describe("WireClient backpressure (#71 Bug A)", () => {
     })
     clients.push(client)
     client.connect()
-    for (let i = 0; i < 50; i++) {
+    // #152: 50 × 40ms = 2s was too tight under GitHub Actions load,
+    // causing the "disconnect drops queued frames cleanly" test to
+    // intermittently fail with "handshake did not complete". 5s gives
+    // slow runners headroom without slowing the happy path (still
+    // breaks out on the first isConnected() check).
+    for (let i = 0; i < 125; i++) {
       if (client.isConnected()) break
       await new Promise((r) => setTimeout(r, 40))
     }


### PR DESCRIPTION
Closes #152.

PR #151 CI hit `Error: handshake did not complete` on `wire-server.test.ts`'s "disconnect drops queued frames cleanly" test. A retry on the same SHA passed cleanly — flake, not regression.

`spawnConnectedClient()` polled 50 × 40ms = 2s for handshake. Under GitHub Actions runner contention this wasn't always enough.

## Fix

Bump iteration count to 125 (5s timeout). Happy path still breaks out on first `isConnected()` check, so no slowdown when the runner is fast.

## Test plan

- [x] 37/37 wire-server tests pass locally