### PR TITLE
fix(rpc): coc_get* governance/equivocation query methods reject malformed filter params (#226)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1730,56 +1730,79 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
-  await t.test("#224: eth_feeHistory rejects non-hex/non-array shapes upfront (no silent coercion)", async () => {
-    // Pre-fix `Number(params[0] ?? 1)` silently mapped null/true/{}/"-0x5"
-    // to the default 1, and `as number[]` was a runtime no-op so non-array
-    // rewardPercentiles silently became "[]". Spec violation; clients
-    // never learned their input was bad.
-    const probe = async (params: unknown[]) => {
-      const r = await fetch(`http://127.0.0.1:${port}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_feeHistory", params }),
-      })
-      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
-    }
-    const malformedBlockCount: unknown[][] = [
-      [true, "latest", []],
-      [false, "latest", []],
-      [{}, "latest", []],
-      [[1, 2], "latest", []],
-      ["not-hex", "latest", []],
-      ["-0x5", "latest", []],
-      ["0x", "latest", []],
-      [-1, "latest", []],
-      [0, "latest", []],
-      [1.5, "latest", []],
-    ]
-    for (const params of malformedBlockCount) {
-      const r = await probe(params)
-      assert.equal(r.error?.code, -32602,
-        `eth_feeHistory(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
-      assert.match(r.error!.message, /blockCount/i, "error must name blockCount")
-    }
+  await t.test("#226: coc_getProposals + coc_getDaoProposals + coc_getEquivocations reject malformed filter params", async () => {
+    // Pre-fix:
+    // - coc_getProposals(true) → `as string | undefined` runtime no-op → silent no-filter → return all
+    // - coc_getDaoProposals(true,false) → silent bypass of both branches → silent no-filter
+    // - coc_getEquivocations(-100) → Number coercion allowed negative sinceMs
+    // - coc_getEquivocations({}) → Number({}) = NaN → undefined-ish behavior in getter
+    // Same class as #220/#224 — silent coercion masking malformed input.
+    const proposalsList: Array<Record<string, unknown>> = []
+    const governanceStub226 = {
+      getProposals: (_filter?: string) => proposalsList,
+      getGovernanceStats: () => ({ activeValidators: 0, totalStake: 0n, pendingProposals: 0, totalProposals: 0, currentEpoch: 0n }),
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub226
+    try {
+      const probe = async (method: string, params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
 
-    const malformedPercentiles: unknown[][] = [
-      ["0x2", "latest", {}],
-      ["0x2", "latest", "fifty"],
-      ["0x2", "latest", 50],
-      ["0x2", "latest", true],
-    ]
-    for (const params of malformedPercentiles) {
-      const r = await probe(params)
-      assert.equal(r.error?.code, -32602,
-        `eth_feeHistory(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
-      assert.match(r.error!.message, /rewardPercentiles/i, "error must name rewardPercentiles")
-    }
+      // coc_getProposals — non-string filter must reject
+      for (const bad of [true, false, 42, {}, [1, 2]]) {
+        const r = await probe("coc_getProposals", [bad])
+        assert.equal(r.error?.code, -32602,
+          `coc_getProposals(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /status filter/i)
+      }
+      // Unknown status string must reject
+      const rUnknown = await probe("coc_getProposals", ["unknown-status"])
+      assert.equal(rUnknown.error?.code, -32602, "unknown status must be -32602")
+      assert.match(rUnknown.error!.message, /status filter|must be one of/i)
+      // Sanity: undefined/null/empty string/valid status all OK
+      for (const ok of [null, undefined, "", "pending", "approved"]) {
+        const r = await probe("coc_getProposals", ok === undefined ? [] : [ok])
+        assert.equal(r.error, undefined, `coc_getProposals(${JSON.stringify(ok)}) must succeed`)
+      }
 
-    // null/undefined for blockCount/percentiles still defaults (omission semantics)
-    const ok1 = await probe([null, "latest", null])
-    assert.equal(ok1.error, undefined, "null blockCount + null percentiles must default cleanly")
-    const ok2 = await probe(["0x2", "latest", [25, 75]])
-    assert.equal(ok2.error, undefined, "well-shaped call must succeed")
+      // coc_getDaoProposals — non-string/non-object filter must reject
+      for (const bad of [true, false, 42, [1, 2]]) {
+        const r = await probe("coc_getDaoProposals", [bad])
+        assert.equal(r.error?.code, -32602,
+          `coc_getDaoProposals(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /filter|expected/i)
+      }
+      // Object with non-string field must reject
+      const rBadStatus = await probe("coc_getDaoProposals", [{ status: 42 }])
+      assert.equal(rBadStatus.error?.code, -32602, "filter.status non-string must be -32602")
+      // Sanity: valid object/string/omitted
+      for (const ok of [null, undefined, "", "pending", { status: "pending" }, { type: "add_validator" }]) {
+        const r = await probe("coc_getDaoProposals", ok === undefined ? [] : [ok])
+        assert.equal(r.error, undefined, `coc_getDaoProposals(${JSON.stringify(ok)}) must succeed`)
+      }
+
+      // coc_getEquivocations — non-integer/negative sinceMs must reject
+      // (NaN can't traverse JSON.stringify → null, so skip it; null is the
+      // "omitted" sentinel and is accepted.)
+      for (const bad of [-1, -100, 1.5, "now", true, {}, [123]]) {
+        const r = await probe("coc_getEquivocations", [bad])
+        assert.equal(r.error?.code, -32602,
+          `coc_getEquivocations(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /sinceMs/i)
+      }
+      // Sanity: 0/positive/null/undefined OK
+      for (const ok of [0, 1000, 1_700_000_000_000, null, undefined]) {
+        const r = await probe("coc_getEquivocations", ok === undefined ? [] : [ok])
+        assert.equal(r.error, undefined, `coc_getEquivocations(${JSON.stringify(ok)}) must succeed`)
+      }
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
+    }
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2035,9 +2035,19 @@ async function handleRpc(
     }
     case "coc_getProposals": {
       if (!hasGovernance(chain)) return []
-      const statusFilter = ((payload.params ?? [])[0] as string | undefined) ?? undefined
+      // #226: pre-fix `as string | undefined` was a runtime no-op so
+      // bool/number/object/array silently slipped through and the
+      // `validStatuses.includes(...)` always returned false → silent
+      // "no filter applied, return all" path. Same class as #220 / #224.
+      const rawStatusFilter = (payload.params ?? [])[0]
+      if (rawStatusFilter !== undefined && rawStatusFilter !== null && typeof rawStatusFilter !== "string") {
+        throw { code: -32602, message: "invalid status filter: expected string or omitted" }
+      }
       const validStatuses = ["pending", "approved", "rejected", "expired"]
-      const filter = statusFilter && validStatuses.includes(statusFilter) ? statusFilter as "pending" | "approved" | "rejected" | "expired" : undefined
+      if (typeof rawStatusFilter === "string" && rawStatusFilter !== "" && !validStatuses.includes(rawStatusFilter)) {
+        throw { code: -32602, message: `invalid status filter: must be one of ${validStatuses.join(", ")}` }
+      }
+      const filter = typeof rawStatusFilter === "string" && rawStatusFilter !== "" ? rawStatusFilter as "pending" | "approved" | "rejected" | "expired" : undefined
       const proposals = chain.governance.getProposals(filter)
       return proposals.map((p) => ({
         id: p.id,
@@ -2084,18 +2094,42 @@ async function handleRpc(
       if (!hasGovernance(chain)) return []
       const gov2 = chain.governance
       if (!gov2.getProposals) return []
-      const filterParam = (payload.params ?? [])[0] as Record<string, unknown> | string | undefined
+      // #226: pre-fix the `as` cast was a runtime no-op so booleans,
+      // numbers, and arrays silently bypassed both string/object
+      // branches → all filters undefined → silent "return all" path.
+      const filterParam = (payload.params ?? [])[0]
+      if (
+        filterParam !== undefined &&
+        filterParam !== null &&
+        typeof filterParam !== "string" &&
+        !(typeof filterParam === "object" && !Array.isArray(filterParam))
+      ) {
+        throw { code: -32602, message: "invalid filter: expected string or object" }
+      }
       let statusFilter2: string | undefined
       let typeFilter: string | undefined
       let proposerFilter: string | undefined
       if (typeof filterParam === "string") {
         statusFilter2 = filterParam
       } else if (filterParam && typeof filterParam === "object") {
-        statusFilter2 = filterParam.status as string | undefined
-        typeFilter = filterParam.type as string | undefined
-        proposerFilter = filterParam.proposer as string | undefined
+        const obj = filterParam as Record<string, unknown>
+        if (obj.status !== undefined && typeof obj.status !== "string") {
+          throw { code: -32602, message: "invalid filter.status: expected string" }
+        }
+        if (obj.type !== undefined && typeof obj.type !== "string") {
+          throw { code: -32602, message: "invalid filter.type: expected string" }
+        }
+        if (obj.proposer !== undefined && typeof obj.proposer !== "string") {
+          throw { code: -32602, message: "invalid filter.proposer: expected string" }
+        }
+        statusFilter2 = obj.status as string | undefined
+        typeFilter = obj.type as string | undefined
+        proposerFilter = obj.proposer as string | undefined
       }
       const validStatuses2 = ["pending", "approved", "rejected", "expired"]
+      if (statusFilter2 && !validStatuses2.includes(statusFilter2)) {
+        throw { code: -32602, message: `invalid status filter: must be one of ${validStatuses2.join(", ")}` }
+      }
       const sFilter = statusFilter2 && validStatuses2.includes(statusFilter2) ? statusFilter2 : undefined
       let results = gov2.getProposals(sFilter)
       if (typeFilter) results = results.filter((p: { type: string }) => p.type === typeFilter)
@@ -2362,7 +2396,18 @@ async function handleRpc(
       return totalGetter(0).length
     }
     case "coc_getEquivocations": {
-      const sinceMs = Number((payload.params ?? [])[0] ?? 0)
+      // #226: pre-fix `Number(params[0] ?? 0)` silently mapped {}, true,
+      // non-numeric strings, NaN → 0 or NaN, and accepted negative
+      // sinceMs that the getter treats as "from epoch start." Validate
+      // upfront as non-negative finite integer.
+      const rawSince = (payload.params ?? [])[0]
+      let sinceMs = 0
+      if (rawSince !== undefined && rawSince !== null) {
+        if (typeof rawSince !== "number" || !Number.isFinite(rawSince) || !Number.isInteger(rawSince) || rawSince < 0) {
+          throw { code: -32602, message: "invalid sinceMs: expected non-negative integer or omitted" }
+        }
+        sinceMs = rawSince
+      }
       const getter = (opts as RpcRuntimeOptions | undefined)?.getBftEquivocations
       if (!getter) return []
       const evidence = getter(sinceMs)


### PR DESCRIPTION
Closes #226.

## Summary

Three coc_* methods (`coc_getProposals`, `coc_getDaoProposals`, `coc_getEquivocations`) silently coerced non-spec filter inputs to fallback defaults instead of returning -32602. Same class as #220/#224 — `as Type` runtime no-op + silent `Number(... ?? 0)` fallback.

Symptom: observability degradation. Ops dashboards/auditing tools passing booleans/objects/negative numbers for filters got 'return all' data and never knew their filter was malformed.

## Test plan

- [x] Added regression test `#226: coc_getProposals + coc_getDaoProposals + coc_getEquivocations reject malformed filter params` — 25 malformed shapes + 11 sanity cases
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 86/86 passing locally
- [x] Verified pre-fix bug against live testnet `http://209.74.64.88:28780`