### PR TITLE
fix(rpc): coc_dhtFindProviders rejects non-integer maxK (#251)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1957,6 +1957,36 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#251: coc_dhtFindProviders rejects non-integer maxK (preserves omitted)", async () => {
+    // Pre-fix `Number((payload.params ?? [])[1] ?? 3)` silently mapped
+    // every malformed maxK to a clamped default: true → 1, "huge" → NaN→3,
+    // {} → NaN→3, -5 → fallback 3, 1.7 → Math.floor → 1. Clients with
+    // shape bugs got plausible result counts and never learned their
+    // input was wrong. Same anti-pattern as #224/#248.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_dhtFindProviders", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const validCid = "bafy-real-cid"
+    // Non-integer or negative maxK → -32602
+    for (const bad of [true, false, "huge", {}, [1, 2], -1, -5, 0, 1.5, 1.7]) {
+      const r = await probe([validCid, bad])
+      assert.equal(r.error?.code, -32602,
+        `maxK=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /maxK|positive integer/i)
+    }
+    // Omitted / null → default 3; positive integer → cap
+    for (const ok of [[validCid], [validCid, null], [validCid, 3], [validCid, 16], [validCid, 64]]) {
+      const r = await probe(ok)
+      assert.notEqual(r.error?.code, -32602,
+        `maxK=${JSON.stringify(ok[1])} must pass shape, got ${JSON.stringify(r)}`)
+    }
+  })
+
   await t.test("#240: admin_addPeer / admin_removePeer reject non-string shape (no silent coercion)", async () => {
     // Pre-fix `String((payload.params ?? [])[1] ?? ...)` silently coerced
     // numbers/bools to plausible peerIds ("123", "true"). Pre-fix

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1895,8 +1895,19 @@ async function handleRpc(
         throw { code: -32602, message: "invalid cid: contains illegal characters or exceeds 512 chars" }
       }
       const cid = rawCid
-      const rawMaxK = Number((payload.params ?? [])[1] ?? 3)
-      const cap = Number.isFinite(rawMaxK) && rawMaxK > 0 ? Math.min(Math.floor(rawMaxK), 64) : 3
+      // #251: pre-fix `Number(... ?? 3)` silently mapped any malformed
+      // maxK (true → 1, "huge" → NaN→3, {} → NaN→3, -5 → fallback 3,
+      // 1.7 → 1 via Math.floor) to a clamped default. Clients passing
+      // wrong shapes got plausible result counts and never knew they
+      // had a bug. Same anti-pattern as #224 (eth_feeHistory blockCount).
+      const rawMaxK = (payload.params ?? [])[1]
+      let cap = 3
+      if (rawMaxK !== undefined && rawMaxK !== null) {
+        if (typeof rawMaxK !== "number" || !Number.isFinite(rawMaxK) || !Number.isInteger(rawMaxK) || rawMaxK < 1) {
+          throw { code: -32602, message: "invalid maxK: expected positive integer or omitted" }
+        }
+        cap = Math.min(rawMaxK, 64)
+      }
       const findProviders = opts?.findProviders as ((cid: string, maxK: number) => string[]) | undefined
       const providers = findProviders?.(cid, cap) ?? []
       return { providers }


### PR DESCRIPTION
Same anti-pattern as #224/#248: `Number(... ?? 3)` silently mapped malformed maxK (true→1, 1.7→1, NaN→3, -5→3) to clamped defaults, masking client shape bugs.

Post-fix: rejects non-integer / negative / zero with -32602 'expected positive integer or omitted'. Omitted/null preserved as default 3.

## Test plan
- [x] Added `#251` regression test — 10 bad shapes + 5 sanity cases
- [x] 94/94 rpc-extended tests pass locally