### PR TITLE
fix(ipfs): #268 map path-too-deep / directory-nesting-too-deep to 400 (not 500)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -635,6 +635,34 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#268: /api/v0/files/* path-too-deep returns 400 (not 500 'internal error')", async () => {
+    // Pre-fix the route-level catch had `/^max mfs depth/i` regex but the
+    // actual messages thrown were "path too deep (max 64 components): ..."
+    // and "directory nesting too deep (max 64): ...". Neither matched, so
+    // deep paths fell through to 500 with `log.error("MFS route failed")` —
+    // every probe spammed an ERROR log. Same regex-mismatch family as #232.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+    // Build path with > MAX_MFS_DEPTH (64) components
+    const deepPath = "/" + Array.from({ length: 100 }, () => "a").join("/")
+    const probes = [
+      `/api/v0/files/ls?arg=${encodeURIComponent(deepPath)}`,
+      `/api/v0/files/stat?arg=${encodeURIComponent(deepPath)}`,
+      `/api/v0/files/mkdir?arg=${encodeURIComponent(deepPath)}`,
+      `/api/v0/files/rm?arg=${encodeURIComponent(deepPath)}`,
+    ]
+    for (const path of probes) {
+      const res = await fetch(path, { method: "POST" })
+      assert.equal(res.status, 400, `${path}: must be 400, got ${res.status}`)
+      const body = await res.json() as { error?: string; message?: string }
+      assert.notEqual(body.error, "internal error",
+        `${path}: must not leak 'internal error', got ${JSON.stringify(body)}`)
+      assert.match(`${body.error} ${body.message ?? ""}`, /too deep|bad request/i,
+        `${path}: error must reference depth, got ${JSON.stringify(body)}`)
+    }
+  })
+
   it("#236: /api/v0/files/cp + /files/mv read second ?arg= for destination (kubo compat)", async () => {
     // Pre-fix the handlers read `?dest=<path>` but kubo HTTP RPC sends
     // dest as a second `?arg=` value. Result: every kubo-CLI / ipfs-http-

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1144,6 +1144,14 @@ export class IpfsHttpServer {
           /^missing /i.test(msg) ||
           /^write would exceed/i.test(msg) ||
           /^max mfs depth/i.test(msg) ||
+          // #268: pre-fix `/^max mfs depth/i` was the only depth-cap regex
+          // but normalizePath actually throws "path too deep (max N
+          // components)" and the recursive helpers throw "directory
+          // nesting too deep (max N)". Neither matched the existing regex,
+          // so deep paths surfaced as 500 "internal error" + an ERROR log
+          // line per probe. Same regex-mismatch family as #232.
+          /^path too deep/i.test(msg) ||
+          /^directory nesting too deep/i.test(msg) ||
           /^path too long/i.test(msg) ||
           /^null byte in path/i.test(msg) ||
           // #232: pre-fix normalizePath threw `Error("path traversal not


### PR DESCRIPTION
Closes #268.

## Bug

The route-level catch in \`ipfs-http.ts:1146\` maps known client-input errors from MFS to HTTP 400. One of the listed regexes is \`/^max mfs depth/i\` — intended to catch the depth-cap errors — but the actual messages thrown by \`normalizePath\` and the recursive helpers are different strings:

- \`normalizePath\`: \"path too deep (max 64 components): ...\"
- recursive remove/copy: \"directory nesting too deep (max 64): ...\"

Neither matches \`/^max mfs depth/i\`, so deep paths fall through to:
\`\`\`typescript
const status = httpErr ? httpErr.status : 500
const code = httpErr ? httpErr.code : \"internal error\"
\`\`\`
producing HTTP 500 \`{\"error\":\"internal error\"}\` + an \`ERROR\` log line per probe. An attacker can spam ERROR logs cheaply with depth-100 requests.

Same regex-mismatch family as #232 (\`path traversal\` fell through to 500 before its regex was added).

## Live repro on 88780 (\`http://209.74.64.88:38800\`)

\`\`\`bash
# depth 50 → 404 \"not found\" (correct)
POST /api/v0/files/ls?arg=/a/a/.../a (50 components)

# depth 100, 200, 500 → 500 \"internal error\" (BUG)
POST /api/v0/files/ls?arg=/a/a/.../a (100+ components)
\`\`\`

## Fix

Add the two missing regexes alongside \`/^max mfs depth/i\`:
- \`/^path too deep/i\`
- \`/^directory nesting too deep/i\`

## Test plan

- [x] New \`#268\` subtest covering ls/stat/mkdir/rm with a 100-component path; asserts 400 and no 'internal error' leakage.
- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` → **51/51 pass**.