### PR TITLE
fix(rpc): parseBlockTag rejects array/object/bool shapes (#194)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1415,6 +1415,34 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(r2.error?.code, -32602, `0.5 must be -32602, got ${r2.error?.code}`)
   })
 
+  await t.test("#194: parseBlockTag rejects array/object/bool shapes (no silent fallback to latest)", async () => {
+    // Pre-fix the unknown-shape branch of parseBlockTag fell through
+    // to `return fallback` — every non-string, non-number input (arrays,
+    // objects, booleans) silently mapped to the latest block height.
+    // A client passing the wrong shape got latest's state with no
+    // signal that their query was malformed.
+    const probe = async (tag: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getBalance",
+          params: ["0x" + "0".repeat(40), tag] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // Array, object, bool → -32602.
+    for (const tag of [["latest"], { k: "v" }, true, false] as const) {
+      const r = await probe(tag)
+      assert.equal(r.error?.code, -32602, `tag=${JSON.stringify(tag)} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /block tag/i, "error must explain the shape")
+    }
+    // Sanity: omitting / null tag is still the canonical "latest" shorthand.
+    const okUndef = await probe(undefined)
+    assert.equal(okUndef.error, undefined, "undefined tag must NOT error")
+    const okNull = await probe(null)
+    assert.equal(okNull.error, undefined, "null tag must NOT error")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2427,6 +2427,12 @@ function safeBigInt(input: string): bigint {
 }
 
 function parseBlockTag(input: unknown, fallback: bigint, finalizedHeight?: bigint): bigint {
+  // #194: omitting the param (undefined / null) is the canonical
+  // "latest" shorthand and stays a silent fallback. Every other
+  // non-string, non-number shape (array, object, bool) used to fall
+  // through to the same fallback, which silently mapped malformed
+  // input to latest — sibling bug to #188.
+  if (input === undefined || input === null) return fallback
   if (typeof input === "number") {
     // #188: pre-fix `BigInt(Math.floor(input))` silently truncated
     // fractional values (1.5 → 1). On a real chain the user would
@@ -2444,7 +2450,7 @@ function parseBlockTag(input: unknown, fallback: bigint, finalizedHeight?: bigin
     if (n < 0n) throw { code: -32602, message: `invalid block number: ${input}` }
     return n
   }
-  return fallback
+  throw { code: -32602, message: "invalid block tag: must be hex quantity or named tag" }
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #194.

## Summary

Sibling bug to #188. `parseBlockTag` had a `return fallback` catch-all for any input not `number` or `string`, silently mapping arrays/objects/bools to the latest block height. Callers passing the wrong shape got latest's state with no signal.

## Reproduction (pre-fix, live testnet)

```bash
for tag in '["latest"]' '{"k":"v"}' 'true' 'false'; do
  curl -s http://209.74.64.88:28780 -X POST \
    -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBalance",
        "params":["0x00...", '"$tag"']}'
done
# All: {"result":"0x..."}  ← latest, silently. Should be -32602.
```

## Fix

`node/src/rpc.ts:2429` — explicit `undefined | null → fallback` (the canonical "latest" shorthand), throw `-32602 invalid block tag` for every other non-string-non-number shape.

## Regression test

`#194: parseBlockTag rejects array/object/bool shapes` probes 4 invalid shapes + 2 sanity probes (undefined, null still fall back).

## Test plan
- [x] `node --test node/src/rpc-extended.test.ts` → 78/78 pass
- [x] `node --test node/src/{rpc,rpc-extended,rpc-semantic-compat}.test.ts` → 90/90 pass