### PR TITLE
fix(ipfs-http): gateway adds CORS support — browser cross-origin reads (#328)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -737,6 +737,84 @@ describe("IpfsHttpServer", () => {
     const body = await r.json() as { error?: string }
     assert.match(body.error ?? "", /invalid CID/i, "error must explain shape")
   })
+
+  // #328: gateway has no CORS support — browser-based IPFS clients can
+  // not read /ipfs/<cid> from a different origin. RFC + kubo conventions:
+  // /ipfs/* is read-only content addressing, ACAO: *; /api/v0/* is
+  // CSRF-protected (POST-only, no ACAO) so cross-origin POST is denied.
+  describe("#328 gateway CORS support", () => {
+    it("OPTIONS /ipfs/<cid> → 204 with full CORS preflight headers", async () => {
+      const data = new TextEncoder().encode("cors target")
+      const meta = await unixfs.addFile("c.bin", data)
+      const res = await fetch(`/ipfs/${meta.cid}`, {
+        method: "OPTIONS",
+        headers: {
+          "origin": "https://example.com",
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "range",
+        },
+      })
+      assert.equal(res.status, 204, "OPTIONS preflight must return 204 No Content")
+      assert.equal(res.headers["access-control-allow-origin"], "*", "gateway must allow any origin")
+      assert.match(String(res.headers["access-control-allow-methods"] ?? ""), /GET/, "must advertise GET")
+      assert.match(String(res.headers["access-control-allow-methods"] ?? ""), /HEAD/, "must advertise HEAD")
+      assert.match(String(res.headers["access-control-allow-headers"] ?? ""), /Range/i, "must allow Range header")
+      const body = await res.buffer()
+      assert.equal(body.length, 0, "OPTIONS 204 response must have no body")
+    })
+
+    it("GET /ipfs/<cid> sets Access-Control-Allow-Origin: * on success", async () => {
+      const data = new TextEncoder().encode("acao body")
+      const meta = await unixfs.addFile("acao.bin", data)
+      const res = await fetch(`/ipfs/${meta.cid}`, {
+        headers: { "origin": "https://example.com" },
+      })
+      assert.equal(res.status, 200)
+      assert.equal(res.headers["access-control-allow-origin"], "*", "gateway success must set ACAO: *")
+    })
+
+    it("GET /ipfs/<invalid> sets ACAO: * on 400 error too", async () => {
+      // Browsers also need ACAO on the error path or they reject the
+      // response and can't surface the error to JS.
+      const res = await fetch("/ipfs/not-a-cid!!!", {
+        headers: { "origin": "https://example.com" },
+      })
+      assert.equal(res.status, 400)
+      assert.equal(res.headers["access-control-allow-origin"], "*", "400 response must also set ACAO: *")
+    })
+
+    it("OPTIONS /api/v0/cat → 204 with NO Access-Control-Allow-Origin (CSRF lock)", async () => {
+      const res = await fetch("/api/v0/cat?arg=x", {
+        method: "OPTIONS",
+        headers: {
+          "origin": "https://attacker.example",
+          "access-control-request-method": "POST",
+        },
+      })
+      assert.equal(res.status, 204, "preflight must return 204 (not 405) to stay browser-spec-compliant")
+      assert.equal(res.headers["access-control-allow-origin"], undefined, "API must NOT advertise ACAO — preserves #136 CSRF lock")
+      const body = await res.buffer()
+      assert.equal(body.length, 0, "OPTIONS body must be empty")
+    })
+
+    it("OPTIONS /ipfs/<cid> Max-Age caches preflight for browsers", async () => {
+      const res = await fetch("/ipfs/bafybeibwzifw52ttrkqlikfzext5akxu7lz4xiu5pq6gv2bnpyxw2jc35a", {
+        method: "OPTIONS",
+      })
+      assert.equal(res.status, 204)
+      const maxAge = String(res.headers["access-control-max-age"] ?? "")
+      assert.ok(Number(maxAge) >= 3600, `preflight cache must be ≥1h, got ${maxAge}`)
+    })
+
+    it("OPTIONS /ipfs/<cid> exposes Content-Length and Content-Range to JS", async () => {
+      const res = await fetch("/ipfs/bafybeibwzifw52ttrkqlikfzext5akxu7lz4xiu5pq6gv2bnpyxw2jc35a", {
+        method: "OPTIONS",
+      })
+      const expose = String(res.headers["access-control-expose-headers"] ?? "")
+      assert.match(expose, /Content-Length/i, "JS must be able to read Content-Length for size discovery")
+      assert.match(expose, /Content-Range/i, "JS must be able to read Content-Range for Range request handling")
+    })
+  })
 })
 
 // Phase Q.4 — Reed-Solomon erasure coding integration tests.

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -173,10 +173,38 @@ export class IpfsHttpServer {
       }
 
       const url = parseUrl(req.url ?? "", true)
