### PR TITLE
fix(rpc): coc_voteProposal strict field validation — no vote direction flip (#290)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2923,6 +2923,29 @@ test("RPC Extended Methods", async (t) => {
       },
     } as Record<string, unknown>
     ;(chain as unknown as Record<string, unknown>).governance = governanceStub278
+  })
+
+  await t.test("#290: coc_voteProposal rejects non-boolean approve + non-string proposalId/voterId (no vote-direction flip)", async () => {
+    // Pre-fix Boolean(voteParams.approve) silently coerced:
+    //   approve:"false" → true (records YES when client meant NO!)
+    //   approve:"no"    → true (same)
+    //   approve:{}      → true
+    //   approve:[]      → true
+    //   approve:0       → false (incidentally correct)
+    // String(voteParams.proposalId/voterId) silently turned
+    // undefined/null/array/object into "undefined"/"null"/"x,y"/
+    // "[object Object]" and forwarded to governance.vote — caused
+    // -32603 leaks downstream when the proposal lookup threw, and
+    // crucially flipped vote direction on the YES/NO axis.
+    // Reuse the same governance stub pattern as #218/#220/#226.
+    const recordedVotes: Array<{ proposalId: string; voterId: string; approve: boolean }> = []
+    const governanceStub290 = {
+      vote: (proposalId: string, voterId: string, approve: boolean) => {
+        recordedVotes.push({ proposalId, voterId, approve })
+      },
+      getProposal: () => ({ id: "p1", status: "pending", votes: new Map() }),
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub290
     try {
       const probe = async (params: unknown[]) => {
         const r = await fetch(`http://127.0.0.1:${port}`, {
@@ -3043,6 +3066,45 @@ test("RPC Extended Methods", async (t) => {
         "the bounded-seen invariant under steady-state churn")
     } finally {
       ;(chain.mempool as unknown as { getAll: typeof origGetAll }).getAll = origGetAll
+  })
+
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_voteProposal", params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      // approve non-boolean shapes — must reject with -32602 (not silently
+      // coerce to true). The "false"/"no"/"0" string cases are the
+      // direction-flip foot-guns; "{}", "[]", "1" round out the panel.
+      for (const bad of ["false", "true", "no", "yes", "0", "1", 0, 1, {}, [], null, undefined]) {
+        const r = await probe([{ proposalId: "p1", voterId: "node-1", approve: bad }])
+        assert.equal(r.error?.code, -32602,
+          `approve=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /invalid approve|expected boolean/i)
+      }
+      // proposalId / voterId non-string shapes — must reject (no silent
+      // String() coercion to "undefined"/"null"/"x,y").
+      for (const bad of [undefined, null, 123, true, false, {}, ["p1"], ""]) {
+        const r1 = await probe([{ proposalId: bad, voterId: "node-1", approve: true }])
+        assert.equal(r1.error?.code, -32602,
+          `proposalId=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r1)}`)
+        const r2 = await probe([{ proposalId: "p1", voterId: bad, approve: true }])
+        assert.equal(r2.error?.code, -32602,
+          `voterId=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r2)}`)
+      }
+      // None of the invalid inputs should have reached the stub.
+      assert.equal(recordedVotes.length, 0,
+        `no invalid vote should have reached governance.vote; got ${JSON.stringify(recordedVotes)}`)
+      // Sanity: well-shaped true/false both succeed, NOT just true.
+      const okYes = await probe([{ proposalId: "p1", voterId: "node-1", approve: true }])
+      assert.equal(okYes.error, undefined, `valid YES vote must succeed, got ${JSON.stringify(okYes)}`)
+      const okNo = await probe([{ proposalId: "p1", voterId: "node-1", approve: false }])
+      assert.equal(okNo.error, undefined, `valid NO vote must succeed, got ${JSON.stringify(okNo)}`)
+      assert.equal(recordedVotes.length, 2, "exactly 2 well-shaped votes recorded")
+      assert.equal(recordedVotes[0].approve, true, "YES vote must be exactly true")
+      assert.equal(recordedVotes[1].approve, false,
+        "NO vote must be exactly false — this is the direction-flip invariant")
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
     }
   })
 

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2238,17 +2238,34 @@ async function handleRpc(
         invalidParams("invalid params: expected non-null object as first param")
       }
       const voteParams = voteRaw as Record<string, unknown>
+      // #290: pre-fix `String(...)` / `Boolean(...)` silently coerced
+      // every shape:
+      //   - String(undefined) = "undefined" → governance.vote() looked
+      //     up proposal "undefined", threw, leaked as -32603.
+      //   - Boolean("false") = true → a client passing the STRING
+      //     "false" recorded a YES vote (direction-flip on a governance
+      //     decision). Same anti-pattern as #260 (eth_getBlockBy*
+      //     includeTx Boolean coercion). Validate each field upfront so
+      //     bogus shapes get -32602 and the YES/NO direction is exact.
+      if (typeof voteParams.proposalId !== "string" || voteParams.proposalId.length === 0) {
+        invalidParams("invalid proposalId: expected non-empty string")
+      }
+      if (typeof voteParams.voterId !== "string" || voteParams.voterId.length === 0) {
+        invalidParams("invalid voterId: expected non-empty string")
+      }
+      if (typeof voteParams.approve !== "boolean") {
+        invalidParams("invalid approve: expected boolean (true|false), not coerced from string/number")
+      }
+      const proposalId = voteParams.proposalId
+      const voterId = voteParams.voterId
+      const approve = voteParams.approve
       // Only the local node can vote via RPC
       const localVoterId = (opts as Record<string, unknown>)?.nodeId as string | undefined
-      if (localVoterId && String(voteParams.voterId) !== localVoterId) {
+      if (localVoterId && voterId !== localVoterId) {
         throw { code: -32003, message: "unauthorized: can only vote as local node" }
       }
-      chain.governance.vote(
-        String(voteParams.proposalId),
-        String(voteParams.voterId),
-        Boolean(voteParams.approve),
-      )
-      const updated = chain.governance.getProposal(String(voteParams.proposalId))
+      chain.governance.vote(proposalId, voterId, approve)
+      const updated = chain.governance.getProposal(proposalId)
       return {
         id: updated?.id,
         status: updated?.status,


### PR DESCRIPTION
## Summary

- Closes #290.
- `coc_voteProposal` wrapped every field with `String()` / `Boolean()`. The `Boolean(voteParams.approve)` coercion is the dangerous one — `Boolean("false") === true`, so a client passing the string `"false"` recorded a YES vote when it meant NO. Vote-direction flip on a governance decision.
- Auth gates this to the local nodeId, so external attackers can't trigger it without spoofing nodeId. But operator scripts that build payloads from env/config and pass `approve` as a string flipped every vote on their validator.
- Same anti-pattern family as #260 (includeTx) / #220 (NPE chain).

## Files

- `node/src/rpc.ts:1937-1968` — three explicit type checks: `typeof proposalId/voterId === "string"` (non-empty), `typeof approve === "boolean"` (no coercion). All reject with `-32602`.
- `node/src/rpc-extended.test.ts` — subtest `#290`:
  - 12 bad `approve` shapes (`"false"/"true"/"no"/"yes"/"0"/"1"/0/1/{}/[]/null/undefined`) all reject with -32602.
  - 8 bad `proposalId` AND `voterId` shapes (`undefined/null/number/bool/{}/array/empty`) all reject with -32602.
  - Counter-check: no invalid input reaches the governance.vote stub.
  - **KEY direction invariant**: `approve:true` records exactly `true`, `approve:false` records exactly `false` — pre-fix `"false"` would have recorded `true`.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 95/95 pass (94 pre-existing + 1 new).
- The new test fails pre-fix on every direction-flip case at the `assert.equal(r.error?.code, -32602, ...)` line.

## Threat class

CWE-704 (Incorrect Type Conversion). Same lens as #260 / #220 family.