### PR TITLE
fix(ipfs-http): /api/v0/cat honors offset + length query params (#174)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -312,6 +312,41 @@ describe("IpfsHttpServer", () => {
     assert.equal(bgBody.error, "block not found")
   })
 
+  it("#174: /api/v0/cat honors offset + length query params", async () => {
+    // Pre-fix the handler accepted offset/length/count via query but
+    // ignored them, returning the full file. Malformed values
+    // (negative, non-numeric) also silently passed.
+    const content = new TextEncoder().encode("ABCDEFGHIJ") // 10 bytes
+    const meta = await unixfs.addFile("range.bin", content)
+    // (a) offset + length slice
+    const r1 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=2&length=3`, { method: "POST" })
+    assert.equal(r1.status, 200)
+    assert.deepEqual(new Uint8Array(await r1.buffer()), new TextEncoder().encode("CDE"))
+    // (b) offset only — tail from index 5
+    const r2 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=5`, { method: "POST" })
+    assert.equal(r2.status, 200)
+    assert.deepEqual(new Uint8Array(await r2.buffer()), new TextEncoder().encode("FGHIJ"))
+    // (c) `count` alias for length (js-ipfs compat)
+    const r3 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=0&count=4`, { method: "POST" })
+    assert.equal(r3.status, 200)
+    assert.deepEqual(new Uint8Array(await r3.buffer()), new TextEncoder().encode("ABCD"))
+    // (d) offset past end → empty (matches kubo)
+    const r4 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=100`, { method: "POST" })
+    assert.equal(r4.status, 200)
+    assert.equal((await r4.buffer()).length, 0)
+    // (e) negative offset → 400
+    const r5 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=-1`, { method: "POST" })
+    assert.equal(r5.status, 400)
+    assert.match((await r5.json() as { error: string }).error, /invalid offset/)
+    // (f) non-numeric offset → 400
+    const r6 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=notnum`, { method: "POST" })
+    assert.equal(r6.status, 400)
+    // (g) no params → full file (unchanged)
+    const r7 = await fetch(`/api/v0/cat?arg=${meta.cid}`, { method: "POST" })
+    assert.equal(r7.status, 200)
+    assert.deepEqual(new Uint8Array(await r7.buffer()), content)
+  })
+
   it("GET /api/v0/pin/ls?arg=<cid> returns only that CID when pinned", async () => {
     const dataA = new TextEncoder().encode("pin-A")
     const dataB = new TextEncoder().encode("pin-B")

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -210,7 +210,10 @@ export class IpfsHttpServer {
         return
       }
       if (url.pathname === "/api/v0/cat") {
-        await this.handleCat(req, res, url.query.arg as string)
+        await this.handleCat(req, res, url.query.arg as string, {
+          offset: url.query.offset as string | undefined,
+          length: (url.query.length ?? url.query.count) as string | undefined,
+        })
         return
       }
       if (url.pathname === "/api/v0/get") {
@@ -566,15 +569,46 @@ export class IpfsHttpServer {
     }))
   }
 
-  private async handleCat(req: http.IncomingMessage, res: http.ServerResponse, cid?: string): Promise<void> {
+  private async handleCat(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    cid?: string,
+    range?: { offset?: string; length?: string },
+  ): Promise<void> {
     if (!cid || !isValidCid(cid)) {
       res.writeHead(400)
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
+    // #174: pre-fix the offset/length/count query params were accepted
+    // by kubo's spec but the handler ignored them, returning the full
+    // file regardless. Worse, malformed values (negative, non-numeric)
+    // silently passed through. Validate + slice now.
+    let offset = 0
+    let length: number | undefined
+    if (range?.offset !== undefined) {
+      const n = Number(range.offset)
+      if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+        res.writeHead(400, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "invalid offset: must be a non-negative integer" }))
+        return
+      }
+      offset = n
+    }
+    if (range?.length !== undefined) {
+      const n = Number(range.length)
+      if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+        res.writeHead(400, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "invalid length: must be a non-negative integer" }))
+        return
+      }
+      length = n
+    }
     const data = await this.readByCid(cid)
+    const buf = Buffer.from(data)
+    const slice = length !== undefined ? buf.subarray(offset, offset + length) : buf.subarray(offset)
     res.writeHead(200)
-    res.end(data)
+    res.end(slice)
   }
 
   private async handleGet(res: http.ServerResponse, cid?: string): Promise<void> {


### PR DESCRIPTION
Closes #174.

## Summary

`/api/v0/cat` accepted the `offset` and `length` query params per kubo's spec but the handler ignored them, returning the full file regardless. Malformed values (negative, non-numeric) silently passed through. MFS `/api/v0/files/read` already forwarded these correctly — `/api/v0/cat` was the outlier.

This is a real **bandwidth multiplier**: a client streaming a 1GB file in 1MB chunks would get 1GB on every chunk request, not 1MB.

## Behavior

| Request | Before | After |
|---|---|---|
| `cat?arg=<cid>&offset=2&length=3` | full file | 3-byte slice from offset 2 |
| `cat?arg=<cid>&offset=5` | full file | tail from offset 5 |
| `cat?arg=<cid>&offset=0&count=4` | full file | first 4 bytes (`count` is js-ipfs-compat alias) |
| `cat?arg=<cid>&offset=100` (past end) | full file | empty (matches kubo) |
| `cat?arg=<cid>&offset=-1` | full file | `400 invalid offset` |
| `cat?arg=<cid>&offset=notnum` | full file | `400 invalid offset` |
| `cat?arg=<cid>` (no params) | full file | full file (unchanged) |

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts tests/e2e/ipfs-e2e.test.ts` → 74/74 pass
- [x] `ipfs-http.test.ts #174` — 7 cases covering each path including negative/non-numeric rejection
- [ ] CI green