### PR TITLE
fix(rpc): #254 coc_getTransactionsByAddress reject non-integer pagination + non-boolean reverse

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2158,6 +2158,52 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okC.error, undefined, `well-shaped getRewardClaim must succeed: ${JSON.stringify(okC)}`)
   })
 
+  await t.test("#254: coc_getTransactionsByAddress rejects non-integer limit/offset and non-boolean reverse", async () => {
+    // Pre-fix `Number((params)[1] ?? 50)` silently coerced `true`→1, `"5"`→5,
+    // `[3]`→3, `{}`→NaN→fallback. `(params[2] !== false)` accepted every
+    // non-false value (`0`, `"false"`, `null`, `""`) as reverse=true. Same
+    // anti-pattern family as #252/#251/#224/#120.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_getTransactionsByAddress", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const addr = `0x${"ab".repeat(20)}`
+    // limit: non-integer shapes must be rejected
+    for (const bad of [true, false, "5", [3], [1, 2], {}, 1.5, -1]) {
+      const r = await probe([addr, bad, true, 0])
+      assert.equal(r.error?.code, -32602,
+        `limit=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // offset: same
+    for (const bad of [true, "0", [0], {}, 0.5, -1]) {
+      const r = await probe([addr, 10, true, bad])
+      assert.equal(r.error?.code, -32602,
+        `offset=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // reverse: non-boolean shapes must be rejected (no silent enable)
+    for (const bad of [0, 1, "false", "true", [true], {}]) {
+      const r = await probe([addr, 10, bad, 0])
+      assert.equal(r.error?.code, -32602,
+        `reverse=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-shaped + null/undefined defaults still succeed
+    for (const params of [
+      [addr, 10, true, 0],
+      [addr, null, null, null],
+      [addr],
+      [addr, undefined, false, undefined],
+    ]) {
+      const r = await probe(params)
+      assert.equal(r.error, undefined,
+        `well-shaped ${JSON.stringify(params)} must succeed, got ${JSON.stringify(r)}`)
+      assert.ok(Array.isArray(r.result), `result must be array for ${JSON.stringify(params)}`)
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -318,6 +318,56 @@ export function requireIntegerParam(params: unknown[], index: number, name: stri
   return raw as number
 }
 
+/**
+ * #254: Optional non-negative integer with default. Treats `undefined`
+ * and `null` as "omitted" and returns the supplied default; rejects
+ * any other non-integer shape with -32602. Pre-fix the
+ * `Number((params)[idx] ?? N)` idiom in `coc_getTransactionsByAddress`
+ * (and similar paginated handlers) silently coerced `true`→1, `"5"`→5,
+ * `[3]`→3, `{}`→NaN→fallback. Same family as #252/#251/#224.
+ */
+export function optionalIntegerParam(
+  params: unknown[],
+  index: number,
+  name: string,
+  defaultValue: number,
+  opts?: { min?: number; max?: number },
+): number {
+  const raw = (params ?? [])[index]
+  if (raw === undefined || raw === null) return defaultValue
+  if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw)) {
+    invalidParams(`invalid ${name}: expected integer or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)
+  }
+  const min = opts?.min ?? 0
+  const max = opts?.max ?? Number.MAX_SAFE_INTEGER
+  if (raw < min || raw > max) {
+    invalidParams(`invalid ${name}: must be between ${min} and ${max}`)
+  }
+  return raw as number
+}
+
+/**
+ * #254: Strict optional boolean. Pre-fix `(params[idx] !== false)` was
+ * the worst kind of silent coercion — every non-`false` value (`0`,
+ * `"false"`, `null`, `{}`, `[]`) parsed as `true`, which is usually the
+ * opposite of what a sloppy client meant when sending `0` or `"false"`.
+ * Returns the supplied default for `undefined`/`null`; rejects every
+ * non-boolean shape with -32602.
+ */
+export function optionalBooleanParam(
+  params: unknown[],
+  index: number,
+  name: string,
+  defaultValue: boolean,
+): boolean {
+  const raw = (params ?? [])[index]
+  if (raw === undefined || raw === null) return defaultValue
+  if (typeof raw !== "boolean") {
+    invalidParams(`invalid ${name}: expected boolean or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)
+  }
+  return raw as boolean
+}
+
 // ---------------------------------------------------------------------------
 // Tx-call field validators
 // ---------------------------------------------------------------------------

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -37,6 +37,8 @@ import {
   requireFilterObject,
   requireStringParam,
   requireIntegerParam,
+  optionalIntegerParam,
+  optionalBooleanParam,
   validateTxCallFields,
   validateLogFilter,
   sanitizeEthersError,
@@ -1701,16 +1703,14 @@ async function handleRpc(
       // of silently missing the index → empty result. Pre-fix, "not-an-address"
       // and "0x123" both returned [] indistinguishable from a real empty
       // address.
-      const rawAddr = String((payload.params ?? [])[0] ?? "")
-      if (!/^0x[0-9a-fA-F]{40}$/.test(rawAddr)) {
-        invalidParams("invalid address: must match /^0x[0-9a-fA-F]{40}$/")
-      }
-      const addr = rawAddr.toLowerCase() as Hex
-      const rawLimit = Number((payload.params ?? [])[1] ?? 50)
-      const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 10_000) : 50
-      const reverse = (payload.params ?? [])[2] !== false
-      const rawOffset = Number((payload.params ?? [])[3] ?? 0)
-      const offset = Number.isFinite(rawOffset) ? Math.min(Math.max(rawOffset, 0), 100_000) : 0
+      // #254: pre-fix `Number((params)[1] ?? 50)` silently coerced
+      // `true`→1, `"5"`→5, `[3]`→3, `{}`→NaN→fallback 50. Same for
+      // offset. The `(params[2] !== false)` reverse check was even
+      // worse — `0`/`"false"`/`null`/`""` all parsed as reverse=true.
+      const addr = requireAddressParam(payload.params ?? [], 0).toLowerCase() as Hex
+      const limit = optionalIntegerParam(payload.params ?? [], 1, "limit", 50, { min: 1, max: 10_000 })
+      const reverse = optionalBooleanParam(payload.params ?? [], 2, "reverse", true)
+      const offset = optionalIntegerParam(payload.params ?? [], 3, "offset", 0, { min: 0, max: 100_000 })
 
       if (typeof chain.getTransactionsByAddress === "function") {
         const txs = await chain.getTransactionsByAddress(addr, { limit, reverse, offset })


### PR DESCRIPTION
Closes #254. Stacks on #253 (depends on the `requireIntegerParam` helper).

## Bug

`coc_getTransactionsByAddress` had three silent-coercion sites for the
optional `limit`, `reverse`, and `offset` params:

\`\`\`typescript
const rawLimit = Number((payload.params ?? [])[1] ?? 50)
const reverse  = (payload.params ?? [])[2] !== false
const rawOffset = Number((payload.params ?? [])[3] ?? 0)
\`\`\`

Live repro on the 88780 testnet (\`http://209.74.64.88:38780\`):

| Input                                                        | Result      |
|--------------------------------------------------------------|-------------|
| \`[addr, true, …]\`        — limit=true                       | 1 result    |
| \`[addr, "5", …]\`         — limit="5"                        | 5 results   |
| \`[addr, [3], …]\`         — limit=[3]                        | 3 results   |
| \`[addr, {}, …]\`          — limit={}                         | fallback 50 |
| \`[addr, 2, 0, 0]\`        — reverse=0                        | reverse=true (!)  |
| \`[addr, 2, "false", 0]\`  — reverse="false"                  | reverse=true (!)  |

The reverse path is the worst: a sloppy client sending \`reverse: "false"\`
gets reverse=true silently — the **opposite** of intent.

## Fix

Two new helpers in \`rpc-validators.ts\`:

- \`optionalIntegerParam(params, idx, name, default, {min, max})\` —
  treats null/undefined as \"omitted\" and uses default; rejects every
  non-integer shape with -32602.
- \`optionalBooleanParam(params, idx, name, default)\` — accepts only
  true/false/null/undefined; rejects every other shape.

Address now routes through \`requireAddressParam\` (existing #122 helper)
for a clearer -32602 message than the inline regex.

## Test plan

- [x] New subtest \`#254\` in \`rpc-extended.test.ts\` covering all bad
      limit/offset/reverse shapes plus sanity for null/undefined/omitted
      defaults.
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\`
      → **96/96 pass**.

## Stack

- Depends on #253 (introduces \`requireIntegerParam\`).
- Targets \`fix/252-reward-manifest-integer-coercion\`; re-target to
  \`main\` when #253 lands.