### PR TITLE
fix(coc-node): wrap JSON.parse in try/catch on POST endpoints (#222)

### DIFF
--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -122,7 +122,16 @@ const server = http.createServer((req, res) => {
     let body = "";
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
-      const payload = JSON.parse(body || "{}") as { challengeId?: string };
+      // #222: wrap JSON.parse — pre-fix a malformed body threw inside
+      // the async callback and bubbled to process.on("uncaughtException"),
+      // either crashing coc-node or leaking the V8 SyntaxError wording.
+      // Unauthenticated DoS / destabilisation vector.
+      let payload: { challengeId?: string };
+      try {
+        payload = JSON.parse(body || "{}");
+      } catch {
+        return json(res, 400, { error: "invalid JSON body" });
+      }
       if (!payload.challengeId) {
         return json(res, 400, { error: "missing challengeId" });
       }
@@ -136,7 +145,14 @@ const server = http.createServer((req, res) => {
     let body = "";
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
-      const payload = JSON.parse(body || "{}") as { challengeId?: string; challengeType?: string; payload?: unknown };
+      // #222: parity with /pose/challenge — wrap JSON.parse so a
+      // malformed body returns 400 instead of crashing the process.
+      let payload: { challengeId?: string; challengeType?: string; payload?: unknown };
+      try {
+        payload = JSON.parse(body || "{}");
+      } catch {
+        return json(res, 400, { error: "invalid JSON body" });
+      }
       if (!payload.challengeId) {
         return json(res, 400, { error: "missing challengeId" });
       }
@@ -291,12 +307,20 @@ const server = http.createServer((req, res) => {
     let body = "";
     req.on("data", (chunk: string) => (body += chunk));
     req.on("end", () => {
-      const payload = JSON.parse(body || "{}") as {
+      // #222: parity with the other two POST endpoints — wrap
+      // JSON.parse so a malformed body returns 400 instead of
+      // crashing the process via uncaughtException.
+      let payload: {
         challengeId?: string;
         nodeId?: string;
         responseBodyHash?: string;
         witnessIndex?: number;
       };
+      try {
+        payload = JSON.parse(body || "{}");
+      } catch {
+        return json(res, 400, { error: "invalid JSON body" });
+      }
       if (!payload.challengeId || !payload.nodeId || !payload.responseBodyHash || payload.witnessIndex === undefined) {
         return json(res, 400, { error: "missing required fields" });
       }


### PR DESCRIPTION
Closes #222.

## Summary

3 POST endpoints (`/pose/challenge`, `/pose/receipt`, `/pose/witness`) called `JSON.parse(body)` directly in the async `req.on("end", ...)` callback. Malformed JSON threw V8 SyntaxError → bubbled to `process.on("uncaughtException")` → process crashes (no handler) or response times out + V8 wording leaks (with handler). Unauth DoS vector.

## Verified locally

```typescript
POST /pose/challenge with body "not-json-at-all"
→ request times out
→ uncaughtException fires: "Unexpected token 'o', \"not-json-at-all\" is not valid JSON"
```

After fix:
```
malformed:  400 { error: 'invalid JSON body' }
empty:      400 { error: 'missing challengeId' }
valid:      200 { accepted: true }
uncaughtException fired: false
```

## Fix

`runtime/coc-node.ts:125, 139, 294` — wrap each `JSON.parse` in try/catch; return 400 with clean message on failure.

## Test plan
- [x] Locally verified before/after (malformed → 400 + no crash; valid → 200)
- Manual review: 3 identical patterns, all converted; no test file exists for coc-node.ts (runtime entrypoint with global state); pattern matches the existing #138 fix on the RPC server JSON.parse path