### PR TITLE
fix(rpc): JSON-RPC envelope rejects jsonrpc!='2.0' + non-conforming id types (#202)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1559,7 +1559,7 @@ test("RPC Extended Methods", async (t) => {
     // string/bool/number flowed through to `payload.params ?? []` and
     // most methods just returned their default response, masking buggy
     // clients. Geth/erigon enforce this; we should too for inter-op.
-    const probe = async (body: Record<string, unknown>) => {
+    const probe204 = async (body: Record<string, unknown>) => {
       const r = await fetch(`http://127.0.0.1:${port}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1569,24 +1569,68 @@ test("RPC Extended Methods", async (t) => {
     }
     // Bad params shapes — all -32600.
     for (const params of ["not-an-array", 42, true, false]) {
-      const r = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params })
+      const r = await probe204({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params })
       assert.equal(r.error?.code, -32600, `params=${JSON.stringify(params)} must be -32600, got ${JSON.stringify(r)}`)
       assert.match(r.error!.message, /params must be/i, "error must explain params shape")
     }
     // Sanity: array params (the canonical form) works.
-    const okArr = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] })
+    const okArr = await probe204({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] })
     assert.equal(okArr.error, undefined, "params=[] must NOT error")
     // Sanity: omitting params works.
-    const okOmit = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
+    const okOmit = await probe204({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
     assert.equal(okOmit.error, undefined, "omitted params must NOT error")
     // Sanity: explicit null works (treated as "no params").
-    const okNull = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: null })
-    assert.equal(okNull.error, undefined, "params=null must NOT error")
+    const okNull204 = await probe204({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: null })
+    assert.equal(okNull204.error, undefined, "params=null must NOT error")
     // Sanity: object params accepted at the envelope layer (handler may
     // still reject if it doesn't support by-name params, but the
     // envelope check is shape-only).
-    const okObj = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: {} })
+    const okObj = await probe204({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: {} })
     assert.equal(okObj.error, undefined, "params={} must NOT error at envelope layer")
+  })
+
+  await t.test("#202: JSON-RPC envelope rejects jsonrpc!='2.0' and non-conforming id types", async () => {
+    // Pre-fix handleOne only checked `!payload || typeof payload !== "object" || !payload.method`.
+    // It accepted jsonrpc:"1.0" (or omitted), and accepted id as object,
+    // array, bool — all spec violations. Conformant clients (geth/erigon)
+    // strictly enforce these, so any inter-op needs the same.
+    const probe = async (body: Record<string, unknown>) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown; id?: unknown }
+    }
+    // jsonrpc must be exactly "2.0"
+    for (const v of ["1.0", "1.1", "", 2, undefined]) {
+      const body: Record<string, unknown> = { id: 1, method: "eth_chainId" }
+      if (v !== undefined) body.jsonrpc = v
+      const r = await probe(body)
+      assert.equal(r.error?.code, -32600, `jsonrpc=${JSON.stringify(v)} must be -32600, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /jsonrpc/i, "error must name the field")
+    }
+    // id must be string | number | null
+    for (const badId of [{ obj: 1 }, [1, 2], true, false]) {
+      const r = await probe({ jsonrpc: "2.0", id: badId, method: "eth_chainId" })
+      assert.equal(r.error?.code, -32600, `id=${JSON.stringify(badId)} must be -32600, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /id must be/i, "error must explain id shape")
+    }
+    // method must be a non-empty string
+    for (const m of [0, "", null, true, ["eth_chainId"]]) {
+      const r = await probe({ jsonrpc: "2.0", id: 1, method: m })
+      assert.equal(r.error?.code, -32600, `method=${JSON.stringify(m)} must be -32600, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-formed envelope still works.
+    const ok = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
+    assert.equal(ok.error, undefined, "well-formed envelope must NOT error")
+    assert.ok(typeof ok.result === "string", "result must be returned")
+    // Sanity: null id is allowed.
+    const okNull = await probe({ jsonrpc: "2.0", id: null, method: "eth_chainId" })
+    assert.equal(okNull.error, undefined, "id=null must be allowed")
+    // Sanity: string id is allowed.
+    const okStr = await probe({ jsonrpc: "2.0", id: "abc", method: "eth_chainId" })
+    assert.equal(okStr.error, undefined, "id as string must be allowed")
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -607,11 +607,33 @@ async function handleOne(
   bftCoordinator?: BftCoordinator,
   opts?: Record<string, unknown>,
 ): Promise<JsonRpcResponse | null> {
-  if (!payload || typeof payload !== "object" || !payload.method) {
+  if (!payload || typeof payload !== "object") {
     // #138: per JSON-RPC §5.1 invalid-request must carry code -32600.
     // Pre-fix this returned only { message }, which clients couldn't
     // distinguish from a malformed response.
-    return { jsonrpc: "2.0", id: payload?.id ?? null, error: { code: -32600, message: "invalid request" } }
+    return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request" } }
+  }
+  // #202: §1 — `jsonrpc` MUST be exactly "2.0". Pre-fix any value (or
+  // omission) flowed through and the server happily echoed back a 2.0
+  // response, masking buggy clients sending "1.0" / "1.1" / numeric 2.
+  if (payload.jsonrpc !== "2.0") {
+    return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: jsonrpc must be exactly '2.0'" } }
+  }
+  if (typeof payload.method !== "string" || payload.method.length === 0) {
+    // Pre-fix only rejected `!payload.method`, accepting `0` and `""`
+    // via JS truthy semantics. Method MUST be a non-empty string.
+    return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: method must be a non-empty string" } }
+  }
+  // #202: §4.1 — id MUST be String, Number, or NULL when present.
+  // Pre-fix objects, arrays, bools were silently echoed back, which
+  // either crashed strict-typed client response parsers or masked
+  // bugs on the caller side.
+  if ("id" in payload) {
+    const id = (payload as JsonRpcRequest).id
+    const idOk = id === null || typeof id === "string" || (typeof id === "number" && Number.isFinite(id))
+    if (!idOk) {
+      return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id must be string, number, or null" } }
+    }
   }
 
   // #204: §4.2 — params, when present, MUST be a Structured value


### PR DESCRIPTION
Closes #202.

## Summary

`handleOne` accepted jsonrpc:"1.0", missing jsonrpc field, id as object/array/bool, and method as truthy-non-string — all JSON-RPC 2.0 §1/§4.1 violations.

## Reproduction (pre-fix, live testnet)

```bash
curl -s "$RPC" -X POST -d '{"jsonrpc":"1.0","id":1,"method":"eth_chainId"}'
# {"result":"0x495c"}  ← should be -32600
curl -s "$RPC" -X POST -d '{"jsonrpc":"2.0","id":{"weird":true},"method":"eth_chainId"}'
# {"id":{"weird":true},"result":"0x495c"}  ← should be -32600
```

## Fix

`node/src/rpc.ts:571` — explicit checks for jsonrpc="2.0", non-empty method string, and id as string|number|null. Each returns -32600 with field-naming message.

## Regression test

`#202: JSON-RPC envelope rejects ...` — probes 5 bad jsonrpc × 4 bad id × 5 bad method shapes, plus 3 sanity probes.

## Test plan
- [x] `node --test node/src/{rpc,rpc-extended,rpc-semantic-compat}.test.ts` → 92/92 pass