### PR TITLE
fix(ipfs): tighten isValidCid length cap to 100 (no ENAMETOOLONG 500 leak) (#216)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -10,6 +10,14 @@ import { UnixFsBuilder } from "./ipfs-unixfs.ts"
 import { IpfsHttpServer } from "./ipfs-http.ts"
 import type { CidString } from "./ipfs-types.ts"
 
+// The IPFS HTTP server uses a module-level rate limiter (100 req/min/IP).
+// With 47+ tests in this file all probing 127.0.0.1, the budget gets
+// thin — adding even one new test can push the C3.1 suite into 429.
+// Bypass for the whole test run; the limiter's own unit tests cover its
+// behaviour, and the IPFS HTTP routes don't change behaviour based on
+// whether the limiter is enabled.
+process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
+
 let tmpDir: string
 let store: IpfsBlockstore
 let unixfs: UnixFsBuilder
@@ -623,6 +631,21 @@ describe("IpfsHttpServer", () => {
     const res = await fetch(`/api/v0/erasure/status?arg=${meta.cid}`, { method: "POST" })
     assert.notEqual(res.status, 500, "unixfs CID erasure/status must not leak 500")
     assert.equal(res.status, 415, `unixfs CID must be 415 not_a_manifest, got ${res.status}`)
+  })
+
+  it("#216: gateway rejects valid-shape CID > 100 chars (no ENAMETOOLONG 500 leak)", async () => {
+    // Pre-fix isValidCid accepted CIDs up to 512 chars. Real CIDs are
+    // ≤ ~80 chars (Qm v0 = 46, bafy v1 ≤ ~80). A 512-char synthetic
+    // CID slipped through to store.get(cid) → open() → ENAMETOOLONG
+    // (Linux NAME_MAX = 255 bytes per path component) → 500 "internal
+    // error" with stack trace logged. Single probe to stay within
+    // the module-shared rate limiter budget (100 req/min/IP).
+    const overlongQm = "Qm" + "1".repeat(510) // 512 chars
+    const r = await fetch(`/ipfs/${overlongQm}`, { method: "GET" })
+    assert.notEqual(r.status, 500, `cid len=${overlongQm.length}: must not leak 500, got ${r.status}`)
+    assert.equal(r.status, 400, `cid len=${overlongQm.length}: must be 400 invalid CID, got ${r.status}`)
+    const body = await r.json() as { error?: string }
+    assert.match(body.error ?? "", /invalid CID/i, "error must explain shape")
   })
 })
 

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1240,7 +1240,13 @@ export class IpfsHttpServer {
  * "bogus" / "b" while allowing the fake-shape CIDs used in fixtures.
  */
 function isValidCid(cid: string): boolean {
-  if (!cid || cid.length < 10 || cid.length > 512) return false
+  // #216: real-world CID max is ~80 chars (Qm v0 = 46, bafy v1 ≤ ~80).
+  // 100 leaves comfortable headroom for any future codec without
+  // exceeding the OS path-component limit (Linux NAME_MAX = 255).
+  // Pre-fix the cap of 512 let synthetic over-long CIDs reach
+  // store.get(cid) which then failed `open()` with ENAMETOOLONG —
+  // leaking as `500 "internal error"` instead of a clean 400.
+  if (!cid || cid.length < 10 || cid.length > 100) return false
   const trimmed = cid.trim()
   if (trimmed !== cid) return false
   if (/[\/\\]|\.\.|\0|\s/.test(cid)) return false


### PR DESCRIPTION
Closes #216.

## Summary

`isValidCid` accepted CIDs up to 512 chars. Real CIDs are ≤ ~80 chars; over-long synthetic input reached `store.get(cid)` → `open()` → ENAMETOOLONG (Linux NAME_MAX=255) → `500 "internal error"`.

## Reproduction (verified locally on main)

```typescript
const cid = "Qm" + "1".repeat(510)  // 512 chars
GET /ipfs/${cid} → 500 {"error":"internal error"}
// logs: "ENAMETOOLONG: name too long, open '.../blocks/Qm111...'"
```

## Fix

`node/src/ipfs-http.ts:1242` — cap at 100 chars instead of 512.

## Regression test

`#216: gateway rejects valid-shape CID > 100 chars`. Also adds `COC_RPC_RATE_LIMIT_DISABLED=1` env at the top of the test file because the IPFS module-singleton rate limiter (100 req/min) was right on the edge — one more probe across the 47-test suite tipped C3.1 tests into 429.

## Test plan
- [x] `node --test node/src/ipfs-http.test.ts` → 47/47 pass