### PR TITLE
fix(rpc): #252 reject non-integer epochId in reward handlers

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2158,6 +2158,52 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okC.error, undefined, `well-shaped getRewardClaim must succeed: ${JSON.stringify(okC)}`)
   })
 
+  await t.test("#254: coc_getTransactionsByAddress rejects non-integer limit/offset and non-boolean reverse", async () => {
+    // Pre-fix `Number((params)[1] ?? 50)` silently coerced `true`→1, `"5"`→5,
+    // `[3]`→3, `{}`→NaN→fallback. `(params[2] !== false)` accepted every
+    // non-false value (`0`, `"false"`, `null`, `""`) as reverse=true. Same
+    // anti-pattern family as #252/#251/#224/#120.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_getTransactionsByAddress", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const addr = `0x${"ab".repeat(20)}`
+    // limit: non-integer shapes must be rejected
+    for (const bad of [true, false, "5", [3], [1, 2], {}, 1.5, -1]) {
+      const r = await probe([addr, bad, true, 0])
+      assert.equal(r.error?.code, -32602,
+        `limit=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // offset: same
+    for (const bad of [true, "0", [0], {}, 0.5, -1]) {
+      const r = await probe([addr, 10, true, bad])
+      assert.equal(r.error?.code, -32602,
+        `offset=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // reverse: non-boolean shapes must be rejected (no silent enable)
+    for (const bad of [0, 1, "false", "true", [true], {}]) {
+      const r = await probe([addr, 10, bad, 0])
+      assert.equal(r.error?.code, -32602,
+        `reverse=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-shaped + null/undefined defaults still succeed
+    for (const params of [
+      [addr, 10, true, 0],
+      [addr, null, null, null],
+      [addr],
+      [addr, undefined, false, undefined],
+    ]) {
+      const r = await probe(params)
+      assert.equal(r.error, undefined,
+        `well-shaped ${JSON.stringify(params)} must succeed, got ${JSON.stringify(r)}`)
+      assert.ok(Array.isArray(r.result), `result must be array for ${JSON.stringify(params)}`)
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2114,6 +2114,50 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#252: coc_getRewardManifest / coc_getRewardClaim reject non-integer epochId (no Number() coercion)", async () => {
+    // Pre-fix `Number((payload.params ?? [])[0] ?? -1)` silently coerced
+    // `true`→1, `[1]`→1, `"1"`→1, `null`→0 — every non-integer that JS
+    // happens to know how to coerce became a real epochId lookup. Same
+    // anti-pattern family as #120/#220/#226/#240/#242. Use the new
+    // `requireIntegerParam` validator.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // Non-integer epochId shapes must be rejected with -32602
+    for (const bad of [true, false, "1", "5", [1], [1, 2], {}, 1.5, -1, -0.5]) {
+      const m = await probe("coc_getRewardManifest", [bad])
+      assert.equal(m.error?.code, -32602,
+        `coc_getRewardManifest(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(m)}`)
+      const c = await probe("coc_getRewardClaim", [bad, `0x${"22".repeat(32)}`])
+      assert.equal(c.error?.code, -32602,
+        `coc_getRewardClaim(${JSON.stringify(bad)}, ...) must be -32602, got ${JSON.stringify(c)}`)
+    }
+    // Missing param → -32602 missing
+    const missing = await probe("coc_getRewardManifest", [])
+    assert.equal(missing.error?.code, -32602)
+    assert.match(missing.error!.message, /missing|epochId/i)
+    // null param → -32602 missing
+    const nullCase = await probe("coc_getRewardManifest", [null])
+    assert.equal(nullCase.error?.code, -32602)
+    // coc_getRewardClaim with non-string nodeId
+    for (const bad of [123, true, {}, [1]]) {
+      const r = await probe("coc_getRewardClaim", [7, bad])
+      assert.equal(r.error?.code, -32602,
+        `coc_getRewardClaim(7, ${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-shaped lookups still resolve (epoch 7 manifest is pre-loaded)
+    const okM = await probe("coc_getRewardManifest", [7])
+    assert.equal(okM.error, undefined, `well-shaped getRewardManifest must succeed: ${JSON.stringify(okM)}`)
+    assert.equal((okM.result as { epochId: number }).epochId, 7)
+    const okC = await probe("coc_getRewardClaim", [7, `0x${"22".repeat(32)}`])
+    assert.equal(okC.error, undefined, `well-shaped getRewardClaim must succeed: ${JSON.stringify(okC)}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -300,6 +300,24 @@ export function requireStringParam(params: unknown[], index: number, name: strin
   return raw as string
 }
 
+/**
+ * #252: Generic non-negative integer-param validator. Pre-fix
+ * `Number((params)[idx] ?? -1)` silently coerced `true`→1, `[1]`→1,
+ * `"1"`→1, `null`→0 so callers got hits for non-integer inputs.
+ * Used for epochId in `coc_getRewardManifest` / `coc_getRewardClaim`.
+ * Same anti-pattern as #120/#220/#226/#240/#242.
+ */
+export function requireIntegerParam(params: unknown[], index: number, name: string): number {
+  const raw = (params ?? [])[index]
+  if (raw === undefined || raw === null) {
+    invalidParams(`missing ${name} parameter`)
+  }
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) {
+    invalidParams(`invalid ${name}: expected non-negative integer, got ${Array.isArray(raw) ? "array" : typeof raw}`)
+  }
+  return raw as number
+}
+
 // ---------------------------------------------------------------------------
 // Tx-call field validators
 // ---------------------------------------------------------------------------

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -318,6 +318,56 @@ export function requireIntegerParam(params: unknown[], index: number, name: stri
   return raw as number
 }
 
+/**
+ * #254: Optional non-negative integer with default. Treats `undefined`
+ * and `null` as "omitted" and returns the supplied default; rejects
+ * any other non-integer shape with -32602. Pre-fix the
+ * `Number((params)[idx] ?? N)` idiom in `coc_getTransactionsByAddress`
+ * (and similar paginated handlers) silently coerced `true`→1, `"5"`→5,
+ * `[3]`→3, `{}`→NaN→fallback. Same family as #252/#251/#224.
+ */
+export function optionalIntegerParam(
+  params: unknown[],
+  index: number,
+  name: string,
+  defaultValue: number,
+  opts?: { min?: number; max?: number },
+): number {
+  const raw = (params ?? [])[index]
+  if (raw === undefined || raw === null) return defaultValue
+  if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw)) {
+    invalidParams(`invalid ${name}: expected integer or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)
+  }
+  const min = opts?.min ?? 0
+  const max = opts?.max ?? Number.MAX_SAFE_INTEGER
+  if (raw < min || raw > max) {
+    invalidParams(`invalid ${name}: must be between ${min} and ${max}`)
+  }
+  return raw as number
+}
+
+/**
+ * #254: Strict optional boolean. Pre-fix `(params[idx] !== false)` was
+ * the worst kind of silent coercion — every non-`false` value (`0`,
+ * `"false"`, `null`, `{}`, `[]`) parsed as `true`, which is usually the
+ * opposite of what a sloppy client meant when sending `0` or `"false"`.
+ * Returns the supplied default for `undefined`/`null`; rejects every
+ * non-boolean shape with -32602.
+ */
+export function optionalBooleanParam(
+  params: unknown[],
+  index: number,
+  name: string,
+  defaultValue: boolean,
+): boolean {
+  const raw = (params ?? [])[index]
+  if (raw === undefined || raw === null) return defaultValue
+  if (typeof raw !== "boolean") {
+    invalidParams(`invalid ${name}: expected boolean or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)
+  }
+  return raw as boolean
+}
+
 // ---------------------------------------------------------------------------
 // Tx-call field validators
 // ---------------------------------------------------------------------------

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -37,6 +37,8 @@ import {
   requireFilterObject,
   requireStringParam,
   requireIntegerParam,
+  optionalIntegerParam,
+  optionalBooleanParam,
   validateTxCallFields,
   validateLogFilter,
   sanitizeEthersError,
@@ -1701,16 +1703,14 @@ async function handleRpc(
       // of silently missing the index → empty result. Pre-fix, "not-an-address"
       // and "0x123" both returned [] indistinguishable from a real empty
       // address.
-      const rawAddr = String((payload.params ?? [])[0] ?? "")
-      if (!/^0x[0-9a-fA-F]{40}$/.test(rawAddr)) {
-        invalidParams("invalid address: must match /^0x[0-9a-fA-F]{40}$/")
-      }
-      const addr = rawAddr.toLowerCase() as Hex
-      const rawLimit = Number((payload.params ?? [])[1] ?? 50)
-      const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 10_000) : 50
-      const reverse = (payload.params ?? [])[2] !== false
-      const rawOffset = Number((payload.params ?? [])[3] ?? 0)
-      const offset = Number.isFinite(rawOffset) ? Math.min(Math.max(rawOffset, 0), 100_000) : 0
+      // #254: pre-fix `Number((params)[1] ?? 50)` silently coerced
+      // `true`→1, `"5"`→5, `[3]`→3, `{}`→NaN→fallback 50. Same for
+      // offset. The `(params[2] !== false)` reverse check was even
+      // worse — `0`/`"false"`/`null`/`""` all parsed as reverse=true.
+      const addr = requireAddressParam(payload.params ?? [], 0).toLowerCase() as Hex
+      const limit = optionalIntegerParam(payload.params ?? [], 1, "limit", 50, { min: 1, max: 10_000 })
+      const reverse = optionalBooleanParam(payload.params ?? [], 2, "reverse", true)
+      const offset = optionalIntegerParam(payload.params ?? [], 3, "offset", 0, { min: 0, max: 100_000 })
 
       if (typeof chain.getTransactionsByAddress === "function") {
         const txs = await chain.getTransactionsByAddress(addr, { limit, reverse, offset })

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -36,6 +36,7 @@ import {
   requireCallObject,
   requireFilterObject,
   requireStringParam,
+  requireIntegerParam,
   validateTxCallFields,
   validateLogFilter,
   sanitizeEthersError,
@@ -2178,10 +2179,8 @@ async function handleRpc(
     case "coc_getRewardManifest": {
       const rewardManifestDir = typeof opts?.rewardManifestDir === "string" ? opts.rewardManifestDir : ""
       if (!rewardManifestDir) return null
-      const epochId = Number((payload.params ?? [])[0] ?? -1)
-      if (!Number.isInteger(epochId) || epochId < 0) {
-        invalidParams("invalid epochId")
-      }
+      // #252: reject non-integer epochId (was: Number(true)→1, Number([1])→1, Number("1")→1)
+      const epochId = requireIntegerParam(payload.params ?? [], 0, "epochId")
       const manifest = readBestRewardManifest(rewardManifestDir, epochId)
       if (!manifest) return null
       return {
@@ -2199,11 +2198,9 @@ async function handleRpc(
     case "coc_getRewardClaim": {
       const rewardManifestDir = typeof opts?.rewardManifestDir === "string" ? opts.rewardManifestDir : ""
       if (!rewardManifestDir) return null
-      const epochId = Number((payload.params ?? [])[0] ?? -1)
-      const nodeId = String((payload.params ?? [])[1] ?? "")
-      if (!Number.isInteger(epochId) || epochId < 0) {
-        invalidParams("invalid epochId")
-      }
+      // #252: reject non-integer epochId and non-string nodeId
+      const epochId = requireIntegerParam(payload.params ?? [], 0, "epochId")
+      const nodeId = requireStringParam(payload.params ?? [], 1, "nodeId")
       if (!/^0x[0-9a-fA-F]+$/.test(nodeId)) {
         invalidParams("invalid nodeId")
       }


### PR DESCRIPTION
Closes #252.

## Bug

`coc_getRewardManifest` and `coc_getRewardClaim` parsed `epochId` with
`Number((payload.params ?? [])[0] ?? -1)`, which silently coerced:

- `true` → 1   (`Number(true) === 1`)
- `[1]`  → 1   (`Number([1])  === 1`)
- `"1"`  → 1   (`Number("1")  === 1`)
- `null` → 0   (well, `-1` via the `?? -1` fallback, which then fails — *only that one fell through to invalidParams by luck*)

All the boolean/array/string variants returned a legitimate lookup
(`null` if missing, manifest object if present) instead of -32602.

Live repro on the 88780 testnet (`http://209.74.64.88:38780`):

\`\`\`bash
curl … -d '{"…method":"coc_getRewardManifest","params":[true]}'
# → {"result":null}      ← bug: accepted as valid lookup for epoch 1
\`\`\`

Same JSON-RPC §5.1 violation as the `String(... ?? "")` and
`(... ?? {}) as Record<string,unknown>` patterns fixed in
#120 / #220 / #224 / #226 / #228 / #234 / #238 / #240 / #242 /
#244 / #246 / #248 / #249 / #250 / #251.

## Fix

- New helper `requireIntegerParam(params, index, name)` in
  `node/src/rpc-validators.ts` — rejects non-`number`,
  non-integer, and negative inputs with `-32602`.
- `coc_getRewardManifest`: replace ad-hoc `Number()` parsing with the
  helper.
- `coc_getRewardClaim`: replace `Number()` for `epochId` and `String()`
  for `nodeId` with the helpers (the hex regex still enforces the
  nodeId charset).

## Test plan

- [x] New subtest \`#252\` in \`rpc-extended.test.ts\` (boolean/array/string/null/negative/non-integer/float epochId + non-string nodeId + well-shaped sanity).
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\` → **94/94 pass**.