### PR TITLE
fix(ipfs): pin/add must require block in local store (#280)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -210,6 +210,37 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(body.Pins, [meta.cid])
   })
 
+  it("#280: POST /api/v0/pin/add rejects CIDs not present in local store (404, no pins.json pollution)", async () => {
+    // Pre-fix handlePinAdd only checked isValidCid format then unconditionally
+    // called store.pin(cid), so any well-formed-but-non-existent CID got added
+    // to pins.json. Attackers could mass-submit valid-format CIDs to grow
+    // pins.json unboundedly (each pin add rewrites the whole file →
+    // disk-fill + write-amplification DoS). Kubo's offline pin/add returns
+    // "block not found locally" in this scenario; mirror that semantic.
+    const fakeCid = "bafkreieeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    // Sanity: well-formed CID passes the format gate (so we're testing the
+    // new existence gate, not the pre-existing #168 format gate).
+    const pinsBefore = await store.listPins()
+    assert.equal(pinsBefore.includes(fakeCid as CidString), false,
+      "fakeCid must not be pinned at start of test")
+    const res = await fetch(`/api/v0/pin/add?arg=${fakeCid}`, { method: "POST" })
+    assert.equal(res.status, 404,
+      `pin/add for non-existent CID must 404, got ${res.status}`)
+    const body = await res.json() as Record<string, unknown>
+    assert.match(String(body.error ?? ""), /not found locally/i)
+    // The critical invariant: pins.json must NOT have been polluted.
+    const pinsAfter = await store.listPins()
+    assert.equal(pinsAfter.includes(fakeCid as CidString), false,
+      "fakeCid must NOT have been added to pins.json — that is the DoS surface")
+    // Sanity: pinning a real (stored) block still works after the fix.
+    const data2 = new TextEncoder().encode("pin me too")
+    const meta2 = await unixfs.addFile("pin2.txt", data2)
+    const ok = await fetch(`/api/v0/pin/add?arg=${meta2.cid}`, { method: "POST" })
+    assert.equal(ok.status, 200, "pin/add for stored block must still succeed")
+    const okBody = await ok.json() as Record<string, unknown>
+    assert.deepEqual(okBody.Pins, [meta2.cid])
+  })
+
   it("#126: POST /api/v0/pin/rm removes a pin, returns 404 on second call", async () => {
     const data = new TextEncoder().encode("pin then unpin")
     const meta = await unixfs.addFile("p.txt", data)

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -837,6 +837,18 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
+    // #280: pre-fix accepted any well-formed CID without requiring the
+    // block to be stored locally. Attackers could mass-submit valid-format
+    // CIDs to grow pins.json unboundedly (each pin add rewrites the whole
+    // file → disk-fill + write-amplification DoS). Kubo's offline mode
+    // returns "block not found locally" in the same scenario; mirror
+    // that: pinning is allowed only for blocks already present in the
+    // local store (put + pin → pin/add must check existence first).
+    if (!(await this.store.has(cid))) {
+      res.writeHead(404, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: "block not found locally" }))
+      return
+    }
     await this.store.pin(cid)
     res.writeHead(200, { "content-type": "application/json" })
     res.end(JSON.stringify({ Pins: [cid] }))


### PR DESCRIPTION
## Summary

- Closes #280.
- `/api/v0/pin/add` accepted any well-formed CID without requiring the block to be present in the local store, so attackers could grow `pins.json` unboundedly by mass-submitting valid-format CIDs (each pin add rewrites the whole file → disk-fill + O(N) write amplification).
- Gated on `store.has(cid)` before `store.pin(cid)`. Missing block → 404 with `"block not found locally"`, mirroring kubo's offline-mode semantics. This naturally caps the pin set at the blockstore size, which is already bounded.
- Live-confirmed on 88780 before fix: `pin/add?arg=<random-fake-CID>` returned 200 OK and `pin/ls` showed the CID had landed in `pins.json` (cleanup via `pin/rm` after PoC).

## Files

- `node/src/ipfs-http.ts:834-852` — `handlePinAdd` gates on `await store.has(cid)`, returns 404 on miss.
- `node/src/ipfs-http.test.ts` — new subtest `#280` covers:
  - pin/add on well-formed-but-unstored CID returns 404
  - error body mentions `"not found locally"`
  - `pins.json` (via `store.listPins()`) is NOT polluted — the actual DoS invariant
  - sanity: stored CIDs still pin successfully (no regression)

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 51/51 pass (50 pre-existing + 1 new)
- [x] After deploy, live-verify on 88780: pin/add for a random fake CID returns 404, pins.json untouched

## Threat class

CWE-770 (Allocation of Resources Without Limits) — same lens as #265 (`eth_getProof` unbounded slot array). User-controllable input that pins arbitrary disk allocation.