### PR TITLE
fix(rpc): eth_sendRawTransaction replacement-underpriced → -32000 (#332)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2399,6 +2399,57 @@ test("RPC Extended Methods", async (t) => {
       "contract T must be in compile output")
   })
 
+  await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {
+    // mempool.addRawTx throws plain Error("replacement tx gas price too
+    // low: need at least X, got Y") when a same-nonce replacement does
+    // not clear the 10% bump threshold. Pre-fix this fell through to the
+    // outer dispatch and surfaced as -32603 "internal error" — clients
+    // treat -32603 as transient and retry, burning the same underpriced
+    // replacement until they give up. Geth uses -32000 for this exact
+    // condition with message "replacement transaction underpriced".
+    const { Wallet, parseEther } = await import("ethers")
+    const wallet = new Wallet(`0x${"03".repeat(32)}`)
+    // Pre-fund the wallet so the mempool accepts the first tx.
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+
+    async function signTx(nonce: number, gasPrice: bigint): Promise<string> {
+      return await wallet.signTransaction({
+        type: 0,
+        to: `0x${"02".repeat(20)}`,
+        value: 1n,
+        nonce,
+        gasPrice,
+        gasLimit: 21_000n,
+        chainId,
+      })
+    }
+
+    // Submit initial tx at nonce N with a base gas price.
+    const startNonce = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+    const initial = await signTx(Number(startNonce), 1_000_000_000n)
+    const initialRes = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [initial] }),
+    })
+    const initialBody = await initialRes.json() as { result?: string; error?: { code: number; message: string } }
+    assert.ok(initialBody.result, `initial submit must succeed: ${JSON.stringify(initialBody)}`)
+
+    // Submit replacement with INSUFFICIENT bump (same gas price → 0% bump,
+    // mempool requires 10%). This is the trigger for the bug.
+    const replacement = await signTx(Number(startNonce), 1_000_000_000n)
+    const replRes = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "eth_sendRawTransaction", params: [replacement] }),
+    })
+    const replBody = await replRes.json() as { error?: { code: number; message: string }; result?: unknown }
+    assert.equal(replBody.error?.code, -32000,
+      `replacement-underpriced must be -32000, got ${replBody.error?.code} (${replBody.error?.message})`)
+    assert.match(replBody.error!.message, /replacement.*gas price too low/i,
+      `error must preserve "replacement tx gas price too low" surface, got: ${JSON.stringify(replBody)}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1076,6 +1076,16 @@ async function handleRpc(
         if (isEthersShapeError) {
           invalidParams("invalid raw transaction: failed to decode")
         }
+        // #332: mempool.addRawTx throws plain Error("replacement tx gas price
+        // too low: ...") when a same-nonce replacement doesn't clear the 10%
+        // bump threshold. Pre-fix this surfaced as -32603 "internal error"
+        // even though it's a clean client-input rejection — the caller just
+        // needs to retry with a higher gas price. Map to -32000 to match
+        // geth's "replacement transaction underpriced" convention.
+        const msg = parseErr instanceof Error ? parseErr.message : String(parseErr)
+        if (/^replacement tx gas price too low/i.test(msg)) {
+          throw { code: -32000, message: msg }
+        }
         throw parseErr
       }
       await p2p.receiveTx(raw)


### PR DESCRIPTION
Closes #332

## Summary

`eth_sendRawTransaction` for a same-nonce replacement without the
required 10% gas-price bump returned -32603 "internal error" instead
of -32000 "replacement transaction underpriced". Clients (ethers.js,
viem, foundry cast) retry on -32603, burning through the same
underpriced replacement until they give up. Live-reproducible on 88780.

## Changes

- `node/src/rpc.ts` — extend eth_sendRawTransaction catch with a regex
  remap for `^replacement tx gas price too low` → throw `{code: -32000, message}`.

- `node/src/rpc-extended.test.ts` — new `#332` subtest covering the
  full flow: pre-fund test wallet, submit initial tx, submit same-nonce
  replacement without bump, assert -32000 + message preserved.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` → 94/94 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Family

Sibling of #276 / PR #277 (mempool client-input error mapping). That
PR maps 9 mempool/chain errors but misses the replacement-underpriced
case — this is the gap. Both PRs share the same goal: give clients
the spec-correct JSON-RPC §5.1 error code so they don't loop on
transient-treatment of client-input errors.

## Related

- #276 / PR #277 — sibling mempool error code mapping
- #286 / PR #287 — sibling eth_call revert surface (-32000 pattern)