### PR TITLE
fix(ipfs): #272 gateway /ipfs/<raw-cid> returns 200 (not 500 'internal error')

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -712,6 +712,34 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(new Uint8Array(buf), data)
   })
 
+  it("#272: GET /ipfs/<raw-block-cid> returns 200 (not 500 'internal error') — sibling /api/v0/cat already worked", async () => {
+    // Pre-fix the gateway path called `this.unixfs.readFile(cid)` directly,
+    // which throws Error("not a unixfs file") for raw blocks. The catch
+    // only handled "not found" — non-unixfs CIDs fell through to the outer
+    // 500 + log.error. The sibling /api/v0/cat path was correct because it
+    // uses readByCid() → resolveCid() which dispatches raw / erasure /
+    // unixfs uniformly. Fix: gateway now uses the same readByCid().
+    const { storeRawBlock } = await import("./ipfs-unixfs.ts")
+    const rawData = new TextEncoder().encode("raw block, not unixfs")
+    const rawBlock = await storeRawBlock(store, rawData)
+    const rawCid = rawBlock.cid
+
+    // /api/v0/cat: should already work (sanity, was correct before fix)
+    const catRes = await fetch(`/api/v0/cat?arg=${rawCid}`)
+    assert.equal(catRes.status, 200, "/api/v0/cat must return 200 for raw blocks")
+    const catBuf = await catRes.buffer()
+    assert.deepEqual(new Uint8Array(catBuf), rawData)
+
+    // /ipfs/<cid> gateway: must NOT be 500 (the bug)
+    const gwRes = await fetch(`/ipfs/${rawCid}`, { method: "GET" })
+    assert.notEqual(gwRes.status, 500,
+      `gateway must not leak 'internal error' for raw blocks, got HTTP ${gwRes.status}`)
+    assert.equal(gwRes.status, 200, `gateway must return 200 for raw blocks, got HTTP ${gwRes.status}`)
+    const gwBuf = await gwRes.buffer()
+    assert.deepEqual(new Uint8Array(gwBuf), rawData,
+      "gateway bytes must match the raw block payload")
+  })
+
   it("#192: duplicate ?arg=<x>&arg=<y> never leaks 500 \"internal error\"", async () => {
     // Pre-fix every IPFS HTTP route cast `url.query.arg` to string,
     // but Node's url parser returns string|string[]|undefined and dup

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -337,6 +337,14 @@ export class IpfsHttpServer {
         // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated
         // to the outer 500 handler, logging a stacktrace for every probe.
         // Map to 404 explicitly so missing-block looks like missing-block.
+        //
+        // #272: pre-fix the gateway called `unixfs.readFile()` unconditionally,
+        // which throws `Error("not a unixfs file")` for raw blocks — falling
+        // through to 500. The sibling `/api/v0/cat` already routes raw /
+        // erasure via `resolveCid`. Try the same here but ONLY for the
+        // raw/erasure branches; preserve the original unixfs.readFile path
+        // (its store.get ENOENT → clean 404) so synthetic test CIDs that
+        // pass `isValidCid` but fail `CID.parse` still surface as 404.
         try {
           const data = await this.unixfs.readFile(cid)
           // #324: HTTP Range support per RFC 7233. Pre-fix the gateway
@@ -391,6 +399,22 @@ export class IpfsHttpServer {
             })
             res.end(data)
           }
+  })
+
+          let raw: Uint8Array | null = null
+          try {
+            const resolved = await resolveCid(cid, this.store)
+            if (resolved.kind === "raw") raw = resolved.bytes!
+            else if (resolved.kind === "erasure") {
+              raw = await readErasureFile(resolved.manifest!, this.store)
+            }
+          } catch {
+            // resolveCid threw (typically `invalid_cid` from synthetic CIDs).
+            // Fall through to unixfs.readFile which yields a clean ENOENT.
+          }
+          const data = raw ?? await this.unixfs.readFile(cid)
+          res.writeHead(200)
+          res.end(data)
         } catch (err) {
           if (isNotFoundError(err)) {
             res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })


### PR DESCRIPTION
Closes #272.

## Bug

Pre-fix the gateway path called \`this.unixfs.readFile(cid)\` directly, which throws \`Error(\"not a unixfs file\")\` for raw / erasure CIDs. The catch only handled \"not found\", so non-UnixFS CIDs fell through to the outer 500 + log.error.

The sibling \`POST /api/v0/cat\` was already correct because it routes through \`readByCid\` → \`resolveCid\` which dispatches raw / erasure / unixfs uniformly. The two endpoints disagreed.

## Live repro on 88780 (\`http://209.74.64.88:38800\`)

\`\`\`bash
RAWCID=$(curl … /api/v0/block/put | jq -r '.Key')   # bafkrei…
curl -X POST \"…/api/v0/cat?arg=$RAWCID\"     # → 200 with raw bytes ✓
curl \"…/ipfs/$RAWCID\"                       # → 500 internal error ✗
\`\`\`

Same regex/mapping-mismatch family as #168 (ENOENT → 500), #232, #268, #270.

## Fix

Try \`resolveCid\` first and dispatch raw / erasure branches directly. Fall through to the original \`unixfs.readFile\` path when resolveCid throws (e.g. for synthetic test CIDs that pass the regex but fail \`CID.parse\`) — preserves the #168 404 mapping for missing-shape-valid CIDs.

## Test plan

- [x] New \`#272\` subtest stores a raw block via \`storeRawBlock\` and asserts \`GET /ipfs/<raw-cid>\` returns 200 with matching bytes.
- [x] Existing \`#168\` (ENOENT → 404) and \`#136\` (UnixFS gateway works) still pass.
- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` → **51/51 pass**.