### PR TITLE
fix(pose-http): sanitize client error messages (#176)

### DIFF
--- a/node/src/pose-http.test.ts
+++ b/node/src/pose-http.test.ts
@@ -290,6 +290,38 @@ test("POST /pose/challenge rejects signer when dynamic challenger authorizer den
   }
 })
 
+test("#176: malformed JSON body returns generic error without V8 SyntaxError leak", async () => {
+  // Pre-fix `String(error)` on JSON.parse failure surfaced the V8
+  // SyntaxError class name + source position to clients — information
+  // disclosure analogous to #156 (ethers leak) and #170 (Buffer.from
+  // silent drop). Now sanitized to "invalid request".
+  const pose = createTestEngine()
+  const { port, close } = await startTestServer(pose)
+  try {
+    const raw = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+      const req = http.request(
+        { hostname: "127.0.0.1", port, path: "/pose/challenge", method: "POST", headers: { "content-type": "application/json" } },
+        (res) => {
+          let data = ""
+          res.on("data", (chunk) => (data += chunk))
+          res.on("end", () => resolve({ status: res.statusCode ?? 500, body: data }))
+        },
+      )
+      req.on("error", reject)
+      req.write("not-json")
+      req.end()
+    })
+    assert.equal(raw.status, 400)
+    // The response body must NOT leak V8 internals — no "SyntaxError",
+    // no source position offset, no Error class name.
+    assert.doesNotMatch(raw.body, /SyntaxError|Unexpected token|position|Error:/, "must not leak V8 / Error class details")
+    const json = JSON.parse(raw.body) as { error: string }
+    assert.equal(json.error, "invalid request")
+  } finally {
+    close()
+  }
+})
+
 function hashStable(value: unknown): `0x${string}` {
   return `0x${keccak256Hex(Buffer.from(stableStringify(value), "utf8"))}` as `0x${string}`
 }

--- a/node/src/pose-http.ts
+++ b/node/src/pose-http.ts
@@ -243,7 +243,12 @@ export function registerPoseRoutes(
           }
           return jsonResponse(res, 200, { accepted: true })
         } catch (error) {
-          return jsonResponse(res, 400, { error: `receipt rejected: ${String(error)}` })
+          // #176: pre-fix `String(error)` leaked the underlying Error
+          // class name to clients. Keep the readable .message since
+          // it carries domain-specific info (quota state, signature
+          // verification result, etc.) but strip the class-name prefix.
+          const msg = error instanceof Error ? error.message : "unknown error"
+          return jsonResponse(res, 400, { error: `receipt rejected: ${msg}` })
         }
       },
     },
@@ -354,7 +359,12 @@ export function handlePoseRequest(
 
       route.handler(payload, res)
     } catch (error) {
-      jsonResponse(res, 400, { error: String(error) })
+      // #176: pre-fix `String(error)` leaked V8 SyntaxError class +
+      // source position for JSON.parse failures, and stack-class info
+      // for other thrown errors. Sanitize to a generic message — same
+      // pattern as the rest of the codebase (eth_sendRawTransaction
+      // #156, web3_sha3 #170, etc.).
+      jsonResponse(res, 400, { error: "invalid request" })
     }
   })
   return true


### PR DESCRIPTION
Closes #176.

## Summary

Two pose-http catch blocks called `String(error)` and passed the result directly to the client. For `JSON.parse` failures this leaked the V8 internal `SyntaxError` class name and source position:

```
POST /pose/challenge -d 'not-json'
→ 400 {"error":"SyntaxError: Unexpected token 'o', \"not-json\" is not valid JSON"}
```

Same information disclosure pattern as #156 (ethers.js version leak) and #170 (Buffer.from silent drop).

## Behavior

| Request | Before | After |
|---|---|---|
| `POST /pose/challenge -d 'not-json'` | `400 SyntaxError: Unexpected token 'o'…` | `400 invalid request` |
| `POST /pose/receipt` (valid JSON, bad receipt) | `400 receipt rejected: Error: <msg>` | `400 receipt rejected: <msg>` (kept .message, dropped class prefix) |

The receipt-rejection path keeps the readable `.message` because it carries domain-specific info (quota state, signature verification result) that the caller needs. Only the class-name prefix is stripped.

## Test plan

- [x] `node --experimental-strip-types --test node/src/pose-http.test.ts node/src/pose-engine.test.ts node/src/pose-auth.test.ts node/src/pose-authorizer.test.ts` → 35/35 pass
- [x] `pose-http.test.ts #176` — sends `"not-json"` body, asserts response body does NOT match `/SyntaxError|Unexpected token|position|Error:/`
- [ ] CI green