### PR TITLE
fix(rpc): eth_call / eth_estimateGas surface revert as code 3 (#286)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -827,11 +827,17 @@ export class EvmChain {
     return this.txs.get(txHash) ?? null
   }
 
+  // #286: declared return type now surfaces `failed` so eth_call /
+  // eth_estimateGas can detect reverts and emit a geth-compatible
+  // -32000/"execution reverted" error with the revert payload as `data`.
+  // Pre-fix the type omitted `failed` even though runCall already populated
+  // it; eth_call silently returned the revert payload as if it were a
+  // success, breaking ethers.js / viem / foundry revert detection.
   async callRaw(
     params: { from?: string; to: string; data?: string; value?: string; gas?: string },
     stateRoot?: string,
     context?: bigint | ExecutionContext,
-  ): Promise<{ returnValue: string; gasUsed: bigint }> {
+  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean }> {
     const executionContext = normalizeExecutionContext(context)
     if (stateRoot || executionContext.blockNumber !== undefined) {
       const stateManager = await this.resolveStateManager(stateRoot)
@@ -1723,7 +1729,10 @@ function formatTraceWord(value: unknown): string {
   return "0x0"
 }
 
-function decodeRevertReason(data: string): string | undefined {
+// #286: exported so eth_call / eth_estimateGas can build a geth-compatible
+// revert error message ("execution reverted: <reason>") from the returned
+// payload.
+export function decodeRevertReason(data: string): string | undefined {
   if (!data || data === "0x" || !data.startsWith("0x")) {
     return undefined
   }

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2300,6 +2300,72 @@ test("RPC Extended Methods", async (t) => {
       `inner topics=1 must pass shape, got ${JSON.stringify(r1)}`)
   })
 
+  })
+
+  await t.test("#286: eth_call / eth_estimateGas surface revert as -32000 (geth-compatible error code 3, no silent 0x return)", async () => {
+    // Pre-fix bug: evm.callRaw's declared return type omitted `failed`
+    // (even though runCall populated it), so the eth_call handler
+    // returned `returnValue` regardless of revert state. Reverted calls
+    // were indistinguishable from view functions returning empty bytes —
+    // ethers.js / viem / foundry cast all rely on error.code===3 to
+    // surface revert reasons. Live PoC on 88780: eth_call with selector
+    // 0xdeadbeef on a real contract returned result:"0x" instead of a
+    // -32000 error.
+    //
+    // The reliable way to trigger a revert from this test fixture is to
+    // stub evm.callRaw to return failed:true with a canonical
+    // Error(string) revert payload. We then verify the rpc dispatcher:
+    //   (a) emits code 3 (not 0x success), and
+    //   (b) decodes the Error(string) payload into the message, and
+    //   (c) preserves the raw payload as `data` for client decoding.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const origCallRaw = evm.callRaw.bind(evm)
+    // Canonical Error(string) revert: selector 0x08c379a0 + ABI(string "Hard!"),
+    // 0x20 offset, length 5, then "Hard!" right-padded to 32 bytes.
+    const revertPayload =
+      "0x08c379a0" +
+      "0000000000000000000000000000000000000000000000000000000000000020" +
+      "0000000000000000000000000000000000000000000000000000000000000005" +
+      "4861726421000000000000000000000000000000000000000000000000000000"
+    ;(evm as unknown as { callRaw: unknown }).callRaw = async () => ({
+      returnValue: revertPayload,
+      gasUsed: 21_000n,
+      failed: true,
+    })
+    try {
+      const probe = async (method: string) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method,
+            params: [{ to: validAddr, data: "0xdeadbeef" }, "latest"],
+          }),
+        })
+        return await r.json() as { result?: unknown; error?: { code: number; message: string; data?: string } }
+      }
+      // eth_call must emit code 3 with decoded reason.
+      const callRes = await probe("eth_call")
+      assert.equal(callRes.error?.code, 3,
+        `eth_call revert must be code 3, got ${JSON.stringify(callRes)}`)
+      assert.match(callRes.error!.message, /execution reverted: Hard!/,
+        "message must include decoded Error(string) reason 'Hard!'")
+      assert.equal(callRes.error!.data, revertPayload,
+        "data field must echo the raw revert payload so clients can ABI-decode it themselves")
+      assert.equal(callRes.result, undefined, "must NOT return a success result")
+      // eth_estimateGas must mirror — pre-fix it returned a gas estimate
+      // for the failed path, leading clients to broadcast txs that are
+      // guaranteed to revert on-chain.
+      const estRes = await probe("eth_estimateGas")
+      assert.equal(estRes.error?.code, 3,
+        `eth_estimateGas revert must be code 3, got ${JSON.stringify(estRes)}`)
+      assert.match(estRes.error!.message, /execution reverted: Hard!/)
+      assert.equal(estRes.result, undefined, "must NOT return a gas estimate for a reverting call")
+    } finally {
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -5,6 +5,7 @@ import { SigningKey, keccak256, hashMessage, Transaction, TypedDataEncoder, getC
 import type { IChainEngine } from "./chain-engine-types.ts"
 import { hasGovernance, hasConfig, hasBlockIndex } from "./chain-engine-types.ts"
 import type { EvmChain, ExecutionContext } from "./evm.ts"
+import { decodeRevertReason } from "./evm.ts"
 import type { Hex, PendingFilter } from "./blockchain-types.ts"
 import type { P2PNode } from "./p2p.ts"
 import type { PoSeEngine } from "./pose-engine.ts"
@@ -664,7 +665,7 @@ async function handleOne(
     if (isNotification) return null
     // Support structured RPC errors (e.g. { code, message } from param validation)
     if (error && typeof error === "object" && "code" in error && "message" in error) {
-      const rpcErr = error as { code: unknown; message: unknown }
+      const rpcErr = error as { code: unknown; message: unknown; data?: unknown }
       // JSON-RPC 2.0 §5.1 requires error.code to be a number. Our internal
       // handlers throw { code: -32xxx, ... } objects (legitimate), but
       // downstream libraries like ethers throw errors with string codes
@@ -674,7 +675,21 @@ async function handleOne(
       const numericCode =
         typeof rpcErr.code === "number" && Number.isInteger(rpcErr.code) ? rpcErr.code : -32603
       const message = typeof rpcErr.message === "string" ? rpcErr.message : "internal error"
-      return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: numericCode, message } }
+      // #286: JSON-RPC 2.0 §5.1 allows an optional `data` field for
+      // additional error info. eth_call's "execution reverted" error
+      // returns the raw revert payload as `data` so ethers.js / viem /
+      // foundry cast can ABI-decode it client-side. Preserve `data` when
+      // present and structured (string, number, boolean, plain object, or
+      // array) — drop hostile shapes like functions / symbols which would
+      // break JSON serialization.
+      const errOut: { code: number; message: string; data?: unknown } = { code: numericCode, message }
+      if (rpcErr.data !== undefined) {
+        const dt = typeof rpcErr.data
+        if (dt === "string" || dt === "number" || dt === "boolean" || (rpcErr.data !== null && (dt === "object"))) {
+          errOut.data = rpcErr.data
+        }
+      }
+      return { jsonrpc: "2.0", id: payload.id ?? null, error: errOut }
     }
     return { jsonrpc: "2.0", id: payload.id ?? null, error: { code: -32603, message: error instanceof Error ? error.message : "internal error" } }
   }
@@ -851,6 +866,23 @@ async function handleRpc(
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #286: pre-fix eth_estimateGas (which delegates to callRaw under the
+      // hood) ignored the underlying call's `failed` flag and returned a
+      // gas estimate even when execution reverted — clients would then
+      // submit a tx that's guaranteed to revert because the estimate was
+      // for a non-revert path that never existed. Probe the call first
+      // and surface the revert as -32000 "execution reverted" matching
+      // geth's JSON-RPC contract.
+      const estProbe = await evm.callRaw({
+        from: estParams.from,
+        to: estParams.to ?? "",
+        data: estParams.data,
+        value: estParams.value,
+        gas: gasForEstimate,
+      }, executionContext.stateRoot, executionContext)
+      if (estProbe.failed) {
+        throwExecutionReverted(estProbe.returnValue)
+      }
       const estimated = await evm.estimateGas({
         from: estParams.from,
         to: estParams.to ?? "",
@@ -893,6 +925,17 @@ async function handleRpc(
         value: callParams.value,
         gas: callParams.gas,
       }, executionContext.stateRoot, executionContext)
+      // #286: pre-fix eth_call returned `returnValue` regardless of
+      // `failed`, so reverted calls were indistinguishable from view
+      // functions returning empty bytes / false. Geth's JSON-RPC contract
+      // requires -32000 "execution reverted" with the revert payload as
+      // `data`; ethers.js / viem / foundry's `cast call` all rely on this
+      // error shape to surface revert reasons to users. The 88780 testnet
+      // returned 200 OK with result:"0x" for any contract call with an
+      // unknown selector before this fix.
+      if (callResult.failed) {
+        throwExecutionReverted(callResult.returnValue)
+      }
       return callResult.returnValue
     }
     case "eth_getStorageAt": {
@@ -2748,6 +2791,18 @@ async function handleRpc(
 }
 
 // safeBigInt + parseBlockTag — extracted to ./rpc-validators.ts (PR-1Q, 2026-05-12).
+
+// #286: emit a geth-compatible "execution reverted" error. Code 3 matches
+// geth's eth/JSON-RPC error.go ReturnTypeError; clients (ethers.js, viem,
+// foundry cast) detect reverts on `error.code === 3` and decode the
+// payload from `error.data`. Decoded reason is appended to the message
+// when available (`Error(string)` → "execution reverted: <reason>";
+// `Panic(uint)` → "execution reverted: Panic(N)").
+function throwExecutionReverted(returnValue: string): never {
+  const reason = decodeRevertReason(returnValue)
+  const message = reason ? `execution reverted: ${reason}` : "execution reverted"
+  throw { code: 3, message, data: returnValue || "0x" }
+}
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {
   const height = await Promise.resolve(chain.getHeight())


### PR DESCRIPTION
## Summary

- Closes #286.
- `evm.callRaw`'s declared return type omitted `failed` even though `runCall` populated it — `eth_call` returned `returnValue` regardless of revert state. Reverted calls were indistinguishable from view functions returning empty bytes, breaking ethers.js / viem / foundry cast revert detection.
- Live-confirmed on 88780: `eth_call` with selector `0xdeadbeef` on a real contract returned `result:"0x"` instead of `error.code===3`.
- Three changes:
  1. `evm.ts`: export `decodeRevertReason`, surface `failed` on `callRaw`'s return type.
  2. `rpc.ts`: `eth_call` + `eth_estimateGas` check `callResult.failed`; throw `{code:3, message:"execution reverted[:reason]", data:payload}` (geth-compatible). `eth_estimateGas` probes via `callRaw` first so reverting calls don't yield bogus gas estimates.
  3. `rpc.ts`: `handleOne` error envelope propagates optional JSON-RPC §5.1 `data` field — required so clients receive the raw revert payload to ABI-decode.

## Files

- `node/src/evm.ts:830-842,1734` — type + export.
- `node/src/rpc.ts:7-8, 559-573, 727-758, 763-786, 2616-2627` — imports, error envelope, eth_call/estimateGas paths, helper `throwExecutionReverted`.
- `node/src/rpc-extended.test.ts` — subtest `#286` stubs `evm.callRaw` to return `failed:true` with canonical `Error("Hard!")` payload; asserts:
  - error code === 3
  - message matches `/execution reverted: Hard!/`
  - data echoes the raw payload (Error selector + ABI-encoded string)
  - result is undefined for both methods

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 95/95 pass
- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts node/src/rpc-data-accuracy.test.ts` — 117/117 pass
- [x] `node --experimental-strip-types --test node/src/evm.test.ts` — 9/9 pass
- [ ] After deploy on 88780: `eth_call(0xb7278a61..., 0xdeadbeef)` returns `error.code===3` with `data:"0x"`

## Threat class

CWE-754 (Improper Check for Unusual or Exceptional Conditions). Same lens as #276/#284. The behavior gap fails silently with downstream user-facing impact (broken revert detection in three major Ethereum tools).