### PR TITLE
fix(rpc): #260 eth_getBlockBy* reject non-boolean includeTx

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2439,6 +2439,14 @@ test("RPC Extended Methods", async (t) => {
     // silently became block 1500 — never hitting parseBlockTag's
     // non-string rejection. Same anti-pattern fixed in #250 for
     // eth_getBlockByNumber.
+  })
+
+  await t.test("#260: eth_getBlockByNumber / eth_getBlockByHash reject non-boolean includeTx", async () => {
+    // Pre-fix `Boolean((params)[1])` silently coerced:
+    //   "false"→true, 0→false, 1→true, ""→false, {}→true, []→true, "yes"→true
+    // The string-vs-bool case is the most user-hostile: a JS client sending
+    // `"false"` as a stringified bool gets the OPPOSITE of intent — full
+    // tx objects (~5-6× more bytes per tx than hashes).
     const probe = async (method: string, params: unknown[]) => {
       const r = await fetch(`http://127.0.0.1:${port}`, {
         method: "POST",
@@ -2783,6 +2791,42 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok3.error, undefined, `feeHistory latest must pass: ${JSON.stringify(ok3)}`)
   })
 
+  })
+
+  })
+
+    const blockTag = "0x0"
+    const blockHash = `0x${"0".repeat(64)}`
+    const cases = [
+      { name: "string 'false'", value: "false" },
+      { name: "string 'true'", value: "true" },
+      { name: "string 'yes'", value: "yes" },
+      { name: "empty string", value: "" },
+      { name: "number 0", value: 0 },
+      { name: "number 1", value: 1 },
+      { name: "array [true]", value: [true] },
+      { name: "empty object", value: {} },
+      { name: "array empty", value: [] },
+    ]
+    for (const c of cases) {
+      const r1 = await probe("eth_getBlockByNumber", [blockTag, c.value])
+      assert.equal(r1.error?.code, -32602,
+        `eth_getBlockByNumber(${blockTag}, ${c.name}) must be -32602, got ${JSON.stringify(r1)}`)
+      const r2 = await probe("eth_getBlockByHash", [blockHash, c.value])
+      assert.equal(r2.error?.code, -32602,
+        `eth_getBlockByHash(<hash>, ${c.name}) must be -32602, got ${JSON.stringify(r2)}`)
+    }
+    // Sanity: strict booleans + omitted/null still work
+    for (const params of [
+      [blockTag],
+      [blockTag, null],
+      [blockTag, true],
+      [blockTag, false],
+    ]) {
+      const r = await probe("eth_getBlockByNumber", params)
+      assert.equal(r.error, undefined,
+        `well-shaped ${JSON.stringify(params)} must succeed: ${JSON.stringify(r)}`)
+    }
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -382,6 +382,14 @@ export function optionalIntegerField(
  * the worst kind of silent coercion — every non-`false` value (`0`,
  * `"false"`, `null`, `{}`, `[]`) parsed as `true`, which is usually the
  * opposite of what a sloppy client meant when sending `0` or `"false"`.
+  })
+
+ * #260: Strict optional boolean for positional RPC params. Pre-fix
+ * `Boolean((payload.params)[idx])` silently coerced `"false"`→true,
+ * `0`→false, `1`→true, `{}`→true, `[]`→true — the asymmetric `Boolean()`
+ * coercion is the opposite of what JSON-RPC §5.1 mandates (strict type).
+ * Worst case: `includeTx="false"` in `eth_getBlockByNumber` returns
+ * full tx objects (~5-6× hash bytes), the opposite of intent.
  * Returns the supplied default for `undefined`/`null`; rejects every
  * non-boolean shape with -32602.
  */
@@ -405,6 +413,8 @@ export function optionalBooleanField(
   defaultValue: boolean,
 ): boolean {
   const raw = obj[name]
+  })
+
   if (raw === undefined || raw === null) return defaultValue
   if (typeof raw !== "boolean") {
     invalidParams(`invalid ${name}: expected boolean or omitted, got ${Array.isArray(raw) ? "array" : typeof raw}`)

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -45,6 +45,9 @@ import {
 
   optionalIntegerField,
   optionalBooleanField,
+  })
+
+  optionalBooleanParam,
   validateTxCallFields,
   validateLogFilter,
   sanitizeEthersError,
@@ -821,7 +824,11 @@ async function handleRpc(
       // → 0n → silently returned the genesis block. Sibling of #188 / #194.
       // resolveBlockNumber accepts unknown and dispatches through parseBlockTag,
       // which rejects non-string / non-number shapes at -32602.
-      const includeTx = Boolean((payload.params ?? [])[1])
+      // #260: pre-fix `Boolean((params)[1])` silently coerced `"false"`→true,
+      // `0`→false, `{}`→true, `[]`→true. Worst: a sloppy client sending
+      // `"false"` got full tx objects (~5-6× hash bytes), the OPPOSITE of
+      // intent. Use strict optionalBooleanParam to reject every non-boolean.
+      const includeTx = optionalBooleanParam(payload.params ?? [], 1, "includeTx", false)
       const number = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const block = await Promise.resolve(chain.getBlockByNumber(number))
       // #112: synthesise a genesis block when block 0 is missing. The
@@ -843,7 +850,8 @@ async function handleRpc(
       // indistinguishable from "valid hash, no such block". Symmetric
       // with #150's eth_getTransactionByHash fix.
       const hash = requireBlockHashParam(payload.params ?? [], 0)
-      const includeTx = Boolean((payload.params ?? [])[1])
+      // #260: same Boolean(...) silent-coercion bug as eth_getBlockByNumber.
+      const includeTx = optionalBooleanParam(payload.params ?? [], 1, "includeTx", false)
       const block = await Promise.resolve(chain.getBlockByHash(hash))
       return formatBlock(block, includeTx, chain, evm)
     }


### PR DESCRIPTION
Closes #260.

## Bug

\`eth_getBlockByNumber\` and \`eth_getBlockByHash\` both used:
\`\`\`typescript
const includeTx = Boolean((payload.params ?? [])[1])
\`\`\`

JS \`Boolean()\` is asymmetric — every truthy non-bool returns full tx objects, every falsy non-bool returns hashes. **Worst case**: \`Boolean("false") === true\`, so a client sending the string \`"false"\` gets the **opposite** of intent: full tx objects (~5-6× more bytes than hashes).

## Live repro on 88780 (\`http://209.74.64.88:38780\`)

\`\`\`
includeTx=false (strict)             → hash strings   ✓
includeTx=true (strict)              → tx objects     ✓
includeTx="false" (Boolean(...)=true) → tx objects    ✗ (opposite of intent!)
includeTx=0 (Boolean(0)=false)        → hash strings  ✗ (sloppy 0/1)
includeTx=1                          → tx objects     ✗
includeTx={} or []                   → tx objects     ✗
\`\`\`

## Fix

Adds \`optionalBooleanParam(params, idx, name, default)\` to \`rpc-validators\` (mirrors the existing positional-param helpers). Applied at both call sites. Returns default for null/undefined, rejects every non-boolean shape with -32602.

## Test plan

- [x] New \`#260\` subtest probing 9 bad shapes ("false","true","yes","",0,1,[true],{},[]) on both \`eth_getBlockByNumber\` and \`eth_getBlockByHash\` + sanity for strict booleans / omitted / null.
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\` → **95/95 pass**.

## Note

If #255 (which already adds \`optionalBooleanParam\`) lands first, the duplicate helper definition will conflict. Easy resolve: drop the duplicate \`export function optionalBooleanParam(...)\` block here, keep the call-site changes.