### PR TITLE
fix(pose-http): /pose/receipt rejects malformed BigInt-bound fields (no V8 leak) (#212)

### DIFF
--- a/node/src/pose-http.test.ts
+++ b/node/src/pose-http.test.ts
@@ -180,6 +180,50 @@ test("POST /pose/receipt rejects unknown challengeId", async () => {
   }
 })
 
+test("#212: POST /pose/receipt rejects malformed responseAtMs without leaking V8 BigInt error", async () => {
+  // Pre-fix `BigInt(String(rc.responseAtMs ?? 0))` threw a V8
+  // SyntaxError ("Cannot convert [object Object] to a BigInt",
+  // "Cannot convert 12.5 to a BigInt") for non-coercible inputs.
+  // The outer catch carried the V8 wording through to clients —
+  // same leak class as #176 (top-level catch / receipt-rejection
+  // V8 leaks). Validate upfront so clients get a clean -32602-style
+  // shape error instead.
+  const pose = createTestEngine()
+  const { port, close } = await startTestServer(pose)
+  try {
+    const validChId = "0x" + "1".repeat(64)
+    const validNodeId = "0x" + "a".repeat(64)
+    const validSig = "0x" + "f".repeat(130)
+    const baseReceipt = {
+      challengeId: validChId,
+      nodeId: validNodeId,
+      nodeSig: validSig,
+    }
+    const cases: Array<{ value: unknown; label: string }> = [
+      { value: {}, label: "object" },
+      { value: [1, 2], label: "array" },
+      { value: "abc", label: "non-digit string" },
+      { value: "12.5", label: "fractional string" },
+      { value: -1, label: "negative number" },
+      { value: 1.5, label: "fractional number" },
+      { value: true, label: "boolean" },
+    ]
+    for (const { value, label } of cases) {
+      const r = await fetchJson(port, "POST", "/pose/receipt", {
+        challengeId: validChId,
+        receipt: { ...baseReceipt, responseAtMs: value },
+      })
+      assert.equal(r.status, 400, `responseAtMs=${label} must be 400, got ${r.status}`)
+      const errStr = String(r.data.error ?? "")
+      assert.match(errStr, /responseAtMs/i, `${label}: error must name the field, got ${errStr}`)
+      assert.doesNotMatch(errStr, /Cannot convert|BigInt|SyntaxError/i,
+        `${label}: must not leak V8 BigInt error wording, got ${errStr}`)
+    }
+  } finally {
+    close()
+  }
+})
+
 test("unmatched route returns false from handlePoseRequest", () => {
   const pose = createTestEngine()
   const routes = registerPoseRoutes(pose)

--- a/node/src/pose-http.ts
+++ b/node/src/pose-http.ts
@@ -15,6 +15,22 @@ setInterval(() => poseRateLimiter.cleanup(), 300_000).unref()
 const DEFAULT_POSE_AUTH_MAX_CLOCK_SKEW_MS = 120_000
 const HEX32_RE = /^0x[0-9a-fA-F]{64}$/
 
+/**
+ * #212: validate a value is safely coercible to a non-negative BigInt
+ * via `BigInt(String(v ?? 0))`. Returns true for undefined/null
+ * (the `?? 0` default kicks in), non-negative integer numbers, and
+ * non-empty digit-only strings. Returns false for object/array/
+ * non-digit strings/fractional numbers — all of which would
+ * otherwise produce a V8 SyntaxError ("Cannot convert X to a
+ * BigInt") that leaked through the outer catch.
+ */
+function isBigIntCoercible(v: unknown): boolean {
+  if (v === undefined || v === null) return true
+  if (typeof v === "number") return Number.isInteger(v) && v >= 0
+  if (typeof v === "string") return /^[0-9]+$/.test(v)
+  return false
+}
+
 export interface PoseAuthEnvelope {
   senderId: string
   timestampMs: number
@@ -219,18 +235,36 @@ export function registerPoseRoutes(
           return jsonResponse(res, 400, { error: "invalid challengeId" })
         }
 
+        // #212: validate BigInt-bound fields upfront. Pre-fix
+        // `BigInt(String(rc.responseAtMs ?? 0))` threw a V8
+        // SyntaxError ("Cannot convert [object Object] to a BigInt",
+        // "Cannot convert 12.5 to a BigInt") for object/array/non-
+        // digit-string inputs. The outer catch carried the V8 wording
+        // through to clients — same leak class as #176.
+        const responseAtMsRaw = rc.responseAtMs
+        if (!isBigIntCoercible(responseAtMsRaw)) {
+          return jsonResponse(res, 400, { error: "invalid responseAtMs: must be a non-negative integer" })
+        }
+        if (payload.challenge) {
+          const ch = payload.challenge as Record<string, unknown>
+          if (!ch.epochId || !ch.nodeId) {
+            return jsonResponse(res, 400, { error: "invalid challenge: missing epochId or nodeId" })
+          }
+          if (!isBigIntCoercible(ch.epochId)) {
+            return jsonResponse(res, 400, { error: "invalid challenge: epochId must be a non-negative integer" })
+          }
+          if (!isBigIntCoercible(ch.issuedAtMs)) {
+            return jsonResponse(res, 400, { error: "invalid challenge: issuedAtMs must be a non-negative integer" })
+          }
+        }
         try {
           const receipt: ReceiptMessage = {
             ...rc,
-            responseAtMs: BigInt(String(rc.responseAtMs ?? 0)),
+            responseAtMs: BigInt(String(responseAtMsRaw ?? 0)),
             responseBody: (rc.responseBody ?? {}) as Record<string, unknown>,
           } as ReceiptMessage
           if (payload.challenge) {
-            // If caller sends a full challenge object, enforce it matches the issued one.
             const ch = payload.challenge as Record<string, unknown>
-            if (!ch.epochId || !ch.nodeId) {
-              return jsonResponse(res, 400, { error: "invalid challenge: missing epochId or nodeId" })
-            }
             const challenge: ChallengeMessage = {
               ...ch,
               challengeId: challengeId as `0x${string}`,


### PR DESCRIPTION
Closes #212.

## Summary

`/pose/receipt` passed user input to `BigInt(String(...))` at three sites; malformed shapes threw V8 SyntaxError ("Cannot convert [object Object] to a BigInt", "Cannot convert 12.5 to a BigInt") and the outer catch leaked the V8 wording to clients. Same leak class as #176 but for BigInt.

## Reproduction (verified locally on main)

```
responseAtMs={}     → 400 "receipt rejected: Cannot convert [object Object] to a BigInt"
responseAtMs=[1,2]  → 400 "receipt rejected: Cannot convert 1,2 to a BigInt"
responseAtMs="12.5" → 400 "receipt rejected: Cannot convert 12.5 to a BigInt"
```

## Fix

`node/src/pose-http.ts:16` — add `isBigIntCoercible` helper (accepts undefined/null, non-negative integer numbers, digit-only strings). Validate `responseAtMs` + `ch.epochId` + `ch.issuedAtMs` upfront with clean field-naming -32602-equivalent errors. Existing engine-level catch stays for domain errors.

## Regression test

`#212: POST /pose/receipt rejects malformed responseAtMs without leaking V8 BigInt error` probes 7 invalid shapes; asserts 400 + field-naming + `!/Cannot convert|BigInt|SyntaxError/i`.

## Test plan
- [x] `node --test node/src/pose-http.test.ts` → 15/15 pass