### PR TITLE
fix(rpc): coc_submit/vote/getDaoProposal return -32601 when governance disabled (was -32603) (#234)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1832,6 +1832,36 @@ test("RPC Extended Methods", async (t) => {
       `must not leak ReferenceError on bool, got ${r3.error!.message}`)
   })
 
+  await t.test("#234: coc_submit/vote/getDaoProposal return -32601 when governance disabled (not -32603)", async () => {
+    // Pre-fix the plain `new Error("governance not enabled")` fell through
+    // the outer catch's generic -32603 path. JSON-RPC §5.1 reserves
+    // -32603 for genuine server faults; "feature not enabled on this
+    // node" is a method-availability concern → -32601. Same class as
+    // #132 (unknown-method fallback).
+    // The test fixture builds a ChainEngine WITHOUT governance, so all
+    // three methods hit the !hasGovernance branch.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const methods: Array<[string, unknown[]]> = [
+      ["coc_submitProposal", [{ type: "add_validator", targetId: "v1", proposer: "n1" }]],
+      ["coc_voteProposal", [{ proposalId: "p1", voterId: "n1", approve: true }]],
+      ["coc_getDaoProposal", ["p1"]],
+    ]
+    for (const [method, params] of methods) {
+      const r = await probe(method, params)
+      assert.equal(r.error?.code, -32601,
+        `${method} must be -32601 when governance disabled, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /governance.*not enabled/i,
+        `${method} error must reference governance, got ${r.error!.message}`)
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1943,7 +1943,14 @@ async function handleRpc(
       }))
     }
     case "coc_submitProposal": {
-      if (!hasGovernance(chain)) throw new Error("governance not enabled")
+      // #234: pre-fix the plain `new Error(...)` fell through to the
+      // outer catch's `-32603 internal error` default. Per JSON-RPC
+      // §5.1, -32603 is for server faults; "feature not enabled on
+      // this node" is a method-availability concern → -32601. Same
+      // class as #132 (unknown-method fallback fix).
+      if (!hasGovernance(chain)) {
+        throw { code: -32601, message: "coc_submitProposal: governance module not enabled on this node" }
+      }
       // #220: pre-fix `(payload.params ?? [])[0] as Record<string,string>`
       // was a no-op cast. With params=[] or params=[null] the first param
       // was undefined/null; the next line then accessed `.proposer` and
@@ -1993,7 +2000,10 @@ async function handleRpc(
       }
     }
     case "coc_voteProposal": {
-      if (!hasGovernance(chain)) throw new Error("governance not enabled")
+      // #234: same -32601 mapping as coc_submitProposal.
+      if (!hasGovernance(chain)) {
+        throw { code: -32601, message: "coc_voteProposal: governance module not enabled on this node" }
+      }
       // #220: same null-check as coc_submitProposal — params=[] / [null]
       // pre-fix bubbled "Cannot read properties of null (reading 'voterId')"
       // through the outer catch as a -32603 V8 leak.
@@ -2063,7 +2073,10 @@ async function handleRpc(
       }))
     }
     case "coc_getDaoProposal": {
-      if (!hasGovernance(chain)) throw new Error("governance not enabled")
+      // #234: same -32601 mapping as coc_submitProposal.
+      if (!hasGovernance(chain)) {
+        throw { code: -32601, message: "coc_getDaoProposal: governance module not enabled on this node" }
+      }
       const proposalId = (payload.params ?? [])[0]
       if (typeof proposalId !== "string" || !proposalId) {
         throw { code: -32602, message: "invalid proposal id: expected non-empty string" }


### PR DESCRIPTION
Closes #234.

## Summary

Three governance RPC methods threw plain `new Error("governance not enabled")`, which the outer catch converted to `-32603 "internal error"`. Per JSON-RPC 2.0 §5.1, -32603 is reserved for genuine server faults; "feature not enabled on this node" is a method-availability concern → -32601. Same class as #132.

```bash
$ curl -s -X POST -H 'Content-Type: application/json' \
    --data '{"jsonrpc":"2.0","method":"coc_getDaoProposal","params":["p1"],"id":1}' \
    http://209.74.64.88:28780
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"governance not enabled"}}
```

Impact: clients can't distinguish "node doesn't support this method" from "server crashed". Dashboards alert on -32603; pre-fix every governance probe on a no-governance node looked like a server fault.

## Test plan

- [x] Added regression test `#234: coc_submit/vote/getDaoProposal return -32601 when governance disabled`
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 88/88 passing locally
- [x] Pre-fix bug verified against live testnet