### PR TITLE
fix(rpc): eth_feeHistory rejects malformed blockCount + rewardPercentiles (#224)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1730,6 +1730,58 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#224: eth_feeHistory rejects non-hex/non-array shapes upfront (no silent coercion)", async () => {
+    // Pre-fix `Number(params[0] ?? 1)` silently mapped null/true/{}/"-0x5"
+    // to the default 1, and `as number[]` was a runtime no-op so non-array
+    // rewardPercentiles silently became "[]". Spec violation; clients
+    // never learned their input was bad.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_feeHistory", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const malformedBlockCount: unknown[][] = [
+      [true, "latest", []],
+      [false, "latest", []],
+      [{}, "latest", []],
+      [[1, 2], "latest", []],
+      ["not-hex", "latest", []],
+      ["-0x5", "latest", []],
+      ["0x", "latest", []],
+      [-1, "latest", []],
+      [0, "latest", []],
+      [1.5, "latest", []],
+    ]
+    for (const params of malformedBlockCount) {
+      const r = await probe(params)
+      assert.equal(r.error?.code, -32602,
+        `eth_feeHistory(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /blockCount/i, "error must name blockCount")
+    }
+
+    const malformedPercentiles: unknown[][] = [
+      ["0x2", "latest", {}],
+      ["0x2", "latest", "fifty"],
+      ["0x2", "latest", 50],
+      ["0x2", "latest", true],
+    ]
+    for (const params of malformedPercentiles) {
+      const r = await probe(params)
+      assert.equal(r.error?.code, -32602,
+        `eth_feeHistory(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /rewardPercentiles/i, "error must name rewardPercentiles")
+    }
+
+    // null/undefined for blockCount/percentiles still defaults (omission semantics)
+    const ok1 = await probe([null, "latest", null])
+    assert.equal(ok1.error, undefined, "null blockCount + null percentiles must default cleanly")
+    const ok2 = await probe(["0x2", "latest", [25, 75]])
+    assert.equal(ok2.error, undefined, "well-shaped call must succeed")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1555,10 +1555,42 @@ async function handleRpc(
     case "eth_protocolVersion":
       return "0x41" // 65
     case "eth_feeHistory": {
-      const rawBlockCount = Number((payload.params ?? [])[0] ?? 1)
-      const blockCount = Number.isFinite(rawBlockCount) && rawBlockCount >= 1 ? Math.floor(rawBlockCount) : 1
+      // #224: pre-fix `Number(params[0] ?? 1)` silently coerced null,
+      // true, {}, "-0x5", etc. to either the default 1 (when `??` fired
+      // on null/undefined) or to NaN → fallback 1. Spec mandates a hex
+      // QUANTITY for blockCount; geth rejects everything else with
+      // -32602. Same class as #188 (parseBlockTag) for the outer slot.
+      const rawBlockCount = (payload.params ?? [])[0]
+      let blockCount: number
+      if (rawBlockCount === undefined || rawBlockCount === null) {
+        blockCount = 1
+      } else if (typeof rawBlockCount === "number") {
+        if (!Number.isInteger(rawBlockCount) || rawBlockCount < 1) {
+          throw { code: -32602, message: "invalid blockCount: must be positive integer" }
+        }
+        blockCount = Math.min(rawBlockCount, 1024)
+      } else if (typeof rawBlockCount === "string") {
+        if (!/^0x[0-9a-fA-F]+$/.test(rawBlockCount)) {
+          throw { code: -32602, message: "invalid blockCount: must match /^0x[0-9a-fA-F]+$/" }
+        }
+        const n = Number(rawBlockCount)
+        if (!Number.isFinite(n) || n < 1) {
+          throw { code: -32602, message: "invalid blockCount: must be >= 1" }
+        }
+        blockCount = Math.min(Math.floor(n), 1024)
+      } else {
+        throw { code: -32602, message: "invalid blockCount: expected hex quantity or positive integer" }
+      }
       const newestBlock = String((payload.params ?? [])[1] ?? "latest")
-      const rewardPercentiles = ((payload.params ?? [])[2] ?? []) as number[]
+      // #224: `as number[]` was a TS runtime no-op so an object/string/
+      // bool silently passed through (`{}.length === undefined`
+      // bypassed the >100 check and the for-loop). Reject non-array
+      // shapes upfront so spec-violating clients get told.
+      const rawPercentiles = (payload.params ?? [])[2]
+      if (rawPercentiles !== undefined && rawPercentiles !== null && !Array.isArray(rawPercentiles)) {
+        throw { code: -32602, message: "invalid rewardPercentiles: expected array" }
+      }
+      const rewardPercentiles = (rawPercentiles ?? []) as number[]
       if (rewardPercentiles.length > 100) {
         throw { code: -32602, message: `rewardPercentiles array too large: ${rewardPercentiles.length} (max 100)` }
       }


### PR DESCRIPTION
Closes #224.

## Summary

`eth_feeHistory` silently coerced `null`/`true`/`{}`/`-0x5`/`0`/`1.5`/etc. for `blockCount` and non-array shapes for `rewardPercentiles` to default values instead of returning -32602. Spec violation (EIP-1559 + JSON-RPC §5.1). Clients passing bad input got plausible-looking data and never learned their request was wrong.

Two silent-coercion sites:
1. `Number(params[0] ?? 1)` — `Number(true) === 1`, `Number({}) === NaN → 1`, etc.
2. `((params[2] ?? []) as number[])` — `as Type` is a TS runtime no-op, `{}.length === undefined` skipped both guards.

Same class as #160 (per-element percentile validation) and #188 (parseBlockTag) but for the OUTER param slots.

## Test plan

- [x] Added regression test `#224: eth_feeHistory rejects non-hex/non-array shapes upfront (no silent coercion)` — 10 blockCount + 4 rewardPercentiles malformed shapes + 2 sanity cases
- [x] `pnpm test:changed` equivalent: `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 86/86 passing locally
- [x] Verified pre-fix bug against live testnet `http://209.74.64.88:28780`