### PR TITLE
fix(rpc): validate eth_sign / eth_signTypedData_v4 inputs upfront (#154)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1087,6 +1087,29 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(json.result, null, "valid-shape but non-existent hash returns null")
   })
 
+  await t.test("#154: eth_sign / eth_signTypedData_v4 validate address + message shape upfront", async () => {
+    // Pre-fix bogus address → -32603 "account not found: <raw>" leaking
+    // the typo. Now validates shape first → -32602; only the
+    // resource-not-found case yields -32004.
+    // (Kept to 2 probes to stay under the per-IP rate-limit shared with
+    // other tests in this fixture.)
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) eth_sign with bogus address → -32602 (pre-fix was -32603)
+    const r1 = await probe("eth_sign", ["bogus", "0x0"])
+    assert.equal(r1.error?.code, -32602, `bogus address must be -32602, got ${r1.error?.code}`)
+    // (b) eth_signTypedData_v4 with valid address but non-object typedData → -32602
+    const unknownAddr = "0x" + "9".repeat(40)
+    const r2 = await probe("eth_signTypedData_v4", [unknownAddr, "not-an-object"])
+    assert.equal(r2.error?.code, -32602, `non-object typedData must be -32602, got ${r2.error?.code}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1018,22 +1018,39 @@ async function handleRpc(
       return await work
     }
     case "eth_sign": {
-      const address = String((payload.params ?? [])[0] ?? "").toLowerCase()
-      const message = String((payload.params ?? [])[1] ?? "")
+      // #154: pre-fix bogus address + missing params surfaced as
+      // -32603 "account not found: <raw input>" leaking the typo
+      // back. Validate shape upfront so clients get -32602; only
+      // address-not-in-dev-keystore yields -32004 (resource not
+      // available — the address is well-formed, just not loaded).
+      const address = requireAddressParam(payload.params ?? [], 0).toLowerCase() as Hex
+      const rawMessage = (payload.params ?? [])[1]
+      if (typeof rawMessage !== "string") {
+        throw { code: -32602, message: "invalid message: expected hex string" }
+      }
+      const messageBody = rawMessage.startsWith("0x") ? rawMessage.slice(2) : rawMessage
+      if (messageBody.length % 2 !== 0 || (messageBody.length > 0 && !/^[0-9a-fA-F]+$/.test(messageBody))) {
+        throw { code: -32602, message: "invalid message: must be even-length hex (with optional 0x prefix)" }
+      }
 
       const account = testAccounts.get(address)
-      if (!account) throw new Error(`account not found: ${address}`)
+      if (!account) throw { code: -32004, message: `account not in dev keystore: ${address}` }
 
-      const messageHash = hashMessage(Buffer.from(message.startsWith("0x") ? message.slice(2) : message, "hex"))
+      const messageHash = hashMessage(Buffer.from(messageBody, "hex"))
       const signature = account.signingKey.sign(messageHash)
       return signature.serialized
     }
     case "eth_signTypedData_v4": {
-      const address = String((payload.params ?? [])[0] ?? "").toLowerCase()
+      // #154: same fix as eth_sign — validate address and typedData
+      // shape upfront so malformed inputs return -32602 not -32603.
+      const address = requireAddressParam(payload.params ?? [], 0).toLowerCase() as Hex
       const typedData = (payload.params ?? [])[1]
+      if (typedData === null || typeof typedData !== "object" || Array.isArray(typedData)) {
+        throw { code: -32602, message: "invalid typedData: expected object" }
+      }
 
       const account = testAccounts.get(address)
-      if (!account) throw new Error(`account not found: ${address}`)
+      if (!account) throw { code: -32004, message: `account not in dev keystore: ${address}` }
 
       // EIP-712 compliant: use TypedDataEncoder for correct domain-separated hash
       const td = typedData as Record<string, unknown>


### PR DESCRIPTION
Closes #154.

## Summary

Pre-fix, malformed `eth_sign` / `eth_signTypedData_v4` calls reached the
keystore lookup with the raw user input, surfacing as a generic
`-32603 "account not found: <raw input>"`. Clients saw their typo echoed back
as an opaque internal error, indistinguishable from a keystore miss on a
valid address.

## Mapping (after fix)

| Input | Code | Reason |
|---|---|---|
| Malformed address (non-hex / wrong length) | `-32602` | parameter shape |
| Malformed message / typedData | `-32602` | parameter shape |
| Valid address not in dev keystore | `-32004` | resource not available |
| Valid + present address | `0x...` signature | success |

## How

Uses `requireAddressParam` (PR #122) for consistent address shape checking
shared with `eth_getBalance` / `eth_call`. Validates message hex and
typedData shape before keystore lookup. Maps the "well-formed but not loaded"
case to `-32004` (resource not available — same code used elsewhere for
"shape is fine, the thing just isn't here right now").

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/websocket-rpc.test.ts` → 79/79 pass
- [x] `rpc-extended.test.ts #154` probes a malformed address and malformed typedData object; trimmed to 2 probes to stay under the per-IP rate-limit shared with other tests in this fixture
- [ ] CI green