### PR TITLE
fix(rpc): validate hash shape upfront in eth_getBlockByHash + siblings (#166)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1217,6 +1217,35 @@ test("RPC Extended Methods", async (t) => {
     assert.match(j.error!.message, /batch too large|max/i, "error must explain the cap")
   })
 
+  await t.test("#166: eth_getBlockByHash + siblings validate hash shape upfront (parity with #150)", async () => {
+    // Pre-fix the *byHash variants silently accepted any input
+    // (undefined, null, short hex, non-hex) and returned null —
+    // indistinguishable from "valid hash, no such block". PR #150
+    // fixed this for eth_getTransactionByHash; #166 extends the same
+    // pattern to eth_getBlockByHash, eth_getBlockTransactionCountByHash,
+    // and eth_getTransactionByBlockHashAndIndex.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) eth_getBlockByHash with short hash → -32602
+    const r1 = await probe("eth_getBlockByHash", ["0x123", false])
+    assert.equal(r1.error?.code, -32602, `short hash must be -32602, got ${r1.error?.code}`)
+    assert.match(r1.error!.message, /block hash/i, "error must name the field")
+    // (b) eth_getBlockTransactionCountByHash with non-hex → -32602
+    const r2 = await probe("eth_getBlockTransactionCountByHash", ["not-hex"])
+    assert.equal(r2.error?.code, -32602, `non-hex must be -32602, got ${r2.error?.code}`)
+    // Sanity: valid 32-byte hex (but non-existent block) returns null, not error.
+    const validButMissing = "0x" + "a".repeat(64)
+    const ok = await probe("eth_getBlockByHash", [validButMissing, false])
+    assert.equal(ok.error, undefined, `valid-shape but non-existent must NOT error: ${JSON.stringify(ok.error)}`)
+    assert.equal(ok.result, null, "valid-shape but non-existent returns null")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -128,6 +128,17 @@ function requireTxHashParam(params: unknown[], index: number, name = "transactio
   return value as Hex
 }
 
+/**
+ * Validate a 32-byte block hash (#166). Pre-fix the *byHash variants
+ * silently accepted any input (undefined, null, short hex, non-hex) and
+ * returned null indistinguishable from "valid hash, no such block".
+ * Same shape rules as transaction hash; the separate name keeps error
+ * messages readable for the caller's surface.
+ */
+function requireBlockHashParam(params: unknown[], index: number): Hex {
+  return requireTxHashParam(params, index, "block hash")
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -704,7 +715,11 @@ async function handleRpc(
       return formatBlock(block, includeTx, chain, evm)
     }
     case "eth_getBlockByHash": {
-      const hash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #166: pre-fix loose String() conversion accepted any input —
+      // undefined, null, short hex, non-hex — and returned null,
+      // indistinguishable from "valid hash, no such block". Symmetric
+      // with #150's eth_getTransactionByHash fix.
+      const hash = requireBlockHashParam(payload.params ?? [], 0)
       const includeTx = Boolean((payload.params ?? [])[1])
       const block = await Promise.resolve(chain.getBlockByHash(hash))
       return formatBlock(block, includeTx, chain, evm)
@@ -1330,7 +1345,8 @@ async function handleRpc(
       return "0x" + Buffer.from(JSON.stringify(blockData)).toString("hex")
     }
     case "eth_getBlockTransactionCountByHash": {
-      const hash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #166: same hash-shape validation as eth_getBlockByHash.
+      const hash = requireBlockHashParam(payload.params ?? [], 0)
       const block = await Promise.resolve(chain.getBlockByHash(hash))
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
@@ -1342,7 +1358,8 @@ async function handleRpc(
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
     case "eth_getTransactionByBlockHashAndIndex": {
-      const blockHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #166: same hash-shape validation as eth_getBlockByHash.
+      const blockHash = requireBlockHashParam(payload.params ?? [], 0)
       const txIndex = Number((payload.params ?? [])[1] ?? 0)
       if (!Number.isInteger(txIndex) || txIndex < 0) return null
       const block = await Promise.resolve(chain.getBlockByHash(blockHash))


### PR DESCRIPTION
Closes #166.

## Summary

Three block-lookup-by-hash methods used loose `String(params[0] ?? '')` conversion and silently accepted **any** input (undefined, null, short hex, non-hex strings, numbers), returning `null` indistinguishable from the valid "well-formed hash, no such block" response.

PR #150 already fixed this pattern for `eth_getTransactionByHash` via `requireTxHashParam`. This PR extends the same 32-byte hex validation to the byHash block methods via a new `requireBlockHashParam` (delegates to `requireTxHashParam`; separate name so error messages read correctly).

## Coverage

- `eth_getBlockByHash`
- `eth_getBlockTransactionCountByHash`
- `eth_getTransactionByBlockHashAndIndex`

The `eth_getUncle*` siblings are PoSe stubs that always return `0x0`/`null` (no uncles in COC) and don't actually look up the hash, so they're out of scope.

## Behavior

| Input | Before | After |
|---|---|---|
| `"0x123"` (short) | `result: null` | `-32602 invalid block hash` |
| `"not-hex"` | `result: null` | `-32602 invalid block hash` |
| `null` / `undefined` | `result: null` | `-32602 invalid block hash` |
| `12345` (number) | `result: null` | `-32602 invalid block hash` |
| `"0x" + "a"*64` (valid, missing) | `result: null` | `result: null` (unchanged) |
| Real block hash | full block | full block (unchanged) |

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/wallet-toolchain-compat.test.ts node/src/viem-toolchain-compat.test.ts` → 85/85 pass
- [x] `rpc-extended.test.ts #166` — short-hash + non-hex probes assert `-32602`, valid-but-missing hash still returns `null`
- [ ] CI green