### PR TITLE
fix(rpc): rollup_getOutputAtBlock uses payload.params (was bare 'params' ReferenceError) (#228)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1782,6 +1782,33 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok2.error, undefined, "well-shaped call must succeed")
   })
 
+  await t.test("#228: rollup_getOutputAtBlock handler uses payload.params (no ReferenceError)", async () => {
+    // Pre-fix the handler referenced bare `params[0]` which is undefined,
+    // so EVERY call threw `ReferenceError: params is not defined` before
+    // any input validation. The rollup endpoint was completely broken
+    // from inception. V8 wording leaked through outer catch as -32603.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "rollup_getOutputAtBlock", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const r1 = await probe(["0x0"])
+    assert.doesNotMatch(JSON.stringify(r1), /params is not defined|ReferenceError/i,
+      `must not leak ReferenceError on "0x0", got ${JSON.stringify(r1)}`)
+    const r2 = await probe(["latest"])
+    assert.doesNotMatch(JSON.stringify(r2), /params is not defined|ReferenceError/i,
+      `must not leak ReferenceError on "latest", got ${JSON.stringify(r2)}`)
+    // Malformed input should now hit parseBlockTag's -32602, not -32603
+    const r3 = await probe([true])
+    assert.equal(r3.error?.code, -32602,
+      `rollup_getOutputAtBlock(true) must be -32602, got ${JSON.stringify(r3)}`)
+    assert.doesNotMatch(r3.error!.message, /params is not defined|ReferenceError/i,
+      `must not leak ReferenceError on bool, got ${r3.error!.message}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2473,7 +2473,16 @@ async function handleRpc(
     }
     // --- Rollup RPC namespace ---
     case "rollup_getOutputAtBlock": {
-      const blockNumber = parseBlockTag(params[0], await Promise.resolve(chain.getHeight()))
+      // #228: pre-fix this referenced bare `params[0]` instead of
+      // `payload.params[0]`. Since `params` is not a defined variable
+      // in scope, every call threw `ReferenceError: params is not
+      // defined` BEFORE any handler logic ran. The rollup endpoint
+      // was completely broken from inception and the V8 wording
+      // leaked through the outer catch as -32603. No test caught it.
+      const blockNumber = parseBlockTag(
+        (payload.params ?? [])[0],
+        await Promise.resolve(chain.getHeight()),
+      )
       const block = await Promise.resolve(chain.getBlockByNumber(blockNumber))
       if (!block || !block.stateRoot) return null
       const { solidityPackedKeccak256 } = await import("ethers")


### PR DESCRIPTION
Closes #228.

## Summary

`rollup_getOutputAtBlock` was **completely broken from inception** — the handler referenced a bare `params[0]` identifier instead of `payload.params[0]`. Every call threw `ReferenceError: params is not defined` and the V8 wording leaked through the outer catch.

```bash
$ curl -s -X POST -H 'Content-Type: application/json' \
    --data '{"jsonrpc":"2.0","method":"rollup_getOutputAtBlock","params":["latest"],"id":1}' \
    http://209.74.64.88:28780
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"params is not defined"}}
```

Impact: OP-stack rollup endpoint unusable. Rollup proposers, fraud-proof verifiers, dispute games all blocked when querying this node. V8 ReferenceError leak (same class as #156/#176/#182).

Audit: `grep -n '[^.]params\\[' node/src/rpc.ts` confirms this was the only site.

## Test plan

- [x] Added regression test `#228: rollup_getOutputAtBlock handler uses payload.params (no ReferenceError)`
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 87/87 passing
- [x] Pre-fix bug verified against live testnet