### PR TITLE
fix(ipfs): #270 map 'cannot move directory into own subtree' to 400

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -843,6 +843,34 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#270: /api/v0/files/mv into own subtree returns 400 (not 500 'internal error')", async () => {
+    // Pre-fix `/^cannot (remove|operate on|copy)/i` was missing `move` from
+    // the alternation. ipfs-mfs throws "cannot move directory into its own
+    // subdirectory" (line 243) — sibling to "cannot copy …" which IS
+    // matched (since `copy` is in the alternation). So /files/cp returned
+    // 400 but /files/mv with the same shape fell through to 500 +
+    // log.error. Same family as #232/#268.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+    // Create /parent/child first
+    let res = await fetch(`/api/v0/files/mkdir?arg=${encodeURIComponent("/parent")}`, { method: "POST" })
+    assert.equal(res.status, 200, "setup mkdir /parent")
+    res = await fetch(`/api/v0/files/mkdir?arg=${encodeURIComponent("/parent/child")}`, { method: "POST" })
+    assert.equal(res.status, 200, "setup mkdir /parent/child")
+    // Try to move /parent into its own subtree → must be 400 (not 500)
+    res = await fetch(
+      `/api/v0/files/mv?arg=${encodeURIComponent("/parent")}&arg=${encodeURIComponent("/parent/child/grandchild")}`,
+      { method: "POST" },
+    )
+    assert.equal(res.status, 400, `mv-into-own-subtree must be 400, got ${res.status}`)
+    const body = await res.json() as { error?: string; message?: string }
+    assert.notEqual(body.error, "internal error",
+      `must not leak 'internal error', got ${JSON.stringify(body)}`)
+    assert.match(`${body.error} ${body.message ?? ""}`, /cannot move|bad request/i,
+      `error must reference move, got ${JSON.stringify(body)}`)
+  })
+
   it("#236: /api/v0/files/cp + /files/mv read second ?arg= for destination (kubo compat)", async () => {
     // Pre-fix the handlers read `?dest=<path>` but kubo HTTP RPC sends
     // dest as a second `?arg=` value. Result: every kubo-CLI / ipfs-http-

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1442,7 +1442,12 @@ export class IpfsHttpServer {
         } else if (
           /is a directory/i.test(msg) ||
           /directory not empty/i.test(msg) ||
-          /^cannot (remove|operate on|copy)/i.test(msg) ||
+          // #270: alternation was missing `move`. ipfs-mfs throws
+          // "cannot move directory into its own subdirectory" (line 243)
+          // for mv-into-own-subtree, sibling to "cannot copy …" which
+          // IS in the alternation. /files/mv with that shape fell through
+          // to 500 + ERROR log. Same regex-mismatch family as #232/#268.
+          /^cannot (remove|operate on|copy|move)/i.test(msg) ||
           /must be/i.test(msg) ||
           /^missing /i.test(msg) ||
           /^write would exceed/i.test(msg) ||


### PR DESCRIPTION
Closes #270.

## Bug

\`ipfs-http.ts:1142\` route-level catch maps known client-input errors from MFS to HTTP 400 via \`/^cannot (remove|operate on|copy)/i\`. The alternation is missing \`move\`. \`ipfs-mfs.ts:243\` throws:

\`\`\`typescript
throw new Error(\`cannot move directory into its own subdirectory: \${srcNorm} -> \${destNorm}\`)
\`\`\`

Its sibling at line 292 throws \`\"cannot copy …\"\` which IS matched (since \`copy\` is in the alternation), so \`/files/cp\` returned 400 — but \`/files/mv\` with the equivalent shape fell through to \`500 {\"error\":\"internal error\"}\` plus an ERROR log line per probe.

Same regex-mismatch family as #232 (path traversal) and #268 (path-too-deep).

## Live repro on 88780 (\`http://209.74.64.88:38800\`)

\`\`\`bash
curl -X POST \"…/files/mkdir?arg=/parent/child&parents=true\"
curl -X POST \"…/files/mv?arg=/parent&arg=/parent/child/grandchild\"
# Actual:   HTTP 500 {\"error\":\"internal error\"}
# Expected: HTTP 400 {\"error\":\"bad request\",\"message\":\"cannot move…\"}
\`\`\`

## Fix

Add \`move\` to the alternation.

## Test plan

- [x] New \`#270\` subtest covering the live-repro case; asserts 400 and no 'internal error' leakage.
- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` → **51/51 pass**.