### PR TITLE
fix(rpc): eth_getLogs + eth_newFilter reject non-object filter param (was silent no-filter) (#238)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1862,6 +1862,41 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#238: eth_getLogs + eth_newFilter reject non-object filter params (no silent no-filter)", async () => {
+    // Pre-fix `((payload.params ?? [])[0] ?? {}) as Record<string, unknown>`
+    // was a TS-only runtime no-op. Boolean/string/number/array all slipped
+    // through as "the object" — fromBlock/toBlock/address/topics reads
+    // returned undefined → validateLogFilter rejected nothing → silent
+    // "all logs" (eth_getLogs) or silent filter-creation (eth_newFilter,
+    // which leaked entries in the MAX_FILTERS-capped map). Same class as
+    // #220/#224/#226/#234.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const badShapes: unknown[][] = [[true], [false], ["string-not-object"], [42], [[1, 2]]]
+    for (const params of badShapes) {
+      for (const method of ["eth_getLogs", "eth_newFilter"]) {
+        const r = await probe(method, params)
+        assert.equal(r.error?.code, -32602,
+          `${method}(${JSON.stringify(params)}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /invalid filter|expected object/i,
+          `${method} error must name the filter shape, got ${r.error!.message}`)
+      }
+    }
+    // Sanity: omitted / null / empty object still work as full-range default
+    const ok1 = await probe("eth_getLogs", [])
+    assert.equal(ok1.error, undefined, "omitted filter must succeed")
+    const ok2 = await probe("eth_getLogs", [null])
+    assert.equal(ok2.error, undefined, "null filter must succeed (treated as {})")
+    const ok3 = await probe("eth_getLogs", [{}])
+    assert.equal(ok3.error, undefined, "empty object filter must succeed")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -195,6 +195,24 @@ function requireCallObject(raw: unknown, methodName: string): Record<string, unk
   return raw as Record<string, unknown>
 }
 
+/**
+ * #238: Filter param validator for eth_getLogs / eth_newFilter. Pre-fix
+ * `(payload.params[0] ?? {}) as Record<string, unknown>` was a TS-only
+ * runtime no-op so booleans, strings, numbers, and arrays slipped through.
+ * Every `.fromBlock` / `.address` / `.topics` read returned undefined →
+ * validateLogFilter saw nothing to reject → silent "no filter" path.
+ * Worse for eth_newFilter: silently created a filter ID for garbage,
+ * leaking entries in the MAX_FILTERS-capped map. Returns {} for
+ * null/undefined to keep `eth_getLogs(null)` working as "default range".
+ */
+function requireFilterObject(raw: unknown): Record<string, unknown> {
+  if (raw === undefined || raw === null) return {}
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw { code: -32602, message: `invalid filter: expected object, got ${Array.isArray(raw) ? "array" : typeof raw}` }
+  }
+  return raw as Record<string, unknown>
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -1015,7 +1033,7 @@ async function handleRpc(
       return tx.hash
     }
     case "eth_getLogs": {
-      const query = ((payload.params ?? [])[0] ?? {}) as Record<string, unknown>
+      const query = requireFilterObject((payload.params ?? [])[0])
       // EIP-234: blockHash is mutually exclusive with fromBlock/toBlock.
       // Pre-fix this silently processed the range and surfaced a confusing
       // "block range too large" error referencing the full chain height.
@@ -1035,7 +1053,7 @@ async function handleRpc(
         cleanupExpiredFilters(filters)
         if (filters.size >= MAX_FILTERS) throw { code: -32005, message: "filter limit exceeded" }
       }
-      const query = ((payload.params ?? [])[0] ?? {}) as Record<string, unknown>
+      const query = requireFilterObject((payload.params ?? [])[0])
       const id = `0x${randomBytes(16).toString("hex")}`
       const newFilterHeight = await Promise.resolve(chain.getHeight())
       const fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
@@ -1404,7 +1422,7 @@ async function handleRpc(
     }
     case "trace_filter": {
       if (!DEBUG_RPC_ENABLED) throw { code: -32601, message: "debug methods disabled (set COC_DEBUG_RPC=1)" }
-      const query = ((payload.params ?? [])[0] ?? {}) as Record<string, unknown>
+      const query = requireFilterObject((payload.params ?? [])[0])
       return await queryTraceFilter(chain, evm, query)
     }
     case "trace_get": {


### PR DESCRIPTION
Closes #238.

## Summary

`eth_getLogs`, `eth_newFilter`, and `trace_filter` cast the first param to `Record<string, unknown>` via a TS-only runtime no-op. Booleans/strings/numbers/arrays slipped through → all field reads returned undefined → silent no-filter path (eth_getLogs returned all logs; eth_newFilter created garbage filter IDs leaking MAX_FILTERS budget).

Same class as #190 / #220 / #224 / #226 / #234.

```bash
$ curl -s -X POST -H 'Content-Type: application/json' \
    --data '{"jsonrpc":"2.0","method":"eth_newFilter","params":[true],"id":1}' \
    http://209.74.64.88:28780
{"jsonrpc":"2.0","id":1,"result":"0x3e5d91ec35b8d8a9fdb7ae263ef72ebc"}  # filter created from 'true'!
```

## Test plan

- [x] Added `requireFilterObject` helper (parallel to `requireCallObject`)
- [x] Added regression test `#238: eth_getLogs + eth_newFilter reject non-object filter` — 5 bad shapes × 2 methods + 3 sanity cases
- [x] Same null/undefined ergonomics preserved (`eth_getLogs(null)` still works)
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 89/89 passing locally
- [x] Pre-fix bug verified against live testnet