### PR TITLE
fix(rpc): coc_chainStats handles undefined cfg.chainId (no V8 TypeError leak) (#184)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1350,6 +1350,23 @@ test("RPC Extended Methods", async (t) => {
     assert.doesNotMatch(r2.error!.message, /version=|INVALID_ARGUMENT|code=/, "must not leak ethers internals")
   })
 
+  await t.test("#184: coc_chainStats does not crash when chain.cfg.chainId is undefined", async () => {
+    // Pre-fix `chain.cfg.chainId.toString(16)` assumed chainId was
+    // always set, but ChainEngineConfig.chainId is optional in the
+    // type. Bare undefined.toString() leaked as
+    // -32603 "Cannot read properties of undefined (reading 'toString')".
+    // This fixture deliberately does NOT pass chainId to ChainEngine
+    // (see line 38-48), so chain.cfg.chainId is undefined here — making
+    // this a direct repro of the bug.
+    const stats = await rpcCall(port, "coc_chainStats") as Record<string, unknown>
+    assert.ok(typeof stats === "object" && stats !== null, "must return an object")
+    assert.equal(stats.chainId, "0x1", `chainId must fall back to "0x1" when cfg.chainId is undefined, got ${stats.chainId}`)
+    assert.ok(typeof stats.blockHeight === "string", "blockHeight must be hex")
+    assert.ok(typeof stats.validatorCount === "number", "validatorCount must be number")
+    // Defend against V8 leak in error path.
+    assert.doesNotMatch(JSON.stringify(stats), /Cannot read properties|undefined.*reading/, "must not leak TypeError")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2137,7 +2137,13 @@ async function handleRpc(
           pendingTxCount: poolStats.size,
           recentTxCount,
           validatorCount: validators.length,
-          chainId: `0x${hasConfig(chain) ? chain.cfg.chainId.toString(16) : "1"}`,
+          // #184: pre-fix the inner ternary assumed chain.cfg.chainId
+          // was defined whenever hasConfig() returned true. But
+          // ChainEngineConfig.chainId is optional in the type — the
+          // constructor only defaults it for the mempool, not for cfg
+          // itself. Bare `undefined.toString(16)` leaked to clients
+          // as -32603 "Cannot read properties of undefined".
+          chainId: `0x${chain.cfg?.chainId?.toString(16) ?? "1"}`,
         }
         chainStatsCache = { result: statsResult, height, cachedAtMs: now }
         return statsResult


### PR DESCRIPTION
Closes #184.

## Summary

`coc_chainStats` read `chain.cfg.chainId.toString(16)` while `hasConfig(chain)` was true. But `ChainEngineConfig.chainId` is optional in the type (`node/src/chain-engine.ts:38` — `chainId?: number`); the constructor defaults it for the mempool only, not for `cfg` itself. With `chainId` unset, the `toString` call threw a V8 TypeError that surfaced as:

```
-32603 "Cannot read properties of undefined (reading 'toString')"
```

Same class of information-disclosure leak as already-fixed #156 / #170 / #176 / #182.

## Fix

Optional chaining + nullish fallback:

```typescript
chainId: `0x${chain.cfg?.chainId?.toString(16) ?? "1"}`,
```

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/rpc-semantic-compat.test.ts` → 86/86 pass
- [x] The `rpc-extended.test.ts` fixture deliberately does NOT pass `chainId` to ChainEngine — `chain.cfg.chainId` is undefined in this fixture, making the new `#184` test a direct repro of the bug
- [x] Test asserts `stats.chainId === "0x1"` (fallback) AND that response body does not contain `"Cannot read properties"`
- [ ] CI green