### PR TITLE
fix(ipfs-http): pin/ls?type=<filter> validates + filters correctly (#308)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -412,6 +412,95 @@ describe("IpfsHttpServer", () => {
     assert.equal(res.status, 400)
   })
 
+  it("#308 GET /api/v0/pin/ls?type=invalid returns 400 (was silently ignored, returning full list)", async () => {
+    // Live-reproducible on 88780 testnet — pre-fix the `type` query param
+    // was dropped entirely. Any value including "invalidtype" returned
+    // 200 with the unfiltered pin set. kubo defines type as enum
+    // {all, direct, indirect, recursive}.
+    const res = await fetch("/api/v0/pin/ls?type=invalidtype")
+    assert.equal(res.status, 400)
+    const body = await res.json() as Record<string, string>
+    assert.match(body.error, /invalid pin type/)
+  })
+
+  it("#308 GET /api/v0/pin/ls?type=direct returns empty Keys (COC has no direct pins)", async () => {
+    // COC's pin model is recursive-only — direct/indirect filters must
+    // return an empty result, NOT the full recursive set. Pre-fix every
+    // type filter returned the same set, so a client filtering by
+    // direct got recursive pins mis-labeled.
+    // First, ensure there's at least one recursive pin in the store so
+    // the "filter returns empty" assertion is meaningful (vs. "no pins").
+    const data = new TextEncoder().encode("p308")
+    const boundary = "----P308Boundary"
+    const body = Buffer.concat([
+      Buffer.from(`--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="file"; filename="p.bin"\r\n' +
+        "Content-Type: application/octet-stream\r\n\r\n"),
+      Buffer.from(data),
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ])
+    await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+
+    const recursive = await fetch("/api/v0/pin/ls?type=recursive")
+    assert.equal(recursive.status, 200)
+    const recursiveJson = await recursive.json() as { Keys: Record<string, unknown> }
+    assert.ok(Object.keys(recursiveJson.Keys).length > 0, "recursive filter must return some pins")
+
+    // Same store, type=direct, should be empty
+    const direct = await fetch("/api/v0/pin/ls?type=direct")
+    assert.equal(direct.status, 200)
+    const directJson = await direct.json() as { Keys: Record<string, unknown> }
+    assert.deepStrictEqual(directJson.Keys, {},
+      "type=direct must return empty Keys (COC has no direct pins) — pre-fix returned full recursive list")
+
+    // type=indirect → empty
+    const indirect = await fetch("/api/v0/pin/ls?type=indirect")
+    assert.equal(indirect.status, 200)
+    const indirectJson = await indirect.json() as { Keys: Record<string, unknown> }
+    assert.deepStrictEqual(indirectJson.Keys, {})
+
+    // type=all → same as recursive (since recursive is all we have)
+    const all = await fetch("/api/v0/pin/ls?type=all")
+    assert.equal(all.status, 200)
+    const allJson = await all.json() as { Keys: Record<string, unknown> }
+    assert.deepStrictEqual(Object.keys(allJson.Keys).sort(), Object.keys(recursiveJson.Keys).sort(),
+      "type=all and type=recursive must return the same Keys for a recursive-only store")
+  })
+
+  it("#308 GET /api/v0/pin/ls?arg=<cid>&type=direct returns 404 (kubo semantics)", async () => {
+    // Filtering an existing recursive pin by direct/indirect → 404
+    // "not pinned (no direct pins)" rather than silently returning it
+    // mis-labeled as recursive.
+    const data = new TextEncoder().encode("p308b")
+    const boundary = "----P308BBoundary"
+    const body = Buffer.concat([
+      Buffer.from(`--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="file"; filename="p.bin"\r\n' +
+        "Content-Type: application/octet-stream\r\n\r\n"),
+      Buffer.from(data),
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ])
+    const addRes = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    const addText = await addRes.text()
+    const cid = JSON.parse(addText.trim().split("\n")[0]).Hash as string
+
+    // arg with type=recursive (or no type) → 200 with the pin
+    const ok = await fetch(`/api/v0/pin/ls?arg=${cid}&type=recursive`)
+    assert.equal(ok.status, 200)
+
+    // Same arg with type=direct → 404 (kubo: not pinned under that type)
+    const denied = await fetch(`/api/v0/pin/ls?arg=${cid}&type=direct`)
+    assert.equal(denied.status, 404)
+  })
+
   it("POST /api/v0/add accepts a 10 MB payload (regression: 10MB PUT was rejected by the 10MB exact cap)", async () => {
     const boundary = "----TenMbBoundary"
     const payload = Buffer.alloc(10 * 1024 * 1024, 0x61) // 10 MB of 'a'

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -271,7 +271,15 @@ export class IpfsHttpServer {
         return
       }
       if (url.pathname === "/api/v0/pin/ls") {
-        await this.handlePinLs(res, argParam)
+        // #308: kubo `pin/ls?type=<all|direct|indirect|recursive>` was
+        // silently dropped — the handler ignored the `type` query param
+        // entirely and always returned the full set with hardcoded
+        // Type:"recursive". Invalid types returned 200 with the full
+        // list instead of 400. Forward + validate at the boundary so
+        // clients filtering by type get correct results (or a clear
+        // error for invalid values).
+        const typeRaw = firstQueryValue(url.query?.type)
+        await this.handlePinLs(res, argParam, typeRaw)
         return
       }
       if (url.pathname === "/api/v0/pin/rm") {
@@ -909,7 +917,21 @@ export class IpfsHttpServer {
     res.end(removed.map((cid) => JSON.stringify({ Key: { "/": cid } })).join("\n"))
   }
 
-  private async handlePinLs(res: http.ServerResponse, cid?: string): Promise<void> {
+  private async handlePinLs(res: http.ServerResponse, cid?: string, type?: string): Promise<void> {
+    // #308: validate `type` against the kubo-defined set. COC's pin model
+    // only stores recursive pins (no direct/indirect distinction), so
+    // type=direct and type=indirect correctly return empty — but invalid
+    // types must surface as 400, not silently degrade to "all".
+    const allowedTypes = ["all", "direct", "indirect", "recursive"] as const
+    type AllowedType = typeof allowedTypes[number]
+    let resolvedType: AllowedType = "all"
+    if (type !== undefined && type !== "") {
+      if (!(allowedTypes as readonly string[]).includes(type)) {
+        throw new HttpError(400, `invalid pin type: must be one of ${allowedTypes.join(", ")}`)
+      }
+      resolvedType = type as AllowedType
+    }
+
     const pins = await this.store.listPins()
     if (cid !== undefined) {
       // Match the kubo `/api/v0/pin/ls?arg=<cid>` semantics: 404 when the
@@ -919,15 +941,25 @@ export class IpfsHttpServer {
       // "not pinned".
       if (!isValidCid(cid)) throw new HttpError(400, "invalid cid")
       if (!pins.includes(cid)) throw new HttpError(404, "not pinned")
+      // If the caller filtered by type and our (recursive-only) pin store
+      // doesn't match, treat as "not pinned under that type" → 404. This
+      // mirrors kubo: `pin/ls?arg=<cid>&type=direct` returns 404 unless
+      // the CID is specifically directly-pinned.
+      if (resolvedType === "direct" || resolvedType === "indirect") {
+        throw new HttpError(404, `not pinned (no ${resolvedType} pins in this store)`)
+      }
       res.writeHead(200, { "content-type": "application/json" })
       res.end(JSON.stringify({ Keys: { [cid]: { Type: "recursive" } } }))
       return
     }
+
+    // No cid filter: return the recursive pin set unless caller asked for
+    // a type COC doesn't store (direct / indirect) → empty Keys map.
+    const showRecursive = resolvedType === "all" || resolvedType === "recursive"
     res.writeHead(200, { "content-type": "application/json" })
-    res.end(JSON.stringify({ Keys: pins.reduce((acc, c) => {
-      acc[c] = { Type: "recursive" }
-      return acc
-    }, {} as Record<string, { Type: string }>) }))
+    res.end(JSON.stringify({ Keys: showRecursive
+      ? pins.reduce((acc, c) => { acc[c] = { Type: "recursive" }; return acc }, {} as Record<string, { Type: string }>)
+      : {} }))
   }
 
   private metaPath(): string {


### PR DESCRIPTION
Closes #308

## Summary

\`pin/ls?type=<all|direct|indirect|recursive>\` was silently dropped — the handler ignored the \`type\` query param entirely. Invalid types returned 200 + full pin list; \`direct\`/\`indirect\` returned the same recursive set as \`recursive\`/\`all\`. Live-reproducible on 88780 (full reproducer in #308).

## Changes

- \`node/src/ipfs-http.ts\`:
  - Route at line 273: forward \`firstQueryValue(url.query?.type)\` to \`handlePinLs\` (mirrors the existing arg-forwarding pattern)
  - \`handlePinLs(res, cid?, type?)\`:
    - Validate \`type\` against allowed kubo set {all, direct, indirect, recursive}; invalid → 400 with allowed-values list
    - \`type=direct\` or \`type=indirect\` → empty Keys (COC is recursive-only)
    - With arg + direct/indirect → 404 \"not pinned (no <type> pins)\" (matches kubo)
    - \`type=recursive\` or \`type=all\` → unchanged full recursive set

- \`node/src/ipfs-http.test.ts\`:
  - \`#308 type=invalidtype → 400 \"invalid pin type\"\`
  - \`#308 type=direct/indirect → empty Keys\` (with real pin in store so the assertion is meaningful)
  - \`#308 type=recursive vs type=all → identical Keys\` (COC recursive-only)
  - \`#308 arg + type=direct → 404\` (kubo \"not pinned under that type\" semantics)

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` → 53/53 pass (50 original + 3 new #308 subtests)
- [x] \`node --experimental-strip-types --test node/src/ipfs-*.test.ts\` → 197/197 IPFS tests pass

## Threat class

Functional bug + kubo API compatibility. Lower severity than the data-integrity bugs (#302/#304/#306) since \`pin/ls\` is read-only, but standard kubo tools misbehave silently.

## Related (same family of silent-query-param-drop)

- #266 / PR #267 — eth_getLogs inner topic cap
- #260 / PR #261 — eth_getBlockBy* includeTx bool
- #294 / PR #295 — debug_/trace_ shape coerce