### PR TITLE
fix(rpc): #258 coc_getContracts reject non-integer fields inside pagination object

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2482,6 +2482,15 @@ test("RPC Extended Methods", async (t) => {
     // `[3]`→3, `{}`→NaN→fallback. `(params[2] !== false)` accepted every
     // non-false value (`0`, `"false"`, `null`, `""`) as reverse=true. Same
     // anti-pattern family as #252/#251/#224/#120.
+  })
+
+  await t.test("#258: coc_getContracts rejects non-integer limit/offset and non-boolean reverse INSIDE pagination object", async () => {
+    // #249 hardened the OUTER param shape (`[true]` → -32602). But the
+    // INNER fields still silently coerced: `{limit: true}` → 1,
+    // `{limit: "5"}` → 5, `{limit: [5]}` → 5, `{reverse: 0}` → true.
+    // Same anti-pattern as #254 (positional sibling). The new
+    // `optionalIntegerField` / `optionalBooleanField` helpers reject
+    // every non-integer / non-boolean shape.
     const probe = async (params: unknown[]) => {
       const r = await fetch(`http://127.0.0.1:${port}`, {
         method: "POST",
@@ -2515,6 +2524,37 @@ test("RPC Extended Methods", async (t) => {
       [addr, null, null, null],
       [addr],
       [addr, undefined, false, undefined],
+  })
+
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_getContracts", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // limit: non-integer fields must be rejected
+    for (const bad of [true, false, "5", [3], [1, 2], {}, 1.5, -1]) {
+      const r = await probe([{ limit: bad }])
+      assert.equal(r.error?.code, -32602,
+        `coc_getContracts({limit:${JSON.stringify(bad)}}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // offset: same
+    for (const bad of [true, "0", [0], {}, 0.5, -1]) {
+      const r = await probe([{ offset: bad }])
+      assert.equal(r.error?.code, -32602,
+        `coc_getContracts({offset:${JSON.stringify(bad)}}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // reverse: non-boolean fields must be rejected
+    for (const bad of [0, 1, "false", "true", [true], {}]) {
+      const r = await probe([{ reverse: bad }])
+      assert.equal(r.error?.code, -32602,
+        `coc_getContracts({reverse:${JSON.stringify(bad)}}) must be -32602, got ${JSON.stringify(r)}`)
+    }
+    // Sanity: well-shaped + omitted fields still succeed
+    for (const params of [
+      [{}],
+      [{ limit: 5 }],
+      [{ limit: 5, offset: 0, reverse: false }],
+      [{ limit: 10, reverse: true }],
+      [],
     ]) {
       const r = await probe(params)
       assert.equal(r.error, undefined,
@@ -2741,6 +2781,8 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok2.error, undefined, `0x0 must pass: ${JSON.stringify(ok2)}`)
     const ok3 = await probe("eth_feeHistory", ["0x1", "latest", []])
     assert.equal(ok3.error, undefined, `feeHistory latest must pass: ${JSON.stringify(ok3)}`)
+  })
+
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -345,11 +345,26 @@ export function requireIntegerParam(params: unknown[], index: number, name: stri
 export function optionalIntegerParam(
   params: unknown[],
   index: number,
+  })
+
+ * #258: Object-field counterpart of {@link requireIntegerParam}/
+ * {@link optionalIntegerParam}. Pre-fix object-shaped pagination
+ * options (`coc_getContracts(opts)`) used silent `Number(opts.limit
+ * ?? N) || N` coercion: `true`→1, `[5]`→5, `"5"`→5, `{}`→NaN→fallback.
+ * The outer object was validated by `requireFilterObject` (#249), but
+ * the inner fields still silently coerced. Same family as #254 (its
+ * positional sibling).
+ */
+export function optionalIntegerField(
+  obj: Record<string, unknown>,
   name: string,
   defaultValue: number,
   opts?: { min?: number; max?: number },
 ): number {
   const raw = (params ?? [])[index]
+  })
+
+  const raw = obj[name]
   if (raw === undefined || raw === null) return defaultValue
   if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw)) {
     invalidParams(`invalid ${name}: expected integer or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)
@@ -377,6 +392,19 @@ export function optionalBooleanParam(
   defaultValue: boolean,
 ): boolean {
   const raw = (params ?? [])[index]
+  })
+
+ * #258: Object-field counterpart of {@link optionalBooleanParam}.
+ * Pre-fix `opts.reverse !== false` accepted every non-`false` value
+ * (`0`, `"false"`, `null`, `{}`) as `reverse=true`. Returns the
+ * supplied default for `undefined`/`null`; rejects every non-boolean.
+ */
+export function optionalBooleanField(
+  obj: Record<string, unknown>,
+  name: string,
+  defaultValue: boolean,
+): boolean {
+  const raw = obj[name]
   if (raw === undefined || raw === null) return defaultValue
   if (typeof raw !== "boolean") {
     invalidParams(`invalid ${name}: expected boolean or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -41,6 +41,10 @@ import {
   requireIntegerParam,
   optionalIntegerParam,
   optionalBooleanParam,
+  })
+
+  optionalIntegerField,
+  optionalBooleanField,
   validateTxCallFields,
   validateLogFilter,
   sanitizeEthersError,
@@ -2533,11 +2537,18 @@ async function handleRpc(
       // #238. Validate shape FIRST so the rejection fires regardless
       // of whether the node has blockIndex enabled.
       const opts = requireFilterObject((payload.params ?? [])[0])
+      // #258: pre-fix `Number(opts.limit ?? 50) || 50` silently coerced
+      // `true`→1, `[5]`→5, `"5"`→5. `opts.reverse !== false` accepted
+      // every non-false value as reverse=true. Same anti-pattern as
+      // #254 (its positional sibling), but inside the validated object.
+      const limit = optionalIntegerField(opts, "limit", 50, { min: 1, max: 10_000 })
+      const offset = optionalIntegerField(opts, "offset", 0, { min: 0, max: 100_000 })
+      const reverse = optionalBooleanField(opts, "reverse", true)
       if (hasBlockIndex(chain)) {
         const contracts = await chain.blockIndex.getContracts({
-          limit: Math.min(Math.max(Number(opts.limit ?? 50) || 50, 1), 10_000),
-          offset: Math.min(Math.max(Number(opts.offset ?? 0) || 0, 0), 100_000),
-          reverse: opts.reverse !== false,
+          limit,
+          offset,
+          reverse,
         })
         return contracts.map((c) => ({
           address: c.address,


### PR DESCRIPTION
Closes #258.

## Bug

#249 hardened the OUTER param shape for \`coc_getContracts\` so \`[true]\` returns -32602. But the INNER fields still silently coerced:

\`\`\`typescript
limit:   Math.min(Math.max(Number(opts.limit  ?? 50) || 50, 1), 10_000)
offset:  Math.min(Math.max(Number(opts.offset ?? 0)  || 0,  0), 100_000)
reverse: opts.reverse !== false
\`\`\`

Live repro on 88780 (\`http://209.74.64.88:38780\`):

| Input                                | Result    |
|--------------------------------------|-----------|
| \`{limit: true}\`                    | 1 result  |
| \`{limit: "5"}\`                     | 5 results |
| \`{limit: [5]}\`                     | 5 results |
| \`{limit: {}}\`                      | fallback 40 (NaN coerce) |
| \`{reverse: 0}\` or \`"false"\`      | reverse=true (!) |

## Fix

Two new object-field helpers in \`rpc-validators.ts\` (mirroring the #254 positional siblings):

- \`optionalIntegerField(obj, name, default, {min, max})\` — rejects every non-integer shape with -32602
- \`optionalBooleanField(obj, name, default)\` — rejects every non-boolean shape with -32602

## Test plan

- [x] New \`#258\` subtest covering bad limit/offset/reverse shapes plus sanity for \`{}\`/omitted defaults.
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\` → **95/95 pass**.