### PR TITLE
fix(storage): block-index getLogs supports OR-set topic slot (#300)

### DIFF
--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3491,7 +3491,7 @@ async function queryLogs(chain: IChainEngine, query: Record<string, unknown>, re
       toBlock,
       address,
       addresses,
-      topics: topics as Array<Hex | null> | undefined,
+      topics: topics as Array<Hex | Hex[] | null> | undefined,
     })
     return results.slice(0, MAX_LOG_RESULTS)
   }

--- a/node/src/storage/block-index.test.ts
+++ b/node/src/storage/block-index.test.ts
@@ -208,6 +208,98 @@ test("BlockIndex: put and get logs", async () => {
   assert.strictEqual(byTopic[0].address, "0xbbbb")
 })
 
+test("#300: getLogs accepts OR-set topic slot (Array<Hex>) without TypeError", async () => {
+  // Pre-fix: matchLogFilter called expected.toLowerCase() unconditionally, so
+  // any caller passing a Hex[] OR-set (standard Ethereum eth_getLogs form,
+  // e.g. "topic[0] is Transfer OR Approval") crashed with
+  //   TypeError: expected.toLowerCase is not a function
+  // surfaced as JSON-RPC -32603 to the client. The bug shipped to 88780 testnet.
+  const db = new MemoryDatabase()
+  const index = new BlockIndex(db)
+
+  const logs: IndexedLog[] = [
+    {
+      address: "0xaaaa" as Hex,
+      topics: ["0xTRANSFER" as Hex, "0xfrom1" as Hex],
+      data: "0x01" as Hex,
+      blockNumber: 1n,
+      blockHash: "0xbh1" as Hex,
+      transactionHash: "0xtx1" as Hex,
+      transactionIndex: 0,
+      logIndex: 0,
+    },
+    {
+      address: "0xbbbb" as Hex,
+      topics: ["0xAPPROVAL" as Hex, "0xfrom2" as Hex],
+      data: "0x02" as Hex,
+      blockNumber: 1n,
+      blockHash: "0xbh1" as Hex,
+      transactionHash: "0xtx2" as Hex,
+      transactionIndex: 1,
+      logIndex: 1,
+    },
+    {
+      address: "0xcccc" as Hex,
+      topics: ["0xMINT" as Hex, "0xfrom3" as Hex],
+      data: "0x03" as Hex,
+      blockNumber: 1n,
+      blockHash: "0xbh1" as Hex,
+      transactionHash: "0xtx3" as Hex,
+      transactionIndex: 2,
+      logIndex: 2,
+    },
+  ]
+  await index.putBlock(createTestBlock(1))
+  await index.putLogs(1n, logs)
+
+  // OR-set at slot 0: should match Transfer OR Approval, NOT Mint
+  const orResult = await index.getLogs({
+    fromBlock: 1n,
+    toBlock: 1n,
+    topics: [["0xTRANSFER" as Hex, "0xAPPROVAL" as Hex]],
+  })
+  assert.strictEqual(orResult.length, 2,
+    `OR-set must match both Transfer and Approval; got ${orResult.length}`)
+  const addrs = orResult.map((l) => l.address).sort()
+  assert.deepStrictEqual(addrs, ["0xaaaa", "0xbbbb"])
+
+  // Single-element OR-set must behave like exact match
+  const singletonOr = await index.getLogs({
+    fromBlock: 1n,
+    toBlock: 1n,
+    topics: [["0xMINT" as Hex]],
+  })
+  assert.strictEqual(singletonOr.length, 1)
+  assert.strictEqual(singletonOr[0].address, "0xcccc")
+
+  // Empty OR-set must NOT crash and must NOT exclude (treated as null/any)
+  const emptyOr = await index.getLogs({
+    fromBlock: 1n,
+    toBlock: 1n,
+    topics: [[]],
+  })
+  assert.strictEqual(emptyOr.length, 3, "empty OR-set should not filter anything")
+
+  // Mixed: slot 0 OR-set + slot 1 exact must AND across slots
+  const mixed = await index.getLogs({
+    fromBlock: 1n,
+    toBlock: 1n,
+    topics: [["0xTRANSFER" as Hex, "0xAPPROVAL" as Hex], "0xfrom2" as Hex],
+  })
+  assert.strictEqual(mixed.length, 1,
+    "OR-set on slot 0 AND exact on slot 1 must yield only Approval-from2")
+  assert.strictEqual(mixed[0].address, "0xbbbb")
+
+  // KEY invariant: case-insensitive match still works inside OR-set
+  const caseInsensitive = await index.getLogs({
+    fromBlock: 1n,
+    toBlock: 1n,
+    topics: [["0xtransfer" as Hex, "0xAPPROVAL" as Hex]],
+  })
+  assert.strictEqual(caseInsensitive.length, 2,
+    "OR-set match must be case-insensitive like the single-topic path")
+})
+
 test("BlockIndex: getLogs across multiple blocks", async () => {
   const db = new MemoryDatabase()
   const index = new BlockIndex(db)

--- a/node/src/storage/block-index.ts
+++ b/node/src/storage/block-index.ts
@@ -67,7 +67,11 @@ export interface LogFilter {
   toBlock?: bigint
   address?: Hex
   addresses?: Hex[]
-  topics?: Array<Hex | null>
+  // Each topic slot accepts: null (any), single Hex (exact match), or Hex[] (OR-set
+  // — log matches if log.topics[i] equals ANY entry). Pre-#300 the inner-array
+  // form was dropped at the type level here and matchLogFilter crashed with
+  // "expected.toLowerCase is not a function" on any caller that passed it.
+  topics?: Array<Hex | Hex[] | null>
 }
 
 export interface AddressTxQuery {
@@ -558,9 +562,21 @@ function matchLogFilter(log: IndexedLog, filter: LogFilter): boolean {
   if (filter.topics && filter.topics.length > 0) {
     for (let i = 0; i < filter.topics.length; i++) {
       const expected = filter.topics[i]
-      if (!expected) continue
+      if (expected === null || expected === undefined) continue
       const actual = log.topics[i]
-      if (!actual || actual.toLowerCase() !== expected.toLowerCase()) return false
+      if (!actual) return false
+      const actualLower = actual.toLowerCase()
+      // #300: a topic slot may be a single Hex OR a Hex[] OR-set per the
+      // Ethereum eth_getLogs spec. Pre-fix this called expected.toLowerCase()
+      // unconditionally, throwing "expected.toLowerCase is not a function"
+      // when the caller passed the standard array form (e.g. matching either
+      // a Transfer or an Approval signature in topic[0]).
+      if (Array.isArray(expected)) {
+        if (expected.length === 0) continue
+        if (!expected.some((e) => typeof e === "string" && e.toLowerCase() === actualLower)) return false
+      } else {
+        if (actualLower !== expected.toLowerCase()) return false
+      }
     }
   }
   return true


### PR DESCRIPTION
Closes #300

## Summary

The persistent log-index path was missing OR-set topic support per Ethereum eth_getLogs spec, causing a raw V8 `TypeError: expected.toLowerCase is not a function` to leak as JSON-RPC -32603 on any query that uses `topics: [[topic1, topic2, ...]]`.

Live-reproducible on 88780 with the curl in #300.

## Changes

- `node/src/storage/block-index.ts`:
  - Widen `LogFilter.topics` from `Array<Hex | null>` to `Array<Hex | Hex[] | null>` so the type matches the spec and what `rpc.ts:queryLogs` actually passes.
  - `matchLogFilter` now branches on `Array.isArray(expected)`: if array, OR-match any entry (case-insensitive); if string, exact compare (unchanged). Empty array is treated as null/any so degenerate `[[]]` doesn't filter.
- `node/src/rpc.ts:queryLogs`: tighten the cast at the `chain.getLogs()` boundary so the inner-array shape is preserved instead of erased.
- `node/src/storage/block-index.test.ts`: new `#300` test with 5 assertions covering 2-entry OR-set, singleton OR-set, empty OR-set, mixed-with-exact AND across slots, and case-insensitive OR-set match.

## Test plan

- [x] `node --experimental-strip-types --test node/src/storage/block-index.test.ts` → 13/13 pass (including new #300 subtest at `ok 9`)
- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/rpc-extended.test.ts` → 99/99 pass (no RPC regression from the `Array<Hex | Hex[] | null>` cast)
- [x] Live curl reproducer in #300 returns the expected matches after fix (verified locally with MemoryDatabase fixture)

## Threat class

Functional bug + minor V8 internal-error leak. Same family as #294 (debug_/trace_ plain-Error leaks) but in the persistent-log-index path that bypasses the request-shape validators.