### PR TITLE
fix(rpc): eth_getLogs rejects non-array topics field (#190)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -19,6 +19,20 @@ async function rpcCall(port: number, method: string, params?: unknown[]) {
   return json.result
 }
 
+// Returns the full JSON-RPC envelope (does NOT throw on .error). Use this
+// when the test asserts on error code/message rather than success result.
+async function rpcCallRaw(port: number, method: string, params?: unknown[]): Promise<{
+  result?: unknown
+  error?: { code: number; message: string }
+}> {
+  const response = await fetch(`http://127.0.0.1:${port}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? [] }),
+  })
+  return await response.json() as { result?: unknown; error?: { code: number; message: string } }
+}
+
 test("RPC Extended Methods", async (t) => {
   const prevDevAccounts = process.env.COC_DEV_ACCOUNTS
   process.env.COC_DEV_ACCOUNTS = "1"
@@ -1441,6 +1455,30 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okUndef.error, undefined, "undefined tag must NOT error")
     const okNull = await probe(null)
     assert.equal(okNull.error, undefined, "null tag must NOT error")
+  })
+
+  await t.test("#190: eth_getLogs rejects non-array topics field (no silent bypass)", async () => {
+    // Pre-fix `validateLogFilter` only validated when Array.isArray(topics).
+    // A client passing topics as a string/object got the same empty-result
+    // response as a syntactically-valid filter — no signal that the query
+    // was malformed. Probes pin the shape contract.
+    const cases: Array<{ topics: unknown; label: string }> = [
+      { topics: "not-array", label: "string" },
+      { topics: { weird: "shape" }, label: "object" },
+      { topics: 12345, label: "number" },
+      { topics: true, label: "bool" },
+    ]
+    for (const { topics, label } of cases) {
+      const resp = await rpcCallRaw(port, "eth_getLogs", [{ fromBlock: "0x0", toBlock: "0x0", topics }])
+      assert.equal(resp.error?.code, -32602, `topics=${label} must be -32602, got ${JSON.stringify(resp)}`)
+      assert.match(resp.error!.message, /invalid filter topics/i, `error must explain shape: ${resp.error!.message}`)
+    }
+    // Sanity: valid empty topics array still returns result.
+    const ok = await rpcCall(port, "eth_getLogs", [{ fromBlock: "0x0", toBlock: "0x0", topics: [] }])
+    assert.ok(Array.isArray(ok), "valid empty topics array must return results array")
+    // Sanity: omitted topics still returns result.
+    const ok2 = await rpcCall(port, "eth_getLogs", [{ fromBlock: "0x0", toBlock: "0x0" }])
+    assert.ok(Array.isArray(ok2), "omitted topics must return results array")
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3371,7 +3371,14 @@ function validateLogFilter(query: Record<string, unknown>): {
     query.address = addresses ?? address
   }
   let topics: Array<Hex | Hex[] | null> | undefined
-  if (Array.isArray(query.topics)) {
+  if (query.topics !== undefined && query.topics !== null) {
+    // #190: pre-fix, a non-array `topics` (string, object, number) silently
+    // bypassed the entire validation block — clients got the same empty-result
+    // response as a syntactically-valid query and never learned their filter
+    // was malformed.
+    if (!Array.isArray(query.topics)) {
+      throw { code: -32602, message: "invalid filter topics: must be array or omitted" }
+    }
     if (query.topics.length > MAX_FILTER_TOPICS) {
       throw { code: -32602, message: `topics array too large: ${query.topics.length} > ${MAX_FILTER_TOPICS} (max indexed log topics)` }
     }


### PR DESCRIPTION
Closes #190.

## Summary

`validateLogFilter` only validated `topics` inside an `Array.isArray(...)` branch. Non-array shapes (string/object/number/bool) silently bypassed validation and returned an empty result, matching the response shape of a syntactically-valid empty filter — no signal that the query was malformed.

## Reproduction (live testnet 209.74.64.88:28780, pre-fix)

```bash
curl -s http://209.74.64.88:28780 -X POST -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"eth_getLogs",
    "params":[{"fromBlock":"0x0","toBlock":"0x0","topics":"not-array"}]}'
# {"jsonrpc":"2.0","id":1,"result":[]}  ← should be -32602
```

## Fix

`node/src/rpc.ts:3352` — gate on `topics !== undefined && topics !== null` instead of `Array.isArray(...)`, then reject non-array with `-32602 invalid filter topics: must be array or omitted`. Spec compliance per JSON-RPC §5.1 / EIP-234.

## Regression test

`#190: eth_getLogs rejects non-array topics field (no silent bypass)` probes string/object/number/bool, plus sanity-checks valid `[]` and omitted topics. Added `rpcCallRaw` helper for clean error-envelope assertion.

## Test plan
- [x] `node --test node/src/rpc-extended.test.ts` → 76/76
- [x] `node --test node/src/{rpc,rpc-extended,rpc-semantic-compat}.test.ts` → 88/88