### PR TITLE
fix(mempool): reject gasLimit below intrinsic (EIP-3 / EIP-2028 / EIP-3860) (#334)

### DIFF
--- a/node/src/mempool.test.ts
+++ b/node/src/mempool.test.ts
@@ -131,6 +131,77 @@ describe("Mempool", () => {
     assert.throws(() => pool.addRawTx(raw), /invalid chain ID/)
   })
 
+  // #334: gasLimit below intrinsic was silently accepted, returning a
+  // success hash from eth_sendRawTransaction but never executing — wasted
+  // nonce slot, unreplayable (10% bump on zero) + mempool-fill DoS.
+  it("rejects gasLimit below intrinsic gas (EIP-3)", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    // Plain transfer: intrinsic = 21000. Submit with 100.
+    const tx = Transaction.from({
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      nonce: 0,
+      gasLimit: "0x64", // 100 — below 21000
+      gasPrice: "0x3b9aca00",
+      chainId: CHAIN_ID,
+      data: "0x",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    assert.throws(
+      () => pool.addRawTx(clone.serialized as Hex),
+      /intrinsic gas too low: have 100, want 21000/,
+      "below-intrinsic gasLimit must throw with geth-style message",
+    )
+  })
+
+  it("rejects gasLimit below intrinsic for contract creation (EIP-3860)", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    // Contract creation: intrinsic = 21000 + 32000 + data cost + initcode word cost.
+    // Init code "0xfe" = 1 nonzero byte = +16. 1 byte init code = ceil(1/32) = 1 word = +2.
+    // Total: 21000 + 32000 + 16 + 2 = 53018. Submit 53000 to verify the precise floor.
+    const tx = Transaction.from({
+      to: null, // creation
+      value: 0n,
+      nonce: 0,
+      gasLimit: 53000n, // 18 below the required 53018
+      gasPrice: "0x3b9aca00",
+      chainId: CHAIN_ID,
+      data: "0xfe",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    assert.throws(
+      () => pool.addRawTx(clone.serialized as Hex),
+      /intrinsic gas too low: have 53000, want 53018/,
+      "creation must charge +32000 base + initcode-word cost",
+    )
+  })
+
+  it("accepts gasLimit exactly at intrinsic floor", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    // Plain transfer with no data — exactly 21000.
+    const tx = Transaction.from({
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      nonce: 0,
+      gasLimit: 21000n,
+      gasPrice: "0x3b9aca00",
+      chainId: CHAIN_ID,
+      data: "0x",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    const added = pool.addRawTx(clone.serialized as Hex)
+    assert.ok(added.hash, "exact-floor tx must be accepted")
+  })
+
   it("picks txs in gas price order with nonce continuity", async () => {
     const pool = new Mempool({ chainId: CHAIN_ID })
     signAndAdd(pool, PK1, 0, "0x3b9aca00") // 1 gwei, nonce 0

--- a/node/src/mempool.ts
+++ b/node/src/mempool.ts
@@ -61,6 +61,42 @@ function partialSelect<T>(arr: T[], k: number, compare: (a: T, b: T) => number):
   }
 }
 
+/**
+ * EIP-3 / EIP-2028 / EIP-3860 intrinsic gas cost — the minimum any tx must
+ * pay before the EVM even starts. Returns the floor `gasLimit` that the
+ * mempool will accept; anything below is rejected as "intrinsic gas too low".
+ *
+ * Components (mainnet/Shanghai constants):
+ *   - 21000   base (any tx)
+ *   - +32000  contract creation (no `to`)
+ *   - +4 per zero data byte / +16 per nonzero data byte (EIP-2028)
+ *   - +2 per 32-byte init-code word (EIP-3860, contract creation only)
+ */
+export function computeIntrinsicGas(tx: Transaction): bigint {
+  let gas = 21000n
+  const isCreation = !tx.to
+  if (isCreation) gas += 32000n
+  const data = tx.data ?? "0x"
+  const hex = data.startsWith("0x") ? data.slice(2) : data
+  if (hex.length > 0) {
+    let zeros = 0n
+    let nonzeros = 0n
+    for (let i = 0; i < hex.length; i += 2) {
+      // Treat odd-length tail (shouldn't happen for valid hex) as nonzero
+      const byte = hex.slice(i, i + 2)
+      if (byte === "00") zeros++
+      else nonzeros++
+    }
+    gas += zeros * 4n + nonzeros * 16n
+    if (isCreation) {
+      const byteLen = BigInt(hex.length / 2)
+      const words = (byteLen + 31n) / 32n
+      gas += words * 2n
+    }
+  }
+  return gas
+}
+
 export class Mempool {
   private readonly txs = new Map<Hex, MempoolTx>()
   // Index: sender -> set of tx hashes for fast per-sender lookups
@@ -140,6 +176,21 @@ export class Mempool {
     const MAX_TX_GAS_LIMIT = 30_000_000n
     if (gasLimit > MAX_TX_GAS_LIMIT) {
       throw new Error(`gasLimit exceeds maximum: ${gasLimit} > ${MAX_TX_GAS_LIMIT}`)
+    }
+
+    // #334: reject gasLimit below the EIP-3 intrinsic gas cost. Pre-fix the
+    // mempool only enforced the upper bound, so a tx with `gasLimit=100`
+    // returned a success hash from eth_sendRawTransaction but could never
+    // execute — wasting a nonce slot and leaving the user with a tx they
+    // can't replace (without a 10% bump on already-zero gas price). Also
+    // a clean mempool-fill DoS surface since these txs sit forever.
+    // Geth surfaces this as -32000 "intrinsic gas too low: gas X, minimum
+    // needed Y"; mirror the message so existing clients parse it.
+    const intrinsicGasRequired = computeIntrinsicGas(tx)
+    if (gasLimit < intrinsicGasRequired) {
+      throw new Error(
+        `intrinsic gas too low: have ${gasLimit}, want ${intrinsicGasRequired}`,
+      )
     }
 
     const item: MempoolTx = {


### PR DESCRIPTION
Closes #334

## Summary

Mempool accepted `gasLimit=100` (well below 21000 intrinsic floor),
returning a success hash from `eth_sendRawTransaction`. Tx then sat
in mempool forever — can't execute, can't be replaced. DoS surface +
silent client UX failure. Live-reproducible on 88780.

## Changes

- `node/src/mempool.ts` — new exported `computeIntrinsicGas(tx)`
  helper implementing:
  - 21000 base (EIP-3)
  - +32000 contract creation
  - +4 per zero / +16 per nonzero data byte (EIP-2028)
  - +2 per 32-byte init-code word (EIP-3860, creation only)

  `addRawTx()` now throws `intrinsic gas too low: have X, want Y`
  (geth-message-compatible) when `gasLimit < required`, inserted
  right after the existing upper-bound check.

- `node/src/mempool.test.ts` — 3 new it-blocks:
  - Below-intrinsic plain transfer rejected
  - Below-intrinsic creation (EIP-3860 word cost verified)
  - Exact-floor 21000 accepted

## Test plan

- [x] `node --experimental-strip-types --test node/src/mempool.test.ts` → 22/22 pass
- [x] `node --experimental-strip-types --test node/src/mempool.test.ts node/src/rpc.test.ts` → 27/27 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Family

Mempool client-input hardening. Same class as #280/#281 (pin/add DoS),
#282/#283 (mempool leak), #292/#293 (coc-node OOM), #332/#333
(replacement underpriced). Theme: validate at the boundary.

## Note on error code

The throw surfaces as `-32603` via the outer dispatch today. PR #277
(#276) will map known mempool errors to `-32602` / `-32005` when it
lands; this throw's message starts with `intrinsic gas too low:` so
it'll naturally pick up that mapping. Keeping the message
geth-compatible (`have X, want Y`) preserves regex matchability for
any future extension.