### PR TITLE
fix(ipfs-http): gateway HEAD /ipfs/<cid> returns 404 — handler only matched GET (#326)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1021,6 +1021,57 @@ describe("IpfsHttpServer", () => {
       const expose = String(res.headers["access-control-expose-headers"] ?? "")
       assert.match(expose, /Content-Length/i, "JS must be able to read Content-Length for size discovery")
       assert.match(expose, /Content-Range/i, "JS must be able to read Content-Range for Range request handling")
+  })
+
+  // #326: HEAD /ipfs/<cid> was returning 404 (handler only matched GET).
+  // RFC 7231 §4.3.2 — HEAD is identical to GET except no message body.
+  // Clients use HEAD for cache probes, pre-flight, size discovery; entire
+  // capability was 100% broken.
+  describe("#326 gateway HEAD method", () => {
+    async function addFile(content: Uint8Array): Promise<CidString> {
+      const meta = await unixfs.addFile("head-test.bin", content)
+      return meta.cid
+    }
+
+    it("HEAD /ipfs/<cid> returns 200 with no body when block exists", async () => {
+      const cid = await addFile(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+      const res = await fetch(`/ipfs/${cid}`, { method: "HEAD" })
+      assert.equal(res.status, 200, "HEAD must return 200 when GET would")
+      const body = await res.buffer()
+      assert.equal(body.length, 0, "HEAD must not include message body per RFC 7231")
+      assert.equal(res.headers["content-length"], "10", "Content-Length must reflect resource size")
+    })
+
+    it("HEAD /ipfs/<cid> returns 404 (no body) for missing block", async () => {
+      // Valid CID shape but never stored
+      const ghostCid = "bafybeibwzifw52ttrkqlikfzext5akxu7lz4xiu5pq6gv2bnpyxw2jc35a"
+      const res = await fetch(`/ipfs/${ghostCid}`, { method: "HEAD" })
+      assert.equal(res.status, 404, "HEAD must surface 404 like GET")
+      const body = await res.buffer()
+      assert.equal(body.length, 0, "HEAD 404 must have no body")
+    })
+
+    it("HEAD /ipfs/<cid> returns 400 (no body) for invalid CID", async () => {
+      const res = await fetch("/ipfs/not-a-real-cid!!!", { method: "HEAD" })
+      assert.equal(res.status, 400, "HEAD must validate CID shape")
+      const body = await res.buffer()
+      assert.equal(body.length, 0, "HEAD 400 must have no body")
+    })
+
+    it("GET /ipfs/<cid> still returns body (regression guard)", async () => {
+      const content = new Uint8Array([42, 43, 44])
+      const cid = await addFile(content)
+      const res = await fetch(`/ipfs/${cid}`)
+      assert.equal(res.status, 200)
+      const buf = await res.buffer()
+      assert.deepEqual(new Uint8Array(buf), content, "GET must still return full body")
+    })
+
+    it("HEAD agrees with GET status code on all paths", async () => {
+      const cid = await addFile(new Uint8Array([9, 9, 9]))
+      const getRes = await fetch(`/ipfs/${cid}`)
+      const headRes = await fetch(`/ipfs/${cid}`, { method: "HEAD" })
+      assert.equal(headRes.status, getRes.status, "HEAD and GET must agree on status code (RFC 7231)")
     })
   })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -266,6 +266,19 @@ export class IpfsHttpServer {
         if (!isValidCid(cid)) {
           res.writeHead(400, { "content-type": "application/json", "access-control-allow-origin": "*" })
           res.end(JSON.stringify({ error: "invalid CID" }))
+  })
+
+      // #326: HEAD must be treated as GET-without-body per RFC 7231 §4.3.2.
+      // Pre-fix the gateway only matched GET, so `curl -I /ipfs/<cid>` fell
+      // through to the /api/v0/ 404 even when the block existed and a real
+      // GET succeeded. Clients use HEAD for cache validation, pre-flight,
+      // and resumable-download discovery — that capability was 100% broken.
+      const isGatewayMethod = req.method === "GET" || req.method === "HEAD"
+      if (isGatewayMethod && url.pathname?.startsWith("/ipfs/")) {
+        const cid = url.pathname.slice(6) // strip "/ipfs/"
+        if (!isValidCid(cid)) {
+          res.writeHead(400, { "content-type": "application/json" })
+          res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: "invalid CID" }))
           return
         }
         // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated
@@ -319,6 +332,21 @@ export class IpfsHttpServer {
           if (isNotFoundError(err)) {
             res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })
             res.end(JSON.stringify({ error: "not found" }))
+  })
+
+          // #326: HEAD response sets Content-Length but no body, matching
+          // RFC 7231 §4.3.2 ("must not send a message body").
+          if (req.method === "HEAD") {
+            res.writeHead(200, { "content-length": String(data.length) })
+            res.end()
+          } else {
+            res.writeHead(200)
+            res.end(data)
+          }
+        } catch (err) {
+          if (isNotFoundError(err)) {
+            res.writeHead(404, { "content-type": "application/json" })
+            res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: "not found" }))
           } else {
             throw err
           }


### PR DESCRIPTION
Closes #326

## Summary

`HEAD /ipfs/<cid>` returned 404 Not Found even when the block existed
and `GET /ipfs/<cid>` succeeded. Gateway handler only matched
`req.method === "GET"`; HEAD fell through to the generic 404. RFC
7231 §4.3.2 mandates HEAD be identical to GET sans body. Live-
reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts` — Accept HEAD as a gateway method alongside GET:
  - Success → `200` + `Content-Length` header, empty body
  - Invalid CID → `400`, empty body
  - Missing block → `404`, empty body
  - GET path unchanged

- `node/src/ipfs-http.test.ts` — new `#326` describe block with 5 subtests:
  - HEAD existing block → 200, no body, correct Content-Length
  - HEAD missing → 404, no body
  - HEAD invalid CID → 400, no body
  - GET still returns full body (regression guard)
  - HEAD/GET status-code agreement (RFC 7231 invariant)

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 55/55 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Threat class

kubo API compat. Lower than data-integrity (#302/#304/#306) but
standard HTTP file-serving expectation — every cache validator,
resumable downloader, and link-checker assumes HEAD support.

## Related

- #168 — pre-fix 404/500 mapping
- #272 / PR #273 — sibling raw-block gateway fix
- #324 / PR #325 — sibling Range header support