### PR TITLE
fix(runtime): cap coc-node /pose/* body at 1 MB — OOM DoS (#292)

### DIFF
--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "./lib/config.ts";
 import { InMemoryStore } from "./lib/state.ts";
 import { IpfsBlockstore } from "../node/src/ipfs-blockstore.ts";
 import { loadStorageProof, MerkleLeavesCache } from "./lib/storage-proof.ts";
+import { readBoundedBody } from "./lib/pose-body-reader.ts";
 import { createNodeSigner, createNodeSignerV2, buildReceiptSignMessage } from "../node/src/crypto/signer.ts";
 import { keccak256Hex } from "../services/relayer/keccak256.ts";
 import { createLogger } from "../node/src/logger.ts";
@@ -109,6 +110,14 @@ function json(res: http.ServerResponse, code: number, payload: unknown): void {
   res.end(JSON.stringify(payload));
 }
 
+// #292: cap body accumulation via runtime/lib/pose-body-reader.ts —
+// pre-fix the three POST endpoints (/pose/challenge, /pose/receipt,
+// /pose/witness) used `let body = ""; req.on("data", c => body += c)`
+// with no size cap and no stream-error handler. The HTTP-side
+// pose-http.ts already enforces 1 MB via MAX_POSE_BODY; the shared
+// helper mirrors that on the runtime path so any future endpoint added
+// here inherits the cap by default.
+
 const server = http.createServer((req, res) => {
   if (!req.url) {
     return json(res, 404, { error: "not found" });
@@ -119,9 +128,11 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === "POST" && req.url === "/pose/challenge") {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
-    req.on("end", () => {
+    // #292: body bounded via readBody (1 MB cap). Pre-fix this was
+    // `let body = ""; req.on("data", c => body += c)` with no size
+    // check — an attacker streaming a multi-GB body could OOM the
+    // process.
+    readBoundedBody(req, res, (body) => {
       // #222: wrap JSON.parse — pre-fix a malformed body threw inside
       // the async callback and bubbled to process.on("uncaughtException"),
       // either crashing coc-node or leaking the V8 SyntaxError wording.
@@ -142,9 +153,9 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.method === "POST" && req.url === "/pose/receipt") {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
-    req.on("end", () => {
+    // #292: body bounded via readBody (1 MB cap). Same DoS class as
+    // /pose/challenge — pre-fix used unbounded body accumulation.
+    readBoundedBody(req, res, (body) => {
       // #222: parity with /pose/challenge — wrap JSON.parse so a
       // malformed body returns 400 instead of crashing the process.
       let payload: { challengeId?: string; challengeType?: string; payload?: unknown };
@@ -304,9 +315,9 @@ const server = http.createServer((req, res) => {
     if (!nodeSignerV2) {
       return json(res, 501, { error: "v2 protocol not enabled" });
     }
-    let body = "";
-    req.on("data", (chunk: string) => (body += chunk));
-    req.on("end", () => {
+    // #292: body bounded via readBody (1 MB cap). Same DoS class as
+    // /pose/challenge — pre-fix used unbounded body accumulation.
+    readBoundedBody(req, res, (body) => {
       // #222: parity with the other two POST endpoints — wrap
       // JSON.parse so a malformed body returns 400 instead of
       // crashing the process via uncaughtException.

--- a/runtime/lib/pose-body-reader.test.ts
+++ b/runtime/lib/pose-body-reader.test.ts
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { readBoundedBody, MAX_RUNTIME_POSE_BODY } from "./pose-body-reader.ts";
+
+// #292: end-to-end test of the bounded body reader. Pre-fix coc-node.ts's
+// /pose/* POSTs accumulated the request body with no size cap — a
+// multi-GB body OOMed the process. This helper now enforces a 1 MB cap
+// (matching node/src/pose-http.ts MAX_POSE_BODY) so the runtime path is
+// symmetric with the HTTP-server path.
+//
+// We spin up a tiny http.Server that mounts readBoundedBody on POST /,
+// then exercise: (a) small body roundtrips, (b) over-cap rejects 413,
+// (c) at-cap accepts, (d) callback never fires on over-cap.
+
+test("readBoundedBody — small body roundtrips", async (t) => {
+  let received = ""
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST") {
+      res.writeHead(404)
+      res.end()
+      return
+    }
+    readBoundedBody(req, res, (body) => {
+      received = body
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ ok: true, len: body.length }))
+    })
+  })
+  server.listen(0)
+  await once(server, "listening")
+  const port = (server.address() as { port: number }).port
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  const body = JSON.stringify({ hello: "world" })
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST", headers: { "content-type": "application/json" }, body,
+  })
+  assert.equal(res.status, 200)
+  const data = await res.json() as { ok: boolean; len: number }
+  assert.equal(data.ok, true)
+  assert.equal(data.len, body.length)
+  assert.equal(received, body)
+})
+
+test("readBoundedBody — body exactly at cap accepts", async (t) => {
+  let callbackFired = false
+  const cap = 1024 // small cap so tests stay fast
+  const server = http.createServer((req, res) => {
+    readBoundedBody(req, res, (body) => {
+      callbackFired = true
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ ok: true, len: body.length }))
+    }, cap)
+  })
+  server.listen(0)
+  await once(server, "listening")
+  const port = (server.address() as { port: number }).port
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  // Body of exactly `cap` bytes — must accept (boundary is `> cap` not `>= cap`).
+  const body = "x".repeat(cap)
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST", body,
+  })
+  assert.equal(res.status, 200)
+  const data = await res.json() as { ok: boolean; len: number }
+  assert.equal(data.len, cap)
+  assert.equal(callbackFired, true, "callback must fire at exactly cap bytes")
+})
+
+test("readBoundedBody — body over cap rejects 413, callback never fires", async (t) => {
+  let callbackFired = false
+  const cap = 1024
+  const server = http.createServer((req, res) => {
+    readBoundedBody(req, res, (_body) => {
+      callbackFired = true
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ ok: true }))
+    }, cap)
+  })
+  server.listen(0)
+  await once(server, "listening")
+  const port = (server.address() as { port: number }).port
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  // 2x cap — must reject with 413, callback must NOT fire.
+  const body = "x".repeat(cap * 2)
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST", body,
+  })
+  assert.equal(res.status, 413, "over-cap body must be 413, not 200")
+  const data = await res.json() as { error?: string }
+  assert.match(data.error ?? "", /body too large/i,
+    `error must say "body too large", got ${JSON.stringify(data)}`)
+  // Give the server a brief moment to settle (no callback should have fired).
+  await new Promise((r) => setTimeout(r, 50))
+  assert.equal(callbackFired, false,
+    "KEY invariant: callback must NEVER fire when body exceeds cap (this is the DoS gate)")
+})
+
+test("readBoundedBody — default cap is 1 MB (MAX_RUNTIME_POSE_BODY)", () => {
+  assert.equal(MAX_RUNTIME_POSE_BODY, 1024 * 1024,
+    "default cap must match HTTP-side pose-http.ts MAX_POSE_BODY (1 MB) for symmetric DoS protection")
+})
+
+test("readBoundedBody — empty body roundtrips with empty string", async (t) => {
+  let received: string | null = null
+  const server = http.createServer((req, res) => {
+    readBoundedBody(req, res, (body) => {
+      received = body
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ ok: true, len: body.length }))
+    })
+  })
+  server.listen(0)
+  await once(server, "listening")
+  const port = (server.address() as { port: number }).port
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  const res = await fetch(`http://127.0.0.1:${port}/`, { method: "POST" })
+  assert.equal(res.status, 200)
+  assert.equal(received, "")
+})

--- a/runtime/lib/pose-body-reader.ts
+++ b/runtime/lib/pose-body-reader.ts
@@ -1,0 +1,62 @@
+// #292: bounded HTTP request body reader for coc-node's /pose/* POST
+// endpoints. Pre-fix the runtime used `let body = ""; req.on("data", c =>
+// body += c)` with no size cap and no stream-error handler — an attacker
+// streaming a multi-GB body could OOM the coc-node process and halt
+// PoSe reception. node/src/pose-http.ts already enforces 1 MB via
+// MAX_POSE_BODY; this is the runtime-side symmetric cap.
+import type http from "node:http";
+
+export const MAX_RUNTIME_POSE_BODY = 1024 * 1024; // 1 MB
+
+interface JsonRes {
+  writeHead(code: number, headers?: Record<string, string>): void;
+  end(body?: string): void;
+}
+
+function writeJson(res: JsonRes, code: number, payload: unknown): void {
+  res.writeHead(code, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+/**
+ * Accumulate the request body into a single string, bounded by
+ * MAX_RUNTIME_POSE_BODY. Calls onBody only once the full body has been
+ * received within the cap. If the cap is exceeded, responds 413 and
+ * destroys the request stream — onBody is NOT invoked.
+ *
+ * Also handles stream errors with a 400 response, so a half-sent body
+ * from a misbehaving client doesn't leave the response hanging.
+ */
+export function readBoundedBody(
+  req: http.IncomingMessage,
+  res: JsonRes,
+  onBody: (body: string) => void,
+  maxBytes: number = MAX_RUNTIME_POSE_BODY,
+): void {
+  let body = "";
+  let aborted = false;
+  req.on("data", (chunk: Buffer | string) => {
+    if (aborted) return;
+    body += typeof chunk === "string" ? chunk : chunk.toString();
+    if (body.length > maxBytes) {
+      aborted = true;
+      writeJson(res, 413, {
+        error: `body too large: ${body.length} > ${maxBytes} (max ${maxBytes / 1024} KB)`,
+      });
+      req.destroy();
+    }
+  });
+  req.on("end", () => {
+    if (!aborted) onBody(body);
+  });
+  req.on("error", () => {
+    if (!aborted) {
+      aborted = true;
+      try {
+        writeJson(res, 400, { error: "request stream error" });
+      } catch {
+        /* response may already be closed */
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Closes #292.
- `runtime/coc-node.ts`'s three POST endpoints (`/pose/challenge`, `/pose/receipt`, `/pose/witness`) accumulated request bodies with no size cap and no stream-error handler. A multi-GB body (or many slow-loris connections) could OOM the coc-node process and halt PoSe reception on that validator.
- `node/src/pose-http.ts` already enforces `MAX_POSE_BODY = 1 MB` — this mirrors the cap on the runtime path so the two layers are symmetric and any future `/pose/*` endpoint inherits the cap by default.
- Same threat class as #288 (eth_compileSolidity event-loop DoS) and #265 (eth_getProof unbounded keys).

## Files

- `runtime/lib/pose-body-reader.ts` (new): exports `readBoundedBody` + `MAX_RUNTIME_POSE_BODY = 1 MB`. The helper sets an `aborted` flag so the original callback **never fires** after the cap is exceeded — otherwise the post-cap business logic would still run against a partial body.
- `runtime/lib/pose-body-reader.test.ts` (new): 5 subtests — small body roundtrip, exactly-at-cap acceptance, **over-cap rejection (KEY invariant: callback must NOT fire)**, default cap value, empty body.
- `runtime/coc-node.ts:8` import the helper; lines 130-152, 155-343, 348-394 (all three endpoints) now route through `readBoundedBody(req, res, (body) => {...})` instead of the unbounded `req.on('data', c => body += c)`.

## Test plan

- [x] `node --experimental-strip-types --test runtime/lib/pose-body-reader.test.ts` — 5/5 pass
- [x] `node --experimental-strip-types --test runtime/coc-relayer.test.ts` — 4/4 still pass (no regression on the only other runtime test that exercises HTTP wiring)
- [ ] Post-deploy live verify: `curl --data-binary @<2MB-file>` against `/pose/challenge` returns 413 instead of OOMing the validator.

## Threat class

CWE-770 (Allocation of Resources Without Limits) + CWE-400. Same lens as #288 and #265.