### PR TITLE
fix(ipfs): /api/v0/files/cp + /files/mv accept kubo-style second ?arg= (#236)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -635,6 +635,58 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#236: /api/v0/files/cp + /files/mv read second ?arg= for destination (kubo compat)", async () => {
+    // Pre-fix the handlers read `?dest=<path>` but kubo HTTP RPC sends
+    // dest as a second `?arg=` value. Result: every kubo-CLI / ipfs-http-
+    // client cp/mv silently failed with 500 because dest was "" →
+    // normalizePath("") → splitPath("/") → "cannot operate on root path
+    // directly". Now reads `arg[1]` first, falls back to ?dest= for
+    // legacy callers.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+    // Seed a source file.
+    await fetch("/api/v0/files/write?arg=/src&create=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("hello"),
+    })
+
+    // kubo-style: two ?arg= values — cp should succeed
+    const cpRes = await fetch("/api/v0/files/cp?arg=/src&arg=/dst", { method: "POST" })
+    assert.equal(cpRes.status, 200, `kubo-style cp must succeed, got ${cpRes.status}`)
+    // Verify dst exists
+    const statRes = await fetch("/api/v0/files/stat?arg=/dst", { method: "POST" })
+    assert.equal(statRes.status, 200, "copied file must exist at /dst")
+
+    // Single arg → 400 with explicit "requires two ?arg=" message (not 500)
+    const oneArgRes = await fetch("/api/v0/files/cp?arg=/src", { method: "POST" })
+    assert.equal(oneArgRes.status, 400, `single-arg cp must be 400, got ${oneArgRes.status}`)
+    const oneArgBody = await oneArgRes.json() as { error?: string; message?: string }
+    assert.notEqual(oneArgBody.error, "internal error",
+      `single-arg cp must not leak 'internal error', got ${JSON.stringify(oneArgBody)}`)
+    assert.match(`${oneArgBody.message ?? ""}`, /two .?arg.? values/i,
+      `single-arg cp error must reference two-arg requirement, got ${JSON.stringify(oneArgBody)}`)
+
+    // mv has the same contract — seed another source
+    await fetch("/api/v0/files/write?arg=/src2&create=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("world"),
+    })
+    const mvRes = await fetch("/api/v0/files/mv?arg=/src2&arg=/dst2", { method: "POST" })
+    assert.equal(mvRes.status, 200, `kubo-style mv must succeed, got ${mvRes.status}`)
+
+    // Legacy ?dest= fallback still works for backward-compat
+    await fetch("/api/v0/files/write?arg=/src3&create=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("legacy"),
+    })
+    const legacyRes = await fetch("/api/v0/files/cp?arg=/src3&dest=/dst3", { method: "POST" })
+    assert.equal(legacyRes.status, 200, `legacy ?dest= cp must still succeed, got ${legacyRes.status}`)
+  })
+
   it("#210: /api/v0/erasure/status maps ErasureError codes to 4xx (no 500 leak)", async () => {
     // Pre-fix the outer catch in IpfsHttpServer only mapped
     // ErasureError "invalid_params" → 400 and "not_found" → 404. The

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -57,6 +57,15 @@ function firstQueryValue(raw: string | string[] | undefined): string | undefined
   return raw
 }
 
+// #236: kubo's /files/cp + /files/mv both take destination as a SECOND
+// `?arg=` value. firstQueryValue coalesced everything to [0]; this
+// returns the Nth value so the second arg lands on the dest field.
+function nthQueryValue(raw: string | string[] | undefined, n: number): string | undefined {
+  if (raw === undefined) return undefined
+  if (Array.isArray(raw)) return raw[n]
+  return n === 0 ? raw : undefined
+}
+
 function isNotFoundError(err: unknown): boolean {
   if (err && typeof err === "object" && "code" in err && (err as { code: unknown }).code === "ENOENT") return true
   const msg = String(err instanceof Error ? err.message : err)
@@ -1055,16 +1064,29 @@ export class IpfsHttpServer {
           break
         }
         case "mv": {
+          // #236: kubo HTTP RPC sends two ?arg= values for src + dest.
+          // Pre-fix this read `?dest=` (which kubo never sends) so the
+          // dest was always "" → mfs.mv("/src","") → splitPath("/")
+          // throws "cannot operate on root path directly" → 500 leak.
           const source = arg
-          const dest = firstQueryValue(url.query?.dest) ?? ""
+          const dest = nthQueryValue(url.query?.arg, 1) ?? firstQueryValue(url.query?.dest) ?? ""
+          if (!source || !dest) {
+            throw new HttpError(400, "bad request", "mv requires two ?arg= values: source and destination")
+          }
           await this.mfs.mv(source, dest)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))
           break
         }
         case "cp": {
+          // #236: same kubo HTTP RPC contract as mv — two ?arg= values.
+          // Keep `?dest=` as legacy fallback for any internal caller
+          // still relying on the old shape.
           const source = arg
-          const dest = firstQueryValue(url.query?.dest) ?? ""
+          const dest = nthQueryValue(url.query?.arg, 1) ?? firstQueryValue(url.query?.dest) ?? ""
+          if (!source || !dest) {
+            throw new HttpError(400, "bad request", "cp requires two ?arg= values: source and destination")
+          }
           await this.mfs.cp(source, dest)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))


### PR DESCRIPTION
Closes #236.

## Summary

`cp` and `mv` MFS handlers read destination from `?dest=` but kubo HTTP RPC sends both source and dest as `?arg=` values. Every kubo-CLI / ipfs-http-client cp/mv silently failed with 500 because dest was "" → `splitPath("/")` → "cannot operate on root path directly".

Per kubo spec (https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-files-cp):
> `POST /api/v0/files/cp?arg=<source>&arg=<dest>`

```bash
$ curl -s -w 'HTTP %{http_code}\n' \
    'http://209.74.64.88:28786/api/v0/files/cp?arg=/src&arg=/dst' -X POST
{"error":"internal error"} HTTP 500
```

Post-fix: `nthQueryValue(arg, 1)` reads second arg; `?dest=` preserved as legacy fallback; missing source/dest → explicit 400.

## Test plan

- [x] Added `#236` regression test — kubo-style cp/mv succeed; single-arg → 400; legacy ?dest= still works
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 50/50 passing
- [x] Pre-fix verified against live testnet