### PR TITLE
fix(rpc): reject oversized JSON-RPC batch with -32600 (no silent truncation) (#164)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1196,6 +1196,27 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(Array.isArray(ok.result), "valid filter returns an array")
   })
 
+  await t.test("#164: oversized JSON-RPC batch rejects with -32600 (no silent truncation)", async () => {
+    // Pre-fix `payload.slice(0, MAX_BATCH_SIZE)` silently dropped items
+    // beyond the 100 cap — clients sending 1000 items got 100 results
+    // and had no way to tell their other 900 requests never ran. For
+    // state-changing requests (eth_sendRawTransaction) that's a silent
+    // data-loss bug. Now reject the whole batch with -32600.
+    const oversizedBatch = Array.from({ length: 101 }, (_, i) => ({
+      jsonrpc: "2.0", id: i, method: "eth_blockNumber", params: [],
+    }))
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(oversizedBatch),
+    })
+    const j = await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    // Must be a single object error response, NOT an array of 100 results.
+    assert.ok(!Array.isArray(j), `expected single error object, got array of length ${Array.isArray(j) ? (j as unknown[]).length : "n/a"}`)
+    assert.equal(j.error?.code, -32600, `expected -32600, got ${j.error?.code}`)
+    assert.match(j.error!.message, /batch too large|max/i, "error must explain the cap")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -467,9 +467,27 @@ export function startRpcServer(
           res.end(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: empty batch" } }))
           return
         }
+        // #164: pre-fix oversized batches were silently truncated via
+        // payload.slice(0, MAX_BATCH_SIZE) — clients got 100 results and
+        // had no way to tell their other 900 requests were dropped. If
+        // those were state-changing (eth_sendRawTransaction), the client
+        // thinks the txs were sent when they never ran. Reject the whole
+        // batch with a single -32600 instead; same pattern as the
+        // oversized-body rejection at line 373.
+        if (Array.isArray(payload) && payload.length > MAX_BATCH_SIZE) {
+          if (!res.headersSent) {
+            res.writeHead(200, { "content-type": "application/json" })
+          }
+          res.end(JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: `batch too large: ${payload.length} items (max ${MAX_BATCH_SIZE})` },
+          }))
+          return
+        }
 
         const response = Array.isArray(payload)
-          ? await Promise.all(payload.slice(0, MAX_BATCH_SIZE).map((item) => handleOne(item, chainId, evm, chain, p2p, filters, bftCoordinator, scopedOpts)))
+          ? await Promise.all(payload.map((item) => handleOne(item, chainId, evm, chain, p2p, filters, bftCoordinator, scopedOpts)))
           : await handleOne(payload, chainId, evm, chain, p2p, filters, bftCoordinator, scopedOpts)
 
         // #140: §4.1 server MUST NOT reply to notifications (requests


### PR DESCRIPTION
Closes #164.

## Summary

Pre-fix `payload.slice(0, MAX_BATCH_SIZE)` silently dropped items beyond the 100 cap. A client sending a 1000-item batch got 100 results and had no way to tell that its other 900 requests never ran. For state-changing requests (`eth_sendRawTransaction` mixed with reads), the client thinks the txs were submitted when they were silently dropped — silent data loss.

## Behavior

| Batch size | Before | After |
|---|---|---|
| 0 (empty) | `-32600` | `-32600` (unchanged from #140) |
| 1-100 | array of N results | array of N results (unchanged) |
| 101+ | array of 100 results (silent loss!) | `-32600 batch too large: N items (max 100)` |

Same rejection pattern as the oversized-body check (line 373) and matches geth/erigon behavior.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/security-hardening.test.ts` → 129/129 pass
- [x] `rpc-extended.test.ts #164` — 101-item batch (boundary case) asserts single error object response with code -32600
- [ ] CI green