### PR TITLE
fix(rpc): cap eth_compileSolidity source at 64 KiB (#288 CRITICAL DoS gate)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2269,6 +2269,17 @@ test("RPC Extended Methods", async (t) => {
       const inner = Array.from({ length: innerN }, (_, i) =>
         `0x${i.toString(16).padStart(64, "0")}`,
       )
+  })
+
+  await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
+    // solc.compile is synchronous emscripten WASM. A single moderately
+    // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,
+    // blocking ALL block production + RPC + PoSe for the duration. Cap
+    // is 64 KiB — covers realistic single-file contracts (OZ's largest
+    // is ~30 KiB) while preventing the worst-case event-loop starvation
+    // a remote attacker can trigger at 100 req/min/IP. The proper fix is
+    // a worker thread; this gate is the surgical interim.
+    const probe = async (source: string) => {
       const r = await fetch(`http://127.0.0.1:${port}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -2277,6 +2288,9 @@ test("RPC Extended Methods", async (t) => {
           id: 1,
           method: "eth_getLogs",
           params: [{ topics: [inner] }],
+  })
+
+          jsonrpc: "2.0", id: 1, method: "eth_compileSolidity", params: [source],
         }),
       })
       return await r.json() as { error?: { code: number; message: string }; result?: unknown }
@@ -2364,6 +2378,25 @@ test("RPC Extended Methods", async (t) => {
     } finally {
       ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
     }
+  })
+
+    // 65 KiB source (1 KiB over the 64 KiB cap) — must reject with -32602.
+    const oversized = "// " + "x".repeat(65 * 1024)
+    const big = await probe(oversized)
+    assert.equal(big.error?.code, -32602,
+      `oversized compile must be -32602, got ${JSON.stringify(big)}`)
+    assert.match(big.error!.message, /source too large/i,
+      "error must name the field and the size cap")
+    // Sanity: a small valid source still compiles (no regression).
+    const small = await probe(
+      "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract T { uint x; }"
+    )
+    assert.equal(small.error, undefined,
+      `small valid source must succeed, got ${JSON.stringify(small)}`)
+    assert.ok(small.result && typeof small.result === "object",
+      "successful compile returns an object")
+    assert.ok("T" in (small.result as Record<string, unknown>),
+      "contract T must be in compile output")
   })
 
   if (prevDevAccounts === undefined) {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -65,6 +65,13 @@ const MAX_FILTERS = 1000
 // p99 latency < ~2 s on a fresh chain.
 const MAX_PROOF_KEYS = 256
 export const FILTER_TTL_MS = 5 * 60 * 1000 // 5 minutes
+// #288: cap on eth_compileSolidity source size. solc.compile is synchronous
+// emscripten WASM and blocks the Node event loop. Without this cap, a
+// single ~15 KB source with many empty contracts blocked the 88780 testnet
+// validator for >5 min. 64 KiB covers realistic single-file contracts (OZ's
+// largest single-file is ~30 KiB) and bounds the worst-case event-loop
+// starvation. The real fix is offloading solc to a worker thread.
+const MAX_COMPILE_SOURCE_SIZE = 64 * 1024
 const CHAIN_STATS_CACHE_TTL_MS = 5_000
 let chainStatsCache: { result: unknown; height: bigint; cachedAtMs: number } | null = null
 let chainStatsComputing: Promise<unknown> | null = null
@@ -1831,6 +1838,19 @@ async function handleRpc(
       const source = rawSource
       if (source.trim().length === 0) {
         invalidParams("invalid Solidity source: expected non-empty source string")
+      }
+      // #288: cap source size. solc.compile is synchronous WASM and
+      // blocks the Node event loop for the duration of compilation —
+      // a single ~15 KB source with 500 empty contracts took >5 min
+      // on the 88780 testnet, during which block production, PoSe,
+      // and all other RPC are starved. With the 100 req/min/IP rate
+      // limit, a single attacker can keep the event loop blocked
+      // indefinitely. Until the compile path is moved to a worker
+      // thread, enforce a hard ceiling. 64 KiB comfortably covers
+      // realistic single-file contracts (OpenZeppelin's largest
+      // single-file is ~30 KiB) while preventing the worst-case DoS.
+      if (source.length > MAX_COMPILE_SOURCE_SIZE) {
+        invalidParams(`Solidity source too large: ${source.length} bytes (max ${MAX_COMPILE_SOURCE_SIZE})`)
       }
       return await compileSoliditySource(source)
     }


### PR DESCRIPTION
## Summary

- Closes #288.
- **CRITICAL DoS**: `solc.compile` is synchronous emscripten WASM. With no source-size cap, a single ~15 KB request **blocked the 88780 validator event loop for 5+ minutes** — no block production, no PoSe ticks, no other RPC during that window.
- At 100 req/min/IP rate limit, one attacker can keep the validator stalled for **8.8 hours from 100 sequential requests** — and they're sequential because they're CPU-bound on the same event loop, not on the network.
- Cap at 64 KiB. OpenZeppelin's largest single-file is ~30 KiB; this comfortably covers realistic single-file contracts while bounding worst-case event-loop starvation per request. The proper fix is a worker thread (see issue followups).
- Same lens as #265 (eth_getProof unbounded slot array) but with stronger amplification — solc is far more CPU-heavy per byte than evm.getProof.

## Files

- `node/src/rpc.ts:54-62` — `MAX_COMPILE_SOURCE_SIZE = 64 * 1024` (alongside the existing `MAX_FILTERS` / `FILTER_TTL_MS` budget constants).
- `node/src/rpc.ts:1612-1640` — handler rejects `source.length > MAX_COMPILE_SOURCE_SIZE` with `-32602 'Solidity source too large'`.
- `node/src/rpc-extended.test.ts` — subtest `#288` asserts:
  - 65 KiB source → -32602 with `/source too large/i`
  - sanity: small valid source still compiles and returns the expected contract artifact

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 95/95 pass (94 pre-existing + 1 new)
- [x] Live pre-fix: 14.9 KB request → 5m19s blocking the validator
- [ ] After deploy: same 14.9 KB request → immediate -32602 (no blocking)

## Threat class

CWE-770 (Allocation of Resources Without Limits) + CWE-400 (Uncontrolled Resource Consumption). Severity rating in #288 issue.

## Followups (not in this PR — separate issues/PRs welcome)

1. Move `solc.compile` to a worker thread (the proper fix; cap is interim).
2. Per-account compile quota for fine-grained rate-limiting.
3. Optional: gate the whole method behind a `COC_ENABLE_SOLC_RPC` env flag (similar to `COC_DEBUG_RPC`). Explorer verification (`/verify`) ships its own client-side solc, so most production nodes don't need server-side compilation.