### PR TITLE
fix(rpc): eth_signTypedData_v4 sanitizes ethers shape errors (#182)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1324,6 +1324,32 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(r2.error?.code, -32602, `non-hex nonce must be -32602, got ${r2.error?.code}`)
   })
 
+  await t.test("#182: eth_signTypedData_v4 sanitizes ethers errors (no version + INVALID_ARGUMENT leak)", async () => {
+    // Pre-fix structural errors from TypedDataEncoder.hash (missing
+    // primaryType, primaryType not in types, circular references)
+    // bubbled up as -32603 with ethers' raw message including
+    // version=6.16.0 and code=INVALID_ARGUMENT. Same class of leak
+    // as #156 (Transaction.from) and #176 (V8 SyntaxError).
+    const accounts = await rpcCall(port, "eth_accounts") as string[]
+    const probe = async (typedData: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_signTypedData_v4", params: [accounts[0], typedData] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) empty typed data — missing primaryType + types → -32602, no leak
+    const r1 = await probe({})
+    assert.equal(r1.error?.code, -32602, `empty typedData must be -32602, got ${r1.error?.code}`)
+    assert.doesNotMatch(r1.error!.message, /version=|INVALID_ARGUMENT|code=/, "must not leak ethers internals")
+    // (b) circular type reference → -32602, no leak
+    const circ = { types: { EIP712Domain: [], A: [{ name: "a", type: "A" }] }, primaryType: "A", domain: {}, message: { a: {} } }
+    const r2 = await probe(circ)
+    assert.equal(r2.error?.code, -32602, `circular ref must be -32602, got ${r2.error?.code}`)
+    assert.doesNotMatch(r2.error!.message, /version=|INVALID_ARGUMENT|code=/, "must not leak ethers internals")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1147,7 +1147,22 @@ async function handleRpc(
       // Remove EIP712Domain from types (TypedDataEncoder handles it internally)
       const filteredTypes = { ...types }
       delete filteredTypes.EIP712Domain
-      const dataHash = TypedDataEncoder.hash(domain, filteredTypes, message)
+      // #182: pre-fix structural errors from TypedDataEncoder.hash
+      // (missing primaryType, primaryType not in types, circular type
+      // references) bubbled up as -32603 with ethers' raw message
+      // including version=6.16.0 and code=INVALID_ARGUMENT. Same class
+      // of leak as #156 (Transaction.from) and #176 (V8 SyntaxError).
+      let dataHash: string
+      try {
+        dataHash = TypedDataEncoder.hash(domain, filteredTypes, message)
+      } catch (encErr) {
+        const isEthersShapeError =
+          encErr && typeof encErr === "object" && typeof (encErr as { code?: unknown }).code === "string"
+        if (isEthersShapeError) {
+          throw { code: -32602, message: "invalid typedData: failed to encode" }
+        }
+        throw encErr
+      }
       const signature = account.signingKey.sign(dataHash)
       return signature.serialized
     }


### PR DESCRIPTION
Closes #182.

## Summary

Structural errors from `ethers.TypedDataEncoder.hash` (missing `primaryType`, primaryType not in `types`, circular type references) bubbled up as `-32603` with the raw ethers message — leaking `version=6.16.0` and `code=INVALID_ARGUMENT` to unauthenticated callers.

Same class of information-disclosure as already-fixed #156 (`eth_sendRawTransaction` Transaction.from leak) and #176 (`pose-http` V8 SyntaxError leak).

## Behavior

| Input | Before | After |
|---|---|---|
| `{}` | `-32603 missing primary type (argument="types", …, code=INVALID_ARGUMENT, version=6.16.0)` | `-32602 invalid typedData: failed to encode` |
| circular type ref | `-32603 circular type reference to "A" (… code=INVALID_ARGUMENT, version=6.16.0)` | `-32602 invalid typedData: failed to encode` |
| missing primaryType | same V8 leak as above | `-32602 invalid typedData: failed to encode` |
| valid typed data | success | success (unchanged) |

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts` → 79/79 pass
- [x] `rpc-extended.test.ts #182` — empty + circular-ref probes assert `-32602` AND message does NOT match `/version=|INVALID_ARGUMENT|code=/`
- [ ] CI green