### PR TITLE
fix(rpc): eth_getTransactionByBlock*AndIndex reject malformed index (#198)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1481,6 +1481,43 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(Array.isArray(ok2), "omitted topics must return results array")
   })
 
+  await t.test("#198: eth_getTransactionByBlock*AndIndex reject malformed index (no silent null)", async () => {
+    // Pre-fix `Number((payload.params ?? [])[1] ?? 0)` coerced any
+    // input — non-hex → NaN → null, "-0x1" → -1 → null, true → 1
+    // (treated as a valid index). Callers got `null` for both
+    // "valid index, no such tx" and "I sent garbage" — indistinguishable.
+    const validBlockHash = "0x" + "1".repeat(64)
+    const cases: Array<{ method: string; params: unknown[]; label: string }> = [
+      { method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", "-0x1"], label: "negative" },
+      { method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", "not-hex"], label: "non-hex" },
+      { method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", true], label: "bool" },
+      { method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", 0], label: "number-not-string" },
+      { method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", null], label: "null" },
+      { method: "eth_getTransactionByBlockHashAndIndex", params: [validBlockHash, "-0x1"], label: "byHash negative" },
+      { method: "eth_getTransactionByBlockHashAndIndex", params: [validBlockHash, "not-hex"], label: "byHash non-hex" },
+    ]
+    for (const { method, params, label } of cases) {
+      const resp = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      const json = await resp.json() as { error?: { code: number; message: string }; result?: unknown }
+      assert.equal(json.error?.code, -32602, `${method}(${label}) must be -32602, got ${JSON.stringify(json)}`)
+      assert.match(json.error!.message, /transaction index/i, `${method}: error must name the field`)
+    }
+    // Sanity: valid hex index does not error (returns null only if the
+    // tx doesn't exist — but that's the expected behaviour, not a
+    // shape rejection).
+    const sanity = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionByBlockNumberAndIndex", params: ["latest", "0x0"] }),
+    })
+    const sanityJson = await sanity.json() as { error?: unknown; result: unknown }
+    assert.equal(sanityJson.error, undefined, "valid hex index must NOT error")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -140,6 +140,26 @@ function requireBlockHashParam(params: unknown[], index: number): Hex {
 }
 
 /**
+ * Validate a JSON-RPC QUANTITY index parameter (#198). EIP-1474
+ * requires indexes to be `0x`-prefixed hex strings. Pre-fix
+ * `Number((payload.params ?? [])[idx] ?? 0)` accepted everything
+ * (NaN for non-hex, negatives for `-0x1`, `1` for `true`) and the
+ * downstream null-return silently masked the malformed cases —
+ * caller couldn't distinguish a real not-found from a buggy query.
+ */
+function requireIndexParam(params: unknown[], index: number, name = "index"): number {
+  const raw = (params ?? [])[index]
+  if (typeof raw !== "string" || !/^0x[0-9a-fA-F]+$/.test(raw)) {
+    throw { code: -32602, message: `invalid ${name} at param ${index}: must match /^0x[0-9a-fA-F]+$/` }
+  }
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 0) {
+    throw { code: -32602, message: `invalid ${name} at param ${index}: must be non-negative integer` }
+  }
+  return n
+}
+
+/**
  * Validate that the first param of eth_call / eth_estimateGas /
  * eth_sendTransaction / eth_createAccessList is an object — not a
  * string, number, array, or boolean. #172: pre-fix the type assertion
@@ -1434,8 +1454,10 @@ async function handleRpc(
     case "eth_getTransactionByBlockHashAndIndex": {
       // #166: same hash-shape validation as eth_getBlockByHash.
       const blockHash = requireBlockHashParam(payload.params ?? [], 0)
-      const txIndex = Number((payload.params ?? [])[1] ?? 0)
-      if (!Number.isInteger(txIndex) || txIndex < 0) return null
+      // #198: validate index shape before Number() so non-hex / negative
+      // surfaces as -32602 instead of silently returning null (which
+      // mimics "valid index, no such tx" — a real not-found).
+      const txIndex = requireIndexParam(payload.params ?? [], 1, "transaction index")
       const block = await Promise.resolve(chain.getBlockByHash(blockHash))
       if (!block || txIndex >= block.txs.length) return null
       return formatRawTransaction(block.txs[txIndex], {
@@ -1445,9 +1467,9 @@ async function handleRpc(
       })
     }
     case "eth_getTransactionByBlockNumberAndIndex": {
-      const tag = String((payload.params ?? [])[0] ?? "latest")
-      const txIdx = Number((payload.params ?? [])[1] ?? 0)
-      if (!Number.isInteger(txIdx) || txIdx < 0) return null
+      const tag = (payload.params ?? [])[0]
+      // #198: validate index shape — same rationale as the *byHash sibling.
+      const txIdx = requireIndexParam(payload.params ?? [], 1, "transaction index")
       const height = await Promise.resolve(chain.getHeight())
       const num = parseBlockTag(tag, height)
       const block = await Promise.resolve(chain.getBlockByNumber(num))


### PR DESCRIPTION
Closes #198.

## Summary

Two sibling methods (`*ByHashAndIndex` and `*ByNumberAndIndex`) used `Number((payload.params ?? [])[1] ?? 0)` which coerces anything — non-hex → NaN, `-0x1` → -1, `true` → 1. Malformed indexes returned `null` indistinguishable from "valid index, no such tx."

## Reproduction (pre-fix, live testnet)

```bash
curl -s http://209.74.64.88:28780 -X POST -d \
  '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["latest","-0x1"]}'
# {"result":null}  ← should be -32602

curl -s http://209.74.64.88:28780 -X POST -d \
  '{"jsonrpc":"2.0","id":2,"method":"eth_getTransactionByBlockNumberAndIndex","params":["latest","not-hex"]}'
# {"result":null}  ← should be -32602
```

## Fix

Add `requireIndexParam` helper symmetric with the existing `requireTxHashParam` / `requireAddressParam` pattern. Apply at both sites.

## Regression test

`#198: eth_getTransactionByBlock*AndIndex reject malformed index` — 7 shapes × 2 methods, asserts -32602 + `/transaction index/i`. Sanity probe confirms valid hex still works.

## Test plan
- [x] `node --test node/src/{rpc,rpc-extended,rpc-semantic-compat}.test.ts` → 91/91 pass