### PR TITLE
fix(ws): #274 eth_subscribe('logs', filter) — add missing validations + use -32602

### DIFF
--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -363,6 +363,59 @@ describe("WebSocket RPC", () => {
     }
   })
 
+  it("#274: eth_subscribe('logs', filter) validates fromBlock / toBlock / blockHash / inner-topic-cap with -32602", async () => {
+    // Pre-fix the LOCAL `validateLogFilter` in websocket-rpc.ts didn't
+    // validate fromBlock/toBlock/blockHash at all, threw `new Error(...)`
+    // (-32603 internal-error) instead of `invalidParams` (-32602), and
+    // had an inner OR-topic cap of 100 versus HTTP's 32 (after #266).
+    // This test asserts WS now matches HTTP — single source of truth.
+    const ws = await connectWs(WS_PORT)
+    try {
+      // fromBlock: negative number / negative string / non-string-non-number → -32602
+      for (const bad of [-1, "-1", true, {}, [1]]) {
+        const err = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { fromBlock: bad }])
+        assert.equal(err.code, -32602,
+          `fromBlock=${JSON.stringify(bad)} must be -32602, got ${err.code} (${err.message})`)
+      }
+      // toBlock: same
+      for (const bad of [-1, "-1", true, {}, [1]]) {
+        const err = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { toBlock: bad }])
+        assert.equal(err.code, -32602,
+          `toBlock=${JSON.stringify(bad)} must be -32602, got ${err.code} (${err.message})`)
+      }
+      // blockHash: anything that isn't a 32-byte hex string → -32602
+      for (const bad of ["not-hex", "0xshort", 123, true, {}, [1]]) {
+        const err = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { blockHash: bad }])
+        assert.equal(err.code, -32602,
+          `blockHash=${JSON.stringify(bad)} must be -32602, got ${err.code} (${err.message})`)
+      }
+      // address: shape-rejected → -32602 (was -32603 pre-fix)
+      const addrErr = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { address: "not-an-address" }])
+      assert.equal(addrErr.code, -32602,
+        `malformed address must be -32602, got ${addrErr.code} (${addrErr.message})`)
+      // Topics: 5 outer → -32602 (was -32603)
+      const tooManyTopicsErr = await sendRpcExpectError(ws, "eth_subscribe",
+        ["logs", { topics: [null, null, null, null, null] }])
+      assert.equal(tooManyTopicsErr.code, -32602,
+        `5 outer topics must be -32602, got ${tooManyTopicsErr.code} (${tooManyTopicsErr.message})`)
+      // Inner topic OR-array: 33+ → -32602 (matches HTTP cap from #266)
+      const inner33 = Array.from({ length: 33 }, (_, i) => `0x${i.toString(16).padStart(64, "0")}`)
+      const innerCapErr = await sendRpcExpectError(ws, "eth_subscribe",
+        ["logs", { topics: [inner33] }])
+      assert.equal(innerCapErr.code, -32602,
+        `inner OR-array of 33 must be -32602, got ${innerCapErr.code} (${innerCapErr.message})`)
+      // Sanity: well-shaped filters still create subscriptions
+      const okHash = `0x${"ab".repeat(32)}`
+      const okAddr = `0x${"cd".repeat(20)}`
+      const okTopic = `0x${"ef".repeat(32)}`
+      const sub1 = await sendRpc(ws, "eth_subscribe",
+        ["logs", { fromBlock: "0x1", toBlock: "0x100", blockHash: okHash, address: okAddr, topics: [okTopic] }])
+      assert.match(sub1, /^0x[0-9a-f]+$/, `well-shaped filter must create subscription, got ${sub1}`)
+    } finally {
+      ws.close()
+    }
+  })
+
   it("#130: 11th subscription on one client returns -32005 (not -32603)", async () => {
     const ws = await connectWs(WS_PORT)
     try {

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -27,6 +27,7 @@ import {
   invalidParams,
   internalError,
   limitExceeded,
+  parseBlockTag,
 } from "./rpc-validators.ts"
 
 const log = createLogger("ws-rpc")
@@ -646,58 +647,92 @@ function constantTimeEqualWs(a: string, b: string): boolean {
 }
 
 /**
- * Validate log subscription filter parameters
+ * Validate log subscription filter parameters.
+ *
+ * #274: pre-fix this divergent local validator (predates the PR-1Q
+ * extraction of validators to ./rpc-validators.ts) missed three classes
+ * of checks present in the shared HTTP validator:
+ *
+ *   - `fromBlock` / `toBlock` — not validated at all (negative numbers,
+ *     bogus strings, huge values all silently accepted)
+ *   - `blockHash` — not validated at all (any string accepted)
+ *   - Inner topic OR-array cap (100 here vs HTTP's 32 after #266) —
+ *     asymmetric DoS amplification
+ *
+ * It also threw `new Error(...)` for malformed input, which the dispatch
+ * layer surfaced as -32603 internal-error instead of -32602 invalid
+ * params. Switch to `invalidParams()` so JSON-RPC §5.1 codes match HTTP.
  */
 function validateLogFilter(params: Record<string, unknown>): LogSubscriptionFilter {
   const filter: LogSubscriptionFilter = {}
 
+  // #274: validate fromBlock/toBlock shape (sibling of HTTP eth_getLogs).
+  // Subscriptions only match future events so the values aren't stored,
+  // but the shape check rejects garbage so clients learn about typos.
+  if (params.fromBlock !== undefined && params.fromBlock !== null) {
+    parseBlockTag(params.fromBlock, 0n)
+  }
+  if (params.toBlock !== undefined && params.toBlock !== null) {
+    parseBlockTag(params.toBlock, 0n)
+  }
+  // #274: blockHash shape check (sibling of HTTP eth_getLogs / #186).
+  if (params.blockHash !== undefined && params.blockHash !== null) {
+    if (typeof params.blockHash !== "string" || !HEX_TOPIC_RE.test(params.blockHash)) {
+      invalidParams("invalid blockHash: must match /^0x[0-9a-fA-F]{64}$/")
+    }
+  }
+
   if (params.address !== undefined) {
     if (Array.isArray(params.address)) {
       if (params.address.length > 100) {
-        throw new Error("address filter array too large (max 100)")
+        invalidParams("address filter array too large (max 100)")
       }
       for (const addr of params.address) {
         if (typeof addr !== "string" || !HEX_ADDRESS_RE.test(addr)) {
-          throw new Error(`invalid address in filter: ${addr}`)
+          invalidParams(`invalid address in filter: ${addr}`)
         }
       }
       filter.address = params.address as string[]
     } else if (typeof params.address === "string") {
       if (!HEX_ADDRESS_RE.test(params.address)) {
-        throw new Error(`invalid address: ${params.address}`)
+        invalidParams(`invalid address: ${params.address}`)
       }
       filter.address = params.address
+    } else if (params.address !== null) {
+      invalidParams(`invalid address: expected string or array of strings`)
     }
   }
 
-  if (params.topics !== undefined) {
+  if (params.topics !== undefined && params.topics !== null) {
     if (!Array.isArray(params.topics)) {
-      throw new Error("topics must be an array")
+      invalidParams("topics must be an array")
     }
-    if (params.topics.length > 4) {
-      throw new Error("topics array must have at most 4 elements")
+    if ((params.topics as unknown[]).length > 4) {
+      invalidParams("topics array must have at most 4 elements")
     }
     const topics: Array<string | string[] | null> = []
-    for (const t of params.topics) {
+    for (const t of params.topics as unknown[]) {
       if (t === null || t === undefined) {
         topics.push(null)
       } else if (Array.isArray(t)) {
-        if (t.length > 100) {
-          throw new Error("topic OR-array too large (max 100)")
+        // #274/#266: cap inner OR-array at 32 (matching HTTP eth_getLogs)
+        // to prevent O(blocks×logs×inner) amplification asymmetry.
+        if (t.length > 32) {
+          invalidParams(`topic OR-array too large (max 32)`)
         }
         for (const item of t) {
           if (typeof item !== "string" || !HEX_TOPIC_RE.test(item)) {
-            throw new Error(`invalid topic in OR-array: ${item}`)
+            invalidParams(`invalid topic in OR-array: ${String(item).slice(0, 80)}`)
           }
         }
         topics.push(t as string[])
       } else if (typeof t === "string") {
         if (!HEX_TOPIC_RE.test(t)) {
-          throw new Error(`invalid topic: ${t}`)
+          invalidParams(`invalid topic: ${t.slice(0, 80)}`)
         }
         topics.push(t)
       } else {
-        throw new Error(`invalid topic type: ${typeof t}`)
+        invalidParams(`invalid topic type: ${Array.isArray(t) ? "array" : typeof t}`)
       }
     }
     filter.topics = topics


### PR DESCRIPTION
Closes #274.

## Bug

\`websocket-rpc.ts:651\` defined its OWN \`validateLogFilter\` that shadowed the shared one in \`rpc-validators.ts\` (predates the PR-1Q extraction). The local version diverged in four ways:

1. **\`fromBlock\` / \`toBlock\` not validated** — negative numbers, bogus strings, huge values silently accepted.
2. **\`blockHash\` not validated at all** — any string accepted.
3. **\`throw new Error(...)\` → -32603 internal-error** — JSON-RPC §5.1 violation; should be -32602 invalid-params.
4. **Inner topic OR-array cap = 100** vs HTTP's 32 (after #266) — asymmetric DoS amplification ceiling.

## Live repro on 88780 (\`ws://209.74.64.88:38790\`)

\`\`\`
eth_subscribe("logs", {fromBlock: -1})       → \"0xebc8...\"  (subscription created)
eth_subscribe("logs", {fromBlock: "-1"})     → \"0x2abc...\"
eth_subscribe("logs", {toBlock: "0xff…f"})   → \"0x4186...\"
eth_subscribe("logs", {blockHash: "not-hex"})→ \"0xa372...\"
eth_subscribe("logs", {address: "bad"})      → -32603 (wrong code class)
eth_subscribe("logs", {topics: [<100 ok>]})  → \"0xa372...\" (over HTTP cap of 32)
\`\`\`

HTTP \`eth_getLogs\` on the same node properly rejects all of these with -32602.

## Fix

Enhance the local validator to:
- Call \`parseBlockTag\` on fromBlock/toBlock for shape (rejects negative/bool/array/object/garbage).
- Validate blockHash against the existing \`HEX_TOPIC_RE\` (32-byte hex).
- Switch all throws to \`invalidParams(...)\` so error code class matches HTTP.
- Tighten inner OR-array cap from 100 → 32 (matches HTTP #266).

## Test plan

- [x] New \`#274\` subtest in \`websocket-rpc.test.ts\` covering 25+ bad shapes + sanity for well-shaped filters.
- [x] \`node --experimental-strip-types --test node/src/websocket-rpc.test.ts\` → **14/14 pass**.

## Note

Almost committed directly to local \`main\` — caught and reset before pushing. Same accident as the #268 fix-branch creation (the prior \`git checkout main\` output's "use git pull" warning interleaved with the new branch checkout, masking that the branch creation succeeded). No upstream impact.