### PR TITLE
fix(rpc): eth_getLogs validates blockHash field shape (#186)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1367,6 +1367,31 @@ test("RPC Extended Methods", async (t) => {
     assert.doesNotMatch(JSON.stringify(stats), /Cannot read properties|undefined.*reading/, "must not leak TypeError")
   })
 
+  await t.test("#186: eth_getLogs validates blockHash field shape (parity with address+topics #162)", async () => {
+    // Pre-fix the blockHash field was accepted as anything — "0x123",
+    // "bogus", null, 42 all returned `result: []` indistinguishable
+    // from "no logs in that block". Now validates 32-byte hex shape
+    // matching the eth_getBlockByHash (#166) rule.
+    const probe = async (filter: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filter] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) Short blockHash → -32602
+    const r1 = await probe({ blockHash: "0x123" })
+    assert.equal(r1.error?.code, -32602, `short blockHash must be -32602, got ${r1.error?.code}`)
+    assert.match(r1.error!.message, /blockHash/i, "error must name the field")
+    // (b) Non-hex blockHash → -32602
+    const r2 = await probe({ blockHash: "bogus" })
+    assert.equal(r2.error?.code, -32602, `non-hex blockHash must be -32602, got ${r2.error?.code}`)
+    // Sanity: omitted / explicit-null blockHash still works (returns []).
+    const ok = await probe({})
+    assert.equal(ok.error, undefined, "omitted blockHash must NOT error")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3326,6 +3326,17 @@ function validateLogFilter(query: Record<string, unknown>): {
   const FILTER_TOPIC_RE = /^0x[0-9a-fA-F]{64}$/
   const MAX_FILTER_ADDRESSES = 100
   const MAX_FILTER_TOPICS = 4
+  // #186: blockHash field shape validation was missed by #162's
+  // address+topics work. Pre-fix `{blockHash: "0x123"}` silently
+  // returned `result: []` indistinguishable from "no logs". Match
+  // the 32-byte hex shape of eth_getBlockByHash (#166).
+  if (query.blockHash !== undefined && query.blockHash !== null) {
+    if (typeof query.blockHash !== "string" || !FILTER_TOPIC_RE.test(query.blockHash)) {
+      throw { code: -32602, message: "invalid blockHash: must match /^0x[0-9a-fA-F]{64}$/" }
+    }
+    // Normalize for downstream consumers (lowercase canonical form).
+    query.blockHash = query.blockHash.toLowerCase()
+  }
   const validateFilterAddr = (raw: unknown, idx: number): Hex => {
     if (typeof raw !== "string" || !FILTER_ADDR_RE.test(raw)) {
       throw { code: -32602, message: `invalid filter address at index ${idx}: must match /^0x[0-9a-fA-F]{40}$/` }


### PR DESCRIPTION
Closes #186.

## Summary

Pre-fix `eth_getLogs` validated `address` + `topics` (PR #162) but missed the third filter field, `blockHash`. Any value — `"0x123"` (short), `"bogus"` (non-hex), `null`, `42` — silently passed and the handler returned `result: []`, indistinguishable from "no logs in that block".

## Scope

This PR fixes only the **shape-validation gap**. The deeper bug from #186 — `eth_getLogs` also silently drops `blockHash` downstream and scans `latest` regardless — is a separate larger change. The shape validation closes the obvious typo-detection hole; a follow-up will wire `blockHash` through to actually scope the query.

## Behavior

| Filter | Before | After |
|---|---|---|
| `{blockHash: "0x123"}` | `result: []` | `-32602 invalid blockHash: must match …` |
| `{blockHash: "bogus"}` | `result: []` | `-32602 invalid blockHash` |
| `{blockHash: null}` / `{}` | `result: []` | `result: []` (unchanged — null means "not set") |
| `{blockHash: 64charValidHex}` | `result: []` | `result: []` (unchanged for now — follow-up impl) |

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/websocket-rpc.test.ts` → 90/90 pass
- [x] `rpc-extended.test.ts #186` — short + non-hex probes assert `-32602`, omitted sanity check
- [ ] CI green