### PR TITLE
fix(rpc): #256 reject array-coerced block tags (3 sibling handlers)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2431,6 +2431,14 @@ test("RPC Extended Methods", async (t) => {
     // happens to know how to coerce became a real epochId lookup. Same
     // anti-pattern family as #120/#220/#226/#240/#242. Use the new
     // `requireIntegerParam` validator.
+  })
+
+  await t.test("#256: block-tag handlers reject single-element-array coercion (eth_getBlockTransactionCountByNumber / eth_getBlockReceipts / eth_feeHistory)", async () => {
+    // Pre-fix three handlers used `String((payload.params)[i] ?? "latest")`.
+    // `String([1500])` is `"1500"`, so a single-element numeric array
+    // silently became block 1500 — never hitting parseBlockTag's
+    // non-string rejection. Same anti-pattern fixed in #250 for
+    // eth_getBlockByNumber.
     const probe = async (method: string, params: unknown[]) => {
       const r = await fetch(`http://127.0.0.1:${port}`, {
         method: "POST",
@@ -2706,6 +2714,33 @@ test("RPC Extended Methods", async (t) => {
       `replacement-underpriced must be -32000, got ${replBody.error?.code} (${replBody.error?.message})`)
     assert.match(replBody.error!.message, /replacement.*gas price too low/i,
       `error must preserve "replacement tx gas price too low" surface, got: ${JSON.stringify(replBody)}`)
+  })
+
+    // eth_getBlockTransactionCountByNumber — block tag at idx 0
+    for (const bad of [[1], [0, 1], true, false, {}]) {
+      const r = await probe("eth_getBlockTransactionCountByNumber", [bad])
+      assert.equal(r.error?.code, -32602,
+        `eth_getBlockTransactionCountByNumber(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // eth_getBlockReceipts — block tag at idx 0
+    for (const bad of [[1], [0, 1], true, {}]) {
+      const r = await probe("eth_getBlockReceipts", [bad])
+      assert.equal(r.error?.code, -32602,
+        `eth_getBlockReceipts(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // eth_feeHistory — newestBlock at idx 1 (blockCount at idx 0 still valid)
+    for (const bad of [[1], [0, 1], true, {}]) {
+      const r = await probe("eth_feeHistory", ["0x1", bad, []])
+      assert.equal(r.error?.code, -32602,
+        `eth_feeHistory("0x1", ${JSON.stringify(bad)}, []) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-shaped tags still succeed
+    const ok1 = await probe("eth_getBlockTransactionCountByNumber", ["latest"])
+    assert.equal(ok1.error, undefined, `latest must pass: ${JSON.stringify(ok1)}`)
+    const ok2 = await probe("eth_getBlockTransactionCountByNumber", ["0x0"])
+    assert.equal(ok2.error, undefined, `0x0 must pass: ${JSON.stringify(ok2)}`)
+    const ok3 = await probe("eth_feeHistory", ["0x1", "latest", []])
+    assert.equal(ok3.error, undefined, `feeHistory latest must pass: ${JSON.stringify(ok3)}`)
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1608,9 +1608,12 @@ async function handleRpc(
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
     case "eth_getBlockTransactionCountByNumber": {
-      const tag = String((payload.params ?? [])[0] ?? "latest")
-      const height = await Promise.resolve(chain.getHeight())
-      const num = parseBlockTag(tag, height)
+      // #256: pre-fix `String((params)[0] ?? "latest")` made `String([1500])
+      // === "1500"` slip past parseBlockTag's non-string rejection,
+      // silently treating a single-element array as block 1500. Pass
+      // the raw input through so parseBlockTag's invalidParams branch
+      // catches every non-string/non-number shape. Same fix as #250.
+      const num = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
@@ -1685,7 +1688,11 @@ async function handleRpc(
       } else {
         invalidParams("invalid blockCount: expected hex quantity or positive integer")
       }
-      const newestBlock = String((payload.params ?? [])[1] ?? "latest")
+      // #256: pre-fix `String((params)[1] ?? "latest")` made `String([1500])
+      // === "1500"` silently coerce a single-element array to block 1500.
+      // Pass raw through resolveBlockNumber so non-string/non-number shapes
+      // hit parseBlockTag's invalidParams branch. Same fix as #250.
+      const newestBlock = (payload.params ?? [])[1]
       // #224: `as number[]` was a TS runtime no-op so an object/string/
       // bool silently passed through (`{}.length === undefined`
       // bypassed the >100 check and the for-loop). Reject non-array
@@ -1899,6 +1906,13 @@ async function handleRpc(
         const num = await resolveBlockNumber(tag, chain)
         block = await Promise.resolve(chain.getBlockByNumber(num))
       }
+  })
+
+      // #256: pre-fix `String((params)[0] ?? "latest")` made `String([1500])
+      // === "1500"` silently coerce a single-element array to block 1500.
+      // Pass raw through resolveBlockNumber. Same fix as #250.
+      const num = await resolveBlockNumber((payload.params ?? [])[0], chain)
+      const block = await Promise.resolve(chain.getBlockByNumber(num))
       if (!block) return null
       const receipts: unknown[] = []
       for (const rawTx of block.txs) {


### PR DESCRIPTION
Closes #256.

## Bug

Three handlers used the same broken idiom:
\`\`\`typescript
const tag = String((payload.params ?? [])[i] ?? "latest")
const num = await resolveBlockNumber(tag, chain)
\`\`\`

Because \`String([1500]) === "1500"\`, a single-element numeric array
silently slipped past parseBlockTag's non-string rejection and was
treated as block 1500. Same anti-pattern fixed in #250 for
\`eth_getBlockByNumber\`.

Live repro on 88780 (\`http://209.74.64.88:38780\`):

\`\`\`bash
curl … '{"…method":"eth_getBlockTransactionCountByNumber","params":[[1500]]}'
# Actual:   {"result":"0x0"}                  ← treated as block 1500
# Expected: {"error":{"code":-32602,…}}

curl … '{"…method":"eth_getBlockReceipts","params":[[1500]]}'
# Actual:   {"result":[]}                     ← treated as block 1500

curl … '{"…method":"eth_feeHistory","params":["0x1",[1500],[]]}'
# Actual:   {"result":{"oldestBlock":"0x5dc",…}}  ← newestBlock=1500
\`\`\`

## Fix

Drop the \`String()\` wrapper and pass \`payload.params[i]\` raw through
\`resolveBlockNumber(unknown, chain)\`. \`parseBlockTag\`'s
\`invalidParams\` branch already rejects every non-string/non-number
shape with -32602.

## Test plan

- [x] New \`#256\` subtest in \`rpc-extended.test.ts\` covering all three
      handlers with \`[1]\`, \`[0,1]\`, \`true\`, \`{}\` + sanity that
      \`"latest"\` / \`"0x0"\` still resolve.
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\`
      → **95/95 pass**.