### PR TITLE
fix(rpc): #276 map mempool/chain client-input errors to -32602 / -32005

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2872,6 +2872,39 @@ test("RPC Extended Methods", async (t) => {
       `well-shaped blockHash must pass shape validation: ${JSON.stringify(ok)}`)
   })
 
+  await t.test("#276: eth_sendRawTransaction maps mempool/chain client-input errors to -32602 (not -32603)", async () => {
+    // Pre-fix mempool/chain-engine throws plain `new Error(...)` for client-input
+    // rejections (wrong chainId, nonce too low, blob tx, gasLimit exceeded,
+    // poisoned tx). The eth_sendRawTransaction catch only filtered ethers shape
+    // errors → plain Errors fell through to outer 500/−32603 internal-error.
+    // This regression asserts the message-pattern remap to -32602.
+    const { Transaction, Wallet, getBytes } = await import("ethers")
+    const wallet = new Wallet(`0x${"01".repeat(32)}`)
+    // Sign a tx with WRONG chainId (mempool requires this.cfg.chainId=18780).
+    const tx = Transaction.from({
+      to: `0x${"02".repeat(20)}`,
+      value: 1n,
+      gasLimit: 21_000n,
+      gasPrice: 1_000_000_000n,
+      nonce: 0,
+      chainId: 99999, // wrong — fixture chain is 18780
+    })
+    const unsignedHash = tx.unsignedHash
+    const sig = wallet.signingKey.sign(getBytes(unsignedHash))
+    const signed = tx.clone()
+    signed.signature = sig
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [signed.serialized] }),
+    })
+    const body = await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    assert.equal(body.error?.code, -32602,
+      `chainId-mismatch must be -32602, got ${body.error?.code} (${body.error?.message})`)
+    assert.match(body.error!.message, /invalid chain ID/,
+      `error must preserve "invalid chain ID" surface, got: ${JSON.stringify(body)}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1097,6 +1097,22 @@ async function handleRpc(
         const msg = parseErr instanceof Error ? parseErr.message : String(parseErr)
         if (/^replacement tx gas price too low/i.test(msg)) {
           throw { code: -32000, message: msg }
+  })
+
+        // #276: mempool / chain-engine throw plain `new Error(...)` for
+        // a handful of client-input rejections that pre-fix surfaced as
+        // -32603 "internal error". Map known message patterns to the
+        // proper JSON-RPC §5.1 codes (-32602 invalid params, -32005
+        // limit exceeded) so indexers/dApps can react correctly. Same
+        // regex-mapping pattern as ipfs-http.ts:1140 for MFS errors.
+        const msg = parseErr instanceof Error ? parseErr.message : String(parseErr)
+        if (
+          /^invalid chain ID|^invalid tx: |^blob transactions|^gasLimit exceeds|^tx .* is poisoned|^tx already confirmed|^nonce too low/i.test(msg)
+        ) {
+          invalidParams(msg)
+        }
+        if (/^mempool is full|exceeds max pending tx limit/i.test(msg)) {
+          limitExceeded(msg)
         }
         throw parseErr
       }


### PR DESCRIPTION
Closes #276.

## Bug

\`mempool.ts\` and \`chain-engine.ts\` throw plain \`new Error(...)\` for ~10 distinct client-input rejections (wrong chainId, nonce too low, blob tx, gasLimit exceeded, poisoned tx, mempool full, pending-limit exceeded). The \`eth_sendRawTransaction\` catch only filtered ethers shape errors (those with string \`.code\`), so these plain Errors fell through to the outer dispatch and surfaced as -32603 \"internal error\".

Per JSON-RPC §5.1, -32603 means the server encountered an unexpected condition. A user-submitted tx with the wrong chainId is the user's fault, not the server's.

## Live repro on 88780 (\`http://209.74.64.88:38780\`)

\`\`\`bash
# Sign tx with chainId=99999 (network is 88780)
curl … '{\"…method\":\"eth_sendRawTransaction\",\"params\":[<signed>]}'
# Actual:   {\"error\":{\"code\":-32603,\"message\":\"invalid chain ID: expected 88780, got 99999\"}}
# Expected: {\"error\":{\"code\":-32602,\"message\":\"invalid chain ID: …\"}}
\`\`\`

Sanity: every other client-input error in \`eth_call\` / \`eth_estimateGas\` already returns -32602 via the shared validators. The mempool/chain layer is the lone holdout.

## Fix

Extend the catch with message-pattern remapping (same regex approach as \`ipfs-http.ts:1140\` for MFS errors):

\`\`\`typescript
if (/invalid chain ID|invalid tx|blob|gasLimit exceeds|poisoned|already confirmed|nonce too low/i.test(msg)) {
  invalidParams(msg)   // -32602
}
if (/mempool is full|exceeds max pending tx limit/i.test(msg)) {
  limitExceeded(msg)   // -32005
}
\`\`\`

## Test plan

- [x] New \`#276\` subtest signs a tx with chainId=99999 and asserts -32602 with the \"invalid chain ID\" surface preserved.
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\` → **95/95 pass**.

## Note

This is the same anti-pattern fixed in #156 (ethers shape errors → -32602) for tx-decode errors, and the same family as #232/#268/#270/#272 (regex-mapping known errors). The message regex sits next to the existing isEthersShapeError check.