### PR TITLE
fix(ipfs): MFS files/read offset rejects negative + fractional (#200)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -553,6 +553,41 @@ describe("IpfsHttpServer", () => {
       )
     }
   })
+
+  it("#200: /api/v0/files/read rejects negative/fractional offset (parity with handleCat)", async () => {
+    // Pre-fix MFS read validated offset only with !Number.isFinite,
+    // so `offset=-1` and `offset=1.5` slipped through to mfs.read and
+    // surfaced as 500 "internal error" or surprising data. handleCat
+    // (the UnixFS cat path) already rejects these with 400; this test
+    // pins the parity rule.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+    // Seed a file so the read call has a real path.
+    await fetch("/api/v0/files/write?arg=/probe&create=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("hello mfs"),
+    })
+    const cases: Array<{ qs: string; expectField: "offset" | "count" }> = [
+      { qs: "offset=-1", expectField: "offset" },
+      { qs: "offset=1.5", expectField: "offset" },
+      { qs: "offset=abc", expectField: "offset" },
+      { qs: "count=-1", expectField: "count" },
+      { qs: "count=1.5", expectField: "count" },
+      { qs: "count=abc", expectField: "count" },
+    ]
+    for (const { qs, expectField } of cases) {
+      const res = await fetch(`/api/v0/files/read?arg=/probe&${qs}`, { method: "POST" })
+      assert.equal(res.status, 400, `${qs}: must be 400, got ${res.status}`)
+      const body = await res.json() as { error?: string }
+      assert.match(body.error ?? "", new RegExp(`invalid ${expectField}`, "i"),
+        `${qs}: error must name the ${expectField} field, got ${JSON.stringify(body)}`)
+    }
+    // Sanity: valid offset + count still works.
+    const ok = await fetch("/api/v0/files/read?arg=/probe&offset=0&count=5", { method: "POST" })
+    assert.equal(ok.status, 200, "valid offset/count must succeed")
+  })
 })
 
 // Phase Q.4 — Reed-Solomon erasure coding integration tests.

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -979,14 +979,23 @@ export class IpfsHttpServer {
           const offsetRaw = url.query?.offset
           const countRaw = url.query?.count
           const opts: { offset?: number; count?: number } = {}
+          // #200: pre-fix offset only checked `!Number.isFinite(n)`, so
+          // negative or fractional values silently flowed to mfs.read and
+          // either surfaced as 500 "internal error" or returned surprising
+          // data. Match the (already correct) handleCat rule so MFS read
+          // and unixfs cat share the same kubo-compatible shape contract.
           if (offsetRaw !== undefined) {
             const n = Number(offsetRaw)
-            if (!Number.isFinite(n)) throw new HttpError(400, "invalid offset")
+            if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+              throw new HttpError(400, "invalid offset")
+            }
             opts.offset = n
           }
           if (countRaw !== undefined) {
             const n = Number(countRaw)
-            if (!Number.isFinite(n) || n < 0) throw new HttpError(400, "invalid count")
+            if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+              throw new HttpError(400, "invalid count")
+            }
             opts.count = n
           }
           const data = await this.mfs.read(arg, opts)


### PR DESCRIPTION
Closes #200.

## Summary

`/api/v0/files/read` validated offset only with `!Number.isFinite(n)` while the sibling `count` rejected negatives too. The handleCat path further requires `Number.isInteger(n)`. Result: negative / fractional MFS offsets slipped through to mfs.read and surfaced as 500 "internal error" or surprising data.

## Fix

`node/src/ipfs-http.ts:982` — adopt the handleCat rule (`!Number.isFinite(n) || n < 0 || !Number.isInteger(n)`) for both offset and count.

## Regression test

`#200: /api/v0/files/read rejects negative/fractional offset` — attaches IpfsMfs, seeds a file, probes 6 invalid combos, asserts 400 + descriptive error. Sanity 200 with valid args.

## Test plan
- [x] `node --test node/src/ipfs-http.test.ts` → 45/45 pass