### PR TITLE
fix(rpc): eth_sendTransaction validates + honors user-provided nonce (#178)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1298,6 +1298,32 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok.error, undefined, `null tx must NOT error: ${JSON.stringify(ok.error)}`)
   })
 
+  await t.test("#178: eth_sendTransaction validates + honors user-provided nonce", async () => {
+    // Pre-fix txParams.nonce was silently dropped — every call used
+    // the next sequential mempool nonce regardless of what the user
+    // passed. Negative / non-hex / NaN nonces all "worked" with the
+    // value ignored. Now: validate shape, honor when present.
+    const accounts = await rpcCall(port, "eth_accounts") as string[]
+    const probe = async (nonce: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_sendTransaction",
+          params: [{ from: accounts[0], to: accounts[1], value: "0x1000", gas: "0x5208", nonce }],
+        }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) negative nonce → -32602 (pre-fix was silently accepted)
+    const r1 = await probe("-1")
+    assert.equal(r1.error?.code, -32602, `negative nonce must be -32602, got ${r1.error?.code}`)
+    assert.match(r1.error!.message, /nonce/i, "error must name the field")
+    // (b) non-hex nonce → -32602
+    const r2 = await probe("not-hex")
+    assert.equal(r2.error?.code, -32602, `non-hex nonce must be -32602, got ${r2.error?.code}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1053,11 +1053,24 @@ async function handleRpc(
       const account = testAccounts.get(from)
       if (!account) throw { code: -32004, message: `account not found: ${from}. Use eth_accounts to list available test accounts.` }
 
+      // #178: pre-fix the user's `nonce` field was silently dropped —
+      // every call used the next sequential mempool nonce regardless.
+      // Negative, NaN, far-future, or "not-hex" all "worked" with the
+      // user's value ignored. Validate shape and honor it when present
+      // (matches the Ethereum JSON-RPC spec).
+      let userNonce: bigint | undefined
+      if (txParams.nonce !== undefined && txParams.nonce !== null && txParams.nonce !== "") {
+        if (typeof txParams.nonce !== "string" || !/^0x[0-9a-fA-F]+$/.test(txParams.nonce)) {
+          throw { code: -32602, message: "invalid nonce: must match /^0x[0-9a-fA-F]+$/" }
+        }
+        userNonce = BigInt(txParams.nonce)
+      }
+
       // Serialize per-account to prevent concurrent nonce collision
       const prev = sendTxLocks.get(from) ?? Promise.resolve()
       const work = prev.catch(() => {}).then(async () => {
         const onchainNonce = await evm.getNonce(from)
-        const nonce = chain.mempool.getPendingNonce(from as Hex, onchainNonce)
+        const nonce = userNonce ?? chain.mempool.getPendingNonce(from as Hex, onchainNonce)
         const gasPrice = txParams.gasPrice ?? "0x3b9aca00" // 1 gwei
         const gasLimitRaw = txParams.gas ?? "0x" + (await evm.estimateGas({
           from: txParams.from,


### PR DESCRIPTION
Closes #178.

## Summary

Pre-fix `txParams.nonce` was silently dropped. Every `eth_sendTransaction` call computed `mempool.getPendingNonce(from)` regardless of what the user passed. Negative, NaN, non-hex, far-future nonces all "worked" silently with the user's value ignored.

This broke the spec'd **replacement-tx** ergonomic (a client trying to unstick a pending tx by submitting a new one with the same nonce got a sequential nonce instead — their stuck tx stayed stuck).

## Behavior

| `nonce` field | Before | After |
|---|---|---|
| absent / null / `""` | next sequential (unchanged) | next sequential (unchanged) |
| `"0x0"`, `"0x1"`, etc. (valid hex) | silently ignored → next sequential | honored |
| `"-1"`, `"not-hex"` | silently ignored → tx submitted with sequential | `-32602 invalid nonce` |

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts` → 78/78 pass
- [x] `rpc-extended.test.ts #178` — negative + non-hex probes assert `-32602`
- [ ] CI green