### PR TITLE
fix(ipfs): /api/v0/object/stat returns 404 for missing CID (was 500 'internal error') (#230)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -469,6 +469,18 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#230: /api/v0/object/stat returns 404 for missing shape-valid CID (not 500)", async () => {
+    // Pre-fix `handleObjectStat` called `store.get(cid)` directly and let
+    // the ENOENT propagate as 500 "internal error" — the sibling
+    // handleCat already mapped this to 404 but object/stat was missed.
+    // Use a syntactically-valid Qm v0 CID that's NOT been added.
+    const missingCid = "QmZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZA"
+    const res = await fetch(`/api/v0/object/stat?arg=${missingCid}`, { method: "POST" })
+    assert.equal(res.status, 404, `must be 404 for missing block, got ${res.status}`)
+    const body = await res.json() as { error?: string }
+    assert.match(body.error ?? "", /not found/i, "must not surface 'internal error'")
+  })
+
   it("#134: /api/v0/object/stat exposes DataSize (not hardcoded 0)", async () => {
     const totalSize = 5000
     const content = Buffer.alloc(totalSize, 0x42)

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -604,7 +604,23 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
-    const block = await this.store.get(cid)
+    // #230: pre-fix the bare `store.get(cid)` call let ENOENT bubble
+    // out as 500 "internal error" when the block was shape-valid but
+    // not present locally. The sibling handleCat correctly maps this
+    // to 404 via isNotFoundError. Mirror that here so observers
+    // probing for a CID can distinguish "we don't have it" (404)
+    // from a real server fault (500).
+    let block: Awaited<ReturnType<typeof this.store.get>>
+    try {
+      block = await this.store.get(cid)
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        res.writeHead(404, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "block not found" }))
+        return
+      }
+      throw err
+    }
     const meta = await this.readFileMeta()
     const file = meta[cid]
     // #134: DataSize and LinksSize were hardcoded to 0. For UnixFS


### PR DESCRIPTION
Closes #230.

## Summary

`/api/v0/object/stat` leaked `500 "internal error"` for shape-valid CIDs that weren't locally present, while the sibling `/api/v0/cat` correctly returned 404. The bare `store.get(cid)` call propagated ENOENT through the outer catch (which only handles HttpError / ErasureError).

```bash
$ curl -s -w 'HTTP %{http_code}\n' 'http://209.74.64.88:28786/api/v0/object/stat?arg=QmZZ...ZZ' -X POST
{"error":"internal error"} HTTP 500
```

Same class as #210 — refining the 500 surface to a more precise 4xx for client-input-driven misses.

## Test plan

- [x] Added regression test `#230: /api/v0/object/stat returns 404 for missing shape-valid CID (not 500)`
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 48/48 passing locally
- [x] Pre-fix bug verified against live testnet