### PR TITLE
fix(ipfs): pubsub 'message too large' returns 413 not 500 (#284)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -241,6 +241,49 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(okBody.Pins, [meta2.cid])
   })
 
+  it("#284: POST /api/v0/pubsub/pub returns 413 (not 500 'internal error') when body exceeds maxMessageSize", async () => {
+    // Pre-fix bug: IpfsPubsub.publish throws a plain Error("message too
+    // large: N > M") when data.length exceeds maxMessageSize. The error
+    // bubbled to the outer try/catch (which only special-cases HttpError
+    // and ErasureError) → 500 "internal error". Clients couldn't tell a
+    // server fault from their own oversized payload. Same class as #276
+    // (mempool plain Errors leaking as -32603). Remap to 413.
+    const { IpfsPubsub } = await import("./ipfs-pubsub.ts")
+    // Tight cap (1 KB) so the test doesn't have to allocate megabytes.
+    const pubsub = new IpfsPubsub({ nodeId: "test-node", maxMessageSize: 1024 })
+    server.attachSubsystems({ pubsub })
+    try {
+      // Sanity: small body → 200 OK.
+      const ok = await fetch("/api/v0/pubsub/pub?arg=test-topic", {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new TextEncoder().encode("small msg"),
+      })
+      assert.equal(ok.status, 200, `small msg must succeed, got ${ok.status}`)
+      // 2 KB body > 1 KB cap → must be 413, NOT 500 "internal error".
+      const oversized = randomBytes(2048)
+      const res = await fetch("/api/v0/pubsub/pub?arg=test-topic", {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: oversized,
+      })
+      assert.equal(res.status, 413,
+        `oversized pubsub msg must be 413, got ${res.status}`)
+      const body = await res.json() as { error?: string; message?: string }
+      assert.match(body.error ?? "", /payload too large/i,
+        `error code must say 'payload too large', got ${JSON.stringify(body)}`)
+      assert.match(body.message ?? "", /message too large/i,
+        "message must surface the underlying pubsub error for diagnostics")
+      // Critical regression-anchor: NEVER surface this client-input
+      // condition as "internal error" — that's the 500 path which means
+      // operator pages, not "your payload is too big".
+      assert.ok(!/internal error/i.test(JSON.stringify(body)),
+        "must NOT surface as 'internal error' — that was the pre-fix mis-classification")
+    } finally {
+      pubsub.stop()
+    }
+  })
+
   it("#126: POST /api/v0/pin/rm removes a pin, returns 404 on second call", async () => {
     const data = new TextEncoder().encode("pin then unpin")
     const meta = await unixfs.addFile("p.txt", data)

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1549,7 +1549,21 @@ export class IpfsHttpServer {
           // because readMultipartFile falls back to raw bytes when there's no
           // boundary in Content-Type.
           const { bytes: body } = await readMultipartFile(req)
-          await this.pubsub.publish(topic, body)
+          // #284: IpfsPubsub.publish throws a plain Error("message too large:
+          // N > M") when data.length exceeds maxMessageSize (default 1 MB).
+          // Without this catch the error fell through the outer try/catch as
+          // 500 "internal error" — clients couldn't tell server fault from
+          // their own oversized payload. Same class as #276 (mempool plain
+          // Errors leaking as -32603); remap to 413 per HTTP semantics.
+          try {
+            await this.pubsub.publish(topic, body)
+          } catch (pubErr) {
+            const msg = pubErr instanceof Error ? pubErr.message : String(pubErr)
+            if (/^message too large/i.test(msg)) {
+              throw new HttpError(413, "payload too large", msg)
+            }
+            throw pubErr
+          }
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))
           break
@@ -1608,6 +1622,23 @@ export class IpfsHttpServer {
           res.end(JSON.stringify({ error: `unknown pubsub command: ${route}` }))
       }
     } catch (err) {
+      // #284: pre-fix this route-level catch unconditionally surfaced 500
+      // "internal error", masking client-input failures (e.g. pubsub
+      // payload too large) as server faults. Honour HttpError throws —
+      // the publish call site rethrows oversized messages as
+      // HttpError(413), and future client-input errors from this route
+      // should also bypass the 500 default.
+      if (err instanceof HttpError) {
+        if (!res.headersSent) {
+          res.writeHead(err.status, { "content-type": "application/json" })
+        }
+        log.warn("IPFS pubsub request rejected", { status: err.status, code: err.code })
+        const messageOut = err.message !== err.code ? err.message : undefined
+        try {
+          res.end(JSON.stringify(messageOut ? { error: err.code, message: messageOut } : { error: err.code }))
+        } catch { /* connection already closed */ }
+        return
+      }
       log.error("pubsub route failed", { error: String(err) })
       res.writeHead(500, { "content-type": "application/json" })
       res.end(JSON.stringify({ error: "internal error" }))


### PR DESCRIPTION
## Summary

- Closes #284.
- `IpfsPubsub.publish` throws a plain `Error("message too large: N > M")` when `data.length` exceeds `maxMessageSize`. The pubsub route-level catch unconditionally wrote `500 "internal error"`, masking a client-input failure as a server fault — same class as #276 (mempool plain Errors leaking as -32603).
- Live-confirmed on 88780: POST /pubsub/pub with 2 MB body returned 500 instead of 413. After the fix the same request returns 413 with `{"error":"payload too large","message":"..."}`.
- Two-step fix:
  1. `handlePubsub` "pub" case: wrap `publish()` and rethrow oversized messages as `HttpError(413, "payload too large", msg)` via regex match.
  2. Route-level catch: honour `HttpError` (currently always returns 500) — so this fix lands, and any future client-input error on the pubsub route also bypasses the operator-paging 500 path.

## Files

- `node/src/ipfs-http.ts:1212-1226` — wrap `publish()` with regex remap of "message too large".
- `node/src/ipfs-http.ts:1284-1306` — route catch routes `HttpError` to its declared status before falling through to 500.
- `node/src/ipfs-http.test.ts` — subtest `#284` attaches an `IpfsPubsub` with `maxMessageSize=1024`, posts a 2 KB body, asserts:
  - status === 413
  - body.error matches /payload too large/i
  - body.message surfaces the underlying pubsub error for diagnostics
  - response body NEVER contains "internal error" (the pre-fix regression anchor)

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 51/51 pass (50 pre-existing + 1 new)
- [x] Live verified on 88780 pre-fix: 2 MB body → 500 "internal error"
- [ ] After deploy: re-verify same request → 413 with "payload too large"

## Threat class

CWE-754 (Improper Check for Unusual or Exceptional Conditions). Same lens as #276/#277.