### PR TITLE
fix(rpc): coc_submitProposal validates stakeAmount before BigInt() (no V8 leak) (#218)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1633,6 +1633,59 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okStr.error, undefined, "id as string must be allowed")
   })
 
+  await t.test("#218: coc_submitProposal rejects malformed stakeAmount without leaking V8 BigInt error", async () => {
+    // Pre-fix `BigInt(proposalParams.stakeAmount)` threw a V8 SyntaxError
+    // when stakeAmount was an object/array/non-digit-string and the
+    // outer catch leaked the V8 wording verbatim. Path is normally
+    // dead (chain has no governance), so monkey-patch a stub onto the
+    // chain instance to make `hasGovernance(chain)` true and reach the
+    // validation. Same leak class as #212 (pose-http).
+    const submittedProposals: Array<Record<string, unknown>> = []
+    const governanceStub = {
+      submitProposal: (type: string, targetId: string, proposer: string, opts: Record<string, unknown>) => {
+        submittedProposals.push({ type, targetId, proposer, opts })
+        return { id: "p1", type, targetId, status: "pending" }
+      },
+    } as Record<string, unknown>
+    // Monkey-patch the chain instance. `hasGovernance` checks for `.governance`.
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub
+    try {
+      const probe = async (stakeAmount: unknown) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method: "coc_submitProposal",
+            params: [{ type: "add_validator", targetId: "v4", proposer: "node-1", stakeAmount }],
+          }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      // Bad shapes → -32602 with `/stakeAmount/i` and NO V8 leak wording.
+      const badCases: unknown[] = [{}, [1, 2], "abc", "1.5", "-1", true]
+      for (const v of badCases) {
+        const r = await probe(v)
+        assert.equal(r.error?.code, -32602, `stakeAmount=${JSON.stringify(v)} must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /stakeAmount/i, "error must name the field")
+        assert.doesNotMatch(r.error!.message, /Cannot convert|BigInt|SyntaxError/i,
+          `must not leak V8 wording, got ${r.error!.message}`)
+      }
+      // Sanity: valid decimal and 0x-hex round-trip; the stub records.
+      const ok1 = await probe("1000")
+      assert.equal(ok1.error, undefined, "decimal stakeAmount must NOT error")
+      const ok2 = await probe("0x3e8")
+      assert.equal(ok2.error, undefined, "0x-hex stakeAmount must NOT error")
+      const ok3 = await probe(42)
+      assert.equal(ok3.error, undefined, "number stakeAmount must NOT error")
+      // Sanity: undefined / empty string → stakeAmount omitted.
+      const ok4 = await probe(undefined)
+      assert.equal(ok4.error, undefined, "undefined stakeAmount must NOT error")
+      assert.ok(submittedProposals.length >= 4, "stub should record the 4 valid calls")
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1918,13 +1918,30 @@ async function handleRpc(
       if (localNodeId && proposalParams.proposer !== localNodeId) {
         throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
       }
+      // #218: validate stakeAmount shape before `BigInt(...)`. Pre-fix
+      // an object/array/non-digit-string flowed straight into BigInt
+      // and threw a V8 SyntaxError ("Cannot convert [object Object] to
+      // a BigInt"). Same leak class as #212 (pose-http) — currently
+      // dead path because governance is disabled on prod, but fixing
+      // now avoids the leak surfacing once R3.2 (88780) enables it.
+      const stakeRaw = proposalParams.stakeAmount as unknown
+      let stakeAmount: bigint | undefined
+      if (stakeRaw !== undefined && stakeRaw !== null && stakeRaw !== "") {
+        const ok =
+          (typeof stakeRaw === "number" && Number.isInteger(stakeRaw) && stakeRaw >= 0) ||
+          (typeof stakeRaw === "string" && /^([0-9]+|0x[0-9a-fA-F]+)$/.test(stakeRaw))
+        if (!ok) {
+          throw { code: -32602, message: "invalid stakeAmount: must be a non-negative integer or 0x-hex" }
+        }
+        stakeAmount = BigInt(stakeRaw as string | number)
+      }
       const proposal = chain.governance.submitProposal(
         proposalParams.type,
         proposalParams.targetId,
         proposalParams.proposer,
         {
           targetAddress: proposalParams.targetAddress,
-          stakeAmount: proposalParams.stakeAmount ? BigInt(proposalParams.stakeAmount) : undefined,
+          stakeAmount,
         },
       )
       return {


### PR DESCRIPTION
Closes #218.

## Summary

`coc_submitProposal` called `BigInt(proposalParams.stakeAmount)` without validating shape. Object/array/non-digit-string inputs threw a V8 SyntaxError; the outer catch leaked the V8 wording verbatim. Same class as #212 (pose-http).

Path is currently dead on prod (governance disabled). Fixing now avoids the leak surfacing when R3.2 (88780) enables governance.

## Fix

`node/src/rpc.ts:1927` — validate `stakeAmount` is non-negative integer number or digit-only / `0x`-hex string. Reject everything else with `-32602` naming the field.

## Regression test

Monkey-patches a governance stub onto the chain (the fixture has no real governance) and probes 6 bad shapes + 4 valid forms. Asserts -32602, field-naming, and `!/Cannot convert|BigInt|SyntaxError/i`.

## Test plan
- [x] `node --test node/src/rpc-extended.test.ts` → 84/84 pass