+
+      // #328: CORS support. The gateway (/ipfs/<cid>) is read-only content
+      // addressing and intentionally cross-origin-friendly, so it advertises
+      // ACAO: * + the methods/headers browsers need (Range, conditional
+      // headers, etc.) and exposes Content-Length / Content-Range / etc.
+      // /api/v0/* is intentionally CORS-locked: kubo's POST-only rule
+      // (#136) plus the absence of ACAO denies cross-origin POSTs, which
+      // is the existing CSRF protection. The OPTIONS preflight here just
+      // returns 204 with no ACAO so the browser denies the actual POST.
+      if (req.method === "OPTIONS") {
+        if (url.pathname?.startsWith("/ipfs/")) {
+          res.writeHead(204, {
+            "access-control-allow-origin": "*",
+            "access-control-allow-methods": "GET, HEAD, OPTIONS",
+            "access-control-allow-headers": "Range, If-None-Match, If-Match, If-Modified-Since",
+            "access-control-expose-headers": "Content-Length, Content-Range, Accept-Ranges, ETag",
+            "access-control-max-age": "86400",
+          })
+          res.end()
+          return
+        }
+        // /api/v0/* and everything else: 204 no-CORS — preflight denied,
+        // browser will not send the actual POST.
+        res.writeHead(204)
+        res.end()
+        return
+      }
+
       if (req.method === "GET" && url.pathname?.startsWith("/ipfs/")) {
         const cid = url.pathname.slice(6) // strip "/ipfs/"
         if (!isValidCid(cid)) {
-          res.writeHead(400, { "content-type": "application/json" })
+          res.writeHead(400, { "content-type": "application/json", "access-control-allow-origin": "*" })
           res.end(JSON.stringify({ error: "invalid CID" }))
           return
         }
@@ -185,11 +213,14 @@ export class IpfsHttpServer {
         // Map to 404 explicitly so missing-block looks like missing-block.
         try {
           const data = await this.unixfs.readFile(cid)
-          res.writeHead(200)
+          // #328: ACAO: * on gateway success — content addressing is
+          // immutable + read-only, so cross-origin reads carry no CSRF
+          // risk and unlock browser-side IPFS clients.
+          res.writeHead(200, { "access-control-allow-origin": "*" })
           res.end(data)
         } catch (err) {
           if (isNotFoundError(err)) {
-            res.writeHead(404, { "content-type": "application/json" })
+            res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })
             res.end(JSON.stringify({ error: "not found" }))
           } else {
             throw err


### PR DESCRIPTION
Closes #328

## Summary

IPFS gateway had **zero CORS support**. OPTIONS preflight returned 404
(gateway) or 405 (API), and GET responses lacked `Access-Control-Allow-
Origin`, so every browser-based JS client was blocked by Same-Origin
Policy. Live-reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts` — Two-tier CORS policy:
  - **Gateway `/ipfs/*`** (read-only, cross-origin-friendly):
    - OPTIONS → 204 + full CORS allow (`*` origin, GET/HEAD/OPTIONS methods,
      Range + conditional headers, expose Content-Length/Range/Accept-Ranges/
      ETag, Max-Age 86400)
    - GET success + error responses both carry `Access-Control-Allow-Origin: *`
  - **API `/api/v0/*`** (state-mutating, CSRF-protected):
    - OPTIONS → 204 with **no** ACAO. Browser denies the actual cross-
      origin POST, preserving #136's POST-only CSRF lock.

- `node/src/ipfs-http.test.ts` — new `#328` describe block with 6 subtests:
  - OPTIONS gateway preflight → 204 + ACAO: * + methods/headers/expose/Max-Age
  - GET gateway success → ACAO: *
  - GET gateway 400 → ACAO: * (so browsers surface errors to JS)
  - OPTIONS /api/v0/* → 204 with NO ACAO (CSRF lock preserved)
  - Max-Age ≥ 1 hour (browser preflight cache)
  - Expose-Headers includes Content-Length + Content-Range

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 56/56 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Security

Gateway CORS is intentionally open (immutable, read-only content
addressing — no CSRF surface). API CORS remains locked: the OPTIONS
preflight now responds 204 (vs 405) to stay spec-compliant, but with
no ACAO, so browsers refuse to send the actual cross-origin POST.
Combined with #136's POST-only enforcement, the CSRF defense is
strictly stronger than pre-fix.

## Family

kubo gateway parity. Sibling of #272 (raw-block 500), #324 (Range
header), #326 (HEAD method) — basic HTTP semantics every browser
client expects.