### PR TITLE
fix(ipfs-http): /api/v0/add?erasure=N+M validates upper bounds (#180)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -347,6 +347,32 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(new Uint8Array(await r7.buffer()), content)
   })
 
+  it("#180: /api/v0/add?erasure=N+M rejects N or M above MAX_DATA/PARITY_SHARDS with 400 (not 500)", async () => {
+    // Pre-fix parseErasureSpec only checked the lower bound (n>=1,
+    // m>=1). Values above MAX_DATA_SHARDS / MAX_PARITY_SHARDS (24
+    // each) parsed cleanly, the body was fully read + UnixFS'd,
+    // *then* erasureEncode threw and handleAdd didn't catch it —
+    // bubbled up as a generic 500 with "internal error" body and a
+    // stacktrace logged. Reject at parse time now so we don't waste
+    // the upload.
+    const r1 = await fetch(`/api/v0/add?erasure=25%2B1`, {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: "hello",
+    })
+    assert.equal(r1.status, 400, `n=25 must be 400 (not 500), got ${r1.status}`)
+    const body1 = await r1.json() as { error: string; message?: string }
+    assert.match(body1.error, /erasure/i)
+    assert.match(body1.message ?? body1.error, /MAX_DATA_SHARDS|exceeds/i)
+    // Symmetric: m above limit also rejects.
+    const r2 = await fetch(`/api/v0/add?erasure=1%2B25`, {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: "hello",
+    })
+    assert.equal(r2.status, 400, `m=25 must be 400, got ${r2.status}`)
+  })
+
   it("GET /api/v0/pin/ls?arg=<cid> returns only that CID when pinned", async () => {
     const dataA = new TextEncoder().encode("pin-A")
     const dataB = new TextEncoder().encode("pin-B")

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -15,6 +15,8 @@ import {
   encodeFile as erasureEncode,
   ErasureError,
   type ErasureManifest,
+  MAX_DATA_SHARDS,
+  MAX_PARITY_SHARDS,
 } from "./ipfs-erasure.ts"
 import {
   resolveCid,
@@ -272,9 +274,25 @@ export class IpfsHttpServer {
       res.writeHead(404)
       res.end(JSON.stringify({ error: "not found" }))
       } catch (err) {
-        const status = err instanceof HttpError ? err.status : 500
-        const code = err instanceof HttpError ? err.code : "internal error"
-        const message = err instanceof HttpError && err.message !== code ? err.message : undefined
+        // #180: defensively map ErasureError to 4xx — the inline
+        // handleCat path already does this for read-side ErasureError,
+        // but handleAdd's `erasureEncode` could also throw with
+        // code="invalid_params" and bubble up as 500 with a useless
+        // "internal error" body if a new ErasureError class slips in.
+        let status = err instanceof HttpError ? err.status : 500
+        let code = err instanceof HttpError ? err.code : "internal error"
+        let message = err instanceof HttpError && err.message !== code ? err.message : undefined
+        if (status === 500 && err instanceof ErasureError) {
+          if (err.code === "invalid_params") {
+            status = 400
+            code = "invalid erasure params"
+            message = err.message
+          } else if (err.code === "not_found") {
+            status = 404
+            code = "not found"
+            message = err.message
+          }
+        }
         if (!res.headersSent) {
           res.writeHead(status, { "content-type": "application/json" })
         }
@@ -1203,6 +1221,17 @@ function parseErasureSpec(spec: string | undefined): { n: number; m: number } | 
   const m = Number(match[2])
   if (!Number.isInteger(n) || !Number.isInteger(m) || n < 1 || m < 1) {
     throw new HttpError(400, "invalid erasure spec", `n and m must be positive integers, got n=${n} m=${m}`)
+  }
+  // #180: pre-fix the upper bound (MAX_DATA_SHARDS / MAX_PARITY_SHARDS)
+  // wasn't enforced here. `erasureEncode` later threw an ErasureError
+  // which handleAdd didn't catch — surfaced as a generic 500 after the
+  // multipart body was fully read and the UnixFS file was already
+  // added. Reject at parse time instead so we don't waste the upload.
+  if (n > MAX_DATA_SHARDS) {
+    throw new HttpError(400, "invalid erasure spec", `n=${n} exceeds MAX_DATA_SHARDS (${MAX_DATA_SHARDS})`)
+  }
+  if (m > MAX_PARITY_SHARDS) {
+    throw new HttpError(400, "invalid erasure spec", `m=${m} exceeds MAX_PARITY_SHARDS (${MAX_PARITY_SHARDS})`)
   }
   return { n, m }
 }


### PR DESCRIPTION
Closes #180.

## Summary

`parseErasureSpec` only checked the lower bound (`n>=1`, `m>=1`). Values above `MAX_DATA_SHARDS` / `MAX_PARITY_SHARDS` (24 each) parsed cleanly, the multipart body was fully read, the UnixFS file was added to the blockstore, **then** `erasureEncode` threw and the error bubbled up to the outer 500 handler — generic `{"error":"internal error"}` body with the real reason only visible in the server log.

## Behavior

| Spec | Before | After |
|---|---|---|
| `25+1` | `500 internal error` | `400 n=25 exceeds MAX_DATA_SHARDS (24)` |
| `1+25` | `500 internal error` | `400 m=25 exceeds MAX_PARITY_SHARDS (24)` |
| `24+24` | `200` | `200` (unchanged) |
| `99+99` | `500 internal error` | `400 n=99 exceeds MAX_DATA_SHARDS (24)` |
| `4+2` | `200` | `200` (unchanged) |

Bonus: defensive `ErasureError → 4xx` mapping added in `handleAdd`'s outer catch (mirrors the read-side mapping already in `handleCat`). Any future ErasureError class additions surface cleanly instead of as 500-no-body.

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts tests/e2e/ipfs-e2e.test.ts` → 75/75 pass
- [x] `ipfs-http.test.ts #180` — n=25 + m=25 probes assert 400 with `MAX_DATA_SHARDS|exceeds` in the message
- [ ] CI green