### PR TITLE
fix(ipfs-mfs): mkdir under a file rejects with ENOTDIR (#302)

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -189,3 +189,71 @@ test("MFS: cannot remove root directory", async () => {
     cleanup()
   }
 })
+
+test("#302: mkdir under an existing FILE must reject with 'not a directory'", async () => {
+  // Live-reproducible bug on 88780 testnet (probe iteration #37):
+  //   POST /api/v0/files/write?arg=/a/file.txt&create=true&parents=true   → 200
+  //   POST /api/v0/files/mkdir?arg=/a/file.txt/sub&parents=true           → 200 (BUG)
+  //   POST /api/v0/files/ls?arg=/a/file.txt                                → lists `sub` as child
+  // Pre-fix mkdir blindly overwrote the file entry in the parent dir
+  // with a `type:"directory"` entry, silently orphaning the UnixFS file
+  // content, and `this.dirs` and `parent.entries` then disagreed on the
+  // type of the same path. POSIX requires ENOTDIR here.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.mkdir("/a", { parents: true })
+    await mfs.write("/a/file.txt", new TextEncoder().encode("hello"), { create: true })
+
+    // KEY invariant 1: mkdir UNDER the file must reject
+    await assert.rejects(
+      () => mfs.mkdir("/a/file.txt/sub", { parents: true }),
+      /not a directory/,
+      "mkdir under a file must reject with 'not a directory' (POSIX ENOTDIR)",
+    )
+
+    // KEY invariant 2: even mkdir AT the file path must reject (no clobber)
+    await assert.rejects(
+      () => mfs.mkdir("/a/file.txt", { parents: true }),
+      /not a directory/,
+      "mkdir at a path that is already a file must reject (no silent overwrite)",
+    )
+
+    // KEY invariant 3: the original file's content + listing must be intact
+    const lsRoot = await mfs.ls("/a")
+    const fileEntry = lsRoot.find((e: { name: string; type: string }) => e.name === "file.txt")
+    assert.ok(fileEntry, "file entry must still exist after rejected mkdir")
+    assert.strictEqual(fileEntry!.type, "file", "entry type must still be 'file', not 'directory'")
+    const stat = await mfs.stat("/a/file.txt")
+    assert.strictEqual(stat.type, "file", "stat must report 'file' for the rejected-mkdir path")
+
+    // KEY invariant 4: write through a file-as-parent must reject too,
+    // since write uses mkdir({parents:true}) under the hood.
+    await assert.rejects(
+      () => mfs.write("/a/file.txt/nested", new Uint8Array([1, 2, 3]), { create: true, parents: true }),
+      /not a directory/,
+      "write with parents:true through a file path must reject — write goes through mkdir",
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test("#302: mkdir at root depth with file collision still rejects", async () => {
+  // Same family, top-level path. Confirms the check fires on the FIRST
+  // component too (not just intermediates), so a flat /root.txt + mkdir
+  // /root.txt is not a regression case.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/root.txt", new TextEncoder().encode("x"), { create: true })
+    await assert.rejects(
+      () => mfs.mkdir("/root.txt", { parents: true }),
+      /not a directory/,
+    )
+    await assert.rejects(
+      () => mfs.mkdir("/root.txt/x", { parents: true }),
+      /not a directory/,
+    )
+  } finally {
+    cleanup()
+  }
+})

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -64,8 +64,20 @@ export class IpfsMfs {
 
       if (this.dirs.has(current)) continue
 
+      // #302: even with parents=true, every intermediate component must
+      // either not exist OR exist as a directory. Pre-fix, mkdir blindly
+      // overwrote a file entry with a directory entry (line 75/81), silently
+      // orphaning UnixFS file content and producing dirs.get() + parent.entries
+      // pointing to the same name with different types. Reproduced live on
+      // 88780: `write /a/file.txt` then `mkdir /a/file.txt/sub --parents`
+      // returned 200 and `ls /a/file.txt` then listed `sub` as a child entry.
+      const parentDir = this.dirs.get(parent)
+      const existingEntry = parentDir?.entries.get(parts[i])
+      if (existingEntry && existingEntry.type === "file") {
+        throw new Error(`not a directory: ${current}`)
+      }
+
       if (!opts?.parents && i < parts.length - 1) {
-        const parentDir = this.dirs.get(parent)
         if (!parentDir?.entries.has(parts[i])) {
           throw new Error(`parent directory not found: ${parent}`)
         }
@@ -75,7 +87,6 @@ export class IpfsMfs {
       this.dirs.set(current, { entries: new Map() })
 
       // Register in parent
-      const parentDir = this.dirs.get(parent)
       if (parentDir) {
         const now = Date.now()
         parentDir.entries.set(parts[i], {


### PR DESCRIPTION
Closes #302

## Summary

File/directory type confusion in MFS: `mkdir` (and `write` via its internal `mkdir({parents:true})` call) silently overwrote a regular file with a directory entry, orphaning UnixFS content and creating an inconsistent state where `this.dirs` and `parent.entries` disagreed on the type of the same path.

Live-reproducible on 88780 (full curl reproducer in #302). 1-line bug: line 75/81 of `mkdir` blindly overwrote any existing entry without checking type.

## Changes

- `node/src/ipfs-mfs.ts`:
  - In `mkdir`'s parent-walk, lookup `parent.entries[parts[i]]` BEFORE creating the new dir node. If it exists with `type:"file"`, throw `"not a directory: ${current}"`. Applies on every component (including leaf), so:
    - `mkdir /a/file.txt`      → reject (file at path)
    - `mkdir /a/file.txt/sub`  → reject (file in path)
    - `mkdir /a/newdir`        → ok (no collision)
  - Documents the bug + 88780 reproducer in a comment.
  
- `node/src/ipfs-mfs.test.ts`:
  - `#302: mkdir under an existing FILE must reject with 'not a directory'` — 4 KEY invariants
  - `#302: mkdir at root depth with file collision still rejects` — top-level path coverage

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-mfs.test.ts` → 15/15 pass (13 original + 2 new #302 subtests)
- [x] `node --experimental-strip-types --test node/src/ipfs-*.test.ts` → 197/197 IPFS tests pass (no regression in blockstore, unixfs, http, mfs, pubsub, erasure, merkle, tar)

## Threat class

Functional bug + data loss + POSIX violation + type confusion. Reachable from any client with MFS write access — single curl reproduces it.

## Related (deferred)

`cp`/`mv` have the sibling type-clobbering at lines 270/320 — `destParent.entries.set` overwrites a directory entry with a file entry (and vice versa). Kubo's "cp into dir" semantics for `cp file existing-dir` is a separate design decision and this PR keeps the fix surface focused. Filed as follow-up in #302.