### PR TITLE
fix(ipfs): /api/v0/files/* path traversal returns 400 (was 500 'internal error') (#232)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -597,6 +597,32 @@ describe("IpfsHttpServer", () => {
     assert.equal(ok.status, 200, "valid offset/count must succeed")
   })
 
+  it("#232: /api/v0/files/* path traversal returns 400 (not 500 'internal error')", async () => {
+    // Pre-fix normalizePath threw `Error("path traversal not allowed: ...")`
+    // for any input with `..`. The route-level catch had regexes for
+    // null-byte / path-too-long / max-depth (all 400) but missed
+    // `^path traversal`, so traversal attempts surfaced as 500.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+    const probes = [
+      `/api/v0/files/mkdir?arg=${encodeURIComponent("/x/../y")}`,
+      `/api/v0/files/mkdir?arg=${encodeURIComponent("/../etc")}`,
+      `/api/v0/files/rm?arg=${encodeURIComponent("/dir/./file")}`,
+      `/api/v0/files/stat?arg=${encodeURIComponent("/foo/../bar")}`,
+      `/api/v0/files/ls?arg=${encodeURIComponent("/x/../y/z")}`,
+    ]
+    for (const path of probes) {
+      const res = await fetch(path, { method: "POST" })
+      assert.equal(res.status, 400, `${path}: must be 400, got ${res.status}`)
+      const body = await res.json() as { error?: string; message?: string }
+      assert.notEqual(body.error, "internal error",
+        `${path}: must not leak 'internal error', got ${JSON.stringify(body)}`)
+      assert.match(`${body.error} ${body.message ?? ""}`, /path traversal|bad request/i,
+        `${path}: error must reference traversal, got ${JSON.stringify(body)}`)
+    }
+  })
+
   it("#210: /api/v0/erasure/status maps ErasureError codes to 4xx (no 500 leak)", async () => {
     // Pre-fix the outer catch in IpfsHttpServer only mapped
     // ErasureError "invalid_params" → 400 and "not_found" → 404. The

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1108,6 +1108,12 @@ export class IpfsHttpServer {
           /^max mfs depth/i.test(msg) ||
           /^path too long/i.test(msg) ||
           /^null byte in path/i.test(msg) ||
+          // #232: pre-fix normalizePath threw `Error("path traversal not
+          // allowed: ...")` for any input containing `..`, but the
+          // catch had no regex for it → 500 "internal error" instead of
+          // the 400 that path-too-long / null-byte / max-depth siblings
+          // already emit. Treat as client-input error.
+          /^path traversal/i.test(msg) ||
           /^invalid /i.test(msg)
         ) {
           httpErr = new HttpError(400, "bad request", msg)


### PR DESCRIPTION
Closes #232.

## Summary

MFS endpoints returned `500 "internal error"` for any path containing `..` traversal components, while sibling rejections (null-byte / path-too-long / max-depth) all correctly returned 400. The route catch regex set in `node/src/ipfs-http.ts:1101` had no entry for the `^path traversal` message thrown by `normalizePath`.

```bash
$ curl -s -w 'HTTP %{http_code}\n' \
    'http://209.74.64.88:28786/api/v0/files/mkdir?arg=/test/../../etc/passwd' \
    -X POST
{"error":"internal error"} HTTP 500
```

Same class as #210 / #230 — refining 500 surface to a more precise 4xx for client-input the server already correctly rejected.

## Test plan

- [x] Added regression test `#232: /api/v0/files/* path traversal returns 400 (not 500 'internal error')` — 5 endpoints × `..` variants
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 48/48 passing locally
- [x] Pre-fix bug verified against live testnet