### PR TITLE
fix(rpc): eth_get/uninstallFilter* reject malformed filter ids (#196)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1518,6 +1518,42 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(sanityJson.error, undefined, "valid hex index must NOT error")
   })
 
+  await t.test("#196: eth_get/uninstallFilter* reject malformed filter ids (no silent String() coercion)", async () => {
+    // Pre-fix `const id = String((payload.params ?? [])[0] ?? "")`
+    // silently coerced any input — number, array, null — to a string
+    // that won't match any real filter. Callers got `[]` / `false`
+    // indistinguishable from "filter expired", and never learned
+    // their poll was malformed. Filter IDs are `0x` + 32 hex chars.
+    const cases: Array<{ method: string; value: unknown; label: string }> = [
+      { method: "eth_getFilterChanges", value: 42, label: "number" },
+      { method: "eth_getFilterChanges", value: null, label: "null" },
+      { method: "eth_getFilterChanges", value: ["0x" + "a".repeat(32)], label: "array" },
+      { method: "eth_getFilterChanges", value: "not-a-filter-id", label: "non-hex string" },
+      { method: "eth_getFilterChanges", value: "0x123", label: "too short" },
+      { method: "eth_uninstallFilter", value: 42, label: "number" },
+      { method: "eth_uninstallFilter", value: "not-a-filter-id", label: "non-hex" },
+      { method: "eth_getFilterLogs", value: { obj: 1 }, label: "object" },
+      { method: "eth_getFilterLogs", value: "0x" + "a".repeat(31), label: "31 chars" },
+    ]
+    for (const { method, value, label } of cases) {
+      const resp = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [value] }),
+      })
+      const json = await resp.json() as { error?: { code: number; message: string }; result?: unknown }
+      assert.equal(json.error?.code, -32602, `${method}(${label}) must be -32602, got ${JSON.stringify(json)}`)
+      assert.match(json.error!.message, /filter id/i, `${method}: error must name the field`)
+    }
+    // Sanity: real filter from eth_newFilter round-trips correctly.
+    const fid = await rpcCall(port, "eth_newFilter", [{ fromBlock: "0x0", toBlock: "latest" }]) as string
+    assert.match(fid, /^0x[0-9a-fA-F]{32}$/, "newFilter must return shape-correct id")
+    const changes = await rpcCall(port, "eth_getFilterChanges", [fid])
+    assert.ok(Array.isArray(changes), "valid filter id must return array result")
+    const removed = await rpcCall(port, "eth_uninstallFilter", [fid])
+    assert.equal(removed, true, "valid filter id uninstall must return true")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -160,6 +160,25 @@ function requireIndexParam(params: unknown[], index: number, name = "index"): nu
 }
 
 /**
+ * Validate a 16-byte filter ID (#196). Filter IDs are minted as
+ * `0x` + `randomBytes(16).toString("hex")` (32 hex chars). Pre-fix
+ * `String((payload.params ?? [])[0] ?? "")` silently coerced any
+ * input — numbers, arrays, objects — to a never-matching string, so
+ * `eth_getFilterChanges` / `eth_getFilterLogs` / `eth_uninstallFilter`
+ * returned `[]` or `false` indistinguishable from "filter expired."
+ */
+function requireFilterId(params: unknown[], index: number): string {
+  const value = (params ?? [])[index]
+  if (typeof value !== "string") {
+    throw { code: -32602, message: `invalid filter id at index ${index}: expected string` }
+  }
+  if (!/^0x[0-9a-fA-F]{32}$/.test(value)) {
+    throw { code: -32602, message: `invalid filter id at index ${index}: must match /^0x[0-9a-fA-F]{32}$/` }
+  }
+  return value.toLowerCase()
+}
+
+/**
  * Validate that the first param of eth_call / eth_estimateGas /
  * eth_sendTransaction / eth_createAccessList is an object — not a
  * string, number, array, or boolean. #172: pre-fix the type assertion
@@ -1007,7 +1026,10 @@ async function handleRpc(
       return id
     }
     case "eth_getFilterChanges": {
-      const id = String((payload.params ?? [])[0] ?? "")
+      // #196: validate filter-id shape upfront so a buggy client polling
+      // with the wrong type (number, array, null) sees -32602 instead of
+      // a perpetual empty stream that mimics "no new events."
+      const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
       if (!filter) return []
       // Refresh the filter's last-access timestamp so cleanupExpiredFilters
@@ -1051,7 +1073,11 @@ async function handleRpc(
       return logs
     }
     case "eth_uninstallFilter": {
-      const id = String((payload.params ?? [])[0] ?? "")
+      // #196: same shape validation as eth_getFilterChanges so a
+      // malformed id surfaces as -32602 rather than silently returning
+      // `false` (which clients can't distinguish from "filter already
+      // expired or never existed").
+      const id = requireFilterId(payload.params ?? [], 0)
       return filters.delete(id)
     }
     case "eth_sendTransaction": {
@@ -1592,7 +1618,8 @@ async function handleRpc(
       return id
     }
     case "eth_getFilterLogs": {
-      const id = String((payload.params ?? [])[0] ?? "")
+      // #196: parity with eth_getFilterChanges / eth_uninstallFilter.
+      const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
       if (!filter) return []
       // Refresh last-access time so active polls keep the filter alive.


### PR DESCRIPTION
Closes #196.

## Summary

`eth_getFilterChanges`, `eth_getFilterLogs`, `eth_uninstallFilter` all opened with `const id = String((payload.params ?? [])[0] ?? "")` — silent coercion of any input shape. Malformed ids returned `[]` / `false` indistinguishable from "filter expired."

## Reproduction (pre-fix, live testnet 209.74.64.88:28780)

```
curl -s "$RPC" -X POST -d '{"jsonrpc":"2.0","id":1,"method":"eth_getFilterChanges","params":[42]}'
# {"result":[]}  ← should be -32602
```

## Fix

Add `requireFilterId` helper (rejects non-string + non-`/^0x[0-9a-fA-F]{32}$/`), call at all three sites. Symmetric with existing `requireTxHashParam` / `requireAddressParam` pattern.

## Regression test

`#196: eth_get/uninstallFilter* reject malformed filter ids` probes 9 shapes × 3 methods + sanity round-trip.

## Test plan
- [x] `node --test node/src/{rpc,rpc-extended,rpc-semantic-compat}.test.ts` → 90/90 pass