### PR TITLE
fix(rpc): harden 9 debug_/trace_ handlers — strict shapes + structured errors (#294)

### DIFF
--- a/node/src/rpc-debug-compatibility.test.ts
+++ b/node/src/rpc-debug-compatibility.test.ts
@@ -1348,4 +1348,75 @@ describe("RPC debug compatibility", () => {
     assert.ok(Array.isArray(decoded.txs))
     assert.equal(decoded.txs.length, 1)
   })
+
+  it("#294: debug_/trace_ tx-hash handlers reject malformed shapes upfront (no String() coercion → -32603 leak)", async () => {
+    // Pre-fix 6 tx-hash-taking debug/trace handlers used
+    //   `const txHash = String((payload.params ?? [])[0] ?? "") as Hex`
+    // which silently coerced numbers/arrays/objects/undefined to
+    // "123"/"x,y"/"[object Object]"/"". Some then threw plain Error
+    // ("transaction not found: <coerced garbage>") which leaked
+    // through the outer -32603 catch with the coerced input echoed back.
+    // Post-fix: requireTxHashParam → -32602 with /^0x[0-9a-fA-F]{64}$/
+    // error, structured -32004 for legitimate-shape-but-not-found.
+    const txHashMethods = [
+      "debug_traceTransaction",
+      "trace_transaction",
+      "trace_replayTransaction",
+      "trace_get",
+      "debug_getRawTransaction",
+    ]
+    const badShapes = [
+      undefined, null, 123, true, false, 1.5, {}, [],
+      "0x", "0x123", "0x" + "g".repeat(64), "not-a-hex",
+    ]
+    for (const method of txHashMethods) {
+      for (const bad of badShapes) {
+        const params = method === "trace_get" ? [bad, []] : [bad]
+        try {
+          await rpc.handleRpcMethod(method, params, CHAIN_ID, evm, engine, p2p)
+          assert.fail(`${method}(${JSON.stringify(bad)}) should have thrown`)
+        } catch (err) {
+          const rpcErr = err as { code?: number; message?: string }
+          assert.equal(rpcErr.code, -32602,
+            `${method}(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(err)}`)
+          assert.match(rpcErr.message ?? "", /transaction hash|expected string/i,
+            `${method} error must name the field; got: ${rpcErr.message}`)
+        }
+      }
+    }
+    // Block-tag handlers: same family, but they were already lenient via
+    // resolveBlockNumber/parseBlockTag. The pre-fix String() wrapper let
+    // single-element arrays through (#256 family); dropping it routes
+    // them to parseBlockTag's strict rejection.
+    const blockTagMethods = [
+      "debug_traceBlockByNumber",
+      "trace_replayBlockTransactions",
+      "trace_block",
+    ]
+    const badTags = [{}, true, [123], { foo: "bar" }]
+    for (const method of blockTagMethods) {
+      for (const bad of badTags) {
+        const params = method === "trace_replayBlockTransactions" ? [bad, []] : [bad]
+        try {
+          await rpc.handleRpcMethod(method, params, CHAIN_ID, evm, engine, p2p)
+          assert.fail(`${method}(${JSON.stringify(bad)}) should have thrown`)
+        } catch (err) {
+          const rpcErr = err as { code?: number; message?: string }
+          assert.equal(rpcErr.code, -32602,
+            `${method}(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(err)}`)
+        }
+      }
+    }
+    // trace_rawTransaction: strict 0x-hex string.
+    for (const bad of [undefined, null, 123, true, "not-hex", "0xZZ", "0x1"]) {
+      try {
+        await rpc.handleRpcMethod("trace_rawTransaction", [bad, []], CHAIN_ID, evm, engine, p2p)
+        assert.fail(`trace_rawTransaction(${JSON.stringify(bad)}) should have thrown`)
+      } catch (err) {
+        const rpcErr = err as { code?: number; message?: string }
+        assert.equal(rpcErr.code, -32602,
+          `trace_rawTransaction(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(err)}`)
+      }
+    }
+  })
 })

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1183,7 +1183,12 @@ async function handleRpc(
     }
     case "debug_traceTransaction": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const txHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #294: pre-fix `String((payload.params)[0] ?? "") as Hex` silently
