### PR TITLE
fix(rpc): JSON-RPC envelope rejects params that aren't Array/Object/omitted (#204)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1554,6 +1554,41 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(removed, true, "valid filter id uninstall must return true")
   })
 
+  await t.test("#204: JSON-RPC envelope rejects params that aren't Array/Object/omitted", async () => {
+    // §4.2 — params, when present, MUST be Array or Object. Pre-fix
+    // string/bool/number flowed through to `payload.params ?? []` and
+    // most methods just returned their default response, masking buggy
+    // clients. Geth/erigon enforce this; we should too for inter-op.
+    const probe = async (body: Record<string, unknown>) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // Bad params shapes — all -32600.
+    for (const params of ["not-an-array", 42, true, false]) {
+      const r = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params })
+      assert.equal(r.error?.code, -32600, `params=${JSON.stringify(params)} must be -32600, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /params must be/i, "error must explain params shape")
+    }
+    // Sanity: array params (the canonical form) works.
+    const okArr = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] })
+    assert.equal(okArr.error, undefined, "params=[] must NOT error")
+    // Sanity: omitting params works.
+    const okOmit = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
+    assert.equal(okOmit.error, undefined, "omitted params must NOT error")
+    // Sanity: explicit null works (treated as "no params").
+    const okNull = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: null })
+    assert.equal(okNull.error, undefined, "params=null must NOT error")
+    // Sanity: object params accepted at the envelope layer (handler may
+    // still reject if it doesn't support by-name params, but the
+    // envelope check is shape-only).
+    const okObj = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: {} })
+    assert.equal(okObj.error, undefined, "params={} must NOT error at envelope layer")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -614,6 +614,17 @@ async function handleOne(
     return { jsonrpc: "2.0", id: payload?.id ?? null, error: { code: -32600, message: "invalid request" } }
   }
 
+  // #204: §4.2 — params, when present, MUST be a Structured value
+  // (Array or Object). Pre-fix passing a string / bool / number flowed
+  // through to `payload.params ?? []` and most methods just returned
+  // their default response, masking buggy clients. Allow omission and
+  // explicit `null` (we treat both as "no params"); reject everything
+  // else with -32600.
+  const rawParams = (payload as JsonRpcRequest).params
+  if (rawParams !== undefined && rawParams !== null && typeof rawParams !== "object") {
+    return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: -32600, message: "invalid request: params must be Array or Object" } }
+  }
+
   // #140: §4.1 — a request without an `id` field is a Notification.
   // The server processes it but MUST NOT respond. Return null and let
   // the dispatcher omit the response from the wire.


### PR DESCRIPTION
Closes #204.

## Summary

`handleOne` never validated `payload.params` type. JSON-RPC 2.0 §4.2 requires params to be Array or Object when present. Pre-fix string/bool/number flowed through; methods ignoring params silently returned success.

## Reproduction (live testnet)

```bash
curl -s "$RPC" -X POST -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":"not-an-array"}'
# {"result":"0x495c"}  ← should be -32600
```

## Fix

`node/src/rpc.ts:602` — after the existing envelope checks, reject params that's not `undefined`, `null`, or `typeof "object"` (covers both Array and Object structured forms) with -32600.

## Regression test

`#204: JSON-RPC envelope rejects params that aren't Array/Object/omitted` — 4 invalid shapes + 4 valid forms (Array/omitted/null/Object).

## Test plan
- [x] `node --test node/src/rpc-extended.test.ts` → 81/81 pass