### PR TITLE
fix(ipfs-http): malformed CIDs → 400, missing blocks → 404 (no 500) (#168)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -247,8 +247,10 @@ describe("IpfsHttpServer", () => {
     // Use single-block put+pin (not unixfs.addFile, which stores
     // chunks at separate CIDs that the root-CID pin does NOT cover —
     // by design, see the flat-GC limitation documented on blockstore.gc).
-    const cidA = "QmGcPinned123456789012345678901234567890ABC"
-    const cidB = "QmGcUnpinned123456789012345678901234567890A"
+    // #168 tightened isValidCid to require real base58 chars (no 0/O/I/l).
+    // Use fake-but-base58-compatible CIDs here.
+    const cidA = "QmGcPinned123456789123456789123456789123456ABC"
+    const cidB = "QmGcUnpinned12345678912345678912345678912345A"
     await store.put({ cid: cidA as CidString, bytes: Buffer.from("pinned content") })
     await store.put({ cid: cidB as CidString, bytes: Buffer.from("unpinned content") })
     await fetch(`/api/v0/pin/add?arg=${cidA}`, { method: "POST" })
@@ -286,6 +288,28 @@ describe("IpfsHttpServer", () => {
     assert.equal(res.status, 404)
     const body = await res.json() as Record<string, string>
     assert.equal(body.error, "block not found")
+  })
+
+  it("#168: /ipfs/<cid> + /api/v0/block/get map malformed→400 and missing→404 (no 500)", async () => {
+    // Pre-fix the gateway and block/get handlers passed any
+    // non-traversal string through isValidCid, then the blockstore
+    // ENOENT propagated as a generic 500 with a stacktrace logged.
+    // Now: malformed CID → 400, valid-shape-missing CID → 404.
+    const missingButValid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhz"
+    // (a) gateway: malformed → 400
+    const gw1 = await fetch(`/ipfs/bogus`)
+    assert.equal(gw1.status, 400, "gateway must reject 'bogus' with 400 (not 500)")
+    // (b) gateway: valid-shape-missing → 404
+    const gw2 = await fetch(`/ipfs/${missingButValid}`)
+    assert.equal(gw2.status, 404, "gateway must surface missing CID as 404 (not 500)")
+    // (c) block/get: malformed → 400
+    const bg1 = await fetch(`/api/v0/block/get?arg=bogus`, { method: "POST" })
+    assert.equal(bg1.status, 400, "block/get must reject 'bogus' with 400")
+    // (d) block/get: valid-shape-missing → 404
+    const bg2 = await fetch(`/api/v0/block/get?arg=${missingButValid}`, { method: "POST" })
+    assert.equal(bg2.status, 404, "block/get must surface missing CID as 404")
+    const bgBody = await bg2.json() as { error: string }
+    assert.equal(bgBody.error, "block not found")
   })
 
   it("GET /api/v0/pin/ls?arg=<cid> returns only that CID when pinned", async () => {

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -150,9 +150,21 @@ export class IpfsHttpServer {
           res.end(JSON.stringify({ error: "invalid CID" }))
           return
         }
-        const data = await this.unixfs.readFile(cid)
-        res.writeHead(200)
-        res.end(data)
+        // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated
+        // to the outer 500 handler, logging a stacktrace for every probe.
+        // Map to 404 explicitly so missing-block looks like missing-block.
+        try {
+          const data = await this.unixfs.readFile(cid)
+          res.writeHead(200)
+          res.end(data)
+        } catch (err) {
+          if (isNotFoundError(err)) {
+            res.writeHead(404, { "content-type": "application/json" })
+            res.end(JSON.stringify({ error: "not found" }))
+          } else {
+            throw err
+          }
+        }
         return
       }
 
@@ -667,9 +679,20 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
-    const block = await loadRawBlock(this.store, cid)
-    res.writeHead(200)
-    res.end(block.bytes)
+    // #168: pre-fix ENOENT for missing blocks propagated to the outer
+    // 500 handler. Map to 404 so missing-block looks like missing-block.
+    try {
+      const block = await loadRawBlock(this.store, cid)
+      res.writeHead(200)
+      res.end(block.bytes)
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        res.writeHead(404, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "block not found" }))
+      } else {
+        throw err
+      }
+    }
   }
 
   private async handleBlockStat(res: http.ServerResponse, cid?: string): Promise<void> {
@@ -678,9 +701,19 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
-    const block = await loadRawBlock(this.store, cid)
-    res.writeHead(200, { "content-type": "application/json" })
-    res.end(JSON.stringify({ Key: block.cid, Size: block.bytes.length }))
+    // #168: same ENOENT → 404 mapping as handleBlockGet.
+    try {
+      const block = await loadRawBlock(this.store, cid)
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ Key: block.cid, Size: block.bytes.length }))
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        res.writeHead(404, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "block not found" }))
+      } else {
+        throw err
+      }
+    }
   }
 
   private async handlePinAdd(_req: http.IncomingMessage, res: http.ServerResponse, cid?: string): Promise<void> {
@@ -1097,12 +1130,28 @@ export class IpfsHttpServer {
   }
 }
 
