### PR TITLE
fix(rpc): coc_submitProposal / coc_voteProposal reject null/undefined params[0] (#220)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1686,6 +1686,50 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#220: coc_submitProposal / coc_voteProposal reject null/undefined params[0] (no V8 NPE leak)", async () => {
+    // Pre-fix `(payload.params ?? [])[0] as Record<...>` was a no-op
+    // cast. With params=[] / [null] the next line accessed .proposer /
+    // .voterId on undefined/null and threw V8 "Cannot read properties
+    // of null/undefined (reading 'X')" — leaked through the outer
+    // catch. Same NPE-leak class as the BigInt V8 leaks in #212/#218.
+    // Reuse the governance stub from #218 to make the path reachable.
+    const governanceStub220 = {
+      submitProposal: () => ({ id: "p1", type: "x", targetId: "v4", status: "pending" }),
+      vote: () => {},
+      getProposal: () => ({ id: "p1", status: "pending", votes: new Map() }),
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub220
+    try {
+      const probe = async (method: string, params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      const methods = ["coc_submitProposal", "coc_voteProposal"]
+      const badPayloads: unknown[][] = [[], [null], [undefined], ["string-not-object"], [42], [[1, 2]]]
+      for (const method of methods) {
+        for (const params of badPayloads) {
+          const r = await probe(method, params)
+          assert.equal(r.error?.code, -32602,
+            `${method}(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
+          assert.match(r.error!.message, /params/i, "error must name params")
+          assert.doesNotMatch(r.error!.message, /Cannot read properties|TypeError/i,
+            `must not leak V8 NPE wording, got ${r.error!.message}`)
+        }
+      }
+      // Sanity: a well-shaped object still reaches the stub (no error).
+      const ok1 = await probe("coc_submitProposal", [{ type: "x", targetId: "y", proposer: "node-1" }])
+      assert.equal(ok1.error, undefined, "well-shaped submit must NOT error")
+      const ok2 = await probe("coc_voteProposal", [{ proposalId: "p1", voterId: "node-1", approve: true }])
+      assert.equal(ok2.error, undefined, "well-shaped vote must NOT error")
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1912,7 +1912,16 @@ async function handleRpc(
     }
     case "coc_submitProposal": {
       if (!hasGovernance(chain)) throw new Error("governance not enabled")
-      const proposalParams = (payload.params ?? [])[0] as Record<string, string>
+      // #220: pre-fix `(payload.params ?? [])[0] as Record<string,string>`
+      // was a no-op cast. With params=[] or params=[null] the first param
+      // was undefined/null; the next line then accessed `.proposer` and
+      // threw a V8 TypeError ("Cannot read properties of undefined/null
+      // (reading 'proposer')") which leaked through the outer catch.
+      const rawParams = (payload.params ?? [])[0]
+      if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
+        throw { code: -32602, message: "invalid params: expected non-null object as first param" }
+      }
+      const proposalParams = rawParams as Record<string, string>
       // Only the local node can submit proposals via RPC
       const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
       if (localNodeId && proposalParams.proposer !== localNodeId) {
@@ -1953,7 +1962,14 @@ async function handleRpc(
     }
     case "coc_voteProposal": {
       if (!hasGovernance(chain)) throw new Error("governance not enabled")
-      const voteParams = (payload.params ?? [])[0] as Record<string, unknown>
+      // #220: same null-check as coc_submitProposal — params=[] / [null]
+      // pre-fix bubbled "Cannot read properties of null (reading 'voterId')"
+      // through the outer catch as a -32603 V8 leak.
+      const voteRaw = (payload.params ?? [])[0]
+      if (!voteRaw || typeof voteRaw !== "object" || Array.isArray(voteRaw)) {
+        throw { code: -32602, message: "invalid params: expected non-null object as first param" }
+      }
+      const voteParams = voteRaw as Record<string, unknown>
       // Only the local node can vote via RPC
       const localVoterId = (opts as Record<string, unknown>)?.nodeId as string | undefined
       if (localVoterId && String(voteParams.voterId) !== localVoterId) {


### PR DESCRIPTION
Closes #220.

## Summary

Both handlers cast `params[0] as Record<...>` without runtime check. `params=[]` / `[null]` → next line throws `Cannot read properties of null/undefined (reading 'X')` — outer catch leaks V8 wording as -32603. Same leak class as #212/#176.

Path currently dead on prod (governance off); fix lands before R3.2 (88780) enables it.

## Fix

`node/src/rpc.ts:1915, 1956` — narrow `params[0]` to non-null non-array object; throw -32602 on malformed.

## Regression test

`#220: ...` — 6 bad shapes × 2 methods = 12 assertions + 2 sanity probes. Reuses #218 governance stub to reach the path.

## Test plan
- [x] `node --test node/src/rpc-extended.test.ts` → 84/84 pass