### PR TITLE
fix(ipfs-http): block/stat is local-only — no fetchRemote on miss (#310)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1079,3 +1079,77 @@ describe("IpfsHttpServer C3.1 replication warning", () => {
     assert.match(warning, /got 0\/2 \(cid=/, `expected 0/2 with cid=..., got "${warning}"`)
   })
 })
+
+describe("#310 block/stat does NOT trigger fetchRemote on local miss", () => {
+  it("unknown CID returns 404 without invoking the remote-fetch hook (DoS surface fix)", async () => {
+    // Pre-fix `handleBlockStat` routed through `loadRawBlock` → `store.get`,
+    // which calls the registered fetchRemote hook on ENOENT and waits up
+    // to ~5s × fanOut for providers + fallback peers. A `block/stat` for
+    // any unknown CID therefore took ~5-10s of wall clock and held a wire
+    // connection slot for the duration — a soft DoS where an unauthenticated
+    // attacker exhausts the 100/min rate-limit budget on slow stat
+    // requests. Kubo's `block/stat` is a local metadata query; this test
+    // pins that semantics.
+    const tmpDir2 = await mkdtemp(join(tmpdir(), "ipfs-http-310-"))
+    const store2 = new IpfsBlockstore(tmpDir2)
+    await store2.init()
+    let fetchRemoteCalled = false
+    let fetchRemoteResolvedAt = 0
+    store2.setHooks({
+      fetchRemote: async () => {
+        fetchRemoteCalled = true
+        // Simulate slow DHT — if the handler awaits this we'll see it in
+        // the elapsed time. The fix should short-circuit BEFORE this
+        // resolves, so this delay never affects the response.
+        await new Promise((r) => setTimeout(r, 3000))
+        fetchRemoteResolvedAt = Date.now()
+        return null
+      },
+    })
+    const unixfs2 = new UnixFsBuilder(store2)
+    const port2 = 30000 + Math.floor(Math.random() * 10000)
+    const server2 = new IpfsHttpServer(
+      { bind: "127.0.0.1", port: port2, storageDir: tmpDir2, nodeId: "t310" },
+      store2,
+      unixfs2,
+    )
+    server2.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    const unknownCid: CidString = "bafybeiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as CidString
+    const t0 = Date.now()
+    const res = await new Promise<{ status: number }>((resolve, reject) => {
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port: port2,
+        path: `/api/v0/block/stat?arg=${unknownCid}`,
+        method: "POST",
+      }, (r) => {
+        const chunks: Buffer[] = []
+        r.on("data", (c) => chunks.push(Buffer.from(c)))
+        r.on("end", () => resolve({ status: r.statusCode ?? 0 }))
+      })
+      req.on("error", reject)
+      req.end()
+    })
+    const elapsed = Date.now() - t0
+
+    try {
+      // KEY invariant 1: response is 404 (block not found)
+      assert.equal(res.status, 404)
+      // KEY invariant 2: fetchRemote hook was NOT invoked (would have
+      // implied loadRawBlock was called for a non-local CID)
+      assert.equal(fetchRemoteCalled, false,
+        "block/stat must NOT invoke fetchRemote for an unknown CID — this is the soft-DoS fix")
+      // KEY invariant 3: response is fast — well under the simulated
+      // 3s fetchRemote delay, proving we short-circuited
+      assert.ok(elapsed < 1000,
+        `block/stat must return quickly (<1s) for an unknown CID, got ${elapsed}ms`)
+      // belt + suspenders — if fetchRemote ran to completion we'd see it
+      assert.equal(fetchRemoteResolvedAt, 0)
+    } finally {
+      await server2.stop()
+      await rm(tmpDir2, { recursive: true, force: true })
+    }
+  })
+})

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -816,6 +816,25 @@ export class IpfsHttpServer {
       res.end(JSON.stringify({ error: !cid ? "missing cid" : "invalid cid" }))
       return
     }
+    // #310: kubo `block/stat` is a LOCAL metadata query. Pre-fix it routed
+    // through `loadRawBlock` → `store.get` which calls `fetchRemote` (DHT
+    // findProviders + 5s per-provider timeout + fallback to every
+    // connected peer) on any local miss. Any client probing for an unknown
+    // CID therefore waited ~5-10s for a 404, and an unauthenticated
+    // attacker could pin ~100 wire-connection slots per minute (rate-limit
+    // budget) by spraying unknown CIDs — a soft DoS surface on a "stat"
+    // endpoint that semantically should never touch the network. Short-
+    // circuit via `store.has()` so block/stat is a cheap fs.access check;
+    // block/get keeps its network-fetch behaviour because that's the whole
+    // point of bitswap-style block retrieval. TOCTOU: if GC races between
+    // has() and loadRawBlock, the ENOENT branch still maps to 404, so the
+    // worst case is one fetchRemote attempt (acceptable, vs. one EVERY
+    // unknown-cid stat pre-fix).
+    if (!(await this.store.has(cid))) {
+      res.writeHead(404, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: "block not found" }))
+      return
+    }
     // #168: same ENOENT → 404 mapping as handleBlockGet.
     try {
       const block = await loadRawBlock(this.store, cid)


### PR DESCRIPTION
Closes #310

## Summary

\`block/stat\` for any unknown CID waited ~5-10s on 88780 because the handler routed through \`loadRawBlock\` → \`store.get\` → \`fetchRemote\` (DHT findProviders + per-provider 5s timeout + connected-peer fallback). Kubo \`block/stat\` is a LOCAL metadata query and shouldn't touch the network at all. Soft-DoS surface: an unauthenticated attacker spraying unknown CIDs burns ~500-1000s of server wall time per IP per minute.

Live-reproducible on 88780 with single curl (full reproducer in #310).

## Changes

- \`node/src/ipfs-http.ts\` — \`handleBlockStat\` checks \`store.has(cid)\` before calling \`loadRawBlock\`. False → 404 immediately, no fetchRemote, no network IO. True → load (fast local path; TOCTOU vs GC still maps ENOENT → 404).
- \`block/get\` keeps its network-fetch behavior — that's the whole point of bitswap.

- \`node/src/ipfs-http.test.ts\` — new \`#310\` test that spins up a server with a fetchRemote hook that adds a 3s artificial delay if called. KEY invariants:
  1. block/stat for unknown CID returns 404
  2. fetchRemote was NOT invoked
  3. Response completed in <1s (proves we short-circuited before the 3s hook would have resolved)

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` → 51/51 pass (50 original + 1 new #310 suite)
- [x] \`node --experimental-strip-types --test node/src/ipfs-*.test.ts\` → 197/197 IPFS tests pass

## Threat class

Soft DoS via rate-limit amplification (~100×) + kubo semantic mismatch. Lower severity than the data-integrity bugs (#302/#304/#306) but the fix is small and the surface is reachable without auth.

## Related

- #280 / PR #281 — sibling: \`pin/add\` requires block in local store
- #292 / PR #293 — sibling defensive pattern: bound unauth-client work