### PR TITLE
fix(rpc): coc_submitProposal strict field validation (#296)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2946,6 +2946,22 @@ test("RPC Extended Methods", async (t) => {
       getProposal: () => ({ id: "p1", status: "pending", votes: new Map() }),
     } as Record<string, unknown>
     ;(chain as unknown as Record<string, unknown>).governance = governanceStub290
+  })
+
+  await t.test("#296: coc_submitProposal rejects non-string type/targetId/proposer and bad targetAddress", async () => {
+    // Pre-fix `as Record<string, string>` was a runtime no-op so
+    // proposalParams.type/targetId/targetAddress flowed into
+    // chain.governance.submitProposal() with whatever shape the
+    // client sent. Same anti-pattern as #290 (coc_voteProposal field
+    // strict validation). Validate each required string upfront.
+    const submittedCalls: Array<{ type: string; targetId: string; proposer: string; opts: Record<string, unknown> }> = []
+    const governanceStub296 = {
+      submitProposal: (type: string, targetId: string, proposer: string, opts: Record<string, unknown>) => {
+        submittedCalls.push({ type, targetId, proposer, opts })
+        return { id: "p1", type, targetId, status: "pending" }
+      },
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub296
     try {
       const probe = async (params: unknown[]) => {
         const r = await fetch(`http://127.0.0.1:${port}`, {
@@ -3103,6 +3119,46 @@ test("RPC Extended Methods", async (t) => {
       assert.equal(recordedVotes[0].approve, true, "YES vote must be exactly true")
       assert.equal(recordedVotes[1].approve, false,
         "NO vote must be exactly false — this is the direction-flip invariant")
+  })
+
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_submitProposal", params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      const base = { type: "add_validator", targetId: "v4", proposer: "node-1" }
+      const badStringShapes = [undefined, null, 123, true, {}, [], ""]
+      for (const bad of badStringShapes) {
+        const rType = await probe([{ ...base, type: bad }])
+        assert.equal(rType.error?.code, -32602,
+          `type=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rType)}`)
+        const rTarget = await probe([{ ...base, targetId: bad }])
+        assert.equal(rTarget.error?.code, -32602,
+          `targetId=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rTarget)}`)
+        const rProposer = await probe([{ ...base, proposer: bad }])
+        assert.equal(rProposer.error?.code, -32602,
+          `proposer=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rProposer)}`)
+      }
+      // targetAddress optional, but wrong-shape must reject.
+      const validAddr = `0x${"ab".repeat(20)}`
+      for (const bad of ["0x", "0x1", "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", validAddr.slice(0, -1), 123, true, {}]) {
+        const r = await probe([{ ...base, targetAddress: bad }])
+        assert.equal(r.error?.code, -32602,
+          `targetAddress=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+      }
+      // None of the rejects should have reached the stub.
+      assert.equal(submittedCalls.length, 0,
+        "no invalid proposal should have reached governance.submitProposal()")
+      // Sanity: well-shaped proposal succeeds; stub records it; addr passes verbatim.
+      const ok = await probe([{ type: "add_validator", targetId: "v4", proposer: "node-1", targetAddress: validAddr }])
+      assert.equal(ok.error, undefined, `well-shaped proposal must succeed, got ${JSON.stringify(ok)}`)
+      assert.equal(submittedCalls.length, 1)
+      assert.equal(submittedCalls[0].type, "add_validator")
+      assert.equal(submittedCalls[0].opts.targetAddress, validAddr,
+        "targetAddress must pass through verbatim")
+      // Sanity: omitted targetAddress succeeds and stub sees undefined.
+      const okOmit = await probe([{ type: "add_validator", targetId: "v5", proposer: "node-1" }])
+      assert.equal(okOmit.error, undefined, `omitted targetAddress must succeed, got ${JSON.stringify(okOmit)}`)
+      assert.equal(submittedCalls[1].opts.targetAddress, undefined)
     } finally {
       delete (chain as unknown as Record<string, unknown>).governance
     }

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2186,7 +2186,31 @@ async function handleRpc(
       if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
         invalidParams("invalid params: expected non-null object as first param")
       }
-      const proposalParams = rawParams as Record<string, string>
+      const proposalParams = rawParams as Record<string, unknown>
+      // #296: pre-fix `as Record<string, string>` was a runtime no-op so
+      // type:123/targetId:[]/targetAddress:{} silently flowed into
+      // governance.submitProposal() — the resulting proposal record
+      // stored a non-string in its type field, and downstream filters
+      // / serializers either rejected via -32603 V8 errors or echoed
+      // the coerced garbage back. Same anti-pattern family as #290
+      // (coc_voteProposal Boolean(approve) flip). Validate each
+      // required string field upfront so bogus shapes get -32602.
+      if (typeof proposalParams.type !== "string" || proposalParams.type.length === 0) {
+        invalidParams("invalid type: expected non-empty string")
+      }
+      if (typeof proposalParams.targetId !== "string" || proposalParams.targetId.length === 0) {
+        invalidParams("invalid targetId: expected non-empty string")
+      }
+      if (typeof proposalParams.proposer !== "string" || proposalParams.proposer.length === 0) {
+        invalidParams("invalid proposer: expected non-empty string")
+      }
+      // targetAddress is optional; when present must be a strict 20-byte hex.
+      if (proposalParams.targetAddress !== undefined && proposalParams.targetAddress !== null) {
+        if (typeof proposalParams.targetAddress !== "string" ||
+            !/^0x[0-9a-fA-F]{40}$/.test(proposalParams.targetAddress)) {
+          invalidParams("invalid targetAddress: must match /^0x[0-9a-fA-F]{40}$/ or be omitted")
+        }
+      }
       // Only the local node can submit proposals via RPC
       const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
       if (localNodeId && proposalParams.proposer !== localNodeId) {
@@ -2210,11 +2234,11 @@ async function handleRpc(
         stakeAmount = BigInt(stakeRaw as string | number)
       }
       const proposal = chain.governance.submitProposal(
-        proposalParams.type,
-        proposalParams.targetId,
-        proposalParams.proposer,
+        proposalParams.type as string,
+        proposalParams.targetId as string,
+        proposalParams.proposer as string,
         {
-          targetAddress: proposalParams.targetAddress,
+          targetAddress: proposalParams.targetAddress as string | undefined,
           stakeAmount,
         },
       )


### PR DESCRIPTION
## Summary

- Closes #296.
- `coc_submitProposal` cast params as `Record<string, string>` — runtime no-op. type/targetId/targetAddress could be any shape and flowed silently into `chain.governance.submitProposal()`. Downstream filters/serializers either rejected via -32603 V8 errors or echoed garbage back.
- Same anti-pattern family as #290 (coc_voteProposal Boolean(approve) flip).
- Gated by localNodeId auth (operator-only), but bad payloads from programmatic scripts that pass `type:1` instead of `type:"add_validator"` silently corrupted governance state.

## Files

- `node/src/rpc.ts:1886-1923` — switched cast to `Record<string, unknown>`; four explicit type checks before `submitProposal()`:
  - `type` / `targetId` / `proposer` — non-empty string
  - `targetAddress` (optional) — strict 20-byte hex `0x[0-9a-fA-F]{40}` when present
- `node/src/rpc-extended.test.ts` — subtest `#296`: 7 bad shapes × 3 required string fields (21 assertions), 7 bad targetAddress shapes, 2 sanity (well-shaped with addr passes verbatim; omitted addr succeeds). Counter-check: no invalid input reaches the governance.submitProposal stub.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 95/95 pass.

## Threat class

CWE-704 (Incorrect Type Conversion). Same lens as #290 / #260 silent-coercion cleanup.