### PR TITLE
fix(rpc): cap method name length to bound echo amplification (#314)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1621,6 +1621,23 @@ test("RPC Extended Methods", async (t) => {
       const r = await probe({ jsonrpc: "2.0", id: 1, method: m })
       assert.equal(r.error?.code, -32600, `method=${JSON.stringify(m)} must be -32600, got ${JSON.stringify(r)}`)
     }
+    // #314: method length must be capped to prevent N-byte echo amplification
+    // via the default "method not supported: <method>" -32601 path. Pre-fix
+    // a 1KB method name flowed through and the full string was echoed back.
+    {
+      const longMethod = "A".repeat(129)
+      const r = await probe({ jsonrpc: "2.0", id: 1, method: longMethod })
+      assert.equal(r.error?.code, -32600, "method >128 chars must be -32600 invalid request")
+      assert.match(r.error!.message, /too long/i, "error must explain length cap")
+      // KEY invariant: the response must NOT echo the malicious method name
+      assert.ok(!r.error!.message.includes("AAAA"),
+        "method-too-long error must NOT echo the input — that's the amplification we're closing")
+      // Boundary: exactly 128 chars must still be accepted at the envelope
+      // layer (it'll surface as -32601 method-not-supported instead, which
+      // is the right shape for a real-but-unknown method).
+      const max = await probe({ jsonrpc: "2.0", id: 1, method: "z".repeat(128) })
+      assert.equal(max.error?.code, -32601, "exactly 128 chars must pass envelope check and reach dispatch")
+    }
     // Sanity: well-formed envelope still works.
     const ok = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
     assert.equal(ok.error, undefined, "well-formed envelope must NOT error")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -504,6 +504,17 @@ async function handleOne(
     // via JS truthy semantics. Method MUST be a non-empty string.
     return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: method must be a non-empty string" } }
   }
+  // #314: cap method name length so a malicious client can't force an
+  // N-byte echo via the default `method not supported: ${payload.method}`
+  // error path (rpc.ts:methodNotFound around the dispatch switch). The
+  // longest standard Ethereum/COC RPC method is ~30 chars
+  // ("eth_getTransactionReceiptsByBlock"). 128 is generous headroom and
+  // bounds the response amplification any unauthenticated client can
+  // force from a malformed request. -32600 (invalid request) per
+  // JSON-RPC §5.1 because the request shape itself is the problem.
+  if (payload.method.length > 128) {
+    return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: method name too long (max 128 chars)" } }
+  }
   // #202: §4.1 — id MUST be String, Number, or NULL when present.
   // Pre-fix objects, arrays, bools were silently echoed back, which
   // either crashed strict-typed client response parsers or masked


### PR DESCRIPTION
Closes #314

## Summary

JSON-RPC method name had no length cap — any N-byte method got echoed verbatim in the `-32601 "method not supported: <method>"` error. An unauthenticated client could amplify their request bytes 1:1 in the response. Live-reproducible on 88780 with a 1KB method name.

## Changes

- `node/src/rpc.ts` — after the existing non-empty-string check in `dispatchOne` envelope validator, add a 128-char cap. -32600 "invalid request: method name too long (max 128 chars)" — JSON-RPC §5.1 shape category. Longest standard method is ~30 chars so 128 leaves generous headroom.

- `node/src/rpc-extended.test.ts` — extended the existing #202 envelope-validation suite:
  - method = "A".repeat(129) → -32600 + "too long" in message
  - KEY invariant: response does NOT echo the malicious method name (closes the amplification)
  - Boundary: exactly 128 chars passes envelope check, surfaces as -32601 method-not-supported

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts node/src/rpc.test.ts` → 99/99 pass

## Threat class

Soft surface — bandwidth amplification (1:1, bounded by MAX_RPC_BODY × rate limit) + input echo. Same family as #202 (envelope validators) and #294 (handler-level shape validation).

## Related

- #202 / PR #203 — sibling envelope validators (jsonrpc, id)
- #294 / PR #295 — sibling handler-level shape validation
- #288 / PR #289 — sibling size cap (eth_compileSolidity)
