### PR TITLE
fix(rpc): DID handlers reject non-string DID/agentId/credentialId (#242)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1954,6 +1954,70 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#242: DID handlers reject non-string DID/agentId/credentialId (no silent coercion)", async () => {
+    // Pre-fix 7 DID/identity handlers used `String((payload.params ?? [])[0] ?? "")`.
+    // String(123)="123", String(true)="true", String({})="[object Object]" — all
+    // bogus identifiers passed downstream. Same anti-pattern as #120/#220/#226/#240.
+    // Stub the resolver + provider so the path reaches shape validation.
+    const didResolverStub = {
+      resolve: async (did: string) => ({ didDocument: { id: did }, didResolutionMetadata: {} }),
+    }
+    const didProviderStub = {
+      getCapabilities: async () => 0n,
+      getFullDelegations: async () => [],
+      getLineage: async () => ({ parents: [], children: [] }),
+      getVerificationMethods: async () => [],
+      getCredentialAnchor: async () => null,
+    }
+    const didPort = port + 2000
+    const didServer = startRpcServer(
+      "127.0.0.1", didPort, chainId, evm, chain, p2p,
+      undefined, undefined, "did-test", undefined,
+      { didResolver: didResolverStub, didDataProvider: didProviderStub } as unknown as Parameters<typeof startRpcServer>[10],
+      undefined,
+    )
+    try {
+      const probe = async (method: string, params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${didPort}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      const methods = [
+        "coc_resolveDid",
+        "coc_getDIDDocument",
+        "coc_getAgentCapabilities",
+        "coc_getDelegations",
+        "coc_getAgentLineage",
+        "coc_getVerificationMethods",
+        "coc_getCredentialAnchor",
+      ]
+      for (const method of methods) {
+        // Non-string shapes → -32602
+        for (const bad of [123, true, false, 1.5, {}, [1, 2]]) {
+          const r = await probe(method, [bad])
+          assert.equal(r.error?.code, -32602,
+            `${method}(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+          assert.match(r.error!.message, /invalid|expected string/i)
+        }
+        // Missing / null / empty → -32602 "missing"
+        for (const empty of [[], [null], [""]]) {
+          const r = await probe(method, empty)
+          assert.equal(r.error?.code, -32602,
+            `${method}(${JSON.stringify(empty)}) must be -32602 missing, got ${JSON.stringify(r)}`)
+        }
+        // Sanity: well-shaped string passes shape validation (no -32602)
+        const ok = await probe(method, ["agent-7"])
+        assert.notEqual(ok.error?.code, -32602,
+          `${method}("agent-7") must pass shape validation, got ${JSON.stringify(ok)}`)
+      }
+    } finally {
+      didServer.close()
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -213,6 +213,24 @@ function requireFilterObject(raw: unknown): Record<string, unknown> {
   return raw as Record<string, unknown>
 }
 
+/**
+ * #242: Generic string-param validator. Pre-fix `String(...)` coercion
+ * silently mapped numbers/booleans/objects to bogus identifiers
+ * ("123"/"true"/"[object Object]") that downstream lookups couldn't
+ * distinguish from real strings. Used for DID/agentId/credentialId
+ * params. Same anti-pattern as #120/#220/#226/#240.
+ */
+function requireStringParam(params: unknown[], index: number, name: string): string {
+  const raw = params[index]
+  if (raw === undefined || raw === null || raw === "") {
+    throw { code: -32602, message: `missing ${name} parameter` }
+  }
+  if (typeof raw !== "string") {
+    throw { code: -32602, message: `invalid ${name}: expected string, got ${Array.isArray(raw) ? "array" : typeof raw}` }
+  }
+  return raw
+}
+
 function optionalHexParam(params: unknown[], index: number): Hex | undefined {
   const value = (params ?? [])[index]
   if (value === undefined || value === null) return undefined
@@ -2605,23 +2623,24 @@ async function handleRpc(
     case "coc_resolveDid": {
       const didResolver = opts?.didResolver as { resolve: (did: string) => Promise<{ didDocument: unknown; didResolutionMetadata: unknown }> } | undefined
       if (!didResolver) throw { code: -32601, message: "DID resolver not configured on this node (requires soulRegistryAddress + didRegistryAddress)" }
-      const did = String((payload.params ?? [])[0] ?? "")
-      if (!did) throw { code: -32602, message: "missing DID parameter" }
+      // #242: pre-fix `String(... ?? "")` silently coerced numbers/bools/
+      // objects to "123"/"true"/"[object Object]" — bogus identifiers
+      // that downstream resolvers couldn't tell apart from real DIDs.
+      // Same anti-pattern as #120/#220/#226/#240.
+      const did = requireStringParam(payload.params ?? [], 0, "DID")
       return didResolver.resolve(did)
     }
     case "coc_getDIDDocument": {
       const didResolver = opts?.didResolver as { resolve: (did: string) => Promise<{ didDocument: unknown }> } | undefined
       if (!didResolver) throw { code: -32601, message: "DID resolver not configured on this node" }
-      const agentId = String((payload.params ?? [])[0] ?? "")
-      if (!agentId) throw { code: -32602, message: "missing agentId parameter" }
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const result = await didResolver.resolve(`did:coc:${agentId}`)
       return result.didDocument ?? null
     }
     case "coc_getAgentCapabilities": {
       const didProvider = opts?.didDataProvider
       if (!didProvider) throw { code: -32601, message: "DID data provider not configured on this node" }
-      const agentId = String((payload.params ?? [])[0] ?? "")
-      if (!agentId) throw { code: -32602, message: "missing agentId parameter" }
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const bitmask = await didProvider.getCapabilities(agentId)
       // Import inline to avoid top-level dependency
       const { capabilityBitmaskToNames } = await import("./did/did-types.ts")
@@ -2630,22 +2649,19 @@ async function handleRpc(
     case "coc_getDelegations": {
       const didProvider = opts?.didDataProvider
       if (!didProvider) throw { code: -32601, message: "DID data provider not configured on this node" }
-      const agentId = String((payload.params ?? [])[0] ?? "")
-      if (!agentId) throw { code: -32602, message: "missing agentId parameter" }
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getFullDelegations(agentId)
     }
     case "coc_getAgentLineage": {
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getLineage) throw { code: -32601, message: "DID data provider not configured on this node" }
-      const agentId = String((payload.params ?? [])[0] ?? "")
-      if (!agentId) throw { code: -32602, message: "missing agentId parameter" }
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getLineage(agentId)
     }
     case "coc_getVerificationMethods": {
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getVerificationMethods) throw { code: -32601, message: "DID data provider not configured on this node" }
-      const agentId = String((payload.params ?? [])[0] ?? "")
-      if (!agentId) throw { code: -32602, message: "missing agentId parameter" }
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getVerificationMethods(agentId)
     }
     case "coc_getCredentialAnchor": {
@@ -2654,8 +2670,7 @@ async function handleRpc(
       // for full credential verification.
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getCredentialAnchor) throw { code: -32601, message: "DID data provider not configured on this node" }
-      const credentialId = String((payload.params ?? [])[0] ?? "")
-      if (!credentialId) throw { code: -32602, message: "missing credentialId parameter" }
+      const credentialId = requireStringParam(payload.params ?? [], 0, "credentialId")
       return didProvider.getCredentialAnchor(credentialId)
     }
     default:


### PR DESCRIPTION
Closes #242.

## Summary

Seven DID/identity RPC handlers used `String((payload.params ?? [])[0] ?? "")` to read the identifier param. `String(123)` = `"123"`, `String(true)` = `"true"`, `String({})` = `"[object Object]"` — all bogus identifiers passed to downstream resolvers/providers as if they were real string DIDs/agentIds.

Same anti-pattern as #120 / #220 / #226 / #240 — silent coercion of non-strings to plausible-looking string defaults.

Affected: `coc_resolveDid`, `coc_getDIDDocument`, `coc_getAgentCapabilities`, `coc_getDelegations`, `coc_getAgentLineage`, `coc_getVerificationMethods`, `coc_getCredentialAnchor`.

## Test plan

- [x] Added `requireStringParam` helper (parallel to `requireFilterObject` / `requireCallObject`)
- [x] Replaced 7 `String(... ?? "")` sites
- [x] Added `#242` regression test on a separate `startRpcServer` with stub DID resolver + provider — 6 bad shapes × 7 methods + 3 missing × 7 methods + sanity assertions
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 90/90 passing