-/** Reject CIDs with path traversal, null bytes, whitespace, or excessive length */
+/**
+ * Reject CIDs with path traversal, null bytes, whitespace, excessive length,
+ * or that don't even look like base58-v0 (`Qm…`) / base32-v1 (`b…`/`B…`).
+ * #168: pre-fix any non-traversal string like `"bogus"` passed, then the
+ * blockstore opened `blocks/bogus`, hit ENOENT, and the handler surfaced
+ * the stacktrace as a generic 500. The 10-char floor rejects typos like
+ * "bogus" / "b" while allowing the fake-shape CIDs used in fixtures.
+ */
 function isValidCid(cid: string): boolean {
-  if (!cid || cid.length > 512) return false
+  if (!cid || cid.length < 10 || cid.length > 512) return false
   const trimmed = cid.trim()
-  if (trimmed !== cid || trimmed.length === 0) return false
-  return !/[\/\\]|\.\.|\0|\s/.test(cid)
+  if (trimmed !== cid) return false
+  if (/[\/\\]|\.\.|\0|\s/.test(cid)) return false
+  // Base58 v0: "Qm" + base58 chars. Strict alphabet (no 0/O/I/l).
+  if (cid.startsWith("Qm")) {
+    return /^Qm[1-9A-HJ-NP-Za-km-z]+$/.test(cid)
+  }
+  // Base32 v1: "b"/"B" + RFC 4648 base32 chars (no 0/1/8/9).
+  if (cid.startsWith("b") || cid.startsWith("B")) {
+    return /^[bB][a-z2-7]+$/.test(cid)
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
Closes #168.

## Summary

Two ways an IPFS HTTP request could surface as `500` even though they're really client-side input errors:

1. **`isValidCid` was too lax** — any string without path-traversal/null/whitespace passed. `"bogus"` reached the blockstore, hit `ENOENT`, and the outer handler logged a stacktrace as `500`.
2. **No `ENOENT` mapping** in the gateway + `block/get` paths — even genuinely well-formed-but-missing CIDs surfaced as `500`.

## Wire matrix

| Request | Before | After |
|---|---|---|
| `GET /ipfs/bogus` | `500 internal error` | `400 invalid CID` |
| `GET /ipfs/<valid-shape-missing>` | `500 internal error` | `404 not found` |
| `POST block/get?arg=bogus` | `500 internal error` | `400 invalid cid` |
| `POST block/get?arg=<missing>` | `500 internal error` | `404 block not found` |
| `GET /ipfs/<stored>` | `200` | `200` (unchanged) |
| `POST block/get?arg=<stored>` | `200` | `200` (unchanged) |

## Implementation

- `isValidCid` now requires real CID prefix (`Qm` base58 / `b`/`B` base32) AND correct character set (no `0`/`O`/`I`/`l` for base58, RFC 4648 alphabet for base32) AND a 10-char floor.
- Gateway and `block/get` / `block/stat` handlers wrap blockstore reads with `isNotFoundError(err)` (already exists at `ipfs-http.ts:39-43`) → 404.

## Test plan

- [x] `node --experimental-strip-types --test $(find node/src -name 'ipfs*.test.ts') tests/e2e/ipfs-e2e.test.ts` → 217/217 pass
- [x] New `#168` test in `ipfs-http.test.ts` covers all 4 wire matrix cells
- [x] Side fix: `#126` `repo/gc` test fixtures updated to base58-compatible CIDs (the old ones contained `0`, not a valid base58 char — they only worked under the lax pre-fix validator)
- [ ] CI green