### PR TITLE
fix(coc-node): cap challenge map size + validate challengeId (#320)

### DIFF
--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { Wallet } from "ethers";
 import { loadConfig } from "./lib/config.ts";
 import { InMemoryStore } from "./lib/state.ts";
+import { recordChallengeBounded } from "./lib/bounded-challenge-store.ts";
 import { IpfsBlockstore } from "../node/src/ipfs-blockstore.ts";
 import { loadStorageProof, MerkleLeavesCache } from "./lib/storage-proof.ts";
 import { createNodeSigner, createNodeSignerV2, buildReceiptSignMessage } from "../node/src/crypto/signer.ts";
@@ -104,6 +105,19 @@ function stableStringify(value: unknown): string {
 
 const challenges = new InMemoryStore<Record<string, unknown>>();
 
+// #320: cap the in-memory challenge map to prevent unbounded growth
+// from unauthenticated POST /pose/challenge spam. Pre-fix the Map had
+// no size cap, no TTL, no LRU; coc-node also has no rate limiter at
+// the runtime layer, so an attacker spamming unique challengeIds could
+// grow the Map until the process OOMed. 100K entries × ~1 KB JSON each
+// is ~100 MB ceiling — generous for legitimate PoSe traffic (challenges
+// resolve within seconds) but bounded for adversarial spam. Eviction
+// is FIFO via insertion-order Map.keys() — older entries are typically
+// already consumed or timed out by the time the cap is hit.
+// Logic extracted to runtime/lib/bounded-challenge-store.ts so the
+// FIFO + dedup-of-existing-key behaviour is unit-tested without spinning
+// up the HTTP server.
+
 function json(res: http.ServerResponse, code: number, payload: unknown): void {
   res.writeHead(code, { "content-type": "application/json" });
   res.end(JSON.stringify(payload));
@@ -132,10 +146,22 @@ const server = http.createServer((req, res) => {
       } catch {
         return json(res, 400, { error: "invalid JSON body" });
       }
-      if (!payload.challengeId) {
-        return json(res, 400, { error: "missing challengeId" });
+      // #320: tighten challengeId shape — pre-fix the falsy check accepted
+      // objects, arrays, numbers as keys via `challenges.set(key, ...)`,
+      // and Map.set treats {} / [] as fresh references, so even a fixed
+      // JSON like {"challengeId":{}} produced a brand-new Map entry on
+      // every request. Require a non-empty string so each entry is
+      // addressable from /pose/receipt by hex/uuid.
+      if (typeof payload.challengeId !== "string" || payload.challengeId.length === 0) {
+        return json(res, 400, { error: "missing or invalid challengeId (must be non-empty string)" });
       }
-      challenges.set(payload.challengeId, payload);
+      // Cap the challenge ID length so an attacker cannot amplify the
+      // payload by spamming many giant strings — even with the FIFO cap
+      // below, each entry holds the full string as a Map key.
+      if (payload.challengeId.length > 256) {
+        return json(res, 400, { error: "challengeId too long (max 256 chars)" });
+      }
+      recordChallengeBounded(challenges, payload.challengeId, payload);
       return json(res, 200, { accepted: true });
     });
     return;

--- a/runtime/lib/bounded-challenge-store.test.ts
+++ b/runtime/lib/bounded-challenge-store.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { InMemoryStore } from "./state.ts";
+import { MAX_CHALLENGES_DEFAULT, recordChallengeBounded } from "./bounded-challenge-store.ts";
+
+test("#320: bounded store inserts up to maxEntries without eviction", () => {
+  const s = new InMemoryStore<{ n: number }>();
+  for (let i = 0; i < 5; i++) {
+    recordChallengeBounded(s, `id-${i}`, { n: i }, 5);
+  }
+  assert.equal(s.keys().length, 5);
+  // All entries readable
+  for (let i = 0; i < 5; i++) {
+    assert.deepEqual(s.get(`id-${i}`), { n: i });
+  }
+});
+
+test("#320: store stays at maxEntries — FIFO evicts oldest", () => {
+  const s = new InMemoryStore<{ n: number }>();
+  const CAP = 3;
+  recordChallengeBounded(s, "a", { n: 1 }, CAP);
+  recordChallengeBounded(s, "b", { n: 2 }, CAP);
+  recordChallengeBounded(s, "c", { n: 3 }, CAP);
+  assert.equal(s.keys().length, 3);
+
+  // Insert a 4th — should evict "a" (oldest)
+  recordChallengeBounded(s, "d", { n: 4 }, CAP);
+  assert.equal(s.keys().length, 3, "size must stay at cap");
+  assert.equal(s.get("a"), undefined, "oldest entry must be evicted");
+  assert.deepEqual(s.get("b"), { n: 2 });
+  assert.deepEqual(s.get("c"), { n: 3 });
+  assert.deepEqual(s.get("d"), { n: 4 });
+
+  // Continue spam — every subsequent insert evicts the next oldest
+  recordChallengeBounded(s, "e", { n: 5 }, CAP);
+  assert.equal(s.keys().length, 3);
+  assert.equal(s.get("b"), undefined, "next oldest must be evicted");
+  assert.deepEqual(s.get("e"), { n: 5 });
+});
+
+test("#320: re-inserting an existing key does NOT trigger eviction", () => {
+  // KEY invariant: if an attacker re-uses the same id, we must NOT
+  // evict another legitimate entry — that would be the cap making
+  // things WORSE than no cap.
+  const s = new InMemoryStore<{ n: number }>();
+  const CAP = 3;
+  recordChallengeBounded(s, "a", { n: 1 }, CAP);
+  recordChallengeBounded(s, "b", { n: 2 }, CAP);
+  recordChallengeBounded(s, "c", { n: 3 }, CAP);
+
+  // Update "a" — should not evict, should not change size
+  recordChallengeBounded(s, "a", { n: 99 }, CAP);
+  assert.equal(s.keys().length, 3, "re-insert must not change size");
+  assert.deepEqual(s.get("a"), { n: 99 }, "value must be updated");
+  assert.deepEqual(s.get("b"), { n: 2 }, "b must still be present");
+  assert.deepEqual(s.get("c"), { n: 3 }, "c must still be present");
+});
+
+test("#320: cap = 1 still functions (degenerate but valid)", () => {
+  const s = new InMemoryStore<number>();
+  recordChallengeBounded(s, "x", 1, 1);
+  assert.equal(s.keys().length, 1);
+  recordChallengeBounded(s, "y", 2, 1);
+  assert.equal(s.keys().length, 1);
+  assert.equal(s.get("x"), undefined);
+  assert.equal(s.get("y"), 2);
+});
+
+test("#320: invalid maxEntries rejected", () => {
+  const s = new InMemoryStore<number>();
+  assert.throws(() => recordChallengeBounded(s, "x", 1, 0), /maxEntries/);
+  assert.throws(() => recordChallengeBounded(s, "x", 1, -1), /maxEntries/);
+});
+
+test("#320: default cap matches MAX_CHALLENGES_DEFAULT", () => {
+  // Sanity — the default must match what coc-node uses, otherwise the
+  // unit test wouldn't reflect production behaviour.
+  assert.equal(MAX_CHALLENGES_DEFAULT, 100_000);
+});

--- a/runtime/lib/bounded-challenge-store.ts
+++ b/runtime/lib/bounded-challenge-store.ts
@@ -1,0 +1,38 @@
+/**
+ * #320: bounded in-memory store for coc-node's pose challenges.
+ *
+ * coc-node has no runtime-layer rate limiter. Pre-fix the Map held by
+ * `coc-node.ts` had no size cap, no TTL, and no LRU, so an attacker
+ * could spam unique challengeIds and grow the Map until the process
+ * OOMed. This module wraps the existing InMemoryStore with FIFO
+ * eviction once the cap is hit. Eviction order is Map insertion order
+ * (V8 guarantees this), so the oldest entry leaves first.
+ */
+
+import type { InMemoryStore } from "./state.ts";
+
+export const MAX_CHALLENGES_DEFAULT = 100_000;
+
+export function recordChallengeBounded<T>(
+  store: InMemoryStore<T>,
+  id: string,
+  value: T,
+  maxEntries: number = MAX_CHALLENGES_DEFAULT,
+): void {
+  if (maxEntries <= 0) {
+    throw new Error(`maxEntries must be > 0, got ${maxEntries}`);
+  }
+  // If id is already in the store, set() replaces in-place and there's
+  // no growth to bound — skip the eviction branch entirely.
+  if (store.get(id) === undefined) {
+    const keys = store.keys();
+    if (keys.length >= maxEntries) {
+      // V8 Map keys() returns insertion order; the first key is the
+      // oldest. Evict it before inserting the new entry so the post-
+      // state has exactly maxEntries.
+      const oldest = keys[0];
+      if (oldest !== undefined) store.delete(oldest);
+    }
+  }
+  store.set(id, value);
+}


### PR DESCRIPTION
Closes #320

## Summary

coc-node's `/pose/challenge` handler stores every received challenge in an in-memory Map that's never trimmed and has no size cap. Combined with no runtime-layer rate limiter, an unauthenticated attacker spamming unique challengeIds (or even fixed `{challengeId:{}}` payloads — fresh object refs each time via JSON.parse) grows the Map unboundedly until coc-node OOMs.

Same family as #282 (pendingTx filter seen-set growth) but on the runtime PoSe layer.

## Changes

- `runtime/coc-node.ts`:
  - challengeId must be a non-empty STRING (was: falsy check, accepted `{}` / `[]` / `42`)
  - challengeId length capped at 256 chars (so a giant string key can't amplify per-entry cost)
  - Insertion routed through `recordChallengeBounded` (100K entry cap, FIFO eviction)

- `runtime/lib/bounded-challenge-store.ts` (new): the eviction helper. FIFO via Map insertion-order semantics. Re-inserting an existing key does NOT trigger eviction (KEY invariant — otherwise the cap is worse than no cap when an attacker re-uses one id).

- `runtime/lib/bounded-challenge-store.test.ts` (new): 6 unit tests
  - Inserts up to cap without eviction
  - FIFO evicts oldest beyond cap
  - Re-insert existing key does NOT evict (KEY invariant)
  - Degenerate cap=1 still functions
  - Invalid maxEntries rejected
  - Default cap matches MAX_CHALLENGES used by coc-node

## Test plan

- [x] `node --experimental-strip-types --test runtime/lib/bounded-challenge-store.test.ts` → 6/6 pass
- [x] `node --experimental-strip-types --test $(find runtime/lib -name '*.test.ts' -type f | sort) runtime/coc-relayer.test.ts` → 170/170 pass

## Threat class

Unauthenticated OOM DoS on the coc-node runtime PoSe layer. Higher severity than the envelope-cap family (#312/#314/#316/#318) because no rate limiter slows the attack.

## Related

- #282 / PR #283 — sibling growth cap (pendingTx filter seen-set)
- #292 / PR #293 — sibling: coc-node /pose/* body cap (not merged yet)
