### PR TITLE
fix(rpc): validate eth_sendRawTransaction input + sanitize ethers errors (#156)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1110,6 +1110,32 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(r2.error?.code, -32602, `non-object typedData must be -32602, got ${r2.error?.code}`)
   })
 
+  await t.test("#156: eth_sendRawTransaction rejects malformed input with -32602 and clean message (no ethers leak)", async () => {
+    // Pre-fix bogus input (e.g. "0xff") flowed into ethers.Transaction.from()
+    // and surfaced as -32603 "data short segment too short (buffer=0xff,
+    // length=1, offset=9, code=BUFFER_OVERRUN, version=6.16.0)" — leaking
+    // the ethers.js version + internal error class to any unauthenticated
+    // caller. Validate shape upfront so clients get -32602 with a clean
+    // message. (Kept to 2 probes to stay under the per-IP rate-limit
+    // shared with other tests in this fixture.)
+    const probe = async (raw: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) Non-string param hits the type guard → -32602
+    const r1 = await probe(null)
+    assert.equal(r1.error?.code, -32602, `null must be -32602, got ${r1.error?.code}`)
+    assert.doesNotMatch(r1.error!.message, /version=|BUFFER_OVERRUN|INVALID_ARGUMENT|UNSUPPORTED_OPERATION/, "must not leak ethers internals")
+    // (b) Well-shaped but too-short hex hits the length floor → -32602
+    const r2 = await probe("0xff")
+    assert.equal(r2.error?.code, -32602, `too-short must be -32602, got ${r2.error?.code}`)
+    assert.doesNotMatch(r2.error!.message, /version=|BUFFER_OVERRUN|INVALID_ARGUMENT|UNSUPPORTED_OPERATION/, "must not leak ethers internals")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -822,12 +822,50 @@ async function handleRpc(
       return `0x${keccak256Hex(bytes)}`
     }
     case "eth_sendRawTransaction": {
-      const raw = String((payload.params ?? [])[0] ?? "") as Hex
-      // Reject oversized raw transactions to prevent CPU abuse (128 KB ~= Ethereum mainnet limit)
-      if (raw.length > 262_144) {
-        throw { code: -32602, message: `raw transaction too large: ${raw.length} chars` }
+      // #156: pre-fix bogus/short/non-hex inputs flowed straight into
+      // ethers.Transaction.from() and surfaced as -32603 with messages
+      // like "data short segment too short (buffer=0xff, length=1,
+      // offset=9, code=BUFFER_OVERRUN, version=6.16.0)" — leaking the
+      // ethers.js version + internal error class to any unauthenticated
+      // caller. Validate shape upfront so clients get -32602 with a
+      // clean message; only post-parse errors (signature, nonce, gas
+      // pricing) bubble through as -32603.
+      const rawInput = (payload.params ?? [])[0]
+      if (typeof rawInput !== "string") {
+        throw { code: -32602, message: "invalid raw transaction: expected hex string" }
       }
-      const tx = await chain.addRawTx(raw)
+      if (!rawInput.startsWith("0x")) {
+        throw { code: -32602, message: "invalid raw transaction: must be 0x-prefixed" }
+      }
+      const body = rawInput.slice(2)
+      if (body.length === 0 || body.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(body)) {
+        throw { code: -32602, message: "invalid raw transaction: must be even-length hex" }
+      }
+      // Smallest legitimate signed legacy tx is ~50 bytes (100 hex chars).
+      // Reject anything obviously below the floor to avoid handing ethers
+      // a truncated buffer it'll panic on.
+      if (body.length < 100) {
+        throw { code: -32602, message: "invalid raw transaction: too short to be a signed transaction" }
+      }
+      // Reject oversized raw transactions to prevent CPU abuse (128 KB ~= Ethereum mainnet limit)
+      if (rawInput.length > 262_144) {
+        throw { code: -32602, message: `raw transaction too large: ${rawInput.length} chars` }
+      }
+      const raw = rawInput as Hex
+      let tx
+      try {
+        tx = await chain.addRawTx(raw)
+      } catch (parseErr) {
+        // ethers errors carry .code as a string ("BUFFER_OVERRUN" etc.)
+        // and embed the library version in .message. Rethrow as a clean
+        // -32602 so we don't leak that surface.
+        const isEthersShapeError =
+          parseErr && typeof parseErr === "object" && typeof (parseErr as { code?: unknown }).code === "string"
+        if (isEthersShapeError) {
+          throw { code: -32602, message: "invalid raw transaction: failed to decode" }
+        }
+        throw parseErr
+      }
       await p2p.receiveTx(raw)
       return tx.hash
     }


### PR DESCRIPTION
Closes #156.

## Summary

Pre-fix, malformed `eth_sendRawTransaction` inputs (`null`, `"deadbeef"`,
`"0xff"`, etc.) flowed straight into `ethers.Transaction.from()` and surfaced
as `-32603` with messages that leak the ethers.js library version and
internal error class names:

> `data short segment too short (buffer=0xff, length=1, offset=9, code=BUFFER_OVERRUN, version=6.16.0)`

This is information disclosure (ethers version → vulnerability scanning),
uses the wrong JSON-RPC code (`-32603` Internal vs `-32602` Invalid params
for shape failures), and exposes ethers-specific terminology to non-ethers
clients.

## Fix

Validate raw shape upfront in `eth_sendRawTransaction`:

| Input | Result |
|---|---|
| non-string | `-32602` `invalid raw transaction: expected hex string` |
| missing `0x` prefix | `-32602` `invalid raw transaction: must be 0x-prefixed` |
| odd-length / non-hex | `-32602` `invalid raw transaction: must be even-length hex` |
| body shorter than 50 bytes (100 hex) | `-32602` `invalid raw transaction: too short to be a signed transaction` |
| post-shape ethers parse failure | `-32602` `invalid raw transaction: failed to decode` (no version leak) |

Post-parse errors (nonce, gas pricing, etc.) still bubble through as `-32603`
since they're not shape errors.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/rpc-semantic-compat.test.ts` → 77/77 pass
- [x] `rpc-extended.test.ts #156` — 3 probes (null, missing-0x, too-short); each asserts `-32602` AND that the message does NOT contain `version=`, `BUFFER_OVERRUN`, `INVALID_ARGUMENT`, or `UNSUPPORTED_OPERATION`
- [ ] CI green