+      // coerced number/array/object inputs to "123"/"x,y"/"[object Object]"
+      // — none of which match any real tx hash, so the lookup returned
+      // "tx not found" with the coerced garbage leaked back. Same family
+      // as #260/#262.
+      const txHash = requireTxHashParam(payload.params ?? [], 0)
       const traceOpts = ((payload.params ?? [])[1] ?? {}) as Record<string, unknown>
       const traceResult = await traceTransactionResult(txHash, chain, evm, {
         disableStorage: Boolean(traceOpts.disableStorage),
@@ -1195,8 +1200,13 @@ async function handleRpc(
     }
     case "debug_traceBlockByNumber": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const blockTag = String((payload.params ?? [])[0] ?? "latest")
-      const traceBlockNum = await resolveBlockNumber(blockTag, chain)
+      // #294: drop the String() coercion wrapper — resolveBlockNumber
+      // (via parseBlockTag) already enforces the spec shape and rejects
+      // arrays/objects/numbers per JSON-RPC #194. Pre-fix `String([42])`
+      // = "42" silently became block 42; `String({})` = "[object Object]"
+      // surfaced as "invalid block number" but with the coerced garbage
+      // leaked into the error message.
+      const traceBlockNum = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const traceOpts2 = ((payload.params ?? [])[1] ?? {}) as Record<string, unknown>
       const traced = await traceBlockTransactions(traceBlockNum, chain, evm, {
         disableStorage: Boolean(traceOpts2.disableStorage),
@@ -1211,10 +1221,14 @@ async function handleRpc(
     }
     case "trace_transaction": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const txHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #294: strict shape + structured -32004 for not-found. Pre-fix
+      // `String(...) as Hex` accepted garbage and the plain Error
+      // (`transaction not found: <coerced input>`) bubbled as -32603
+      // with the input leaked back to the caller.
+      const txHash = requireTxHashParam(payload.params ?? [], 0)
       const txContext = await locateTraceTransactionContext(chain, txHash)
       if (!txContext) {
-        throw new Error(`transaction not found: ${txHash}`)
+        throw { code: -32004, message: `transaction not found: ${txHash}` }
       }
       const result = await traceTransactionResult(txHash, chain, evm)
       return formatLocalizedOpenEthereumCallTraces(result.callTraces, txContext)
@@ -1248,33 +1262,44 @@ async function handleRpc(
     }
     case "trace_replayTransaction": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const txHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #294: strict tx-hash validation (same family as trace_transaction).
+      const txHash = requireTxHashParam(payload.params ?? [], 0)
       const traceTypes = normalizeReplayTraceTypes((payload.params ?? [])[1])
       const result = await traceTransactionResult(txHash, chain, evm)
       return formatTraceReplayResult(result, traceTypes)
     }
     case "trace_replayBlockTransactions": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const blockTag = String((payload.params ?? [])[0] ?? "latest")
+      // #294: drop String() coercion wrapper (same as debug_traceBlockByNumber).
       const traceTypes = normalizeReplayTraceTypes((payload.params ?? [])[1])
-      const blockNumber = await resolveBlockNumber(blockTag, chain)
+      const blockNumber = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const results = await traceBlockTransactions(blockNumber, chain, evm)
       return results.map((result) => formatTraceReplayResult(result, traceTypes))
     }
     case "trace_rawTransaction": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const rawTx = String((payload.params ?? [])[0] ?? "")
+      // #294: strict 0x-hex string; pre-fix String() let bool/number/array
+      // through and traceRawTxOnState failed downstream with a leaked
+      // V8 / ethers error.
+      const rawTxParam = (payload.params ?? [])[0]
+      if (typeof rawTxParam !== "string" || rawTxParam.length === 0) {
+        invalidParams("invalid raw transaction: expected non-empty 0x-prefixed hex string")
+      }
+      if (!/^0x[0-9a-fA-F]+$/.test(rawTxParam) || rawTxParam.length % 2 !== 0) {
+        invalidParams("invalid raw transaction: must be even-length 0x-prefixed hex")
+      }
+      const rawTx = rawTxParam
       const traceTypes = normalizeReplayTraceTypes((payload.params ?? [])[1])
       const result = await evm.traceRawTxOnState(rawTx)
       return formatTraceReplayResult(result, traceTypes)
     }
     case "trace_block": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const blockTag = String((payload.params ?? [])[0] ?? "latest")
-      const blockNumber = await resolveBlockNumber(blockTag, chain)
+      // #294: drop String() coercion; structured -32004 for not-found.
+      const blockNumber = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const block = await Promise.resolve(chain.getBlockByNumber(blockNumber))
       if (!block) {
-        throw new Error(`block not found: ${blockTag}`)
+        throw { code: -32004, message: `block not found: ${blockNumber}` }
       }
       const traces = await traceBlockTransactions(blockNumber, chain, evm)
       return traces.flatMap((traceResult, txIndex) =>
@@ -1293,11 +1318,12 @@ async function handleRpc(
     }
     case "trace_get": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const txHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #294: strict tx-hash validation + structured -32004 for not-found.
+      const txHash = requireTxHashParam(payload.params ?? [], 0)
       const traceAddress = normalizeTraceAddressPath((payload.params ?? [])[1])
       const txContext = await locateTraceTransactionContext(chain, txHash)
       if (!txContext) {
-        throw new Error(`transaction not found: ${txHash}`)
+        throw { code: -32004, message: `transaction not found: ${txHash}` }
       }
       const result = await traceTransactionResult(txHash, chain, evm)
       const matched = result.callTraces.find((callTrace) =>
@@ -1317,7 +1343,8 @@ async function handleRpc(
       }
     case "debug_getRawTransaction": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const rawTxHash = String((payload.params ?? [])[0] ?? "") as Hex
+      // #294: strict tx-hash validation (same family as debug_traceTransaction).
+      const rawTxHash = requireTxHashParam(payload.params ?? [], 0)
       // Find block containing the transaction
       if (typeof chain.getTransactionByHash === "function") {
         const txRecord = await chain.getTransactionByHash(rawTxHash)


### PR DESCRIPTION
## Summary

- Closes #294.
- 9 debug_/trace_ handlers used `String((payload.params)[0] ?? '...')` to coerce txHash/blockTag/rawTx params. Wrong-shape inputs (number/array/object/undefined) silently became plausible-looking strings and either leaked back via plain `Error("not found: <garbage>")` (-32603 with input visible) or hit downstream V8 errors.
- `COC_DEBUG_RPC=1` (devnet default) exposes the entire surface.
- Same anti-pattern family as #260/#262/#150 silent-coercion cleanup.

## Files

- `node/src/rpc.ts` — 9 handlers rerouted:
  - 5 tx-hash handlers → `requireTxHashParam(payload.params, 0)`
  - 3 block-tag handlers → drop the `String()` wrapper (`resolveBlockNumber(unknown, chain)` already enforces spec via `parseBlockTag`)
  - 1 raw-tx handler (`trace_rawTransaction`) → explicit `/^0x[0-9a-fA-F]+$/` even-length check
  - 3 plain `Error("not found: <input>")` throws → structured `{code: -32004, message: ...}`
- `node/src/rpc-debug-compatibility.test.ts` — subtest `#294` covers 60 tx-hash assertions (12 bad shapes × 5 methods), 12 block-tag assertions (4 bad shapes × 3 methods), 7 raw-tx assertions.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-debug-compatibility.test.ts` — 24/24 pass (23 pre-existing + 1 new)
- [x] Combined `rpc.test + rpc-extended + rpc-data-accuracy + rpc-debug-compatibility` — 140/140 pass (no regression)

## Threat class

CWE-704 (Incorrect Type Conversion) + CWE-209 (Error Information Exposure). Gated behind `COC_DEBUG_RPC=1` so production default config is safe; devnets and debug-RPC-enabled indexers are exposed.