### PR TITLE
fix(ws-rpc): cap method length + cap string id length + reject id control chars (#318)

### DIFF
--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -447,6 +447,53 @@ describe("WebSocket RPC", () => {
       const ok = await probe({ jsonrpc: "2.0", id: 1, method: "eth_chainId" })
       assert.equal(ok.error, undefined, "well-formed envelope must NOT error")
       assert.ok(typeof ok.result === "string", "result must be returned")
+
+      // #318: WS-RPC parity with HTTP #314/#316 — method length cap +
+      // string id length cap + control-char rejection. Pre-fix the WS
+      // envelope inherited the same amplification + log-injection
+      // surfaces as HTTP had before #314/#316: a client could send a
+      // 5000-char method or id and get it echoed in the response.
+      {
+        const longMethod = "A".repeat(129)
+        const r = await probe({ jsonrpc: "2.0", id: 1, method: longMethod })
+        assert.equal(r.error?.code, -32600, "WS method >128 chars must be -32600")
+        assert.match(r.error!.message, /too long/i, "WS error must explain length cap")
+        assert.ok(!JSON.stringify(r).includes("AAAA"),
+          "WS method-too-long error must NOT echo the input")
+      }
+      {
+        const longId = "Z".repeat(257)
+        const r = await probe({ jsonrpc: "2.0", id: longId, method: "eth_chainId" })
+        assert.equal(r.error?.code, -32600, "WS id >256 chars must be -32600")
+        assert.match(r.error!.message, /id too long/i, "WS error must name the field")
+        assert.ok(!JSON.stringify(r).includes("ZZZZZ"),
+          "WS id-too-long error must NOT echo the input")
+      }
+      // Control chars in id — same family as #312 (pubsub topic) / #316 (HTTP id)
+      for (const bad of ["line1\nline2", "with\rCR", "tab\there", "null\u0000byte", "del\u007fhere"]) {
+        const r = await probe({ jsonrpc: "2.0", id: bad, method: "eth_chainId" })
+        assert.equal(r.error?.code, -32600, `WS id with control char must be -32600 (id=${JSON.stringify(bad)})`)
+        assert.match(r.error!.message, /control character/i, "error must explain control-char rule")
+        const serialized = JSON.stringify(r)
+        for (const ch of bad) {
+          const code = ch.charCodeAt(0)
+          if (code < 0x20 || code === 0x7f) {
+            assert.ok(!serialized.includes(ch),
+              `WS response must not contain raw control char U+${code.toString(16).padStart(4, "0")} from id`)
+          }
+        }
+      }
+      // Boundary: exactly-at-cap inputs pass the envelope check. The
+      // test stub uses a generic Error in its default branch so unknown
+      // methods surface as -32603 here (vs -32601 in prod), but either
+      // way the request is dispatched, not blocked by the envelope.
+      const okMax = await probe({ jsonrpc: "2.0", id: 1, method: "z".repeat(128) })
+      assert.ok(okMax.error && (okMax.error.code === -32601 || okMax.error.code === -32603),
+        `WS method of exactly 128 chars must reach dispatch (any non-envelope code), got ${JSON.stringify(okMax)}`)
+      assert.doesNotMatch(okMax.error!.message, /too long/i,
+        "exactly 128 chars must NOT be rejected by the length cap")
+      const okMaxId = await probe({ jsonrpc: "2.0", id: "y".repeat(256), method: "eth_chainId" })
+      assert.equal(okMaxId.error, undefined, "WS id of exactly 256 chars must be accepted")
     } finally {
       ws.close()
     }

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -340,6 +340,21 @@ export class WsRpcServer {
       })
       return
     }
+    // #318: WS-RPC envelope is a parallel code path to the HTTP RPC envelope
+    // (rpc.ts:dispatchOne). The same method-length and id-shape caps that #314
+    // / #316 added on the HTTP side are missing here. WS-RPC also echoes the
+    // id in every response and forwards the method into "method not supported:
+    // ${method}" via methodNotFound, so the same amplification +
+    // log-injection / parser-confusion surfaces apply. Mirror the HTTP rules
+    // verbatim so a client cannot bypass the caps by switching transport.
+    if (payload.method.length > 128) {
+      this.send(ws, {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32600, message: "invalid request: method name too long (max 128 chars)" },
+      })
+      return
+    }
     if ("id" in payload) {
       const id = payload.id
       const idOk = id === null || typeof id === "string" || (typeof id === "number" && Number.isFinite(id))
@@ -350,6 +365,28 @@ export class WsRpcServer {
           error: { code: -32600, message: "invalid request: id must be string, number, or null" },
         })
         return
+      }
+      // #318: bound string-id surface — parallel to #316 on the HTTP side.
+      // 256 chars accommodates UUIDs (36) and hex hashes (66). Regex uses
+      // Unicode-escape form to avoid NUL bytes in the source file (lesson
+      // from the #312 / #316 PR experience).
+      if (typeof id === "string") {
+        if (id.length > 256) {
+          this.send(ws, {
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: "invalid request: id too long (max 256 chars)" },
+          })
+          return
+        }
+        if (/[\u0000-\u001f\u007f]/.test(id)) {
+          this.send(ws, {
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32600, message: "invalid request: id contains control characters" },
+          })
+          return
+        }
       }
     }
     const rawParams = (payload as { params?: unknown }).params


### PR DESCRIPTION
Closes #318

## Summary

WS-RPC parity with HTTP RPC envelope caps from #314 (method length) and #316 (string id length + control chars). The WS path had the same #202 base shape checks but was missing the size caps — clients switching transport could bypass the HTTP-side amplification + injection caps.

## Changes

- `node/src/websocket-rpc.ts` — In `WsRpcServer.handleMessage` envelope path, after the existing non-empty-string method check, add a 128-char cap. After the existing string-id type check, add a 256-char cap and a control-char rejection (Unicode-escape regex `/[ -]/`, matching the HTTP path).

- `node/src/websocket-rpc.test.ts` — Extended the existing #206 envelope-validation suite:
  - 129-char method → -32600 "too long", response does NOT echo input
  - 257-char id → -32600 "id too long", response does NOT echo input
  - 5 control-char ids (CR/LF/tab/NUL/DEL) → -32600 "control character"
  - KEY invariant: no raw control char from the input survives in the response
  - Boundary: 128-char method passes envelope (reaches dispatch); 256-char id passes envelope and is reflected in the success response

## Test plan

- [x] `node --experimental-strip-types --test node/src/websocket-rpc.test.ts` → 13/13 pass

## Threat class

Soft surface — amplification + injection on the WS transport. Closes the gap left by #314/#316 (which only hardened HTTP).

## Related

- #312 / PR #313 — pubsub topic control chars
- #314 / PR #315 — HTTP method length cap
- #316 / PR #317 — HTTP string id length + control chars
