### PR TITLE
fix(ipfs-mfs): write honors offset on all paths + HTTP forwards offset (#306)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1328,11 +1328,28 @@ export class IpfsHttpServer {
           // handles both: it extracts the file bytes from multipart, or returns
           // raw bytes when the request has no boundary in Content-Type.
           const { bytes: body } = await readMultipartFile(req)
-          await this.mfs.write(arg, body, {
+          // #306: pre-fix the HTTP handler dropped the `offset` query param
+          // entirely — every kubo-style `files/write?offset=N` request was
+          // accepted with 200 but the offset never reached `mfs.write`. This
+          // silently broke partial-write clients (kubo CLI, js-ipfs, etherman)
+          // and made the validation inside mfs.write unreachable. Mirror the
+          // existing offset validation rule from the `read` handler at line
+          // 1027 so the shape contract is the same for both ends of an MFS
+          // partial I/O round-trip.
+          const writeOpts: { create?: boolean; truncate?: boolean; parents?: boolean; offset?: number } = {
             create: url.query?.create === "true",
             truncate: url.query?.truncate === "true",
             parents: url.query?.parents === "true",
-          })
+          }
+          const offsetRaw = firstQueryValue(url.query?.offset)
+          if (offsetRaw !== undefined) {
+            const n = Number(offsetRaw)
+            if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+              throw new HttpError(400, "invalid offset: must be a non-negative integer")
+            }
+            writeOpts.offset = n
+          }
+          await this.mfs.write(arg, body, writeOpts)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))
           break

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -283,6 +283,35 @@ test("#304: mv/cp onto an existing DIRECTORY rejects (no type clobber)", async (
     // KEY invariant 4: read /D as a file must NOT return file content
     // (i.e. the dir was never overwritten, parent.entries still says directory)
     await assert.rejects(() => mfs.read("/D"), /not a file|is a directory|cannot read directory/i)
+  })
+
+test("#306: write to NEW file with offset pads with zeros (sparse-style)", async () => {
+  // Live-reproducible on 88780 testnet (probe iteration #39):
+  //   /api/v0/files/write?arg=/sparse.bin&create=true&offset=100 -F data=TAIL
+  //   /api/v0/files/stat?arg=/sparse.bin   → {"Size": 5, ...}   ← BUG: offset dropped
+  //   /api/v0/files/read?arg=/sparse.bin   → "TAIL\n"            ← 5 bytes, not 105
+  // Pre-fix: the offset-handling block at mfs-write was inside
+  // `if (existing && !opts?.truncate && opts?.offset !== undefined)`, so the
+  // `create:true, offset:N` (no existing file) path silently dropped offset.
+  // The HTTP route also did not forward offset to mfs.write — see #306
+  // sibling fix in ipfs-http.ts. Kubo MFS semantics: file becomes
+  // zeros(N) + data.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    const tail = new TextEncoder().encode("TAIL")
+    await mfs.write("/sparse.bin", tail, { create: true, offset: 100 })
+
+    // KEY invariant 1: file size = offset + data.length, not just data.length
+    const stat = await mfs.stat("/sparse.bin")
+    assert.strictEqual(stat.size, 104, "new-file + offset must produce size = offset + data.length")
+
+    // KEY invariant 2: prefix is all zeros, suffix is the data
+    const read = await mfs.read("/sparse.bin")
+    assert.strictEqual(read.length, 104)
+    for (let i = 0; i < 100; i++) {
+      assert.strictEqual(read[i], 0, `byte ${i} must be zero (zero-padded prefix)`)
+    }
+    assert.strictEqual(new TextDecoder().decode(read.slice(100)), "TAIL")
   } finally {
     cleanup()
   }
@@ -330,6 +359,76 @@ test("#304: mv/cp file onto existing DIRECTORY entry (type mismatch at leaf) rej
       /type mismatch|destination is a directory/,
       "mv dir onto existing file must reject (cannot replace file with dir silently)",
     )
+  })
+
+test("#306: write with truncate+offset replaces existing then pads", async () => {
+  // Pre-fix `truncate:true + offset` also silently dropped offset because
+  // the condition required `!opts?.truncate`. Kubo: truncate then write at
+  // offset = pad with zeros + data.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/t.bin", new TextEncoder().encode("ORIGINAL"), { create: true })
+    await mfs.write("/t.bin", new TextEncoder().encode("NEW"), { truncate: true, offset: 5 })
+
+    const stat = await mfs.stat("/t.bin")
+    assert.strictEqual(stat.size, 8, "truncate+offset must produce size = offset + new data length")
+
+    const read = await mfs.read("/t.bin")
+    for (let i = 0; i < 5; i++) {
+      assert.strictEqual(read[i], 0, `byte ${i} must be zero (truncate discarded original; offset padded)`)
+    }
+    assert.strictEqual(new TextDecoder().decode(read.slice(5)), "NEW")
+  } finally {
+    cleanup()
+  }
+})
+
+test("#306: write with invalid offset rejects on every path", async () => {
+  // Pre-fix the offset<0 check only ran when `existing && !truncate`. New-file
+  // and truncate paths bypassed it. Now the check is up-front and uniform.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    // Negative offset on new file
+    await assert.rejects(
+      () => mfs.write("/n.bin", new Uint8Array([1, 2]), { create: true, offset: -5 }),
+      /invalid offset/,
+    )
+    // NaN / non-integer
+    await assert.rejects(
+      () => mfs.write("/nan.bin", new Uint8Array([1, 2]), { create: true, offset: NaN }),
+      /invalid offset/,
+    )
+    await assert.rejects(
+      () => mfs.write("/frac.bin", new Uint8Array([1, 2]), { create: true, offset: 1.5 }),
+      /invalid offset/,
+    )
+    // Negative + truncate (was bypassed pre-fix)
+    await mfs.write("/x.bin", new TextEncoder().encode("seed"), { create: true })
+    await assert.rejects(
+      () => mfs.write("/x.bin", new Uint8Array([1, 2]), { truncate: true, offset: -1 }),
+      /invalid offset/,
+    )
+
+    // offset=0 must continue to work (boundary, not invalid)
+    await mfs.write("/zero.bin", new TextEncoder().encode("Z"), { create: true, offset: 0 })
+    const read = await mfs.read("/zero.bin")
+    assert.strictEqual(new TextDecoder().decode(read), "Z")
+  } finally {
+    cleanup()
+  }
+})
+
+test("#306: existing-file overwrite at offset preserves tail (regression for old path)", async () => {
+  // This is the path that WAS working pre-fix. Verify it still works to
+  // catch regressions from the refactor.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/o.bin", new TextEncoder().encode("ABCDEFGHIJ"), { create: true })
+    await mfs.write("/o.bin", new TextEncoder().encode("XYZ"), { offset: 3 })
+
+    const read = await mfs.read("/o.bin")
+    assert.strictEqual(new TextDecoder().decode(read), "ABCXYZGHIJ",
+      "overwrite at offset must preserve bytes before+after the written slice")
   } finally {
     cleanup()
   }

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -131,17 +131,37 @@ export class IpfsMfs {
       throw new Error(`file not found: ${normalized} (use create=true to create)`)
     }
 
+    // #306: validate offset on ALL paths (new file, truncate, and overwrite),
+    // not just the `existing && !truncate` overwrite path. Pre-fix the offset
+    // check lived inside the overwrite branch only, so:
+    //   - `create:true` (no existing) + negative offset → silently dropped
+    //   - `create:true` + non-numeric offset → silently dropped (NaN)
+    //   - `truncate:true` + offset → silently dropped
+    // The HTTP route never forwarded offset to mfs.write either (#306 sibling
+    // fix in ipfs-http.ts), so these were doubly hidden. Now offset is
+    // validated up-front and applied uniformly per kubo MFS semantics:
+    //   write(path, data, {offset:N})  → file = zeros(N) + data + tail(existing)
+    if (opts?.offset !== undefined) {
+      if (!Number.isFinite(opts.offset) || !Number.isInteger(opts.offset) || opts.offset < 0) {
+        throw new Error(`invalid offset: ${opts.offset} (must be non-negative integer)`)
+      }
+    }
+
+    const MAX_WRITE_SIZE = 64 * 1024 * 1024 // 64 MiB
     let finalData = data
-    if (existing && !opts?.truncate && opts?.offset !== undefined) {
-      if (opts.offset < 0) throw new Error("offset must be non-negative")
-      // Guard against memory exhaustion from large offset + data.length
-      const MAX_WRITE_SIZE = 64 * 1024 * 1024 // 64 MiB
+
+    if (opts?.offset !== undefined && opts.offset > 0) {
       const mergedSize = opts.offset + data.length
-      if (mergedSize > MAX_WRITE_SIZE) throw new Error(`write would exceed max size (${MAX_WRITE_SIZE} bytes)`)
-      // Append/overwrite at offset
-      const existingData = await this.unixfs.readFile(existing.cid)
+      if (mergedSize > MAX_WRITE_SIZE) {
+        throw new Error(`write would exceed max size (${MAX_WRITE_SIZE} bytes)`)
+      }
+
+      // For new-file or truncate cases, start from a zero buffer of length offset.
+      // For existing+!truncate, start from existing content (preserve tail).
+      const useExisting = existing && !opts?.truncate
+      const existingData = useExisting ? await this.unixfs.readFile(existing!.cid) : new Uint8Array(0)
       const merged = new Uint8Array(Math.max(existingData.length, mergedSize))
-      merged.set(existingData)
+      if (useExisting) merged.set(existingData)
       merged.set(data, opts.offset)
       finalData = merged
     }


### PR DESCRIPTION
Closes #306

## Summary

Two-layer bug found via 88780 testnet probing — kubo \`files/write?offset=N\` requests were accepted with 200 OK but the offset was silently dropped on every path that wasn't \"existing file, no truncate\". The HTTP route never forwarded offset to the MFS layer at all; the MFS layer's validation lived inside a guarded block that bypassed new-file and truncate cases.

Live-reproducible on 88780 with single curl (full reproducer in #306).

## Changes

### \`node/src/ipfs-http.ts\` — Layer 1 (HTTP forwarding)
The \`files/write\` route reads \`create\`, \`truncate\`, \`parents\` from the query but didn't read \`offset\`. Now parses + validates offset using the same rule the existing \`read\` handler uses at line 1027 (Number.isFinite + Number.isInteger + non-negative → 400 \"invalid offset\"). Passes to \`mfs.write({offset:n})\`.

### \`node/src/ipfs-mfs.ts\` — Layer 2 (MFS semantics)
The offset-handling block at \`write:124\` was guarded by \`if (existing && !opts?.truncate && opts?.offset !== undefined)\`, so:
- new-file + offset → offset dropped, file = data.length bytes
- truncate + offset → same
- offset<0 / NaN / fractional on those paths → not validated (validation inside the same if-block)

Refactored:
1. Move offset validation up-front (always runs)
2. When offset > 0: start from a zero-buffer if there's no existing content (new file or truncate=true), otherwise start from existing content (preserves the original behavior for the working path)
3. Preserve the 64 MiB \`MAX_WRITE_SIZE\` cap unchanged

### \`node/src/ipfs-mfs.test.ts\` — Regression tests
Four new \`#306\` subtests:
1. NEW file + offset:100 + data \"TAIL\" → size 104, prefix all zeros, suffix is \"TAIL\"
2. truncate:true + offset:5 → discards existing, file = zeros + new data
3. Invalid offset (negative, NaN, fractional) rejects on EVERY path including create:true and truncate:true (was bypassed pre-fix)
4. Existing-file overwrite at offset preserves bytes before+after the written slice (regression for the path that worked pre-fix)

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-mfs.test.ts\` → 17/17 pass (13 original + 4 new #306 subtests at ok 14-17)
- [x] \`node --experimental-strip-types --test node/src/ipfs-*.test.ts\` → 197/197 IPFS tests pass (no regression in blockstore, unixfs, http, mfs, pubsub, erasure, merkle, tar)

## Threat class

Functional bug + validation bypass + kubo API compatibility. Reachable from every client using kubo's standard \`files/write --offset N\` API.

## Related

- #302 / PR #303 — mkdir under file rejects (MFS type confusion)
- #304 / PR #305 — cp/mv onto dir rejects (MFS type clobbering)
- #200 — already-merged sibling fix for the READ path's offset validation