### PR TITLE
fix(rpc): admin_addPeer / admin_removePeer reject non-string shape (#240)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1897,6 +1897,63 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok3.error, undefined, "empty object filter must succeed")
   })
 
+  await t.test("#240: admin_addPeer / admin_removePeer reject non-string shape (no silent coercion)", async () => {
+    // Pre-fix `String((payload.params ?? [])[1] ?? ...)` silently coerced
+    // numbers/bools to plausible peerIds ("123", "true"). Pre-fix
+    // String({}) = "[object Object]" failed the regex, but bool/number
+    // slipped through. Same anti-pattern as #120/#220/#226/#238.
+    // Need a second server with enableAdminRpc=true since the main test
+    // fixture leaves admin off.
+    const adminPort = port + 1000
+    const adminServer = startRpcServer(
+      "127.0.0.1", adminPort, chainId, evm, chain, p2p,
+      undefined, undefined, "admin-test", undefined,
+      undefined,                            // runtimeOptions
+      { enableAdminRpc: true },             // rpcAuthOptions (12th arg)
+    )
+    try {
+      const probe = async (method: string, params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${adminPort}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      const validUrl = "http://127.0.0.1:19780"
+      // peerId is non-string → -32602
+      for (const badId of [123, true, false, 1.5]) {
+        const r = await probe("admin_addPeer", [validUrl, badId])
+        assert.equal(r.error?.code, -32602,
+          `admin_addPeer(_, ${JSON.stringify(badId)}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /peer ID|expected string/i)
+      }
+      // peerUrl is non-string → -32602
+      for (const badUrl of [123, true, {}, [validUrl]]) {
+        const r = await probe("admin_addPeer", [badUrl, "valid-id"])
+        assert.equal(r.error?.code, -32602,
+          `admin_addPeer(${JSON.stringify(badUrl)}, _) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /peer URL|expected.*string/i)
+      }
+      // admin_removePeer with non-string peerId → -32602
+      for (const badId of [123, true, false, {}, []]) {
+        const r = await probe("admin_removePeer", [badId])
+        assert.equal(r.error?.code, -32602,
+          `admin_removePeer(${JSON.stringify(badId)}) must be -32602, got ${JSON.stringify(r)}`)
+      }
+      // Sanity: well-shaped calls clear shape validation. The test
+      // fixture's p2p stub may not provide discovery.addDiscoveredPeers,
+      // so we only assert the response is NOT -32602 (= shape passed).
+      const ok = await probe("admin_addPeer", [validUrl, "valid-id"])
+      assert.notEqual(ok.error?.code, -32602, "well-shaped admin_addPeer must pass shape validation")
+      const okOmit = await probe("admin_addPeer", [validUrl])
+      assert.notEqual(okOmit.error?.code, -32602,
+        "omitted peerId must default to `peer-<timestamp>` (shape passes)")
+    } finally {
+      adminServer.close()
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2485,8 +2485,20 @@ async function handleRpc(
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         throw { code: -32601, message: "admin methods disabled" }
       }
-      const peerUrl = String((payload.params ?? [])[0] ?? "")
-      const peerId = String((payload.params ?? [])[1] ?? `peer-${Date.now()}`)
+      // #240: pre-fix `String(...)` silently coerced numbers/bools to
+      // plausible-looking strings ("123", "true"), bypassing the
+      // alphanumeric peerId regex and the URL parse check. Reject
+      // non-string shapes upfront. Same class as #120/#220/#226/#238.
+      const peerUrlRaw = (payload.params ?? [])[0]
+      if (typeof peerUrlRaw !== "string" || peerUrlRaw.length === 0) {
+        throw { code: -32602, message: "invalid peer URL: expected non-empty string" }
+      }
+      const peerIdRaw = (payload.params ?? [])[1]
+      if (peerIdRaw !== undefined && peerIdRaw !== null && typeof peerIdRaw !== "string") {
+        throw { code: -32602, message: "invalid peer ID: expected string" }
+      }
+      const peerUrl = peerUrlRaw
+      const peerId = (peerIdRaw ?? `peer-${Date.now()}`) as string
       try { new URL(peerUrl) } catch {
         throw { code: -32602, message: "invalid peer URL" }
       }
@@ -2500,10 +2512,18 @@ async function handleRpc(
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         throw { code: -32601, message: "admin methods disabled" }
       }
-      const removePeerId = String((payload.params ?? [])[0] ?? "")
-      if (!removePeerId) {
+      // #240: same shape guard as admin_addPeer — pre-fix `String(true)`
+      // = "true" silently masqueraded as a peerId and the removePeer
+      // call no-op'd successfully, returning true and confusing the
+      // caller about whether the action took effect.
+      const removePeerRaw = (payload.params ?? [])[0]
+      if (removePeerRaw === undefined || removePeerRaw === null || removePeerRaw === "") {
         throw { code: -32602, message: "peer id required" }
       }
+      if (typeof removePeerRaw !== "string") {
+        throw { code: -32602, message: "invalid peer ID: expected string" }
+      }
+      const removePeerId = removePeerRaw
       p2p.discovery.removePeer(removePeerId)
       return true
     }


### PR DESCRIPTION
Closes #240.

## Summary

`admin_addPeer` / `admin_removePeer` used `String(...)` coercion on peerUrl + peerId, silently turning numbers/bools into ad-hoc peer identities (peerId `"123"` from number `123`, `"true"` from bool). Same anti-pattern as #120/#220/#226/#238 — silent coercion of non-strings to plausible-looking string defaults.

```bash
$ curl -s -X POST -H 'Content-Type: application/json' \
    --data '{"jsonrpc":"2.0","method":"admin_addPeer","params":["coc://x@x:1",123],"id":1}' \
    http://209.74.64.88:28780
{"result":true}   # silently created peer with id="123"
```

Impact: identity collision (peerId `123` vs `"123"`), inconsistent error semantics across the RPC surface, attack vector in deployments with admin RPC enabled (the chainId 18780 testnet has it on).

## Test plan

- [x] Added `#240` regression test on a second startRpcServer with `enableAdminRpc: true` — 4 bad peerId shapes + 4 bad peerUrl shapes + 5 bad removePeer shapes + sanity assertions
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 90/90 passing locally
- [x] Pre-fix bug verified against live testnet