### PR TITLE
fix(ipfs-http): pubsub topic rejects control characters (#312)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1930,4 +1930,105 @@ describe("#324 IPFS gateway honors HTTP Range header", () => {
     assert.equal(res.status, 200)
     assert.equal(res.headers["accept-ranges"], "bytes")
   })
+
+describe("#312 pubsub topic rejects control characters", () => {
+  let pubsubTmpDir: string
+  let pubsubServer: IpfsHttpServer
+  let pubsubPort: number
+  let pubsubBaseUrl: string
+
+  beforeEach(async () => {
+    const { IpfsPubsub } = await import("./ipfs-pubsub.ts")
+    pubsubTmpDir = await mkdtemp(join(tmpdir(), "ipfs-http-312-"))
+    const s = new IpfsBlockstore(pubsubTmpDir)
+    await s.init()
+    const u = new UnixFsBuilder(s)
+    pubsubPort = 30000 + Math.floor(Math.random() * 10000)
+    pubsubBaseUrl = `http://127.0.0.1:${pubsubPort}`
+    pubsubServer = new IpfsHttpServer(
+      { bind: "127.0.0.1", port: pubsubPort, storageDir: pubsubTmpDir, nodeId: "t312" },
+      s,
+      u,
+    )
+    pubsubServer.attachSubsystems({ pubsub: new IpfsPubsub({ nodeId: "t312" }) })
+    pubsubServer.start()
+    await new Promise((r) => setTimeout(r, 100))
+  })
+
+  afterEach(async () => {
+    await pubsubServer.stop()
+    await rm(pubsubTmpDir, { recursive: true, force: true })
+  })
+
+  async function localFetch(path: string, opts?: { method?: string; body?: Uint8Array | string }): Promise<{ status: number; json: () => Promise<unknown> }> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(path, pubsubBaseUrl)
+      const req = http.request({
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        method: opts?.method ?? "POST",
+      }, (r) => {
+        const chunks: Buffer[] = []
+        r.on("data", (c) => chunks.push(Buffer.from(c)))
+        r.on("end", () => {
+          const buf = Buffer.concat(chunks)
+          resolve({
+            status: r.statusCode ?? 0,
+            json: () => Promise.resolve(JSON.parse(buf.toString())),
+          })
+        })
+      })
+      req.on("error", reject)
+      if (opts?.body) req.write(opts.body)
+      req.end()
+    })
+  }
+
+  it("pub with null byte in topic → 400 (log-injection / parser-confusion surface)", async () => {
+    // Live-reproducible on 88780: pubsub/pub?arg=evil%00null returned 200
+    // and the topic later showed up in pubsub/ls as "evil\0null".
+    // log.info("subscribed", {topic}) writes the topic to logs — line-based
+    // loggers may truncate at \0 or split on \n. Subscribers receiving
+    // ndjson get topicIDs:["evil\0null"] and may misparse on
+    // null-terminator-aware clients.
+    const res = await localFetch("/api/v0/pubsub/pub?arg=evil%00null", {
+      method: "POST",
+      body: new TextEncoder().encode("payload"),
+    })
+    assert.equal(res.status, 400)
+    const body = await res.json() as Record<string, string>
+    assert.match(body.error, /control character/i)
+  })
+
+  it("pub with newline + carriage return in topic → 400 (CRLF injection)", async () => {
+    const res = await localFetch("/api/v0/pubsub/pub?arg=evil%0a%0devil", {
+      method: "POST",
+      body: new TextEncoder().encode("payload"),
+    })
+    assert.equal(res.status, 400)
+  })
+
+  it("sub with null byte in topic → 400 (same family, same rule)", async () => {
+    const res = await localFetch("/api/v0/pubsub/sub?arg=sub%00evil", { method: "POST" })
+    assert.equal(res.status, 400)
+  })
+
+  it("pub with normal UTF-8 multibyte topic still works (no over-rejection)", async () => {
+    // Boundary: chinese / emoji topics should remain valid. The C0 + DEL
+    // ban is narrow enough that multi-byte UTF-8 (0x80+) survives.
+    const res = await localFetch("/api/v0/pubsub/pub?arg=" + encodeURIComponent("订阅-🚀"), {
+      method: "POST",
+      body: new TextEncoder().encode("hi"),
+    })
+    assert.equal(res.status, 200)
+  })
+
+  it("pub with regular ASCII topic still works", async () => {
+    const res = await localFetch("/api/v0/pubsub/pub?arg=normal-topic_42", {
+      method: "POST",
+      body: new TextEncoder().encode("hi"),
+    })
+    assert.equal(res.status, 200)
+  })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1554,6 +1554,27 @@ export class IpfsHttpServer {
         return
       }
 
+      // #312: reject control characters in topic name. Pre-fix, a topic
+      // like `evil\0null` was accepted by pub AND sub; pubsub/ls then
+      // returned `{"Strings":["evil\0null"]}`. Concerns:
+      // - Log injection: `log.info("subscribed", {topic})` in
+      //   ipfs-pubsub.ts:109 — line-based loggers may truncate at \0
+      //   or split on \n
+      // - Subscriber-side parser confusion: a subscriber receiving the
+      //   ndjson stream gets `topicIDs:["evil\0null"]` and may
+      //   break on null-terminator-aware C clients
+      // - Topic-name confusion: two topics that differ only in control
+      //   chars look identical in many UIs
+      // Reject any control char in C0/DEL range (U+0000-U+001F, U+007F).
+      // Allow normal printable + UTF-8 multibyte (matches kubo's
+      // "no whitespace" guidance loosely while keeping interop with
+      // multi-language topic names).
+      if (topic && /[\u0000-\u001f\u007f]/.test(topic)) {
+        res.writeHead(400, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "topic contains control characters" }))
+        return
+      }
+
       switch (route) {
         case "pub": {
           if (!topic) {


### PR DESCRIPTION
Closes #312

## Summary

Pubsub topics accepted null bytes and other C0/DEL control characters — `pubsub/pub?arg=evil%00null` returned 200 OK and the topic showed up in `pubsub/ls` as `"evil null"`. Exposed three soft surfaces:
- Log injection via the `log.info("subscribed", {topic})` call site
- Subscriber parser confusion for null-terminator-aware C clients
- UI / list confusion for two topics that differ only in control chars

Live-reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts` — In `handlePubsubRoute`, reject any topic containing a C0 control char (U+0000-U+001F) or DEL (U+007F) with 400. Applied BEFORE the route switch so both `pub` and `sub` get the same rule. Multi-byte UTF-8 (chinese, emoji) survives because the regex character class stops at U+007F.

- `node/src/ipfs-http.test.ts` — New `#312` describe block with its own pubsub-enabled test server (the existing tests don't enable pubsub via `attachSubsystems`). 5 subtests:
  - pub with null byte → 400 + "control character" error
  - pub with newline + carriage return → 400 (CRLF injection)
  - sub with null byte → 400 (same family)
  - pub with chinese + emoji UTF-8 → 200 (no over-rejection)
  - pub with normal ASCII → 200 (no over-rejection)

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 55/55 pass (50 original + 5 new #312)
- [x] `node --experimental-strip-types --test node/src/ipfs-*.test.ts` → 197/197 IPFS tests pass

## Threat class

Soft attack surface — log injection + parser confusion on an unauthenticated endpoint. Lower than the data-integrity bugs (#302/#304/#306) but reachable with one curl.

## Related

- #284 / PR #285 — sibling: pubsub message-too-large bound
- #292 / PR #293 — sibling defensive pattern: bound unauth-client work
