### PR TITLE
fix(ipfs-http): gateway honors HTTP Range header (RFC 7233) (#324)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1438,4 +1438,122 @@ describe("#310 block/stat does NOT trigger fetchRemote on local miss", () => {
       await rm(tmpDir2, { recursive: true, force: true })
     }
   })
+  })
+
+describe("#324 IPFS gateway honors HTTP Range header", () => {
+  it("bytes=N-M returns 206 Partial Content with correct slice", async () => {
+    // Pre-fix the gateway ignored Range entirely — every request
+    // returned the full body with 200. Without Range support, resumable
+    // downloads, video seek, and partial-content fetches don't work.
+    const data = Buffer.alloc(1000)
+    for (let i = 0; i < data.length; i++) data[i] = i % 256
+    const meta = await unixfs.addFile("range-test.bin", data)
+
+    // bytes=100-199 → 100 bytes (byte 100 through 199 inclusive)
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=100-199" } })
+    assert.equal(res.status, 206, "Range request must return 206 Partial Content")
+    assert.equal(res.headers["content-range"], `bytes 100-199/1000`)
+    assert.equal(Number(res.headers["content-length"]), 100)
+    const buf = await res.buffer()
+    assert.equal(buf.length, 100)
+    // Verify the bytes are correct
+    for (let i = 0; i < 100; i++) {
+      assert.equal(buf[i], (100 + i) % 256, `byte ${i} mismatch`)
+    }
+  })
+
+  it("bytes=N- returns 206 with slice from N to end", async () => {
+    const data = Buffer.alloc(500, 0x42)
+    const meta = await unixfs.addFile("range-open.bin", data)
+
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=400-" } })
+    assert.equal(res.status, 206)
+    assert.equal(res.headers["content-range"], "bytes 400-499/500")
+    assert.equal(Number(res.headers["content-length"]), 100)
+  })
+
+  it("bytes=-N suffix-byte-range returns the last N bytes", async () => {
+    const data = Buffer.alloc(1000)
+    for (let i = 0; i < data.length; i++) data[i] = i % 256
+    const meta = await unixfs.addFile("range-suffix.bin", data)
+
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=-50" } })
+    assert.equal(res.status, 206)
+    assert.equal(res.headers["content-range"], "bytes 950-999/1000")
+    assert.equal(Number(res.headers["content-length"]), 50)
+    const buf = await res.buffer()
+    assert.equal(buf[0], 950 % 256)
+    assert.equal(buf[49], 999 % 256)
+  })
+
+  it("end beyond EOF is clamped to total-1 per RFC 7233", async () => {
+    const data = Buffer.alloc(100, 0)
+    const meta = await unixfs.addFile("range-clamp.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=50-9999" } })
+    assert.equal(res.status, 206)
+    assert.equal(res.headers["content-range"], "bytes 50-99/100")
+    assert.equal(Number(res.headers["content-length"]), 50)
+  })
+
+  it("start beyond EOF returns 416 Range Not Satisfiable", async () => {
+    const data = Buffer.alloc(100, 0)
+    const meta = await unixfs.addFile("range-oob.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=500-600" } })
+    assert.equal(res.status, 416)
+    assert.equal(res.headers["content-range"], "bytes */100",
+      "416 must include Content-Range with unknown range and known total")
+  })
+
+  it("malformed Range: syntactically-invalid units ignored (200), valid-but-bad returns 416", async () => {
+    // Per RFC 7233 §4.4, 416 is for "valid form but out-of-range"; a
+    // Range header the server can't even parse should be IGNORED (200
+    // full body returned). Distinguish the two categories carefully so
+    // we don't 416-storm legitimate-but-different units like
+    // bytes=abc-def (un-parseable) or items=1-10 (different unit).
+    const data = Buffer.alloc(100, 0)
+    const meta = await unixfs.addFile("range-malformed.bin", data)
+
+    // Unparseable bytes= forms — RFC says "ignore", return full 200
+    for (const ignored of ["bytes=abc-def", "bytes=--5"]) {
+      const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: ignored } })
+      assert.equal(res.status, 200, `Range "${ignored}" is unparseable; must fall back to 200`)
+    }
+
+    // Syntactically valid but unsatisfiable — RFC says 416
+    for (const bad of ["bytes=10-5", "bytes=-"]) {
+      const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: bad } })
+      assert.equal(res.status, 416, `Range "${bad}" is satisfiability-failure; must return 416`)
+    }
+  })
+
+  it("non-bytes Range unit is ignored, full 200 returned", async () => {
+    // RFC 7233: unknown range units MUST be ignored — the recipient
+    // returns the entire representation.
+    const data = Buffer.alloc(200, 0x55)
+    const meta = await unixfs.addFile("range-unitmiss.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "items=1-10" } })
+    assert.equal(res.status, 200)
+    assert.equal(res.headers["accept-ranges"], "bytes")
+    const buf = await res.buffer()
+    assert.equal(buf.length, 200)
+  })
+
+  it("multi-range request falls back to full 200 (we don't generate multipart/byteranges)", async () => {
+    const data = Buffer.alloc(100, 0)
+    const meta = await unixfs.addFile("range-multi.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`, { headers: { Range: "bytes=0-9,50-59" } })
+    assert.equal(res.status, 200,
+      "multi-range may legally fall back to 200 — clients must handle this per RFC 7233")
+    const buf = await res.buffer()
+    assert.equal(buf.length, 100)
+  })
+
+  it("Accept-Ranges: bytes is advertised on full 200 responses too", async () => {
+    // So well-behaved clients can re-request with Range on a follow-up
+    const data = Buffer.alloc(100, 0)
+    const meta = await unixfs.addFile("range-advertise.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`)
+    assert.equal(res.status, 200)
+    assert.equal(res.headers["accept-ranges"], "bytes")
+  })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -277,6 +277,43 @@ export class IpfsHttpServer {
           // immutable + read-only, so cross-origin reads carry no CSRF
           // risk and unlock browser-side IPFS clients.
           res.writeHead(200, { "access-control-allow-origin": "*" })
+  })
+
+          // #324: HTTP Range support per RFC 7233. Pre-fix the gateway
+          // returned the full body for every request, even when the
+          // client sent `Range: bytes=N-M` — making resumable downloads,
+          // video seek, and partial-content fetches all impossible.
+          // kubo's gateway honors Range; ours had not. Parse a SINGLE
+          // bytes-range request; multi-range (comma-separated) is
+          // uncommon and falls back to 200 full body to avoid a
+          // multipart/byteranges response generator. Malformed Range
+          // → 416 Range Not Satisfiable per spec.
+          const rangeHeader = req.headers["range"]
+          if (typeof rangeHeader === "string" && rangeHeader.length > 0 && !rangeHeader.includes(",")) {
+            const parsed = parseRangeBytes(rangeHeader, data.length)
+            if (parsed === "invalid") {
+              res.writeHead(416, {
+                "content-type": "application/json",
+                "content-range": `bytes */${data.length}`,
+              })
+              res.end(JSON.stringify({ error: "range not satisfiable" }))
+              return
+            }
+            if (parsed !== "ignore") {
+              const slice = data.subarray(parsed.start, parsed.end + 1)
+              res.writeHead(206, {
+                "content-range": `bytes ${parsed.start}-${parsed.end}/${data.length}`,
+                "content-length": slice.length,
+                "accept-ranges": "bytes",
+              })
+              res.end(slice)
+              return
+            }
+          }
+          // No Range header (or unsupported multi-range): advertise
+          // Accept-Ranges so well-behaved clients can re-request with
+          // Range on a subsequent fetch.
+          res.writeHead(200, { "accept-ranges": "bytes" })
           res.end(data)
         } catch (err) {
           if (isNotFoundError(err)) {
@@ -1481,6 +1518,60 @@ function isValidCid(cid: string): boolean {
     return /^[bB][a-z2-7]+$/.test(cid)
   }
   return false
+}
+
+/**
+ * #324: parse a single bytes-range request per RFC 7233.
+ * Returns:
+ *   { start, end }   — valid single-range (inclusive bounds)
+ *   "invalid"        — syntactically valid but unsatisfiable (e.g.
+ *                      start > total-1, or both endpoints absent)
+ *                      → caller returns 416
+ *   "ignore"         — does not look like a `bytes=` range; treat as
+ *                      no Range header → caller returns full 200
+ *
+ * Forms supported:
+ *   bytes=N-M    (start N, end M; M defaults to total-1 when absent)
+ *   bytes=N-     (start N, end is total-1)
+ *   bytes=-N     (suffix; last N bytes; clamped to file size)
+ * Multi-range (comma-separated) is rejected at the caller before we
+ * get here, so we don't generate multipart/byteranges responses.
+ */
+function parseRangeBytes(header: string, totalSize: number):
+  | { start: number; end: number }
+  | "invalid"
+  | "ignore"
+{
+  // RFC 7233 §3.1 — units are case-insensitive
+  const trimmed = header.trim()
+  const match = /^bytes\s*=\s*(\d*)\s*-\s*(\d*)$/i.exec(trimmed)
+  if (!match) return "ignore"
+  const startStr = match[1]
+  const endStr = match[2]
+  if (startStr === "" && endStr === "") return "invalid"
+
+  let start: number, end: number
+  if (startStr === "") {
+    // suffix-byte-range-spec: last N bytes
+    const suffix = Number(endStr)
+    if (!Number.isFinite(suffix) || !Number.isInteger(suffix) || suffix <= 0) return "invalid"
+    if (totalSize === 0) return "invalid"
+    start = Math.max(0, totalSize - suffix)
+    end = totalSize - 1
+  } else {
+    start = Number(startStr)
+    if (!Number.isFinite(start) || !Number.isInteger(start) || start < 0) return "invalid"
+    if (start >= totalSize) return "invalid"
+    if (endStr === "") {
+      end = totalSize - 1
+    } else {
+      end = Number(endStr)
+      if (!Number.isFinite(end) || !Number.isInteger(end) || end < start) return "invalid"
+      // Per RFC 7233, clamp end to total-1 when client requests beyond EOF
+      if (end > totalSize - 1) end = totalSize - 1
+    }
+  }
+  return { start, end }
 }
 
 /**


### PR DESCRIPTION
Closes #324

## Summary

`/ipfs/<cid>` gateway returned the full body regardless of `Range:` header. Resumable downloads, video seek, and partial fetches all silently broken. Live-reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts` — Gateway handler now parses single bytes-range per RFC 7233:
  - Valid satisfiable → 206 Partial Content + Content-Range + Content-Length
  - Valid unsatisfiable (start > total-1, end < start, empty `-`) → 416 with `Content-Range: bytes */total`
  - Unparseable syntax / non-bytes unit → ignored (200 full body per spec)
  - Multi-range (comma-separated) → 200 full body (no multipart/byteranges)
  - `Accept-Ranges: bytes` advertised on 200 responses too

  New `parseRangeBytes(header, totalSize)` helper handles `bytes=N-M`, `bytes=N-`, `bytes=-N` forms with clamping to total-1.

- `node/src/ipfs-http.test.ts` — new `#324` describe block with 8 subtests:
  - bytes=N-M with byte-exact verification
  - bytes=N-, bytes=-N (suffix)
  - end clamping beyond EOF
  - start beyond EOF → 416
  - syntax-invalid vs satisfiability-failure (200 vs 416)
  - non-bytes unit ignored
  - multi-range fallback to 200
  - Accept-Ranges: bytes advertised on plain 200 too

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 59/59 pass (50 original + 8 new #324 + 1 prior describe block)
- [x] `node --experimental-strip-types --test node/src/ipfs-*.test.ts` → 197/197 IPFS tests pass

## Memory note

Current implementation reads full body via `unixfs.readFile(cid)` and slices in memory. Correct but suboptimal for very large files; streaming is a separate enhancement. The MAX_READ_SIZE cap (50 MB) bounds the worst case.

## Threat class

kubo API compat + functional. Lower than data-integrity (#302/#304/#306) but standard HTTP file-serving expectation per RFC 7233.

## Related

- #270 / PR #271 — sibling kubo arg-form compat
- #236 — sibling kubo multipart compat
- #272 / PR #273 — sibling gateway 500 fix
