### PR TITLE
fix(verifier): verify challenger sig before consuming nonce (#298)

### DIFF
--- a/services/verifier/receipt-verifier-v2.ts
+++ b/services/verifier/receipt-verifier-v2.ts
@@ -65,27 +65,15 @@ export class ReceiptVerifierV2 {
     receipt: ReceiptMessageV2,
     witnesses: WitnessAttestation[],
   ): Promise<VerificationResultV2> {
-    // Layer 1: Nonce replay check
-    if (this.deps.nonceRegistry) {
-      const v1Like = {
-        challengeId: challenge.challengeId,
-        epochId: challenge.epochId,
-        nodeId: challenge.nodeId,
-        challengeType: challenge.challengeType,
-        nonce: challenge.nonce,
-        randSeed: "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex32,
-        issuedAtMs: challenge.issuedAtMs,
-        deadlineMs: challenge.deadlineMs,
-        querySpec: challenge.querySpec,
-        challengerId: challenge.challengerId,
-        challengerSig: challenge.challengerSig,
-      }
-      if (!this.deps.nonceRegistry.consume(v1Like)) {
-        return { ok: false, reason: "nonce replay detected", resultCode: ResultCode.NonceMismatch }
-      }
-    }
+    // #298: Layer 1 was "consume nonce", Layer 2 was "verify sig". Swapped
+    // so we never poison the nonce registry on a failed-sig attempt.
+    // Same defensive ordering as receipt-verifier.ts:28. Currently this
+    // path is reached only from local-trusted callers (pose-engine,
+    // coc-agent), so the attack isn't reachable today, but moving the
+    // sig check first is fail-fast and survives any future externally-
+    // reachable receipt endpoint.
 
-    // Layer 2: Challenger EIP-712 sig verify
+    // Layer 1: Challenger EIP-712 sig verify
     const challengeTypeNum = challenge.challengeType === "U" ? 0 : challenge.challengeType === "S" ? 1 : 2
     const challengeData = {
       challengeId: challenge.challengeId,
@@ -107,6 +95,26 @@ export class ReceiptVerifierV2 {
       challengerAddr,
     )) {
       return { ok: false, reason: "invalid challenger EIP-712 signature", resultCode: ResultCode.InvalidSig }
+    }
+
+    // Layer 2: Nonce replay check (only consume after sig verified)
+    if (this.deps.nonceRegistry) {
+      const v1Like = {
+        challengeId: challenge.challengeId,
+        epochId: challenge.epochId,
+        nodeId: challenge.nodeId,
+        challengeType: challenge.challengeType,
+        nonce: challenge.nonce,
+        randSeed: "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex32,
+        issuedAtMs: challenge.issuedAtMs,
+        deadlineMs: challenge.deadlineMs,
+        querySpec: challenge.querySpec,
+        challengerId: challenge.challengerId,
+        challengerSig: challenge.challengerSig,
+      }
+      if (!this.deps.nonceRegistry.consume(v1Like)) {
+        return { ok: false, reason: "nonce replay detected", resultCode: ResultCode.NonceMismatch }
+      }
     }
 
     // Layer 3: Field matching

--- a/services/verifier/receipt-verifier.test.ts
+++ b/services/verifier/receipt-verifier.test.ts
@@ -76,3 +76,43 @@ test("receipt verifier rejects nonce replay", () => {
   assert.equal(second.ok, false)
   assert.equal(second.reason, "nonce replay detected")
 })
+
+test("#298: failed challenger-sig verify does NOT consume nonce (no poisoning)", () => {
+  // Pre-fix the verifier consumed the nonce BEFORE verifying the
+  // challenger signature. An attacker who submitted a (challenge,
+  // receipt) pair with a forged sig could poison the nonce so a
+  // legitimate challenger's later real receipt would get "nonce replay
+  // detected." Currently the call sites are local-trusted but the
+  // defensive ordering is fail-fast and survives future externally-
+  // reachable receipt endpoints.
+  let sigVerifyCalls = 0
+  const nonceRegistry = new NonceRegistry()
+  const verifier = new ReceiptVerifier({
+    nonceRegistry,
+    verifyChallengerSig: () => {
+      sigVerifyCalls++
+      // First call: bad sig (attacker's forged pair). Later calls: good.
+      return sigVerifyCalls > 1
+    },
+    verifyNodeSig: () => true,
+    verifyUptimeResult: () => true,
+  })
+
+  // Attempt 1: bad sig — must reject AND must NOT consume nonce.
+  const attack = verifier.verify(challenge, okReceipt)
+  assert.equal(attack.ok, false)
+  assert.equal(attack.reason, "invalid challenger signature",
+    "bad-sig must fail with sig reason, not nonce reason")
+
+  // Attempt 2: same nonce + good sig — must succeed.
+  // KEY invariant: nonce registry was not poisoned by the previous failed-sig attempt.
+  const legit = verifier.verify(challenge, okReceipt)
+  assert.equal(legit.ok, true,
+    `legitimate receipt with same nonce must still succeed after bad-sig attempt; got ${JSON.stringify(legit)}`)
+
+  // Attempt 3: same nonce a 3rd time — now nonce is legitimately consumed.
+  const replay = verifier.verify(challenge, okReceipt)
+  assert.equal(replay.ok, false)
+  assert.equal(replay.reason, "nonce replay detected",
+    "3rd attempt with same nonce must hit replay detection (this is the legit nonce-protection path)")
+})

--- a/services/verifier/receipt-verifier.ts
+++ b/services/verifier/receipt-verifier.ts
@@ -26,11 +26,22 @@ export class ReceiptVerifier {
   }
 
   verify(challenge: ChallengeMessage, receipt: ReceiptMessage): VerificationResult {
-    if (this.deps.nonceRegistry && !this.deps.nonceRegistry.consume(challenge)) {
-      return { ok: false, reason: "nonce replay detected" }
-    }
+    // #298: verify challenger signature BEFORE consuming the nonce.
+    // Pre-fix ordering consumed first then verified — an attacker who
+    // could inject (challenge, receipt) pairs with forged sigs (e.g. via
+    // a future externally-reachable receipt endpoint) would poison the
+    // nonce registry: their bogus-sig receipt consumed the nonce, then
+    // the real challenger's later receipt got "nonce replay detected"
+    // even though it was the legitimate one. Currently all callers
+    // (node/src/pose-engine.ts, runtime/coc-agent.ts) pair receipts with
+    // locally-issued challenges so the attack isn't reachable today, but
+    // the defensive ordering is fail-fast and survives future endpoints
+    // being added that take (challenge, receipt) from clients.
     if (!this.deps.verifyChallengerSig(challenge)) {
       return { ok: false, reason: "invalid challenger signature" }
+    }
+    if (this.deps.nonceRegistry && !this.deps.nonceRegistry.consume(challenge)) {
+      return { ok: false, reason: "nonce replay detected" }
     }
     if (receipt.challengeId !== challenge.challengeId || receipt.nodeId !== challenge.nodeId) {
       return { ok: false, reason: "challenge/receipt mismatch" }


### PR DESCRIPTION
## Summary

- Closes #298.
- Both `ReceiptVerifier` (v1) and `ReceiptVerifierV2` consumed the nonce **before** verifying the challenger signature. Fail-fast ordering violation + latent nonce-poisoning DoS surface if a future PR adds an externally-reachable receipt endpoint.
- Currently NOT exploitable (call sites at `pose-engine.ts:193,212` and `coc-agent.ts:1481` pair receipts with locally-issued challenges only), but the verifier shouldn't depend on its callers being trusted.
- Swap the order: sig first, then nonce. Same fix applied to v1 and v2.

## Files

- `services/verifier/receipt-verifier.ts:28-49` — sig verify before nonce consume.
- `services/verifier/receipt-verifier-v2.ts:67-118` — same swap (Layer 1 was nonce, Layer 2 was sig → swapped; nonce consume reborn as Layer 2 below sig).
- `services/verifier/receipt-verifier.test.ts` — subtest `#298` covers the three-attempt flow proving the **KEY invariant**: a failed-sig attempt does NOT consume the nonce, so a subsequent legitimate receipt with the same nonce still succeeds.

## Test plan

- [x] `node --experimental-strip-types --test services/verifier/receipt-verifier.test.ts` — 5/5 pass (4 pre-existing + 1 new).
- [x] All services tests (`find services -name '*.test.ts'`) — 142/142 pass (was 141 + 1 new).

## Threat class

CWE-696 (Incorrect Behavior Order) + CWE-913 (Improper Resource Control). Defensive hardening, latent DoS-class issue.

## Notes for reviewer

The v1 fix is a 3-line block swap. The v2 fix is structurally identical — Layer 1 and Layer 2 are renumbered (Layer 1 was nonce; now Layer 1 is sig). The `Hex32` import in v2 is still needed because the v1Like construction stays inside the nonce block.