### PR TITLE
fix(ipfs-http): files/stat returns kubo-compat PascalCase keys (#158)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -922,9 +922,21 @@ export class IpfsHttpServer {
           break
         }
         case "stat": {
+          // #158: pre-fix this serialized the internal MfsStat shape
+          // (hash/size/cumulativeSize/type/blocks — camelCase) directly,
+          // breaking kubo-compat clients like ipfs-http-client which
+          // expect PascalCase Hash/Size/CumulativeSize/Type/Blocks. The
+          // sibling `files/ls` handler already does the right mapping;
+          // align stat with that convention.
           const stat = await this.mfs.stat(arg || "/")
           res.writeHead(200, { "content-type": "application/json" })
-          res.end(JSON.stringify(stat))
+          res.end(JSON.stringify({
+            Hash: stat.hash,
+            Size: stat.size,
+            CumulativeSize: stat.cumulativeSize,
+            Type: stat.type,
+            Blocks: stat.blocks,
+          }))
           break
         }
         case "flush": {

--- a/tests/e2e/ipfs-e2e.test.ts
+++ b/tests/e2e/ipfs-e2e.test.ts
@@ -424,16 +424,25 @@ describe("IPFS E2E", () => {
       assert.ok(names.includes("hello.txt"))
     })
 
-    it("stat returns file metadata", async () => {
+    it("stat returns file metadata in kubo-compat PascalCase shape (#158)", async () => {
       const res = await fetch(
         `${base}/api/v0/files/stat?arg=/test-dir/hello.txt`,
         { method: "POST" },
       )
       assert.equal(res.status, 200)
       const json = (await res.json()) as Record<string, unknown>
-      assert.ok(json.hash)
-      assert.ok(typeof json.size === "number")
-      assert.equal(json.type, "file")
+      // #158: kubo's /api/v0/files/stat returns PascalCase keys.
+      // Pre-fix we emitted camelCase (hash/size/cumulativeSize/type/blocks)
+      // which broke ipfs-http-client + every other kubo-compat client.
+      assert.ok(json.Hash, "must have PascalCase Hash field")
+      assert.ok(typeof json.Size === "number", "Size must be a number")
+      assert.equal(json.Type, "file")
+      assert.ok(typeof json.CumulativeSize === "number")
+      assert.ok(typeof json.Blocks === "number")
+      // Negative: legacy camelCase keys must NOT be present.
+      assert.equal(json.hash, undefined, "legacy camelCase hash must be gone")
+      assert.equal(json.size, undefined, "legacy camelCase size must be gone")
+      assert.equal(json.type, undefined, "legacy camelCase type must be gone")
     })
 
     it("rm removes file and ls shows empty directory", async () => {


### PR DESCRIPTION
Closes #158.

## Summary

`/api/v0/files/stat` was the last MFS endpoint emitting **camelCase** response keys (`hash`, `size`, `cumulativeSize`, `type`, `blocks`) instead of kubo's **PascalCase** (`Hash`, `Size`, `CumulativeSize`, `Type`, `Blocks`). This broke `ipfs-http-client`, `helia/http-rpc-client`, and any other kubo-compat client.

`files/ls` already mapped correctly — `files/stat` was inconsistent with its own neighbor.

## Before

```
POST /api/v0/files/stat?arg=/
→ {"hash":"","size":0,"cumulativeSize":0,"type":"directory","blocks":0}
```

## After

```
POST /api/v0/files/stat?arg=/
→ {"Hash":"","Size":0,"CumulativeSize":0,"Type":"directory","Blocks":0}
```

Internal `MfsStat` shape is unchanged — only the wire mapping moves.

## Test plan

- [x] `node --experimental-strip-types --test $(find node/src -name 'ipfs*.test.ts') tests/e2e/ipfs-e2e.test.ts` → 217/217 pass
- [x] `tests/e2e/ipfs-e2e.test.ts` `stat returns file metadata in kubo-compat PascalCase shape (#158)` — asserts both presence of PascalCase keys AND absence of legacy camelCase keys
- [ ] CI green