### PR TITLE
fix(rpc): cap string id length + reject control chars (#316)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1616,6 +1616,45 @@ test("RPC Extended Methods", async (t) => {
       assert.equal(r.error?.code, -32600, `id=${JSON.stringify(badId)} must be -32600, got ${JSON.stringify(r)}`)
       assert.match(r.error!.message, /id must be/i, "error must explain id shape")
     }
+    // #316: cap string-id length to bound 1:1 echo amplification. Pre-fix a
+    // 5000-char string id flowed straight back into every response.
+    {
+      const longId = "Z".repeat(257)
+      const r = await probe({ jsonrpc: "2.0", id: longId, method: "eth_chainId" })
+      assert.equal(r.error?.code, -32600, "id >256 chars must be -32600")
+      assert.match(r.error!.message, /id too long/i, "error must explain length cap")
+      // KEY invariant: response does NOT echo the malicious id
+      assert.ok(!JSON.stringify(r).includes("ZZZZZ"),
+        "id-too-long error must NOT echo the input — closes the amplification")
+      // Boundary: exactly 256 chars must still be accepted
+      const max = await probe({ jsonrpc: "2.0", id: "y".repeat(256), method: "eth_chainId" })
+      assert.equal(max.error, undefined, "id of exactly 256 chars must be accepted")
+      assert.ok(typeof max.result === "string", "well-formed envelope must produce result")
+    }
+    // #316: reject control chars in string id — same log-injection /
+    // parser-confusion family as #312 (pubsub topic).
+    {
+      for (const bad of ["line1\nline2", "with\rCR", "tab\there", "null\u0000byte", "del\u007fhere"]) {
+        const r = await probe({ jsonrpc: "2.0", id: bad, method: "eth_chainId" })
+        assert.equal(r.error?.code, -32600, `id=${JSON.stringify(bad)} must reject as -32600`)
+        assert.match(r.error!.message, /control character/i, "error must explain control-char rule")
+        // KEY invariant: invalid-envelope response resets id to null
+        // per JSON-RPC §5.1; no raw control char from the input may
+        // survive in the response.
+        assert.equal(r.id, null, "invalid envelope must reset id to null")
+        const serialized = JSON.stringify(r)
+        for (const ch of bad) {
+          const code = ch.charCodeAt(0)
+          if (code < 0x20 || code === 0x7f) {
+            assert.ok(!serialized.includes(ch),
+              `response must not contain raw control char U+${code.toString(16).padStart(4, "0")} from id`)
+          }
+        }
+      }
+      // Normal string ids still pass
+      const r = await probe({ jsonrpc: "2.0", id: "abc-123_456", method: "eth_chainId" })
+      assert.equal(r.error, undefined, "normal ASCII id must pass")
+    }
     // method must be a non-empty string
     for (const m of [0, "", null, true, ["eth_chainId"]]) {
       const r = await probe({ jsonrpc: "2.0", id: 1, method: m })

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -514,6 +514,22 @@ async function handleOne(
     if (!idOk) {
       return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id must be string, number, or null" } }
     }
+    // #316: bound the string-id surface. Pre-fix:
+    //   - 5000-char id flowed straight back into every response (1:1 echo
+    //     amplification, same family as #314 for method names)
+    //   - Control chars (\n, \r, \0) in id were echoed verbatim, opening
+    //     the same log-injection / parser-confusion surface as #312
+    //     (pubsub topic).
+    // UUIDs (36 chars) and hex hashes (66 chars) sit well under 256, so
+    // the cap doesn't break legitimate tracing tools.
+    if (typeof id === "string") {
+      if (id.length > 256) {
+        return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id too long (max 256 chars)" } }
+      }
+      if (/[\u0000-\u001f\u007f]/.test(id)) {
+        return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id contains control characters" } }
+      }
+    }
   }
 
   // #204: §4.2 — params, when present, MUST be a Structured value


### PR DESCRIPTION
Closes #316

## Summary

JSON-RPC `id` field had no length cap and accepted control characters — 5000-char ids echoed 1:1 in every response, and ids containing `\n`/`\r`/`\0`/`\x7f` flowed through verbatim. Live-reproducible on 88780.

Two-in-one: amplification (same family as #314 method length) + control-char injection (same family as #312 pubsub topic).

## Changes

- `node/src/rpc.ts` — In `handleOne` envelope validator after the existing `#202` type check, add for string ids:
  - length > 256 → -32600 "id too long"
  - matches `/[ -]/` → -32600 "id contains control characters"

  256 chars accommodates UUIDs (36), hex hashes (66), and most tracing IDs. The regex uses Unicode-escape form to avoid NUL bytes contaminating the source file (lesson from #312 PR).

- `node/src/rpc-extended.test.ts` — Extended the existing `#202` envelope-validation suite:
  - 257-char id → -32600 + "too long", response does NOT echo the input
  - 5 control-char ids (CR/LF/tab/NUL/DEL) → -32600 + "control character"
  - KEY invariant: invalid-envelope response resets `id` to `null` per JSON-RPC §5.1, and no raw control char from the input survives in the response
  - Boundary: 256 chars passes envelope; normal ASCII id passes

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts node/src/rpc.test.ts` → 99/99 pass

## Threat class

Same family as #312 / #314. Soft surface — amplification + injection. The id field is echoed in EVERY JSON-RPC response, so this fix protects every endpoint reachable by an unauthenticated client.

## Related

- #312 / PR #313 — sibling: pubsub topic control chars
- #314 / PR #315 — sibling: method name length cap
- #202 / PR #203 — base envelope validators (id type check)
