### PR TITLE
fix(rpc): eth_call + 5 siblings reject non-object first param (#172)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1274,6 +1274,30 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(valid.result, "0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1")
   })
 
+  await t.test("#172: eth_call / eth_estimateGas reject non-object first param", async () => {
+    // Pre-fix `((params)[0] ?? {}) as Record<string,string>` was a
+    // no-op type assertion; strings/arrays/numbers coerced to {} and
+    // the EVM returned "0x" or a default gas estimate. Now: only
+    // object | null | undefined accepted.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) eth_call with string tx → -32602
+    const r1 = await probe("eth_call", ["string-input", "latest"])
+    assert.equal(r1.error?.code, -32602, `string tx must be -32602, got ${r1.error?.code}`)
+    // (b) eth_estimateGas with array tx → -32602
+    const r2 = await probe("eth_estimateGas", [["array"]])
+    assert.equal(r2.error?.code, -32602, `array tx must be -32602, got ${r2.error?.code}`)
+    // Sanity: null still treated as empty (ergonomic for ping-style probes).
+    const ok = await probe("eth_call", [null, "latest"])
+    assert.equal(ok.error, undefined, `null tx must NOT error: ${JSON.stringify(ok.error)}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -139,6 +139,23 @@ function requireBlockHashParam(params: unknown[], index: number): Hex {
   return requireTxHashParam(params, index, "block hash")
 }
 
+/**
+ * Validate that the first param of eth_call / eth_estimateGas /
+ * eth_sendTransaction / eth_createAccessList is an object — not a
+ * string, number, array, or boolean. #172: pre-fix the type assertion
+ * `as Record<string, string>` was a no-op at runtime; non-object input
+ * coerced to an effectively-empty tx and the EVM returned "0x".
+ * null/undefined pass through as `undefined` so the caller can still
+ * fall back to `{}` (matches geth's `eth_call(null)` ergonomic).
+ */
+function requireCallObject(raw: unknown, methodName: string): Record<string, unknown> | undefined {
+  if (raw === null || raw === undefined) return undefined
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw { code: -32602, message: `invalid ${methodName} object: expected object, got ${Array.isArray(raw) ? "array" : typeof raw}` }
+  }
+  return raw as Record<string, unknown>
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -731,7 +748,11 @@ async function handleRpc(
       return `0x${suggestedPrice.toString(16)}`
     }
     case "eth_estimateGas": {
-      const estParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: reject non-object first param (string/array/number/bool)
+      // upfront — the `as Record<string,string>` cast was a no-op at
+      // runtime so garbage input coerced to {} and returned a default
+      // 21000-ish gas estimate.
+      const estParams = (requireCallObject((payload.params ?? [])[0], "eth_estimateGas") ?? {}) as Record<string, string>
       // #128: pre-fix the regex was /^0x[0-9a-fA-F]{1,40}$/ which
       // accepted "0x1" or any 1-39 hex chars. Same class as #124 fix
       // for eth_call but eth_estimateGas was missed in that pass.
@@ -765,7 +786,10 @@ async function handleRpc(
       return await evm.getCode(codeAddr, stateRoot)
     }
     case "eth_call": {
-      const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: reject non-object first param upfront — runtime type
+      // assertion bypass let strings/arrays/numbers coerce to {} and
+      // return a no-op "0x" instead of the expected -32602.
+      const callParams = (requireCallObject((payload.params ?? [])[0], "eth_call") ?? {}) as Record<string, string>
       const to = callParams.to ?? ""
       // #124: pre-fix the regex was /^0x[0-9a-fA-F]{1,40}$/ which
       // accepted "0x1" or any 1-39 hex chars. An address must be
@@ -1011,7 +1035,10 @@ async function handleRpc(
       return filters.delete(id)
     }
     case "eth_sendTransaction": {
-      const txParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: same shape validation as eth_call. Pre-fix the type
+      // assertion bypass let non-object input through; downstream
+      // "missing from address" was the only thing that caught it.
+      const txParams = (requireCallObject((payload.params ?? [])[0], "eth_sendTransaction") ?? {}) as Record<string, string>
       const from = txParams.from?.toLowerCase()
       if (!from) throw { code: -32602, message: "missing from address" }
       if (!/^0x[0-9a-fA-F]{40}$/.test(from)) {
@@ -1112,7 +1139,8 @@ async function handleRpc(
       return signature.serialized
     }
     case "eth_createAccessList": {
-      const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: shape validation symmetric with eth_call.
+      const callParams = (requireCallObject((payload.params ?? [])[0], "eth_createAccessList") ?? {}) as Record<string, string>
       // #148: validate address + value/gas/data shape upfront.
       if (callParams.to && !/^0x[0-9a-fA-F]{40}$/.test(callParams.to)) {
         throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
@@ -1136,7 +1164,8 @@ async function handleRpc(
     }
     case "debug_traceCall": {
       if (!DEBUG_RPC_ENABLED) throw { code: -32601, message: "debug methods disabled (set COC_DEBUG_RPC=1)" }
-      const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: shape validation symmetric with eth_call.
+      const callParams = (requireCallObject((payload.params ?? [])[0], "debug_traceCall") ?? {}) as Record<string, string>
       // #148: validate shape — same as eth_call.
       if (callParams.to && !/^0x[0-9a-fA-F]{40}$/.test(callParams.to)) {
         throw { code: -32602, message: "invalid to address: must match /^0x[0-9a-fA-F]{40}$/" }
@@ -1201,7 +1230,8 @@ async function handleRpc(
     }
     case "trace_call": {
       if (!DEBUG_RPC_ENABLED) throw { code: -32601, message: "debug methods disabled (set COC_DEBUG_RPC=1)" }
-      const callParams = ((payload.params ?? [])[0] ?? {}) as Record<string, string>
+      // #172: shape validation symmetric with eth_call.
+      const callParams = (requireCallObject((payload.params ?? [])[0], "trace_call") ?? {}) as Record<string, string>
       const traceTypes = normalizeReplayTraceTypes((payload.params ?? [])[1])
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[2], chain)
       const result = await evm.traceCall({


### PR DESCRIPTION
Closes #172.

## Summary

Six methods used the pattern `((payload.params ?? [])[0] ?? {}) as Record<string, string>` to extract the tx-shaped first arg. The `as` is a TypeScript type assertion that does **not** validate at runtime, so strings, arrays, numbers, booleans all coerced to an effectively-empty tx object. The methods then returned `"0x"` (eth_call) or default `21000`-ish gas estimates (eth_estimateGas) — silent successes for what should be `-32602`.

## Mapping

| Method | Pre-fix behavior with `["string-input", "latest"]` | After |
|---|---|---|
| `eth_call` | `result: "0x"` | `-32602` |
| `eth_estimateGas` | `result: "0xe3bc"` | `-32602` |
| `eth_sendTransaction` | `-32602 missing from address` (downstream catch) | `-32602 expected object` (clearer) |
| `eth_createAccessList` | `result: {...}` | `-32602` |
| `debug_traceCall` | `result: {...}` (when enabled) | `-32602` |
| `trace_call` | `result: {...}` (when enabled) | `-32602` |

Added shared `requireCallObject(raw, methodName)` helper that accepts `null`/`undefined` (preserved as the ergonomic for `eth_call(null)` ping probes, matching geth) but rejects arrays/strings/numbers/booleans.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts` → 76/76 pass
- [x] `rpc-extended.test.ts #172` — string + array probes assert `-32602`, `null` sanity check confirms ergonomic preserved
- [ ] CI green