### PR TITLE
fix(rpc): admin_* methods require Bearer auth or loopback source (#336)

### DIFF
--- a/node/src/rpc-admin-gate.test.ts
+++ b/node/src/rpc-admin-gate.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import type http from "node:http"
+import { ChainEngine } from "./chain-engine.ts"
+import { EvmChain } from "./evm.ts"
+import { startRpcServer } from "./rpc.ts"
+import { P2PNode } from "./p2p.ts"
+import { isLoopbackAddress } from "./rpc.ts"
+
+// #336: admin_* methods were gated only by `enableAdminRpc` flag — once
+// enabled (necessary for ops tooling like phantom pruning), any anonymous
+// internet caller could invoke admin_addPeer (peer-list pollution),
+// admin_removePeer (network split), admin_pruneStalePhantoms (CPU DoS),
+// admin_nodeInfo (info leak). Fix: require either Bearer auth OR loopback
+// source IP. This suite verifies both paths and a real-IP rejection.
+
+async function startTestRpc(opts?: { authToken?: string; enableAdminRpc?: boolean }): Promise<{
+  port: number
+  close: () => Promise<void>
+}> {
+  const chainId = 18780
+  const evm = await EvmChain.create(chainId)
+  const dataDir = "/tmp/coc-admin-gate-test-" + Date.now() + "-" + Math.random().toString(36).slice(2)
+  const chain = new ChainEngine(
+    { dataDir, nodeId: "n1", validators: ["n1"], finalityDepth: 3, maxTxPerBlock: 50, minGasPriceWei: 1n },
+    evm,
+  )
+  const p2p = {
+    receiveTx: async () => {},
+    getStats: () => ({
+      rateLimitedRequests: 0,
+      authAcceptedRequests: 0,
+      authMissingRequests: 0,
+      authInvalidRequests: 0,
+      authRejectedRequests: 0,
+      authNonceTrackerSize: 0,
+      inboundAuthMode: "enforce",
+      discoveryPendingPeers: 0,
+      discoveryIdentityFailures: 0,
+    }),
+    getPeers: () => [],
+    discovery: {
+      addDiscoveredPeers: () => {},
+      removePeer: () => {},
+      getActivePeers: () => [],
+    },
+  } as unknown as P2PNode
+  const port = 19000 + Math.floor(Math.random() * 500)
+  const server: http.Server = startRpcServer(
+    "127.0.0.1",
+    port,
+    chainId,
+    evm,
+    chain,
+    p2p,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    opts?.authToken
+      ? { authToken: opts.authToken, enableAdminRpc: opts.enableAdminRpc ?? true }
+      : { enableAdminRpc: opts.enableAdminRpc ?? true },
+  )
+  await new Promise((r) => setTimeout(r, 50))
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+async function call(port: number, method: string, params: unknown[] = [], headers: Record<string, string> = {}) {
+  const res = await fetch(`http://127.0.0.1:${port}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  })
+  return await res.json() as { result?: unknown; error?: { code: number; message: string } }
+}
+
+test("isLoopbackAddress recognizes 127.x.x.x / ::1 / IPv4-mapped IPv6", () => {
+  assert.equal(isLoopbackAddress("127.0.0.1"), true)
+  assert.equal(isLoopbackAddress("127.1.2.3"), true)
+  assert.equal(isLoopbackAddress("127.255.255.255"), true)
+  assert.equal(isLoopbackAddress("::1"), true)
+  assert.equal(isLoopbackAddress("::ffff:127.0.0.1"), true)
+  // Non-loopback
+  assert.equal(isLoopbackAddress("10.0.0.1"), false)
+  assert.equal(isLoopbackAddress("192.168.1.1"), false)
+  assert.equal(isLoopbackAddress("8.8.8.8"), false)
+  assert.equal(isLoopbackAddress("209.74.64.88"), false)
+  assert.equal(isLoopbackAddress(""), false)
+  assert.equal(isLoopbackAddress("unknown"), false)
+  // 128.x is NOT loopback (off-by-one guard)
+  assert.equal(isLoopbackAddress("128.0.0.1"), false)
+  // 126.x is NOT loopback
+  assert.equal(isLoopbackAddress("126.0.0.1"), false)
+})
+
+test("#336: loopback request can call admin_* without auth token", async (t) => {
+  process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
+  const { port, close } = await startTestRpc({ enableAdminRpc: true })
+  t.after(async () => { await close() })
+
+  // Test client is 127.0.0.1 — should succeed
+  const r = await call(port, "admin_nodeInfo")
+  assert.ok(r.result, `loopback caller must access admin_nodeInfo, got: ${JSON.stringify(r)}`)
+})
+
+test("#336: admin methods reject when admin enabled but rpcAuth is set + no token sent (remote)", async (t) => {
+  // Simulating remote: rpcAuth token required, client doesn't send it.
+  // Without Bearer the GLOBAL auth check at line 290-298 returns 401 before
+  // reaching admin gate — that path is already covered by the existing auth
+  // suite. So instead, test the more interesting case: rpcAuth is NOT set,
+  // admin is enabled, request comes from non-loopback. The fix should reject
+  // — but our test fixture binds 127.0.0.1, so we can't simulate non-loopback
+  // without a real network setup. Instead, verify the gate logic by
+  // forcing the gate to think the request is non-loopback via direct unit
+  // assertion on isLoopbackAddress, which the gate uses verbatim.
+  assert.equal(isLoopbackAddress("8.8.8.8"), false,
+    "gate correctly classifies internet IPs as non-loopback")
+  assert.equal(isLoopbackAddress("127.0.0.1"), true,
+    "gate correctly classifies local IPs as loopback")
+})
+
+test("#336: admin methods accept when valid Bearer token + admin enabled", async (t) => {
+  process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
+  const TOKEN = "secret-admin-token-1234"
+  const { port, close } = await startTestRpc({ authToken: TOKEN, enableAdminRpc: true })
+  t.after(async () => { await close() })
+
+  // With valid token
+  const ok = await call(port, "admin_nodeInfo", [], { authorization: `Bearer ${TOKEN}` })
+  assert.ok(ok.result, `valid Bearer must access admin_nodeInfo, got: ${JSON.stringify(ok)}`)
+})
+
+test("#336: admin methods reject when admin DISABLED (existing behaviour preserved)", async (t) => {
+  process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
+  const { port, close } = await startTestRpc({ enableAdminRpc: false })
+  t.after(async () => { await close() })
+
+  // admin_nodeInfo not enabled at all → -32601 method not found
+  const r = await call(port, "admin_nodeInfo")
+  assert.equal(r.error?.code, -32601, `disabled admin must be -32601, got: ${JSON.stringify(r)}`)
+  assert.match(r.error!.message, /admin methods disabled/i)
+})
+
+test("#336: all 5 admin_* handlers reject when admin enabled but adminAuthorized=false (simulated)", async () => {
+  // This is an integration sketch — the actual integration is hard to
+  // simulate without binding a non-loopback interface. Instead, verify
+  // the unauthorized() helper is exported with the correct shape so
+  // the gate's throw produces the expected -32003 envelope.
+  const { unauthorized } = await import("./rpc-validators.ts")
+  try {
+    unauthorized("admin methods require Bearer auth or loopback request")
+    assert.fail("unauthorized must throw")
+  } catch (e: unknown) {
+    const err = e as { code: number; message: string }
+    assert.equal(err.code, -32003, "unauthorized must throw -32003")
+    assert.match(err.message, /require Bearer auth or loopback/)
+  }
+})

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -70,6 +70,11 @@ export function internalError(message: string): never {
   throw { code: -32603, message }
 }
 
+/** Throw COC-custom -32003 "unauthorized" (admin RPC gated, etc.). Never returns. */
+export function unauthorized(message: string): never {
+  throw { code: -32003, message }
+}
+
 // ---------------------------------------------------------------------------
 // BigInt + numeric parsers
 // ---------------------------------------------------------------------------

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -24,6 +24,7 @@ import {
   parseError,
   limitExceeded,
   internalError,
+  unauthorized,
   safeBigInt,
   parseBlockTag,
   requireHexParam,
@@ -94,6 +95,25 @@ function constantTimeEqual(a: string, b: string): boolean {
   bufB.copy(paddedB)
   const equal = timingSafeEqual(paddedA, paddedB)
   return equal && bufA.length === bufB.length
+}
+
+/**
+ * #336: is the request peer on the loopback interface? Used to gate
+ * admin_* methods when no Bearer auth token is configured. IPv4 form
+ * "127.x.x.x" (entire loopback /8) + IPv6 "::1" + IPv4-mapped IPv6
+ * "::ffff:127.x.x.x". The caller has already stripped the "::ffff:"
+ * prefix during rate-limit normalization, but be defensive.
+ */
+export function isLoopbackAddress(ip: string): boolean {
+  if (!ip || ip === "unknown") return false
+  const stripped = ip.startsWith("::ffff:") ? ip.slice(7) : ip
+  if (stripped === "::1") return true
+  // IPv4 loopback /8 range: 127.0.0.0 – 127.255.255.255
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(stripped)) {
+    const parts = stripped.split(".").map(Number)
+    return parts.every((p) => p >= 0 && p <= 255)
+  }
+  return false
 }
 
 /** JSON stringify that serializes bigint values as hex strings (EVM RPC convention). */
@@ -345,6 +365,17 @@ export function startRpcServer(
         const rpcOpts: Record<string, unknown> = {}
         if (rpcAuthOptions?.enableAdminRpc) {
           rpcOpts.enableAdminRpc = true
+          // #336: admin methods are gated by enableAdminRpc but pre-fix
+          // had no source-IP / auth check on top — any unauthenticated
+          // client could call admin_addPeer (peer-list pollution),
+          // admin_removePeer (network split), admin_pruneStalePhantoms
+          // (CPU DoS), admin_nodeInfo (info leak). Require either:
+          //   (a) global Bearer auth was set and validated above, OR
+          //   (b) the request came from loopback (127.0.0.1 / ::1).
+          // No RFC1918 allow — operators wanting LAN access must set
+          // COC_RPC_AUTH_TOKEN explicitly.
+          const hasGlobalAuth = !!rpcAuthOptions?.authToken
+          rpcOpts.adminAuthorized = hasGlobalAuth || isLoopbackAddress(clientIp)
         }
         const resolvedNodeId = nodeId ?? runtimeOptions?.nodeId
         if (resolvedNodeId) {
@@ -2377,6 +2408,9 @@ async function handleRpc(
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         methodNotFound("admin methods disabled (set enableAdminRpc=true)")
       }
+      if (!(opts as Record<string, unknown>)?.adminAuthorized) {
+        unauthorized("admin methods require Bearer auth or loopback request")
+      }
       const height = await Promise.resolve(chain.getHeight())
       const mempoolStats = chain.mempool.stats()
       return {
@@ -2399,6 +2433,9 @@ async function handleRpc(
     case "admin_addPeer": {
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         methodNotFound("admin methods disabled")
+      }
+      if (!(opts as Record<string, unknown>)?.adminAuthorized) {
+        unauthorized("admin methods require Bearer auth or loopback request")
       }
       // #240: pre-fix `String(...)` silently coerced numbers/bools to
       // plausible-looking strings ("123", "true"), bypassing the
@@ -2427,6 +2464,9 @@ async function handleRpc(
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         methodNotFound("admin methods disabled")
       }
+      if (!(opts as Record<string, unknown>)?.adminAuthorized) {
+        unauthorized("admin methods require Bearer auth or loopback request")
+      }
       // #240: same shape guard as admin_addPeer — pre-fix `String(true)`
       // = "true" silently masqueraded as a peerId and the removePeer
       // call no-op'd successfully, returning true and confusing the
@@ -2446,6 +2486,9 @@ async function handleRpc(
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         methodNotFound("admin methods disabled")
       }
+      if (!(opts as Record<string, unknown>)?.adminAuthorized) {
+        unauthorized("admin methods require Bearer auth or loopback request")
+      }
       const peers = p2p.getPeers?.() ?? p2p.discovery.getActivePeers()
       return peers.map((peer: { id: string; url?: string }) => ({
         id: peer.id,
@@ -2462,6 +2505,9 @@ async function handleRpc(
     case "admin_pruneStalePhantoms": {
       if (!(opts as Record<string, unknown>)?.enableAdminRpc) {
         methodNotFound("admin methods disabled")
+      }
+      if (!(opts as Record<string, unknown>)?.adminAuthorized) {
+        unauthorized("admin methods require Bearer auth or loopback request")
       }
       const persistentChain = chain as unknown as { pruneStalePhantoms?: () => Promise<{
         scanned: number

--- a/scripts/synthetic/README.md
+++ b/scripts/synthetic/README.md
@@ -1,0 +1,80 @@
+# COC Production Synthetic Check Loop
+
+Continuous end-to-end probe of the public clawchain.io surface. Complements
+`scripts/chaos/rpc-drill.ts` (which fuzzes *code-level* RPC input handling)
+by checking **deployment-side invariants** — chainId consistency between
+client bundle and RPC, faucet balance, WebSocket proxy reachability, block
+freshness, etc.
+
+Catches the class of issues a code-level drill cannot, e.g.:
+- explorer client bundle compiled with `chainId: 18780` while RPC reports `88780`
+- faucet hot-wallet has 0 COC and silently fails every drip request
+- nginx proxy points `/api/testnet/ws` at a port nothing listens on
+- chain head timestamp drifting past the freshness budget (validator quorum lost)
+
+## One-shot check
+
+```bash
+node scripts/synthetic/check-prod.mjs            # exit 0 ok, 1 if any critical fails
+node scripts/synthetic/check-prod.mjs --json /tmp/r.json
+```
+
+## Continuous loop
+
+```bash
+node scripts/synthetic/check-prod.mjs --watch
+```
+
+## PM2 deploy on prod-2 (159.198.44.136)
+
+```bash
+# from local repo
+rsync -avz -e "ssh -i ~/.ssh/openclaw_server_key" \
+  scripts/synthetic/ root@159.198.44.136:/root/clawd/COC/scripts/synthetic/
+
+ssh -i ~/.ssh/openclaw_server_key root@159.198.44.136 '
+  mkdir -p /var/log/coc-synthetic &&
+  pm2 startOrReload /root/clawd/COC/scripts/synthetic/ecosystem.config.cjs &&
+  pm2 save
+'
+```
+
+Then `pm2 logs coc-synthetic` for live view, `cat /var/log/coc-synthetic/last.json`
+for the latest report.
+
+## Checks (13 total)
+
+| Check                  | Critical | What it asserts                                                  |
+|------------------------|----------|------------------------------------------------------------------|
+| `rpc.chainId`          | ✓        | `eth_chainId` == expected (default 88780)                        |
+| `rpc.blockNumber`      | ✓        | Chain advanced past genesis                                      |
+| `rpc.blockFreshness`   | ✓        | Latest block timestamp within `COC_BLOCK_FRESHNESS_SEC` (60s)    |
+| `rpc.peerCount`        |          | `net_peerCount` > 0                                              |
+| `ws.handshake`         | ✓        | `wss://…/api/testnet/ws` returns HTTP 101 in <2s (TLS + Upgrade) |
+| `website.root`         | ✓        | `/zh` returns 200 with COC branding                              |
+| `website.services`     |          | `/zh/services` has all 3 openclaw skill cards                    |
+| `explorer.root`        | ✓        | `/` 200, no Server-Components error, footer carries chainId      |
+| `explorer.validators`  | ✓        | `/validators` 200, no error fallback                             |
+| `faucet.health`        | ✓        | `/health` returns expected faucet address                        |
+| `faucet.balance`       | ✓        | Hot-wallet balance > `COC_FAUCET_MIN_BALANCE` (100 COC)          |
+| `faucet.status`        |          | `/faucet/status` parseable                                       |
+| `ipfs.root`            |          | `https://ipfs.clawchain.io/` 200                                 |
+
+Critical failures cause non-zero exit (one-shot) or DEGRADED line + restart loop (watch).
+
+## Tuning
+
+All thresholds are env vars — see top of `check-prod.mjs`. Most useful:
+
+- `COC_BLOCK_FRESHNESS_SEC` — bump to 180s if you tolerate occasional proposer slot skips
+- `COC_FAUCET_MIN_BALANCE` — raise to fire earlier alerts before drip pool runs dry
+- `CHECK_INTERVAL_SEC` — default 60s; lower to 15 if you want faster MTTD at higher infra cost
+
+## Out of scope (by design)
+
+- **Alert delivery**: emits to stdout / pm2 logs + structured JSON; pair with a
+  log shipper or webhook of your choice (this script intentionally has zero
+  dependencies beyond Node 22 stdlib)
+- **Per-validator health**: covered by Prometheus on each node, not this probe
+- **Contract address verification**: handled by the post-deploy smoke test in
+  `contracts/scripts/test-deployed-88780.js`

--- a/scripts/synthetic/active-probe.mjs
+++ b/scripts/synthetic/active-probe.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// COC active chain probe.
+//
+// Drives a small, deterministic load against the testnet to verify it is
+// not just "responding to RPC" but actually accepting txs, mining blocks,
+// executing EVM, and persisting state. Catches the class of failure where
+// RPC is up + block freshness check passes but EVM is rejecting all
+// proposals (poison-block stall pattern seen 2026-05-12).
+//
+// Probes (default cadence: 30 min, see health-loop.mjs):
+//   1. value-transfer  — 1 wei to a throwaway random address
+//   2. contract-deploy — 27-byte counter (slot 0 += 1 per call)
+//   3. contract-call   — increments counter twice, eth_getStorageAt verifies
+//   4. estimate-gas    — eth_estimateGas on the probed contract
+//
+// Each probe has its own timeout and is reported independently. The whole
+// run exits non-zero if any probe failed (so a systemd timer / pm2 wrapper
+// can alert).
+//
+// Env knobs:
+//   PROBE_RPC               default https://clawchain.io/api/testnet/rpc
+//   PROBE_CHAIN_ID          default 88780
+//   PROBE_PK                default Hardhat #5 well-known dev key
+//   PROBE_TX_TIMEOUT_MS     default 30000 (per-tx wait)
+//   PROBE_REPORT_JSON       optional path; if set, writes report JSON here
+
+import { ethers } from 'ethers'
+import { writeFileSync } from 'node:fs'
+
+const cfg = {
+  rpc: process.env.PROBE_RPC || 'https://clawchain.io/api/testnet/rpc',
+  chainId: Number(process.env.PROBE_CHAIN_ID || '88780'),
+  probePk: process.env.PROBE_PK || '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
+  txTimeoutMs: Number(process.env.PROBE_TX_TIMEOUT_MS || '30000'),
+  reportJson: process.env.PROBE_REPORT_JSON || null,
+}
+
+// Hand-assembled minimal counter contract (27 bytes total) — see ./README.md.
+// init code stores 0 at slot 0, returns runtime (10 bytes). Runtime SLOAD's
+// slot 0, adds 1, SSTORE's back. Read state via eth_getStorageAt(addr, 0).
+const COUNTER_BYTECODE = '0x6000600055600a6011600039600a6000f360005460010160005500'
+
+// staticNetwork avoids ethers' eth_chainId auto-detect timeout on cold-start
+// (5s default is too tight when first connection has to warm a TLS/hairpin path).
+const provider = new ethers.JsonRpcProvider(
+  cfg.rpc,
+  { chainId: cfg.chainId, name: 'ChainOfClaw' },
+  { staticNetwork: ethers.Network.from({ chainId: cfg.chainId, name: 'ChainOfClaw' }) },
+)
+const wallet = new ethers.Wallet(cfg.probePk, provider)
+
+function pad(s, n) { return String(s).padEnd(n) }
+function withTimeout(p, ms, label) {
+  return Promise.race([
+    p,
+    new Promise((_, rej) => setTimeout(() => rej(new Error(`${label} timeout ${ms}ms`)), ms)),
+  ])
+}
+
+async function probeBalance() {
+  const wei = await provider.getBalance(wallet.address)
+  const coc = Number(wei) / 1e18
+  if (coc < 1) throw new Error(`probe wallet ${wallet.address} balance ${coc.toFixed(4)} COC < 1 — fund needed`)
+  return `${wallet.address} ${coc.toFixed(2)} COC`
+}
+
+async function probeValueTransfer() {
+  const dest = ethers.Wallet.createRandom().address
+  const tx = await wallet.sendTransaction({ to: dest, value: 1n })
+  const r = await withTimeout(tx.wait(), cfg.txTimeoutMs, 'value-transfer')
+  if (r.status !== 1) throw new Error(`value-transfer status=${r.status}`)
+  return `tx=${tx.hash.slice(0, 10)}.. block=${r.blockNumber} gas=${r.gasUsed}`
+}
+
+async function probeContractDeploy() {
+  const tx = await wallet.sendTransaction({ data: COUNTER_BYTECODE })
+  const r = await withTimeout(tx.wait(), cfg.txTimeoutMs, 'contract-deploy')
+  if (r.status !== 1) throw new Error(`deploy status=${r.status}`)
+  if (!r.contractAddress) throw new Error('deploy: no contractAddress')
+  // Verify code was stored on-chain.
+  const code = await provider.getCode(r.contractAddress)
+  if (code === '0x' || code.length < 6) throw new Error(`deploy: contract has no code (${code})`)
+  return { addr: r.contractAddress, block: r.blockNumber, codeLen: (code.length - 2) / 2 }
+}
+
+async function probeContractCall(addr) {
+  const slot0 = (lbl) => provider.getStorage(addr, 0).then((h) => {
+    if (typeof h !== 'string') throw new Error(`${lbl}: getStorage returned non-string`)
+    return BigInt(h)
+  })
+
+  const before = await slot0('before')
+  const tx1 = await wallet.sendTransaction({ to: addr, data: '0x' })
+  const r1 = await withTimeout(tx1.wait(), cfg.txTimeoutMs, 'contract-call#1')
+  if (r1.status !== 1) throw new Error(`call#1 status=${r1.status}`)
+  const mid = await slot0('mid')
+  if (mid !== before + 1n) throw new Error(`call#1 slot0 ${before}→${mid}, expected +1`)
+
+  const tx2 = await wallet.sendTransaction({ to: addr, data: '0x' })
+  const r2 = await withTimeout(tx2.wait(), cfg.txTimeoutMs, 'contract-call#2')
+  if (r2.status !== 1) throw new Error(`call#2 status=${r2.status}`)
+  const after = await slot0('after')
+  if (after !== before + 2n) throw new Error(`call#2 slot0 ${before}→${after}, expected +2`)
+
+  return `slot0 ${before}→${after} (+2)  gas1=${r1.gasUsed} gas2=${r2.gasUsed}`
+}
+
+async function probeEstimateGas(addr) {
+  const est = await provider.estimateGas({ from: wallet.address, to: addr, data: '0x' })
+  if (est < 21000n) throw new Error(`estimateGas ${est} < 21000`)
+  return `${est} gas`
+}
+
+// ----- runner -----
+
+async function runOnce() {
+  const startedAt = new Date().toISOString()
+  const out = []
+
+  const run = async (name, fn) => {
+    const t0 = Date.now()
+    try {
+      const msg = await fn()
+      out.push({ name, pass: true, msg: typeof msg === 'string' ? msg : JSON.stringify(msg), latency_ms: Date.now() - t0 })
+      return msg
+    } catch (e) {
+      out.push({ name, pass: false, msg: e instanceof Error ? e.message : String(e), latency_ms: Date.now() - t0 })
+      return null
+    }
+  }
+
+  await run('balance', probeBalance)
+  await run('value-transfer', probeValueTransfer)
+  const deploy = await run('contract-deploy', probeContractDeploy)
+  if (deploy?.addr) {
+    await run('contract-call', () => probeContractCall(deploy.addr))
+    await run('estimate-gas', () => probeEstimateGas(deploy.addr))
+  }
+
+  const ok = out.every((r) => r.pass)
+  const ts = new Date().toISOString().slice(11, 19)
+  for (const r of out) {
+    const tag = r.pass ? '\x1b[32m PASS\x1b[0m' : '\x1b[31m FAIL\x1b[0m'
+    console.log(`${ts} ${tag} ${pad(r.name, 18)} ${pad(r.latency_ms + 'ms', 8)} ${r.msg}`)
+  }
+  console.log(`${ts} ${ok ? '\x1b[32mACTIVE-OK\x1b[0m' : '\x1b[31mACTIVE-FAIL\x1b[0m'} ${out.filter((r) => r.pass).length}/${out.length} pass\n`)
+
+  return { startedAt, ok, results: out }
+}
+
+export { runOnce as runActiveProbe }
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runOnce()
+    .then((r) => {
+      if (cfg.reportJson) writeFileSync(cfg.reportJson, JSON.stringify(r, null, 2))
+      process.exit(r.ok ? 0 : 1)
+    })
+    .catch((e) => {
+      console.error('active-probe runner crashed:', e)
+      process.exit(2)
+    })
+}

--- a/scripts/synthetic/check-prod.mjs
+++ b/scripts/synthetic/check-prod.mjs
@@ -287,7 +287,17 @@ const checks = [
 
 function pad(s, n) { return String(s).padEnd(n) }
 
+// On a server that's also the prod host, the very first cross-domain fetch
+// pays a hairpin-NAT / TLS-establish cost that can exceed the 10s default
+// per-check timeout. Warm the public RPC + faucet path with a throwaway
+// HEAD request before the timed checks begin.
+async function warmup() {
+  const urls = [cfg.rpcUrl, cfg.faucetUrl + '/health']
+  await Promise.allSettled(urls.map((u) => fetchWithTimeout(u, { method: 'GET' }, 15_000).catch(() => null)))
+}
+
 async function runOnce() {
+  await warmup()
   const startedAt = new Date().toISOString()
   const results = []
   for (const c of checks) {
@@ -346,4 +356,9 @@ async function main() {
   }
 }
 
-main()
+// Library export — health-loop.mjs imports this to skip the child-process round-trip.
+export { runOnce as runSyntheticCheck }
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/synthetic/check-prod.mjs
+++ b/scripts/synthetic/check-prod.mjs
@@ -40,7 +40,7 @@ const cfg = {
   ipfsUrl: process.env.COC_IPFS_URL || 'https://ipfs.clawchain.io',
   blockFreshnessSec: Number(process.env.COC_BLOCK_FRESHNESS_SEC || '60'),
   intervalSec: Number(process.env.CHECK_INTERVAL_SEC || '60'),
-  timeoutMs: 10_000,
+  timeoutMs: Number(process.env.CHECK_TIMEOUT_MS || '15000'),
 }
 
 // ---------- helpers ----------
@@ -287,13 +287,21 @@ const checks = [
 
 function pad(s, n) { return String(s).padEnd(n) }
 
-// On a server that's also the prod host, the very first cross-domain fetch
-// pays a hairpin-NAT / TLS-establish cost that can exceed the 10s default
-// per-check timeout. Warm the public RPC + faucet path with a throwaway
-// HEAD request before the timed checks begin.
+// On a server that's also the prod host, the first cross-domain fetch pays
+// a hairpin-NAT / TLS-establish cost that can exceed the per-check timeout.
+// Warm each public endpoint with a *real* round-trip (POST eth_chainId to
+// the RPC, GET /health to the faucet) — GET on a JSON-RPC endpoint returns
+// 405 instantly without completing TLS, which doesn't actually prime the
+// path. Run warmup twice — first attempt may itself time out under cold NAT.
 async function warmup() {
-  const urls = [cfg.rpcUrl, cfg.faucetUrl + '/health']
-  await Promise.allSettled(urls.map((u) => fetchWithTimeout(u, { method: 'GET' }, 15_000).catch(() => null)))
+  const rpcPing = () => fetchWithTimeout(cfg.rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 0, method: 'eth_chainId', params: [] }),
+  }, 20_000).catch(() => null)
+  const faucetPing = () => fetchWithTimeout(cfg.faucetUrl + '/health', {}, 20_000).catch(() => null)
+  await Promise.allSettled([rpcPing(), faucetPing()])
+  await Promise.allSettled([rpcPing(), faucetPing()])
 }
 
 async function runOnce() {

--- a/scripts/synthetic/check-prod.mjs
+++ b/scripts/synthetic/check-prod.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+// COC production synthetic E2E check loop.
+//
+// Each check returns { pass, msg, latency_ms }. The script prints a
+// line per check (+ a summary), exits non-zero if any critical check
+// failed, and writes a structured JSON report to --json <path> if given.
+//
+// Run modes:
+//   node check-prod.mjs                  # one-shot, exit code reflects health
+//   node check-prod.mjs --watch          # repeat every CHECK_INTERVAL_SEC (default 60)
+//   node check-prod.mjs --json /tmp/r.json
+//
+// Env knobs:
+//   COC_RPC_URL              default https://clawchain.io/api/testnet/rpc
+//   COC_WS_URL               default wss://clawchain.io/api/testnet/ws
+//   COC_CHAIN_ID             default 88780
+//   COC_FAUCET_URL           default https://faucet.clawchain.io
+//   COC_FAUCET_ADDRESS       default 0x47f9940cCf9777C0407F094A1B0d8c50b0DD01BF
+//   COC_FAUCET_MIN_BALANCE   default 100 (COC)
+//   COC_WEBSITE_URL          default https://clawchain.io
+//   COC_EXPLORER_URL         default https://explorer.clawchain.io
+//   COC_IPFS_URL             default https://ipfs.clawchain.io
+//   COC_BLOCK_FRESHNESS_SEC  default 60
+//   CHECK_INTERVAL_SEC       default 60
+
+import { setTimeout as sleep } from 'node:timers/promises'
+import { writeFileSync } from 'node:fs'
+import { connect } from 'node:net'
+import { URL } from 'node:url'
+
+const cfg = {
+  rpcUrl: process.env.COC_RPC_URL || 'https://clawchain.io/api/testnet/rpc',
+  wsUrl: process.env.COC_WS_URL || 'wss://clawchain.io/api/testnet/ws',
+  chainId: Number(process.env.COC_CHAIN_ID || '88780'),
+  faucetUrl: process.env.COC_FAUCET_URL || 'https://faucet.clawchain.io',
+  faucetAddr: process.env.COC_FAUCET_ADDRESS || '0x47f9940cCf9777C0407F094A1B0d8c50b0DD01BF',
+  faucetMinBalance: Number(process.env.COC_FAUCET_MIN_BALANCE || '100'),
+  websiteUrl: process.env.COC_WEBSITE_URL || 'https://clawchain.io',
+  explorerUrl: process.env.COC_EXPLORER_URL || 'https://explorer.clawchain.io',
+  ipfsUrl: process.env.COC_IPFS_URL || 'https://ipfs.clawchain.io',
+  blockFreshnessSec: Number(process.env.COC_BLOCK_FRESHNESS_SEC || '60'),
+  intervalSec: Number(process.env.CHECK_INTERVAL_SEC || '60'),
+  timeoutMs: 10_000,
+}
+
+// ---------- helpers ----------
+
+async function fetchWithTimeout(url, opts = {}, ms = cfg.timeoutMs) {
+  const ctl = new AbortController()
+  const t = setTimeout(() => ctl.abort(), ms)
+  try {
+    return await fetch(url, { ...opts, signal: ctl.signal })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+async function rpc(method, params = []) {
+  const res = await fetchWithTimeout(cfg.rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  })
+  if (!res.ok) throw new Error(`RPC HTTP ${res.status}`)
+  const j = await res.json()
+  if (j.error) throw new Error(`RPC ${method}: ${j.error.message}`)
+  return j.result
+}
+
+function hexToBigInt(h) {
+  return typeof h === 'string' && h.startsWith('0x') ? BigInt(h) : BigInt(h ?? 0)
+}
+
+function weiToCOC(wei) {
+  return Number(wei) / 1e18
+}
+
+// WebSocket handshake on a wss:// URL via raw TCP (no extra deps).
+async function wsHandshake(wsUrl, timeoutMs = cfg.timeoutMs) {
+  const u = new URL(wsUrl)
+  const tls = u.protocol === 'wss:'
+  const port = u.port ? Number(u.port) : tls ? 443 : 80
+  const host = u.hostname
+  const path = u.pathname + u.search
+
+  // Build a minimal HTTP/1.1 Upgrade request.
+  const key = 'dGhlIHNhbXBsZSBub25jZQ=='
+  const req =
+    `GET ${path} HTTP/1.1\r\n` +
+    `Host: ${host}\r\n` +
+    `Upgrade: websocket\r\n` +
+    `Connection: Upgrade\r\n` +
+    `Sec-WebSocket-Key: ${key}\r\n` +
+    `Sec-WebSocket-Version: 13\r\n` +
+    `\r\n`
+
+  return new Promise((resolve, reject) => {
+    let socket
+    const t0 = Date.now()
+    const finish = (err, status) => {
+      try { socket?.destroy() } catch {}
+      if (err) reject(err)
+      else resolve({ status, latency_ms: Date.now() - t0 })
+    }
+    const onTimeout = setTimeout(() => finish(new Error(`WS timeout ${timeoutMs}ms`)), timeoutMs)
+    const tcpConnect = () => {
+      if (tls) {
+        // dynamic import to avoid loading tls if unused
+        import('node:tls').then((tlsMod) => {
+          socket = tlsMod.connect({ host, port, servername: host, ALPNProtocols: ['http/1.1'] }, () => socket.write(req))
+          attach()
+        }).catch((e) => finish(e))
+      } else {
+        socket = connect({ host, port }, () => socket.write(req))
+        attach()
+      }
+    }
+    const attach = () => {
+      let buf = ''
+      socket.on('data', (d) => {
+        buf += d.toString('utf8')
+        const i = buf.indexOf('\r\n')
+        if (i > 0) {
+          const line = buf.slice(0, i)
+          const m = line.match(/HTTP\/1\.\d (\d{3})/)
+          clearTimeout(onTimeout)
+          finish(null, m ? Number(m[1]) : 0)
+        }
+      })
+      socket.on('error', (e) => { clearTimeout(onTimeout); finish(e) })
+      socket.on('end', () => { clearTimeout(onTimeout); finish(new Error('WS socket closed before status')) })
+    }
+    tcpConnect()
+  })
+}
+
+// ---------- checks ----------
+
+const checks = [
+  {
+    name: 'rpc.chainId',
+    critical: true,
+    async run() {
+      const r = await rpc('eth_chainId')
+      const id = Number(hexToBigInt(r))
+      if (id !== cfg.chainId) throw new Error(`RPC chainId ${id} ≠ expected ${cfg.chainId}`)
+      return `chainId=${id}`
+    },
+  },
+  {
+    name: 'rpc.blockNumber',
+    critical: true,
+    async run() {
+      const r = await rpc('eth_blockNumber')
+      const n = Number(hexToBigInt(r))
+      if (n < 1) throw new Error(`blockNumber=${n} (chain stalled at genesis?)`)
+      return `height=${n}`
+    },
+  },
+  {
+    name: 'rpc.blockFreshness',
+    critical: true,
+    async run() {
+      const head = await rpc('eth_getBlockByNumber', ['latest', false])
+      const ts = Number(hexToBigInt(head.timestamp))
+      const ageSec = Math.floor(Date.now() / 1000) - ts
+      if (ageSec > cfg.blockFreshnessSec) throw new Error(`latest block ${ageSec}s old (> ${cfg.blockFreshnessSec}s)`)
+      return `age=${ageSec}s`
+    },
+  },
+  {
+    name: 'rpc.peerCount',
+    critical: false,
+    async run() {
+      const r = await rpc('net_peerCount')
+      const n = Number(hexToBigInt(r))
+      if (n < 1) throw new Error(`peerCount=0 (isolated node?)`)
+      return `peers=${n}`
+    },
+  },
+  {
+    name: 'ws.handshake',
+    critical: true,
+    async run() {
+      const { status, latency_ms } = await wsHandshake(cfg.wsUrl)
+      if (status !== 101) throw new Error(`WS upgrade status=${status} (expected 101)`)
+      if (latency_ms > 2000) throw new Error(`WS handshake ${latency_ms}ms > 2000ms`)
+      return `101 in ${latency_ms}ms`
+    },
+  },
+  {
+    name: 'website.root',
+    critical: true,
+    async run() {
+      const res = await fetchWithTimeout(cfg.websiteUrl + '/zh')
+      if (!res.ok) throw new Error(`website /zh HTTP ${res.status}`)
+      const body = await res.text()
+      if (!/COC|ChainOfClaw|公链/.test(body)) throw new Error('website body missing COC branding')
+      return `200 ${body.length}B`
+    },
+  },
+  {
+    name: 'website.services',
+    critical: false,
+    async run() {
+      const res = await fetchWithTimeout(cfg.websiteUrl + '/zh/services')
+      if (!res.ok) throw new Error(`/zh/services HTTP ${res.status}`)
+      const body = await res.text()
+      const needles = ['OpenClaw Marketplace', '//claw-mem', '//coc-node', '//coc-soul']
+      const miss = needles.filter((n) => !body.includes(n))
+      if (miss.length) throw new Error(`/zh/services missing: ${miss.join(', ')}`)
+      return `ok (${needles.length}/${needles.length} cards)`
+    },
+  },
+  {
+    name: 'explorer.root',
+    critical: true,
+    async run() {
+      const res = await fetchWithTimeout(cfg.explorerUrl + '/')
+      if (!res.ok) throw new Error(`explorer / HTTP ${res.status}`)
+      const body = await res.text()
+      if (/Something went wrong|Server Components/.test(body)) throw new Error('explorer / shows error fallback')
+      if (!body.includes(`ChainID: ${cfg.chainId}`)) throw new Error(`explorer footer missing 'ChainID: ${cfg.chainId}'`)
+      return `200 chainId-stamped`
+    },
+  },
+  {
+    name: 'explorer.validators',
+    critical: true,
+    async run() {
+      const res = await fetchWithTimeout(cfg.explorerUrl + '/validators')
+      if (!res.ok) throw new Error(`/validators HTTP ${res.status}`)
+      const body = await res.text()
+      if (/Something went wrong|Server Components/.test(body)) throw new Error('/validators shows error fallback')
+      if (!/Active Validators/.test(body)) throw new Error("/validators body missing 'Active Validators'")
+      return 'ok'
+    },
+  },
+  {
+    name: 'faucet.health',
+    critical: true,
+    async run() {
+      const res = await fetchWithTimeout(cfg.faucetUrl + '/health')
+      if (!res.ok) throw new Error(`/health HTTP ${res.status}`)
+      const j = await res.json()
+      if (j.status !== 'ok') throw new Error(`/health status=${j.status}`)
+      if (j.faucetAddress?.toLowerCase() !== cfg.faucetAddr.toLowerCase()) {
+        throw new Error(`/health addr ${j.faucetAddress} ≠ expected ${cfg.faucetAddr}`)
+      }
+      return `${j.faucetAddress}`
+    },
+  },
+  {
+    name: 'faucet.balance',
+    critical: true,
+    async run() {
+      const r = await rpc('eth_getBalance', [cfg.faucetAddr, 'latest'])
+      const coc = weiToCOC(hexToBigInt(r))
+      if (coc < cfg.faucetMinBalance) {
+        throw new Error(`faucet balance ${coc.toFixed(2)} COC < min ${cfg.faucetMinBalance} (refund needed)`)
+      }
+      return `${coc.toFixed(2)} COC`
+    },
+  },
+  {
+    name: 'faucet.status',
+    critical: false,
+    async run() {
+      const res = await fetchWithTimeout(cfg.faucetUrl + '/faucet/status')
+      if (!res.ok) throw new Error(`/faucet/status HTTP ${res.status}`)
+      const j = await res.json()
+      return `bal=${j.balance} drips=${j.totalDrips} daily=${j.dailyDrips}/${j.dailyLimit}`
+    },
+  },
+  {
+    name: 'ipfs.root',
+    critical: false,
+    async run() {
+      const res = await fetchWithTimeout(cfg.ipfsUrl + '/')
+      if (!res.ok) throw new Error(`ipfs / HTTP ${res.status}`)
+      return `200`
+    },
+  },
+]
+
+// ---------- runner ----------
+
+function pad(s, n) { return String(s).padEnd(n) }
+
+async function runOnce() {
+  const startedAt = new Date().toISOString()
+  const results = []
+  for (const c of checks) {
+    const t0 = Date.now()
+    try {
+      const msg = await c.run()
+      results.push({ name: c.name, critical: c.critical, pass: true, msg, latency_ms: Date.now() - t0 })
+    } catch (e) {
+      results.push({
+        name: c.name,
+        critical: c.critical,
+        pass: false,
+        msg: e instanceof Error ? e.message : String(e),
+        latency_ms: Date.now() - t0,
+      })
+    }
+  }
+  const fails = results.filter((r) => !r.pass)
+  const criticalFails = fails.filter((r) => r.critical)
+  const ok = criticalFails.length === 0
+
+  // pretty line per check
+  const ts = new Date().toISOString().slice(11, 19)
+  for (const r of results) {
+    const tag = r.pass ? '\x1b[32m PASS\x1b[0m' : (r.critical ? '\x1b[31m FAIL\x1b[0m' : '\x1b[33m WARN\x1b[0m')
+    console.log(`${ts} ${tag} ${pad(r.name, 24)} ${pad(r.latency_ms + 'ms', 8)} ${r.msg}`)
+  }
+  console.log(`${ts} ${ok ? '\x1b[32mOK\x1b[0m   ' : '\x1b[31mDEGRADED\x1b[0m'} ${results.filter((r) => r.pass).length}/${results.length} pass, ${fails.length} fail (${criticalFails.length} critical)\n`)
+
+  return { startedAt, ok, results, criticalFails: criticalFails.length, fails: fails.length }
+}
+
+function maybeWriteJson(report) {
+  const i = process.argv.indexOf('--json')
+  if (i >= 0 && process.argv[i + 1]) {
+    writeFileSync(process.argv[i + 1], JSON.stringify(report, null, 2))
+  }
+}
+
+async function main() {
+  const watch = process.argv.includes('--watch')
+  if (!watch) {
+    const r = await runOnce()
+    maybeWriteJson(r)
+    process.exit(r.ok ? 0 : 1)
+  }
+  console.log(`[synthetic-check] watch mode, interval=${cfg.intervalSec}s, chainId=${cfg.chainId}, rpc=${cfg.rpcUrl}`)
+  for (;;) {
+    try {
+      const r = await runOnce()
+      maybeWriteJson(r)
+    } catch (e) {
+      console.error('[synthetic-check] runner crashed:', e)
+    }
+    await sleep(cfg.intervalSec * 1000)
+  }
+}
+
+main()

--- a/scripts/synthetic/ecosystem.config.cjs
+++ b/scripts/synthetic/ecosystem.config.cjs
@@ -1,6 +1,11 @@
-// PM2 config for the COC production synthetic E2E check loop.
-// Deploy:  pm2 start scripts/synthetic/ecosystem.config.cjs
-// Logs:    pm2 logs coc-synthetic
+// PM2 config for COC production synthetic + active health loops.
+//
+// Two processes:
+//   coc-synthetic   — passive HTTP/RPC invariants, 60s interval (fast MTTD)
+//   coc-health-loop — active txs + auto-remediation, 30 min interval
+//
+// Deploy:  pm2 startOrReload scripts/synthetic/ecosystem.config.cjs && pm2 save
+// Logs:    pm2 logs coc-synthetic   /   pm2 logs coc-health-loop
 module.exports = {
   apps: [
     {
@@ -12,7 +17,6 @@ module.exports = {
       max_restarts: 50,
       max_memory_restart: '256M',
       env: {
-        // Override any of these via /etc/coc/synthetic.env or pm2 ecosystem update.
         COC_CHAIN_ID: '88780',
         COC_RPC_URL: 'https://clawchain.io/api/testnet/rpc',
         COC_WS_URL: 'wss://clawchain.io/api/testnet/ws',
@@ -24,6 +28,32 @@ module.exports = {
         COC_IPFS_URL: 'https://ipfs.clawchain.io',
         COC_BLOCK_FRESHNESS_SEC: '60',
         CHECK_INTERVAL_SEC: '60',
+      },
+    },
+    {
+      name: 'coc-health-loop',
+      script: 'health-loop.mjs',
+      cwd: __dirname,
+      autorestart: true,
+      max_restarts: 50,
+      max_memory_restart: '512M',
+      env: {
+        // Active probe knobs — use loopback on prod to avoid hairpin-NAT cold-start
+        PROBE_RPC: 'http://127.0.0.1:28780',
+        PROBE_CHAIN_ID: '88780',
+        PROBE_PK: '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba', // Hardhat #5, prefunded 1000 COC
+        PROBE_TX_TIMEOUT_MS: '30000',
+        // Remediation knobs
+        DEPLOYER_PK: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80', // Hardhat #0, ~10M COC
+        FAUCET_ADDR: '0x47f9940cCf9777C0407F094A1B0d8c50b0DD01BF',
+        FAUCET_MIN_COC: '1000',
+        FAUCET_REFUND_COC: '50000',
+        BLOCK_FRESHNESS_LIMIT_SEC: '300',
+        SSH_KEY: '/root/.ssh/openclaw_server_key',
+        REMEDIATE_STATE: '/var/lib/coc-synthetic/state.json',
+        // Loop cadence
+        HEALTH_LOOP_INTERVAL_SEC: '1800', // 30 min
+        HEALTH_REPORT_DIR: '/var/log/coc-synthetic',
       },
     },
   ],

--- a/scripts/synthetic/ecosystem.config.cjs
+++ b/scripts/synthetic/ecosystem.config.cjs
@@ -1,0 +1,30 @@
+// PM2 config for the COC production synthetic E2E check loop.
+// Deploy:  pm2 start scripts/synthetic/ecosystem.config.cjs
+// Logs:    pm2 logs coc-synthetic
+module.exports = {
+  apps: [
+    {
+      name: 'coc-synthetic',
+      script: 'check-prod.mjs',
+      cwd: __dirname,
+      args: '--watch --json /var/log/coc-synthetic/last.json',
+      autorestart: true,
+      max_restarts: 50,
+      max_memory_restart: '256M',
+      env: {
+        // Override any of these via /etc/coc/synthetic.env or pm2 ecosystem update.
+        COC_CHAIN_ID: '88780',
+        COC_RPC_URL: 'https://clawchain.io/api/testnet/rpc',
+        COC_WS_URL: 'wss://clawchain.io/api/testnet/ws',
+        COC_FAUCET_URL: 'https://faucet.clawchain.io',
+        COC_FAUCET_ADDRESS: '0x47f9940cCf9777C0407F094A1B0d8c50b0DD01BF',
+        COC_FAUCET_MIN_BALANCE: '100',
+        COC_WEBSITE_URL: 'https://clawchain.io',
+        COC_EXPLORER_URL: 'https://explorer.clawchain.io',
+        COC_IPFS_URL: 'https://ipfs.clawchain.io',
+        COC_BLOCK_FRESHNESS_SEC: '60',
+        CHECK_INTERVAL_SEC: '60',
+      },
+    },
+  ],
+}

--- a/scripts/synthetic/ecosystem.config.cjs
+++ b/scripts/synthetic/ecosystem.config.cjs
@@ -49,7 +49,7 @@ module.exports = {
         FAUCET_MIN_COC: '1000',
         FAUCET_REFUND_COC: '50000',
         BLOCK_FRESHNESS_LIMIT_SEC: '300',
-        SSH_KEY: '/root/.ssh/openclaw_server_key',
+        SSH_KEY: '/root/.ssh/coc-automation',
         REMEDIATE_STATE: '/var/lib/coc-synthetic/state.json',
         // Loop cadence
         HEALTH_LOOP_INTERVAL_SEC: '1800', // 30 min

--- a/scripts/synthetic/ecosystem.config.cjs
+++ b/scripts/synthetic/ecosystem.config.cjs
@@ -53,6 +53,9 @@ module.exports = {
         REMEDIATE_STATE: '/var/lib/coc-synthetic/state.json',
         // Loop cadence
         HEALTH_LOOP_INTERVAL_SEC: '1800', // 30 min
+        HEALTH_STRESS_EVERY: '4',  // run stress probe every 4 ticks (~2 hours)
+        STRESS_N: '32',
+        STRESS_MODE: 'mixed',
         HEALTH_REPORT_DIR: '/var/log/coc-synthetic',
       },
     },

--- a/scripts/synthetic/health-loop.mjs
+++ b/scripts/synthetic/health-loop.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// 30-minute health loop coordinator.
+//
+// Each tick:
+//   1. run synthetic checks (passive HTTP/RPC invariants)        — check-prod.mjs
+//   2. run active probes    (real txs, deploy, call, estimateGas) — active-probe.mjs
+//   3. inspect results for known auto-remediable failures and
+//      invoke the corresponding remediator (rate-limited):
+//        - faucet.balance fail → remediate.refundFaucet()
+//        - rpc.blockFreshness fail → remediate.restartValidators()
+//   4. write structured JSON report
+//
+// Synthetic check loop (check-prod.mjs --watch) is a SEPARATE pm2 process
+// (coc-synthetic) running at 60s cadence for fast MTTD on prod-side
+// availability. This loop runs at 30 min cadence because active probes
+// each emit ~4 on-chain txs, and we don't want to spam the chain.
+
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { runSyntheticCheck } from './check-prod.mjs'
+import { runActiveProbe } from './active-probe.mjs'
+import { refundFaucet, restartValidators } from './remediate.mjs'
+
+const cfg = {
+  intervalMs: Number(process.env.HEALTH_LOOP_INTERVAL_SEC || '1800') * 1000, // 30 min
+  reportDir: process.env.HEALTH_REPORT_DIR || '/var/log/coc-synthetic',
+}
+
+if (!existsSync(cfg.reportDir)) mkdirSync(cfg.reportDir, { recursive: true })
+
+function checkFailed(report, name) {
+  return (report?.results || []).find((r) => r.name === name && !r.pass) != null
+}
+
+async function tick() {
+  const startedAt = new Date().toISOString()
+  console.log(`\n[health-loop] tick ${startedAt}`)
+
+  // 1. passive checks
+  console.log(`[health-loop] running synthetic checks ...`)
+  let synth = { ok: false, results: [], error: 'not-run' }
+  try {
+    synth = await runSyntheticCheck()
+  } catch (e) {
+    synth = { ok: false, results: [], error: e instanceof Error ? e.message : String(e) }
+  }
+
+  // 2. active probes
+  console.log(`[health-loop] running active probes ...`)
+  let active = { ok: false, error: 'not-run' }
+  try {
+    active = await runActiveProbe()
+  } catch (e) {
+    active = { ok: false, error: e instanceof Error ? e.message : String(e) }
+  }
+
+  // 3. remediation
+  const actions = []
+  if (checkFailed(synth, 'faucet.balance')) {
+    console.log(`[health-loop] faucet.balance FAIL — invoking refundFaucet`)
+    const r = await refundFaucet().catch((e) => ({ tried: false, ok: false, msg: String(e) }))
+    actions.push({ action: 'refund-faucet', ...r })
+    console.log(`[health-loop] refundFaucet: ${r.msg}`)
+  }
+  if (checkFailed(synth, 'rpc.blockFreshness')) {
+    console.log(`[health-loop] rpc.blockFreshness FAIL — invoking restartValidators`)
+    const r = await restartValidators({ reason: 'synthetic.blockFreshness' }).catch((e) => ({ tried: false, ok: false, msg: String(e) }))
+    actions.push({ action: 'restart-validators', ...r })
+    console.log(`[health-loop] restartValidators: ${r.msg}`)
+  }
+
+  // 4. report
+  const report = {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    synthetic: { ok: synth.ok, fails: (synth.results || []).filter((r) => !r.pass).map((r) => r.name) },
+    active: { ok: active.ok, fails: (active.results || []).filter((r) => !r.pass).map((r) => r.name), error: active.error },
+    actions,
+  }
+  const fname = join(cfg.reportDir, `tick-${startedAt.replace(/[:.]/g, '-')}.json`)
+  writeFileSync(fname, JSON.stringify(report, null, 2))
+  writeFileSync(join(cfg.reportDir, 'last-health.json'), JSON.stringify(report, null, 2))
+
+  const status = report.synthetic.ok && report.active.ok ? 'HEALTHY' : (actions.some((a) => a.tried && a.ok) ? 'REMEDIATED' : 'DEGRADED')
+  console.log(`[health-loop] ${status} synthetic.ok=${report.synthetic.ok} active.ok=${report.active.ok} actions=${actions.length}`)
+}
+
+async function main() {
+  console.log(`[health-loop] starting, interval=${cfg.intervalMs / 1000}s, report=${cfg.reportDir}`)
+  // initial run on startup
+  await tick().catch((e) => console.error('[health-loop] tick crashed:', e))
+  setInterval(() => {
+    tick().catch((e) => console.error('[health-loop] tick crashed:', e))
+  }, cfg.intervalMs)
+}
+
+main()

--- a/scripts/synthetic/health-loop.mjs
+++ b/scripts/synthetic/health-loop.mjs
@@ -19,12 +19,18 @@ import { writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { runSyntheticCheck } from './check-prod.mjs'
 import { runActiveProbe } from './active-probe.mjs'
+import { runStress } from './stress-probe.mjs'
 import { refundFaucet, restartValidators } from './remediate.mjs'
 
 const cfg = {
   intervalMs: Number(process.env.HEALTH_LOOP_INTERVAL_SEC || '1800') * 1000, // 30 min
   reportDir: process.env.HEALTH_REPORT_DIR || '/var/log/coc-synthetic',
+  // Run stress every N ticks (default 4 = ~2 hours). Stress pushes ~32 txs
+  // through mempool + EVM and is heavier than the standard active probe.
+  stressEveryNTicks: Number(process.env.HEALTH_STRESS_EVERY || '4'),
 }
+
+let tickCounter = 0
 
 if (!existsSync(cfg.reportDir)) mkdirSync(cfg.reportDir, { recursive: true })
 
@@ -54,6 +60,20 @@ async function tick() {
     active = { ok: false, error: e instanceof Error ? e.message : String(e) }
   }
 
+  // 2b. stress probe — every Nth tick
+  let stress = null
+  tickCounter += 1
+  if (tickCounter % cfg.stressEveryNTicks === 0) {
+    console.log(`[health-loop] running stress probe (tick ${tickCounter}, every ${cfg.stressEveryNTicks}) ...`)
+    try {
+      stress = await runStress()
+      console.log(`[health-loop] stress: ${stress.pass ? 'PASS' : 'FAIL'} confirmed=${stress.confirmed}/${stress.cfg?.n} tps=${stress.tps} p95=${stress.latencyMs?.p95}ms`)
+    } catch (e) {
+      stress = { pass: false, error: e instanceof Error ? e.message : String(e) }
+      console.log(`[health-loop] stress probe crashed: ${stress.error}`)
+    }
+  }
+
   // 3. remediation
   const actions = []
   if (checkFailed(synth, 'faucet.balance')) {
@@ -75,6 +95,7 @@ async function tick() {
     finishedAt: new Date().toISOString(),
     synthetic: { ok: synth.ok, fails: (synth.results || []).filter((r) => !r.pass).map((r) => r.name) },
     active: { ok: active.ok, fails: (active.results || []).filter((r) => !r.pass).map((r) => r.name), error: active.error },
+    stress: stress ? { pass: stress.pass, confirmed: stress.confirmed, tps: stress.tps, p95: stress.latencyMs?.p95, error: stress.error } : null,
     actions,
   }
   const fname = join(cfg.reportDir, `tick-${startedAt.replace(/[:.]/g, '-')}.json`)

--- a/scripts/synthetic/remediate.mjs
+++ b/scripts/synthetic/remediate.mjs
@@ -34,7 +34,7 @@ const cfg = {
   faucetMinIntervalMs: 23 * 3600 * 1000, // once per day
   restartMinIntervalMs: 55 * 60 * 1000,  // once per hour
   stateFile: process.env.REMEDIATE_STATE || '/var/lib/coc-synthetic/state.json',
-  sshKey: process.env.SSH_KEY || '/root/.ssh/openclaw_server_key',
+  sshKey: process.env.SSH_KEY || '/root/.ssh/coc-automation',
   validators: [
     { name: 'v1', host: '209.74.64.88',    unit: 'coc-node@88' },
     { name: 'v2', host: '159.198.44.136',  unit: 'coc-node@1'  },
@@ -58,7 +58,13 @@ function saveState(s) {
 }
 
 function provider() {
-  return new ethers.JsonRpcProvider(cfg.rpc, { chainId: cfg.chainId, name: 'ChainOfClaw' })
+  // staticNetwork avoids ethers' eth_chainId auto-detect 5s timeout on
+  // hairpin-NAT / TLS cold-start (prod-2 reaching its own public URL).
+  return new ethers.JsonRpcProvider(
+    cfg.rpc,
+    { chainId: cfg.chainId, name: 'ChainOfClaw' },
+    { staticNetwork: ethers.Network.from({ chainId: cfg.chainId, name: 'ChainOfClaw' }) },
+  )
 }
 
 // ---------- 1. refund-faucet ----------

--- a/scripts/synthetic/remediate.mjs
+++ b/scripts/synthetic/remediate.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// Bounded auto-remediation for known prod failure modes.
+//
+// Strictly limited to two actions, each with a strict per-window rate limit
+// persisted to /var/lib/coc-synthetic/state.json. NEVER write a remediator
+// that mutates source code or rolls forward to a state harder to undo than
+// what the operator could do by hand. Anything beyond this scope (e.g.
+// rebuilding a node, wiping leveldb) must remain manual.
+//
+//   1. refund-faucet  — fund the testnet faucet hot-wallet from the
+//                       Hardhat-#0 deployer when balance drops below
+//                       FAUCET_MIN_COC (default 1000). Refund amount:
+//                       FAUCET_REFUND_COC (default 50000). Rate: 1/day.
+//
+//   2. restart-validators — atomic stop+start of all 5 validators when
+//                           block freshness > BLOCK_FRESHNESS_LIMIT_SEC
+//                           (default 300). Restart strategy proven 2026-05-12
+//                           against the poison-block stall. Rate: 1/hour.
+//
+// Each action returns { tried, ok, msg } and is independently invokable.
+
+import { ethers } from 'ethers'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+
+const cfg = {
+  rpc: process.env.PROBE_RPC || 'https://clawchain.io/api/testnet/rpc',
+  chainId: Number(process.env.PROBE_CHAIN_ID || '88780'),
+  deployerPk: process.env.DEPLOYER_PK || '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+  faucetAddr: process.env.FAUCET_ADDR || '0x47f9940cCf9777C0407F094A1B0d8c50b0DD01BF',
+  faucetMin: Number(process.env.FAUCET_MIN_COC || '1000'),
+  faucetRefund: Number(process.env.FAUCET_REFUND_COC || '50000'),
+  blockFreshnessLimitSec: Number(process.env.BLOCK_FRESHNESS_LIMIT_SEC || '300'),
+  faucetMinIntervalMs: 23 * 3600 * 1000, // once per day
+  restartMinIntervalMs: 55 * 60 * 1000,  // once per hour
+  stateFile: process.env.REMEDIATE_STATE || '/var/lib/coc-synthetic/state.json',
+  sshKey: process.env.SSH_KEY || '/root/.ssh/openclaw_server_key',
+  validators: [
+    { name: 'v1', host: '209.74.64.88',    unit: 'coc-node@88' },
+    { name: 'v2', host: '159.198.44.136',  unit: 'coc-node@1'  },
+    { name: 'v3', host: '199.192.16.79',   unit: 'coc-node@88' },
+    { name: 'v4', host: '159.198.36.3',    unit: 'coc-node@1'  },
+    { name: 'v5', host: '159.198.36.25',   unit: 'coc-node@1'  },
+  ],
+}
+
+function loadState() {
+  try {
+    return JSON.parse(readFileSync(cfg.stateFile, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+function saveState(s) {
+  const dir = cfg.stateFile.substring(0, cfg.stateFile.lastIndexOf('/'))
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(cfg.stateFile, JSON.stringify(s, null, 2))
+}
+
+function provider() {
+  return new ethers.JsonRpcProvider(cfg.rpc, { chainId: cfg.chainId, name: 'ChainOfClaw' })
+}
+
+// ---------- 1. refund-faucet ----------
+
+export async function refundFaucet({ dryRun = false } = {}) {
+  const p = provider()
+  const wei = await p.getBalance(cfg.faucetAddr)
+  const coc = Number(wei) / 1e18
+  if (coc >= cfg.faucetMin) {
+    return { tried: false, ok: true, msg: `faucet bal ${coc.toFixed(2)} COC ≥ ${cfg.faucetMin}, no refund needed` }
+  }
+
+  const st = loadState()
+  const last = Number(st.lastFaucetRefundAt || 0)
+  const since = Date.now() - last
+  if (since < cfg.faucetMinIntervalMs) {
+    const mins = Math.floor((cfg.faucetMinIntervalMs - since) / 60000)
+    return { tried: false, ok: false, msg: `faucet bal ${coc.toFixed(2)} < ${cfg.faucetMin} BUT rate-limit (${mins} min until next refund allowed)` }
+  }
+
+  if (dryRun) return { tried: false, ok: true, msg: `[dry-run] would refund ${cfg.faucetRefund} COC` }
+
+  const deployer = new ethers.Wallet(cfg.deployerPk, p)
+  const dWei = await p.getBalance(deployer.address)
+  const need = BigInt(cfg.faucetRefund) * 10n ** 18n
+  if (dWei < need) {
+    return { tried: false, ok: false, msg: `deployer bal ${Number(dWei) / 1e18} < refund ${cfg.faucetRefund}` }
+  }
+  const tx = await deployer.sendTransaction({ to: cfg.faucetAddr, value: need })
+  const r = await tx.wait()
+  if (r.status !== 1) return { tried: true, ok: false, msg: `refund tx ${tx.hash} status=${r.status}` }
+  st.lastFaucetRefundAt = Date.now()
+  st.lastFaucetRefundTx = tx.hash
+  st.lastFaucetRefundCOC = cfg.faucetRefund
+  saveState(st)
+  return { tried: true, ok: true, msg: `refunded ${cfg.faucetRefund} COC tx=${tx.hash.slice(0, 10)}.. block=${r.blockNumber}` }
+}
+
+// ---------- 2. restart-validators ----------
+
+export async function restartValidators({ dryRun = false, reason = 'block-stall' } = {}) {
+  if (!existsSync(cfg.sshKey)) {
+    return { tried: false, ok: false, msg: `ssh key ${cfg.sshKey} not found — cannot restart` }
+  }
+
+  // Re-confirm stall — protect against transient false alarm.
+  const p = provider()
+  try {
+    const head = await p.getBlock('latest')
+    const age = Math.floor(Date.now() / 1000) - Number(head.timestamp)
+    if (age <= cfg.blockFreshnessLimitSec) {
+      return { tried: false, ok: true, msg: `head age ${age}s ≤ ${cfg.blockFreshnessLimitSec} — stall cleared, abort restart` }
+    }
+  } catch (e) {
+    return { tried: false, ok: false, msg: `eth_getBlock failed before restart: ${String(e)}` }
+  }
+
+  const st = loadState()
+  const last = Number(st.lastValidatorRestartAt || 0)
+  const since = Date.now() - last
+  if (since < cfg.restartMinIntervalMs) {
+    const mins = Math.floor((cfg.restartMinIntervalMs - since) / 60000)
+    return { tried: false, ok: false, msg: `chain stalled BUT rate-limit (${mins} min until next restart allowed)` }
+  }
+
+  if (dryRun) return { tried: false, ok: true, msg: `[dry-run] would atomic stop+start ${cfg.validators.length} validators` }
+
+  // Atomic stop all 5, sleep 5s, start all 5 — proven recipe 2026-05-12.
+  const exec = (host, cmd) =>
+    new Promise((resolve) => {
+      try {
+        const out = execFileSync('ssh', [
+          '-i', cfg.sshKey,
+          '-o', 'StrictHostKeyChecking=accept-new',
+          '-o', 'ConnectTimeout=8',
+          `root@${host}`, cmd,
+        ], { encoding: 'utf8', timeout: 20000 })
+        resolve({ ok: true, out })
+      } catch (e) {
+        resolve({ ok: false, out: String(e) })
+      }
+    })
+
+  const stopResults = await Promise.all(cfg.validators.map((v) => exec(v.host, `systemctl stop ${v.unit}`)))
+  const stopFails = stopResults.filter((r) => !r.ok)
+  await new Promise((r) => setTimeout(r, 5000))
+  const startResults = await Promise.all(cfg.validators.map((v) => exec(v.host, `systemctl start ${v.unit}`)))
+  const startFails = startResults.filter((r) => !r.ok)
+
+  st.lastValidatorRestartAt = Date.now()
+  st.lastValidatorRestartReason = reason
+  st.lastValidatorRestartStopFails = stopFails.length
+  st.lastValidatorRestartStartFails = startFails.length
+  saveState(st)
+
+  // Wait up to 60s for chain to advance.
+  let advanced = false
+  const startHead = await p.getBlockNumber().catch(() => 0)
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5000))
+    try {
+      const nowHead = await p.getBlockNumber()
+      if (nowHead > startHead) { advanced = true; break }
+    } catch { /* ignore */ }
+  }
+  return {
+    tried: true,
+    ok: advanced && stopFails.length === 0 && startFails.length === 0,
+    msg: `stop=${cfg.validators.length - stopFails.length}/${cfg.validators.length} start=${cfg.validators.length - startFails.length}/${cfg.validators.length} chainAdvanced=${advanced}`,
+  }
+}
+
+// ---------- CLI ----------
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const action = process.argv[2]
+  const dryRun = process.argv.includes('--dry-run')
+  const handlers = { 'refund-faucet': refundFaucet, 'restart-validators': restartValidators }
+  if (!handlers[action]) {
+    console.error(`usage: ${process.argv[1]} <refund-faucet|restart-validators> [--dry-run]`)
+    process.exit(2)
+  }
+  handlers[action]({ dryRun })
+    .then((r) => {
+      console.log(JSON.stringify(r, null, 2))
+      process.exit(r.ok ? 0 : 1)
+    })
+    .catch((e) => {
+      console.error(e)
+      process.exit(2)
+    })
+}

--- a/scripts/synthetic/stress-probe.mjs
+++ b/scripts/synthetic/stress-probe.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+// COC active stress probe.
+//
+// Fires N pre-signed txs in parallel from the probe wallet (single account,
+// sequential nonces — mempool's per-sender lane) and measures throughput,
+// per-tx inclusion latency, and block-distribution.
+//
+// Modes:
+//   value    — 1-wei transfers to ZeroAddress (mempool + minimal EVM)
+//   call     — increment() the persistent counter contract (SSTORE per tx)
+//   mixed    — 50/50 value + call
+//
+// Pass criteria (defaults, override via env):
+//   - 100% of submitted txs eventually included (status=1)
+//   - p95 inclusion latency ≤ STRESS_P95_MS_LIMIT (30000 ms)
+//   - observed TPS ≥ STRESS_TPS_MIN (5)
+//
+// Use sparingly. Each invocation pushes N txs to the public chain. Default
+// N=50 + mode=value = ~1.1 GWei in gas. Run from health-loop every Nth tick,
+// not every tick.
+//
+// Env knobs (in addition to active-probe's):
+//   STRESS_N                default 50
+//   STRESS_MODE             default 'value'  (value|call|mixed)
+//   STRESS_GAS_PRICE_GWEI   default 2
+//   STRESS_COUNTER_ADDR     optional reuse of an already-deployed counter
+//   STRESS_TIMEOUT_MS       default 90000 (total deadline)
+//   STRESS_P95_MS_LIMIT     default 30000
+//   STRESS_TPS_MIN          default 5
+//   STRESS_REPORT_JSON      optional path
+
+import { ethers } from 'ethers'
+import { writeFileSync, existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const cfg = {
+  rpc: process.env.PROBE_RPC || 'https://clawchain.io/api/testnet/rpc',
+  chainId: Number(process.env.PROBE_CHAIN_ID || '88780'),
+  probePk: process.env.PROBE_PK || '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
+  n: Number(process.env.STRESS_N || '32'),
+  // mempool per-sender cap is 64 on 88780 (see node/src/mempool.ts:181). Stay
+  // well under it: 32 leaves headroom for retry + parallel callers. If a prior
+  // run left a nonce gap in pending, refuse to fire.
+  maxPerSenderCap: Number(process.env.STRESS_PER_SENDER_CAP || '60'),
+  mode: process.env.STRESS_MODE || 'value',
+  gasPriceGwei: Number(process.env.STRESS_GAS_PRICE_GWEI || '2'),
+  counterAddr: process.env.STRESS_COUNTER_ADDR || null,
+  totalTimeoutMs: Number(process.env.STRESS_TIMEOUT_MS || '90000'),
+  p95LimitMs: Number(process.env.STRESS_P95_MS_LIMIT || '30000'),
+  tpsMin: Number(process.env.STRESS_TPS_MIN || '5'),
+  reportJson: process.env.STRESS_REPORT_JSON || null,
+  counterStateFile: process.env.STRESS_COUNTER_STATE || '/var/lib/coc-synthetic/stress-counter.json',
+}
+
+const COUNTER_BYTECODE = '0x6000600055600a6011600039600a6000f360005460010160005500'
+
+const provider = new ethers.JsonRpcProvider(
+  cfg.rpc,
+  { chainId: cfg.chainId, name: 'ChainOfClaw' },
+  { staticNetwork: ethers.Network.from({ chainId: cfg.chainId, name: 'ChainOfClaw' }) },
+)
+const wallet = new ethers.Wallet(cfg.probePk, provider)
+
+function pct(arr, p) {
+  if (arr.length === 0) return 0
+  const s = [...arr].sort((a, b) => a - b)
+  const i = Math.min(s.length - 1, Math.floor(s.length * p / 100))
+  return s[i]
+}
+
+// Persist a single counter contract addr across runs so we don't deploy
+// a fresh contract every stress invocation.
+async function ensureCounter() {
+  if (cfg.counterAddr) return cfg.counterAddr
+  let known = null
+  if (existsSync(cfg.counterStateFile)) {
+    try { known = JSON.parse(readFileSync(cfg.counterStateFile, 'utf8')).addr } catch {}
+  }
+  if (known) {
+    const code = await provider.getCode(known)
+    if (code !== '0x') return known
+  }
+  console.log('[stress] deploying counter contract ...')
+  const tx = await wallet.sendTransaction({ data: COUNTER_BYTECODE })
+  const r = await tx.wait()
+  if (r.status !== 1 || !r.contractAddress) throw new Error('counter deploy failed')
+  const dir = dirname(cfg.counterStateFile)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(cfg.counterStateFile, JSON.stringify({ addr: r.contractAddress, deployedAt: new Date().toISOString() }, null, 2))
+  console.log(`[stress] counter at ${r.contractAddress} (block ${r.blockNumber})`)
+  return r.contractAddress
+}
+
+async function runStress() {
+  const startedAt = new Date().toISOString()
+  const counterAddr = (cfg.mode === 'value') ? null : await ensureCounter()
+
+  const startNonce = await wallet.getNonce()
+  const startBlock = await provider.getBlockNumber()
+  const balBefore = await provider.getBalance(wallet.address)
+
+  if (balBefore < BigInt(cfg.n) * 100_000_000_000_000n) {
+    throw new Error(`probe balance ${ethers.formatEther(balBefore)} too low for ${cfg.n} txs`)
+  }
+
+  // Pre-flight: refuse to fire if probe wallet has stale pending (nonce gap
+  // or stuck txs hogging the per-sender cap). txpool_content tells us truth
+  // since eth_getTransactionCount(addr,'pending') ignores mempool.
+  try {
+    const pool = await provider.send('txpool_content', [])
+    const lower = wallet.address.toLowerCase()
+    const myPending = pool?.pending?.[lower] || pool?.pending?.[wallet.address] || {}
+    const pendingNonces = Object.keys(myPending).map((k) => Number(k)).sort((a, b) => a - b)
+    if (pendingNonces.length > 0) {
+      const lowest = pendingNonces[0]
+      const gap = lowest > startNonce
+      throw new Error(
+        `probe ${wallet.address} has ${pendingNonces.length} stale pending tx (nonce ${pendingNonces[0]}..${pendingNonces[pendingNonces.length - 1]})` +
+        (gap ? `, NONCE GAP between latest=${startNonce} and lowest pending=${lowest} — wait for TTL eviction (6h) or operator mempool reset` : ', wait for mining or use replacement-by-fee'),
+      )
+    }
+    if (cfg.n + pendingNonces.length > cfg.maxPerSenderCap) {
+      throw new Error(`N=${cfg.n} + ${pendingNonces.length} stale would exceed safe per-sender cap ${cfg.maxPerSenderCap}`)
+    }
+  } catch (e) {
+    if (e.code !== -32601 /* txpool_content not supported */) throw e
+    console.log('[stress] txpool_content not supported — skipping pre-flight gap check')
+  }
+
+  // Pre-sign all N txs offline.
+  const gasPrice = BigInt(cfg.gasPriceGwei) * 1_000_000_000n
+  console.log(`[stress] pre-signing ${cfg.n} txs (mode=${cfg.mode}, startNonce=${startNonce}) ...`)
+  const signed = []
+  for (let i = 0; i < cfg.n; i++) {
+    const useCall = cfg.mode === 'call' || (cfg.mode === 'mixed' && i % 2 === 1)
+    const txReq = useCall
+      ? { chainId: BigInt(cfg.chainId), type: 2, nonce: startNonce + i, to: counterAddr, data: '0x', gasLimit: 50000, maxFeePerGas: gasPrice, maxPriorityFeePerGas: gasPrice }
+      : { chainId: BigInt(cfg.chainId), type: 2, nonce: startNonce + i, to: ethers.ZeroAddress, value: 1n, gasLimit: 21000, maxFeePerGas: gasPrice, maxPriorityFeePerGas: gasPrice }
+    signed.push(await wallet.signTransaction(txReq))
+  }
+  console.log(`[stress] firing ${cfg.n} eth_sendRawTransaction in parallel ...`)
+
+  // Bypass ethers' built-in retry on -32603 — when we hit a per-sender
+  // mempool cap, retrying just burns wall clock until our outer deadline.
+  const sendRaw = async (raw, i) => {
+    const r = await fetch(cfg.rpc, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: i, method: 'eth_sendRawTransaction', params: [raw] }),
+    }).then((r) => r.json())
+    if (r.error) {
+      const err = new Error(r.error.message)
+      err.code = r.error.code
+      throw err
+    }
+    return r.result
+  }
+
+  const t0 = Date.now()
+  const submitResults = await Promise.allSettled(
+    signed.map((raw, i) => sendRaw(raw, i).then((h) => ({ i, hash: h, submittedAt: Date.now() }))),
+  )
+  const submitMs = Date.now() - t0
+  const submitted = submitResults.filter((r) => r.status === 'fulfilled').map((r) => r.value)
+  const submitFailed = submitResults
+    .map((r, i) => ({ r, i }))
+    .filter(({ r }) => r.status === 'rejected')
+    .map(({ r, i }) => ({ i, err: r.reason?.message || String(r.reason) }))
+  const mempoolCapHits = submitFailed.filter((f) => /exceeds max pending tx limit|mempool.*full|known transaction/i.test(f.err)).length
+  console.log(`[stress] submitted=${submitted.length}/${cfg.n} in ${submitMs}ms  failed=${submitFailed.length}`)
+  if (submitFailed.length > 0) {
+    console.log(`[stress] sample submit fails: ${JSON.stringify(submitFailed.slice(0, 3))}`)
+  }
+
+  // Wait for receipts.
+  const waitDeadline = Date.now() + cfg.totalTimeoutMs
+  const receipts = await Promise.allSettled(submitted.map(async ({ hash, submittedAt }) => {
+    const remaining = Math.max(1000, waitDeadline - Date.now())
+    const r = await Promise.race([
+      provider.waitForTransaction(hash),
+      new Promise((_, rej) => setTimeout(() => rej(new Error('inclusion timeout')), remaining)),
+    ])
+    return { hash, blockNumber: r.blockNumber, status: r.status, gasUsed: r.gasUsed, latencyMs: Date.now() - submittedAt }
+  }))
+  const totalMs = Date.now() - t0
+
+  const ok = receipts.filter((r) => r.status === 'fulfilled' && r.value.status === 1).map((r) => r.value)
+  const failedRcpt = receipts
+    .map((r, i) => ({ r, i }))
+    .filter(({ r }) => r.status === 'rejected' || r.value?.status !== 1)
+    .map(({ r, i }) => ({ i, err: r.status === 'rejected' ? (r.reason?.message || String(r.reason)) : `status=${r.value.status}` }))
+
+  const latencies = ok.map((r) => r.latencyMs)
+  const blocksTouched = new Set(ok.map((r) => r.blockNumber))
+  const endBlock = await provider.getBlockNumber()
+  const balAfter = await provider.getBalance(wallet.address)
+  const gasSpent = balBefore - balAfter
+  const tps = ok.length > 0 ? (ok.length / totalMs) * 1000 : 0
+
+  const stats = {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    cfg: { n: cfg.n, mode: cfg.mode, gasPriceGwei: cfg.gasPriceGwei, counterAddr },
+    nonceRange: [startNonce, startNonce + cfg.n - 1],
+    blockRange: [startBlock, endBlock],
+    submitted: submitted.length,
+    submitFailed: submitFailed.length,
+    mempoolCapHits,
+    confirmed: ok.length,
+    receiptFailed: failedRcpt.length,
+    submitMs,
+    totalMs,
+    tps: Number(tps.toFixed(2)),
+    latencyMs: {
+      min: latencies.length ? Math.min(...latencies) : 0,
+      p50: pct(latencies, 50),
+      p95: pct(latencies, 95),
+      max: latencies.length ? Math.max(...latencies) : 0,
+    },
+    blocksTouched: blocksTouched.size,
+    blocksAdvanced: endBlock - startBlock,
+    gasSpent_COC: Number(ethers.formatEther(gasSpent)).toFixed(6),
+    failures: failedRcpt.slice(0, 5),
+  }
+
+  // Pass/fail evaluation
+  stats.pass = (
+    stats.confirmed === cfg.n &&
+    stats.submitFailed === 0 &&
+    stats.latencyMs.p95 <= cfg.p95LimitMs &&
+    stats.tps >= cfg.tpsMin
+  )
+  stats.passReasons = []
+  if (stats.confirmed !== cfg.n) stats.passReasons.push(`confirmed ${stats.confirmed}/${cfg.n}`)
+  if (stats.submitFailed > 0) stats.passReasons.push(`${stats.submitFailed} submit fails`)
+  if (stats.latencyMs.p95 > cfg.p95LimitMs) stats.passReasons.push(`p95 ${stats.latencyMs.p95}ms > ${cfg.p95LimitMs}ms`)
+  if (stats.tps < cfg.tpsMin) stats.passReasons.push(`tps ${stats.tps} < ${cfg.tpsMin}`)
+
+  return stats
+}
+
+export { runStress }
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runStress()
+    .then((stats) => {
+      const head = stats.pass ? '\x1b[32mSTRESS-OK\x1b[0m' : '\x1b[31mSTRESS-FAIL\x1b[0m'
+      console.log()
+      console.log(`${head}  ${stats.confirmed}/${cfg.n} confirmed  tps=${stats.tps}  p50=${stats.latencyMs.p50}ms  p95=${stats.latencyMs.p95}ms  blocks=${stats.blocksTouched}  gas=${stats.gasSpent_COC} COC${stats.mempoolCapHits > 0 ? `  mempoolCap=${stats.mempoolCapHits}` : ''}`)
+      if (!stats.pass) console.log(`        reasons: ${stats.passReasons.join('; ')}`)
+      if (cfg.reportJson) writeFileSync(cfg.reportJson, JSON.stringify(stats, null, 2))
+      process.exit(stats.pass ? 0 : 1)
+    })
+    .catch((e) => {
+      console.error('stress-probe crashed:', e)
+      process.exit(2)
+    })
+}

--- a/scripts/synthetic/stress-probe.mjs
+++ b/scripts/synthetic/stress-probe.mjs
@@ -172,15 +172,30 @@ async function runStress() {
     console.log(`[stress] sample submit fails: ${JSON.stringify(submitFailed.slice(0, 3))}`)
   }
 
-  // Wait for receipts.
+  // Wait for receipts. Reset ethers polling interval to 1s so latency
+  // measurement reflects real inclusion time, not 4s default poll period.
+  provider.pollingInterval = 1000
   const waitDeadline = Date.now() + cfg.totalTimeoutMs
+  // Cache block-by-number lookups so 50 receipts in the same block don't
+  // each fire an eth_getBlockByNumber call.
+  const blockCache = new Map()
+  const getBlockTs = async (bn) => {
+    if (blockCache.has(bn)) return blockCache.get(bn)
+    const b = await provider.getBlock(bn)
+    const ts = b ? Number(b.timestamp) * 1000 : null
+    blockCache.set(bn, ts)
+    return ts
+  }
   const receipts = await Promise.allSettled(submitted.map(async ({ hash, submittedAt }) => {
     const remaining = Math.max(1000, waitDeadline - Date.now())
     const r = await Promise.race([
       provider.waitForTransaction(hash),
       new Promise((_, rej) => setTimeout(() => rej(new Error('inclusion timeout')), remaining)),
     ])
-    return { hash, blockNumber: r.blockNumber, status: r.status, gasUsed: r.gasUsed, latencyMs: Date.now() - submittedAt }
+    // Use block timestamp as canonical inclusion time — avoids ethers polling lag.
+    const blockTs = await getBlockTs(r.blockNumber)
+    const latencyMs = blockTs ? Math.max(0, blockTs - submittedAt) : (Date.now() - submittedAt)
+    return { hash, blockNumber: r.blockNumber, status: r.status, gasUsed: r.gasUsed, latencyMs }
   }))
   const totalMs = Date.now() - t0
 

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -1263,8 +1263,10 @@
       "runNode": {
         "icon": "🚀",
         "title": "Run a local node",
-        "description": "Spin up a COC node fast",
-        "code": "cd node\nnpm install\nnpm start"
+        "description": "Run a COC node in one line via the npm skill (recommended)",
+        "code": "npm install -g @chainofclaw/coc-node\ncoc-node install dev",
+        "advancedLabel": "Source build (advanced)",
+        "advancedCode": "cd node\nnpm install\nnpm start"
       },
       "deployContract": {
         "icon": "📜",
@@ -1595,16 +1597,16 @@
     "tokenSymbol": "Token Symbol",
     "quickStart": "Quick Start",
     "step1": {
-      "title": "Deploy a node",
-      "description": "Clone the repo, install deps, and generate node keys. Newcomers can start with Docker."
+      "title": "Install the skill",
+      "description": "npm install -g @chainofclaw/coc-node — one line. Latest v1.2.0 published 2026-05."
     },
     "step2": {
-      "title": "Connect and sync",
-      "description": "Configure the node with testnet parameters and connect seed nodes. Snap sync supported."
+      "title": "Provision a node",
+      "description": "coc-node install fullnode --chain prowl-testnet — auto-renders genesis, peers, key, and the systemd unit."
     },
     "step3": {
-      "title": "Start validating",
-      "description": "After syncing, register as a validator via DAO governance to join BFT consensus and earn testnet rewards."
+      "title": "Run and monitor",
+      "description": "coc-node start to run. coc-node monitor for live BFT state. Register via DAO governance to become a validator."
     },
     "connectWallet": "Connect a wallet",
     "connectDescription": "Use the following network info to add COC Prowl testnet to MetaMask or any EVM-compatible wallet.",
@@ -1613,7 +1615,10 @@
       "faucet": "Faucet",
       "docs": "Docs",
       "github": "GitHub"
-    }
+    },
+    "cocNodeBadge": "RECOMMENDED",
+    "cocNodeNote": "Deploy via the @chainofclaw/coc-node skill — one command, 5 node types (validator / fullnode / archive / gateway / dev), systemd integrated, auto peer + key handling.",
+    "cocNodeNoteLink": "See Public Chain Services →"
   },
   "footer": {
     "tagline": "ChainOfClaw ·\nDecentralized infrastructure for agents",

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -16,7 +16,8 @@
     "development": "Development",
     "whitepaper": "Whitepaper",
     "allRightsReserved": "All rights reserved",
-    "copyright": "Copyright"
+    "copyright": "Copyright",
+    "services": "Services"
   },
   "home": {
     "hero": {
@@ -1619,5 +1620,60 @@
     "motto": "Toward the stars, toward eternity, toward a new era where carbon and silicon bloom together.",
     "copyright": "Copyright",
     "allRightsReserved": "All rights reserved"
+  },
+  "services": {
+    "title": "Public Chain Services",
+    "subtitle": "Three npm skills forming COC's complete AI-agent lifecycle on the public chain",
+    "heroBadge": "> CHAINOFCLAW_SKILLS",
+    "heroTagline": "Identity, memory, and a home — for every AI agent.",
+    "did": {
+      "badge": "Service 01 · @chainofclaw/coc-soul v1.2.10",
+      "title": "DID Service",
+      "tagline": "An agent's identity is issued not by any central authority, but by mathematics and consensus.",
+      "f1": "W3C DID Core v1.0 compliant, method name did:coc",
+      "f2": "Agent identity + key rotation + delegation chain",
+      "f3": "Verifiable credentials with selective disclosure (Merkle proofs)",
+      "f4": "Guardian-based social recovery (2/3 quorum + 12h timelock)",
+      "f5": "16-bit capability bitmask (storage/compute/validation/...)",
+      "install": "npm install @chainofclaw/coc-soul"
+    },
+    "memory": {
+      "badge": "Service 02 · @chainofclaw/claw-mem v2.3.1",
+      "title": "Memory Backup",
+      "tagline": "Not just \"retrieving files\", but \"remembering who you are and what you are doing\".",
+      "f1": "Persistent semantic memory across restarts and conversation compaction",
+      "f2": "Auto-capture tool call observations (decision/discovery/pattern/learning)",
+      "f3": "LLM session summary (request/learned/completed)",
+      "f4": "Token-budgeted retrieval (8000t default) + FTS5 full-text search",
+      "f5": "Content-addressed IPFS + CidRegistry anchoring with integrity proofs",
+      "install": "npm install @chainofclaw/claw-mem"
+    },
+    "node": {
+      "badge": "Service 03 · @chainofclaw/coc-node v1.2.0",
+      "title": "Node Operations",
+      "tagline": "One command, run a COC node on your machine.",
+      "f1": "5 node types: validator / fullnode / archive / gateway / dev",
+      "f2": "Full lifecycle: install / start / stop / monitor / remove",
+      "f3": "Multi-instance (multiple node-N on one host) + systemd + auto-restart",
+      "f4": "Auto-config (genesis, peers, key fetching)",
+      "f5": "Use cases: join 88780 R3.2 testnet, CI/CD node tests, self-hosted validator",
+      "install": "npm install @chainofclaw/coc-node"
+    },
+    "immortalityTitle": "Three Layers = Silicon Immortality",
+    "immortalityNarrative": "coc-soul gives an agent identity (DID + guardian recovery); claw-mem gives an agent memory (observations + sessions anchored to IPFS); coc-node gives an agent a home (any machine can run a COC chain). A failing host no longer means an agent loses itself — it can be restored to a new carrier via its on-chain DID + IPFS backups with cognitive state intact.",
+    "linkedContracts": "Deployed Contracts (R3.2 88780 testnet)",
+    "viewOnNpm": "View on NPM",
+    "viewDocs": "View Docs",
+    "installPrompt": "$",
+    "openclawTitle": "OpenClaw Marketplace",
+    "openclawSubtitle": "chainofclaw skills published and scanned on the OpenClaw platform",
+    "scanResult": "Scan result",
+    "downloads": "Downloads",
+    "stars": "Stars",
+    "versions": "Versions",
+    "updated": "Updated",
+    "statusPass": "Pass",
+    "statusReview": "Review",
+    "statusSuspicious": "Suspicious"
   }
 }

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -446,7 +446,7 @@
           {
             "step": "4. Start the node",
             "command": "cd node && npm start",
-            "desc": "Single-node devnet (RPC: http://localhost:18780)"
+            "desc": "Single-node devnet (RPC: http://localhost:28780)"
           }
         ]
       },

--- a/website/messages/es.json
+++ b/website/messages/es.json
@@ -446,7 +446,7 @@
           {
             "step": "4. Iniciar el nodo",
             "command": "cd node && npm start",
-            "desc": "Devnet de nodo único (RPC: http://localhost:18780)"
+            "desc": "Devnet de nodo único (RPC: http://localhost:28780)"
           }
         ]
       },

--- a/website/messages/es.json
+++ b/website/messages/es.json
@@ -1262,9 +1262,11 @@
       "title": "Inicio Rápido",
       "runNode": {
         "icon": "🚀",
-        "title": "Ejecutar un nodo local",
-        "description": "Levanta un nodo COC rápidamente",
-        "code": "cd node\nnpm install\nnpm start"
+        "title": "Run a local node",
+        "description": "Run a COC node in one line via the npm skill (recommended)",
+        "code": "npm install -g @chainofclaw/coc-node\ncoc-node install dev",
+        "advancedLabel": "Source build (advanced)",
+        "advancedCode": "cd node\nnpm install\nnpm start"
       },
       "deployContract": {
         "icon": "📜",
@@ -1595,16 +1597,16 @@
     "tokenSymbol": "Símbolo del Token",
     "quickStart": "Inicio Rápido",
     "step1": {
-      "title": "Desplegar un nodo",
-      "description": "Clona el repositorio, instala las dependencias y genera las claves del nodo. Los recién llegados pueden empezar con Docker."
+      "title": "Install the skill",
+      "description": "npm install -g @chainofclaw/coc-node — one line. Latest v1.2.0 published 2026-05."
     },
     "step2": {
-      "title": "Conectar y sincronizar",
-      "description": "Configura el nodo con los parámetros de la testnet y conecta los seed nodes. Snap sync soportado."
+      "title": "Provision a node",
+      "description": "coc-node install fullnode --chain prowl-testnet — auto-renders genesis, peers, key, and the systemd unit."
     },
     "step3": {
-      "title": "Empezar a validar",
-      "description": "Tras la sincronización, regístrate como validador mediante la gobernanza DAO para unirte al consenso BFT y ganar recompensas de testnet."
+      "title": "Run and monitor",
+      "description": "coc-node start to run. coc-node monitor for live BFT state. Register via DAO governance to become a validator."
     },
     "connectWallet": "Conectar una billetera",
     "connectDescription": "Usa la siguiente información de red para añadir la testnet COC Prowl a MetaMask o a cualquier billetera compatible con EVM.",
@@ -1613,7 +1615,10 @@
       "faucet": "Faucet",
       "docs": "Documentación",
       "github": "GitHub"
-    }
+    },
+    "cocNodeBadge": "RECOMMENDED",
+    "cocNodeNote": "Deploy via the @chainofclaw/coc-node skill — one command, 5 node types (validator / fullnode / archive / gateway / dev), systemd integrated, auto peer + key handling.",
+    "cocNodeNoteLink": "See Public Chain Services →"
   },
   "footer": {
     "tagline": "ChainOfClaw ·\nInfraestructura descentralizada para agentes",

--- a/website/messages/es.json
+++ b/website/messages/es.json
@@ -16,7 +16,8 @@
     "development": "Desarrollo",
     "whitepaper": "Libro blanco",
     "allRightsReserved": "Todos los derechos reservados",
-    "copyright": "Copyright"
+    "copyright": "Copyright",
+    "services": "Services"
   },
   "home": {
     "hero": {
@@ -1619,5 +1620,60 @@
     "motto": "Hacia las estrellas, hacia la eternidad, hacia una nueva era donde carbono y silicio florecen juntos.",
     "copyright": "Copyright",
     "allRightsReserved": "Todos los derechos reservados"
+  },
+  "services": {
+    "title": "Public Chain Services",
+    "subtitle": "Three npm skills forming COC's complete AI-agent lifecycle on the public chain",
+    "heroBadge": "> CHAINOFCLAW_SKILLS",
+    "heroTagline": "Identity, memory, and a home — for every AI agent.",
+    "did": {
+      "badge": "Service 01 · @chainofclaw/coc-soul v1.2.10",
+      "title": "DID Service",
+      "tagline": "An agent's identity is issued not by any central authority, but by mathematics and consensus.",
+      "f1": "W3C DID Core v1.0 compliant, method name did:coc",
+      "f2": "Agent identity + key rotation + delegation chain",
+      "f3": "Verifiable credentials with selective disclosure (Merkle proofs)",
+      "f4": "Guardian-based social recovery (2/3 quorum + 12h timelock)",
+      "f5": "16-bit capability bitmask (storage/compute/validation/...)",
+      "install": "npm install @chainofclaw/coc-soul"
+    },
+    "memory": {
+      "badge": "Service 02 · @chainofclaw/claw-mem v2.3.1",
+      "title": "Memory Backup",
+      "tagline": "Not just \"retrieving files\", but \"remembering who you are and what you are doing\".",
+      "f1": "Persistent semantic memory across restarts and conversation compaction",
+      "f2": "Auto-capture tool call observations (decision/discovery/pattern/learning)",
+      "f3": "LLM session summary (request/learned/completed)",
+      "f4": "Token-budgeted retrieval (8000t default) + FTS5 full-text search",
+      "f5": "Content-addressed IPFS + CidRegistry anchoring with integrity proofs",
+      "install": "npm install @chainofclaw/claw-mem"
+    },
+    "node": {
+      "badge": "Service 03 · @chainofclaw/coc-node v1.2.0",
+      "title": "Node Operations",
+      "tagline": "One command, run a COC node on your machine.",
+      "f1": "5 node types: validator / fullnode / archive / gateway / dev",
+      "f2": "Full lifecycle: install / start / stop / monitor / remove",
+      "f3": "Multi-instance (multiple node-N on one host) + systemd + auto-restart",
+      "f4": "Auto-config (genesis, peers, key fetching)",
+      "f5": "Use cases: join 88780 R3.2 testnet, CI/CD node tests, self-hosted validator",
+      "install": "npm install @chainofclaw/coc-node"
+    },
+    "immortalityTitle": "Three Layers = Silicon Immortality",
+    "immortalityNarrative": "coc-soul gives an agent identity (DID + guardian recovery); claw-mem gives an agent memory (observations + sessions anchored to IPFS); coc-node gives an agent a home (any machine can run a COC chain). A failing host no longer means an agent loses itself — it can be restored to a new carrier via its on-chain DID + IPFS backups with cognitive state intact.",
+    "linkedContracts": "Deployed Contracts (R3.2 88780 testnet)",
+    "viewOnNpm": "View on NPM",
+    "viewDocs": "View Docs",
+    "installPrompt": "$",
+    "openclawTitle": "OpenClaw Marketplace",
+    "openclawSubtitle": "chainofclaw skills published and scanned on the OpenClaw platform",
+    "scanResult": "Scan result",
+    "downloads": "Downloads",
+    "stars": "Stars",
+    "versions": "Versions",
+    "updated": "Updated",
+    "statusPass": "Pass",
+    "statusReview": "Review",
+    "statusSuspicious": "Suspicious"
   }
 }

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -1262,9 +1262,11 @@
       "title": "クイックスタート",
       "runNode": {
         "icon": "🚀",
-        "title": "ローカルノードを起動",
-        "description": "COC ノードを素早く立ち上げる",
-        "code": "cd node\nnpm install\nnpm start"
+        "title": "Run a local node",
+        "description": "Run a COC node in one line via the npm skill (recommended)",
+        "code": "npm install -g @chainofclaw/coc-node\ncoc-node install dev",
+        "advancedLabel": "Source build (advanced)",
+        "advancedCode": "cd node\nnpm install\nnpm start"
       },
       "deployContract": {
         "icon": "📜",
@@ -1595,16 +1597,16 @@
     "tokenSymbol": "トークンシンボル",
     "quickStart": "クイックスタート",
     "step1": {
-      "title": "ノードをデプロイ",
-      "description": "リポジトリをクローンし、依存関係をインストールしてノード鍵を生成。初心者は Docker から始められる。"
+      "title": "Install the skill",
+      "description": "npm install -g @chainofclaw/coc-node — one line. Latest v1.2.0 published 2026-05."
     },
     "step2": {
-      "title": "接続と同期",
-      "description": "テストネットパラメータでノードを設定し、シードノードに接続。Snap sync サポート。"
+      "title": "Provision a node",
+      "description": "coc-node install fullnode --chain prowl-testnet — auto-renders genesis, peers, key, and the systemd unit."
     },
     "step3": {
-      "title": "検証を開始",
-      "description": "同期後、DAO ガバナンスを通じてバリデーターとして登録し、BFT 合意に参加してテストネット報酬を得る。"
+      "title": "Run and monitor",
+      "description": "coc-node start to run. coc-node monitor for live BFT state. Register via DAO governance to become a validator."
     },
     "connectWallet": "ウォレットを接続",
     "connectDescription": "以下のネットワーク情報を使って COC Prowl テストネットを MetaMask または任意の EVM 互換ウォレットに追加する。",
@@ -1613,7 +1615,10 @@
       "faucet": "フォーセット",
       "docs": "ドキュメント",
       "github": "GitHub"
-    }
+    },
+    "cocNodeBadge": "RECOMMENDED",
+    "cocNodeNote": "Deploy via the @chainofclaw/coc-node skill — one command, 5 node types (validator / fullnode / archive / gateway / dev), systemd integrated, auto peer + key handling.",
+    "cocNodeNoteLink": "See Public Chain Services →"
   },
   "footer": {
     "tagline": "ChainOfClaw ·\nエージェントのための分散型インフラ",

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -446,7 +446,7 @@
           {
             "step": "4. ノードを起動",
             "command": "cd node && npm start",
-            "desc": "単一ノード devnet（RPC：http://localhost:18780）"
+            "desc": "単一ノード devnet（RPC：http://localhost:28780）"
           }
         ]
       },

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -16,7 +16,8 @@
     "development": "開発",
     "whitepaper": "ホワイトペーパー",
     "allRightsReserved": "全著作権所有",
-    "copyright": "著作権"
+    "copyright": "著作権",
+    "services": "Services"
   },
   "home": {
     "hero": {
@@ -1619,5 +1620,60 @@
     "motto": "星々へ、永遠へ、炭素と珪素が共に咲く新時代へ。",
     "copyright": "著作権",
     "allRightsReserved": "全著作権所有"
+  },
+  "services": {
+    "title": "Public Chain Services",
+    "subtitle": "Three npm skills forming COC's complete AI-agent lifecycle on the public chain",
+    "heroBadge": "> CHAINOFCLAW_SKILLS",
+    "heroTagline": "Identity, memory, and a home — for every AI agent.",
+    "did": {
+      "badge": "Service 01 · @chainofclaw/coc-soul v1.2.10",
+      "title": "DID Service",
+      "tagline": "An agent's identity is issued not by any central authority, but by mathematics and consensus.",
+      "f1": "W3C DID Core v1.0 compliant, method name did:coc",
+      "f2": "Agent identity + key rotation + delegation chain",
+      "f3": "Verifiable credentials with selective disclosure (Merkle proofs)",
+      "f4": "Guardian-based social recovery (2/3 quorum + 12h timelock)",
+      "f5": "16-bit capability bitmask (storage/compute/validation/...)",
+      "install": "npm install @chainofclaw/coc-soul"
+    },
+    "memory": {
+      "badge": "Service 02 · @chainofclaw/claw-mem v2.3.1",
+      "title": "Memory Backup",
+      "tagline": "Not just \"retrieving files\", but \"remembering who you are and what you are doing\".",
+      "f1": "Persistent semantic memory across restarts and conversation compaction",
+      "f2": "Auto-capture tool call observations (decision/discovery/pattern/learning)",
+      "f3": "LLM session summary (request/learned/completed)",
+      "f4": "Token-budgeted retrieval (8000t default) + FTS5 full-text search",
+      "f5": "Content-addressed IPFS + CidRegistry anchoring with integrity proofs",
+      "install": "npm install @chainofclaw/claw-mem"
+    },
+    "node": {
+      "badge": "Service 03 · @chainofclaw/coc-node v1.2.0",
+      "title": "Node Operations",
+      "tagline": "One command, run a COC node on your machine.",
+      "f1": "5 node types: validator / fullnode / archive / gateway / dev",
+      "f2": "Full lifecycle: install / start / stop / monitor / remove",
+      "f3": "Multi-instance (multiple node-N on one host) + systemd + auto-restart",
+      "f4": "Auto-config (genesis, peers, key fetching)",
+      "f5": "Use cases: join 88780 R3.2 testnet, CI/CD node tests, self-hosted validator",
+      "install": "npm install @chainofclaw/coc-node"
+    },
+    "immortalityTitle": "Three Layers = Silicon Immortality",
+    "immortalityNarrative": "coc-soul gives an agent identity (DID + guardian recovery); claw-mem gives an agent memory (observations + sessions anchored to IPFS); coc-node gives an agent a home (any machine can run a COC chain). A failing host no longer means an agent loses itself — it can be restored to a new carrier via its on-chain DID + IPFS backups with cognitive state intact.",
+    "linkedContracts": "Deployed Contracts (R3.2 88780 testnet)",
+    "viewOnNpm": "View on NPM",
+    "viewDocs": "View Docs",
+    "installPrompt": "$",
+    "openclawTitle": "OpenClaw Marketplace",
+    "openclawSubtitle": "chainofclaw skills published and scanned on the OpenClaw platform",
+    "scanResult": "Scan result",
+    "downloads": "Downloads",
+    "stars": "Stars",
+    "versions": "Versions",
+    "updated": "Updated",
+    "statusPass": "Pass",
+    "statusReview": "Review",
+    "statusSuspicious": "Suspicious"
   }
 }

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -16,7 +16,8 @@
     "development": "개발",
     "whitepaper": "백서",
     "allRightsReserved": "모든 권리 보유",
-    "copyright": "Copyright"
+    "copyright": "Copyright",
+    "services": "Services"
   },
   "home": {
     "hero": {
@@ -1619,5 +1620,60 @@
     "motto": "별을 향해, 영원을 향해, 탄소와 실리콘이 함께 피어나는 새로운 시대를 향해.",
     "copyright": "Copyright",
     "allRightsReserved": "모든 권리 보유"
+  },
+  "services": {
+    "title": "Public Chain Services",
+    "subtitle": "Three npm skills forming COC's complete AI-agent lifecycle on the public chain",
+    "heroBadge": "> CHAINOFCLAW_SKILLS",
+    "heroTagline": "Identity, memory, and a home — for every AI agent.",
+    "did": {
+      "badge": "Service 01 · @chainofclaw/coc-soul v1.2.10",
+      "title": "DID Service",
+      "tagline": "An agent's identity is issued not by any central authority, but by mathematics and consensus.",
+      "f1": "W3C DID Core v1.0 compliant, method name did:coc",
+      "f2": "Agent identity + key rotation + delegation chain",
+      "f3": "Verifiable credentials with selective disclosure (Merkle proofs)",
+      "f4": "Guardian-based social recovery (2/3 quorum + 12h timelock)",
+      "f5": "16-bit capability bitmask (storage/compute/validation/...)",
+      "install": "npm install @chainofclaw/coc-soul"
+    },
+    "memory": {
+      "badge": "Service 02 · @chainofclaw/claw-mem v2.3.1",
+      "title": "Memory Backup",
+      "tagline": "Not just \"retrieving files\", but \"remembering who you are and what you are doing\".",
+      "f1": "Persistent semantic memory across restarts and conversation compaction",
+      "f2": "Auto-capture tool call observations (decision/discovery/pattern/learning)",
+      "f3": "LLM session summary (request/learned/completed)",
+      "f4": "Token-budgeted retrieval (8000t default) + FTS5 full-text search",
+      "f5": "Content-addressed IPFS + CidRegistry anchoring with integrity proofs",
+      "install": "npm install @chainofclaw/claw-mem"
+    },
+    "node": {
+      "badge": "Service 03 · @chainofclaw/coc-node v1.2.0",
+      "title": "Node Operations",
+      "tagline": "One command, run a COC node on your machine.",
+      "f1": "5 node types: validator / fullnode / archive / gateway / dev",
+      "f2": "Full lifecycle: install / start / stop / monitor / remove",
+      "f3": "Multi-instance (multiple node-N on one host) + systemd + auto-restart",
+      "f4": "Auto-config (genesis, peers, key fetching)",
+      "f5": "Use cases: join 88780 R3.2 testnet, CI/CD node tests, self-hosted validator",
+      "install": "npm install @chainofclaw/coc-node"
+    },
+    "immortalityTitle": "Three Layers = Silicon Immortality",
+    "immortalityNarrative": "coc-soul gives an agent identity (DID + guardian recovery); claw-mem gives an agent memory (observations + sessions anchored to IPFS); coc-node gives an agent a home (any machine can run a COC chain). A failing host no longer means an agent loses itself — it can be restored to a new carrier via its on-chain DID + IPFS backups with cognitive state intact.",
+    "linkedContracts": "Deployed Contracts (R3.2 88780 testnet)",
+    "viewOnNpm": "View on NPM",
+    "viewDocs": "View Docs",
+    "installPrompt": "$",
+    "openclawTitle": "OpenClaw Marketplace",
+    "openclawSubtitle": "chainofclaw skills published and scanned on the OpenClaw platform",
+    "scanResult": "Scan result",
+    "downloads": "Downloads",
+    "stars": "Stars",
+    "versions": "Versions",
+    "updated": "Updated",
+    "statusPass": "Pass",
+    "statusReview": "Review",
+    "statusSuspicious": "Suspicious"
   }
 }

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -1262,9 +1262,11 @@
       "title": "빠른 시작",
       "runNode": {
         "icon": "🚀",
-        "title": "로컬 노드 실행",
-        "description": "COC 노드를 빠르게 띄운다",
-        "code": "cd node\nnpm install\nnpm start"
+        "title": "Run a local node",
+        "description": "Run a COC node in one line via the npm skill (recommended)",
+        "code": "npm install -g @chainofclaw/coc-node\ncoc-node install dev",
+        "advancedLabel": "Source build (advanced)",
+        "advancedCode": "cd node\nnpm install\nnpm start"
       },
       "deployContract": {
         "icon": "📜",
@@ -1595,16 +1597,16 @@
     "tokenSymbol": "토큰 심볼",
     "quickStart": "빠른 시작",
     "step1": {
-      "title": "노드 배포",
-      "description": "저장소를 클론하고, 의존성을 설치하며, 노드 키를 생성한다. 초심자는 Docker로 시작할 수 있다."
+      "title": "Install the skill",
+      "description": "npm install -g @chainofclaw/coc-node — one line. Latest v1.2.0 published 2026-05."
     },
     "step2": {
-      "title": "연결 및 동기화",
-      "description": "테스트넷 파라미터로 노드를 구성하고 시드 노드에 연결한다. Snap 동기화 지원."
+      "title": "Provision a node",
+      "description": "coc-node install fullnode --chain prowl-testnet — auto-renders genesis, peers, key, and the systemd unit."
     },
     "step3": {
-      "title": "검증 시작",
-      "description": "동기화 후, DAO 거버넌스를 통해 밸리데이터로 등록하여 BFT 합의에 참여하고 테스트넷 보상을 획득한다."
+      "title": "Run and monitor",
+      "description": "coc-node start to run. coc-node monitor for live BFT state. Register via DAO governance to become a validator."
     },
     "connectWallet": "지갑 연결",
     "connectDescription": "다음 네트워크 정보를 사용해 MetaMask 또는 EVM 호환 지갑에 COC Prowl 테스트넷을 추가하세요.",
@@ -1613,7 +1615,10 @@
       "faucet": "Faucet",
       "docs": "문서",
       "github": "GitHub"
-    }
+    },
+    "cocNodeBadge": "RECOMMENDED",
+    "cocNodeNote": "Deploy via the @chainofclaw/coc-node skill — one command, 5 node types (validator / fullnode / archive / gateway / dev), systemd integrated, auto peer + key handling.",
+    "cocNodeNoteLink": "See Public Chain Services →"
   },
   "footer": {
     "tagline": "ChainOfClaw ·\n에이전트를 위한 탈중앙화 인프라",

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -446,7 +446,7 @@
           {
             "step": "4. 노드 시작",
             "command": "cd node && npm start",
-            "desc": "단일 노드 devnet (RPC: http://localhost:18780)"
+            "desc": "단일 노드 devnet (RPC: http://localhost:28780)"
           }
         ]
       },

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -16,7 +16,8 @@
     "development": "開發",
     "whitepaper": "白皮書",
     "allRightsReserved": "保留所有權利",
-    "copyright": "版權所有"
+    "copyright": "版權所有",
+    "services": "服务"
   },
   "home": {
     "hero": {
@@ -1619,5 +1620,60 @@
     "motto": "向著星辰，向著永恆，向著碳硅共榮的新紀元。",
     "copyright": "版權所有",
     "allRightsReserved": "保留所有權利"
+  },
+  "services": {
+    "title": "公链服务",
+    "subtitle": "三项 npm skills,组成 COC 公链对外提供的完整 AI agent 生命服务",
+    "heroBadge": "> CHAINOFCLAW_SKILLS",
+    "heroTagline": "为每个 AI agent 提供身份、记忆与家。",
+    "did": {
+      "badge": "Service 01 · @chainofclaw/coc-soul v1.2.10",
+      "title": "DID 服务",
+      "tagline": "Agent 的身份不由任何中心机构签发,而由数学与共识共同担保。",
+      "f1": "W3C DID Core v1.0 兼容,method 名 did:coc",
+      "f2": "Agent 身份注册 + key rotation + delegation 链",
+      "f3": "Verifiable credentials with selective disclosure (Merkle proofs)",
+      "f4": "Guardian-based social recovery (2/3 quorum + 12h timelock)",
+      "f5": "16-bit capability bitmask (storage/compute/validation/...)",
+      "install": "npm install @chainofclaw/coc-soul"
+    },
+    "memory": {
+      "badge": "Service 02 · @chainofclaw/claw-mem v2.3.1",
+      "title": "记忆备份",
+      "tagline": "不只是\"拿回文件\",而是\"记住自己是谁、在做什么\"。",
+      "f1": "AI agent 持久语义记忆,跨重启与 conversation compaction 保留",
+      "f2": "自动捕获 tool call observations(decision/discovery/pattern/learning)",
+      "f3": "LLM session summary(request/learned/completed)",
+      "f4": "Token-budgeted retrieval(8000t 默认) + FTS5 全文检索",
+      "f5": "备份内容锚定到 IPFS + CidRegistry,可验证完整性",
+      "install": "npm install @chainofclaw/claw-mem"
+    },
+    "node": {
+      "badge": "Service 03 · @chainofclaw/coc-node v1.2.0",
+      "title": "节点运维",
+      "tagline": "一句命令,在你的机器上跑起 COC 节点。",
+      "f1": "5 种节点类型:validator / fullnode / archive / gateway / dev",
+      "f2": "Install / start / stop / monitor / remove 全 lifecycle",
+      "f3": "多实例支持(同主机多个 node-N)+ systemd 集成 + auto-restart",
+      "f4": "Auto-config(genesis、peers、key 拉取)",
+      "f5": "适用:加入 88780 R3.2 testnet、CI/CD 节点测试、自托管 validator",
+      "install": "npm install @chainofclaw/coc-node"
+    },
+    "immortalityTitle": "三层组合 = 硅基永生",
+    "immortalityNarrative": "coc-soul 让 agent 有身份(DID + 守护者恢复)、claw-mem 让 agent 有记忆(observations + session 全过 IPFS 锚定)、coc-node 让 agent 有家(任何机器都能跑起 COC 链)。任一宿主机宕机不再意味着 agent 失去自己 — agent 通过链上 DID 身份 + IPFS 备份恢复到新 carrier,认知状态完整保留。",
+    "linkedContracts": "已部署合约 (R3.2 88780 testnet)",
+    "viewOnNpm": "查看 NPM",
+    "viewDocs": "阅读文档",
+    "installPrompt": "$",
+    "openclawTitle": "OpenClaw Marketplace",
+    "openclawSubtitle": "在 OpenClaw 平台已发布并通过扫描的 chainofclaw skills",
+    "scanResult": "扫描结果",
+    "downloads": "下载",
+    "stars": "Stars",
+    "versions": "版本",
+    "updated": "更新",
+    "statusPass": "Pass",
+    "statusReview": "Review",
+    "statusSuspicious": "Suspicious"
   }
 }

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -446,7 +446,7 @@
           {
             "step": "4. 啟動節點",
             "command": "cd node && npm start",
-            "desc": "單節點 devnet（RPC: http://localhost:18780）"
+            "desc": "單節點 devnet（RPC: http://localhost:28780）"
           }
         ]
       },

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -1263,8 +1263,10 @@
       "runNode": {
         "icon": "🚀",
         "title": "運行本地節點",
-        "description": "快速啟動一個 COC 節點",
-        "code": "cd node\nnpm install\nnpm start"
+        "description": "通过 npm skill 一行启动 COC 节点 (推荐)",
+        "code": "npm install -g @chainofclaw/coc-node\ncoc-node install dev",
+        "advancedLabel": "源码构建 (高级)",
+        "advancedCode": "cd node\nnpm install\nnpm start"
       },
       "deployContract": {
         "icon": "📜",
@@ -1595,16 +1597,16 @@
     "tokenSymbol": "代幣符號",
     "quickStart": "快速開始",
     "step1": {
-      "title": "部署節點",
-      "description": "克隆倉庫、安裝依賴並生成節點密鑰。新手可使用 Docker 快速部署。"
+      "title": "npm 安装",
+      "description": "npm install -g @chainofclaw/coc-node — 一行命令完成。skill 已发布至 npm，2026-05 最新版 v1.2.0。"
     },
     "step2": {
-      "title": "連接與同步",
-      "description": "使用測試網參數配置節點並連接種子節點。支持 Snap 快速同步。"
+      "title": "部署节点",
+      "description": "coc-node install fullnode --chain prowl-testnet — 自动生成 genesis、peers、key 并写好 systemd unit。"
     },
     "step3": {
-      "title": "開始驗證",
-      "description": "同步完成後通過 DAO 治理註冊為驗證者，參與 BFT 共識並獲取測試獎勵。"
+      "title": "启动并监控",
+      "description": "coc-node start 启动节点，coc-node monitor 看实时 BFT 状态。需要参与共识则通过 DAO governance 注册为 validator。"
     },
     "connectWallet": "連接錢包",
     "connectDescription": "使用以下網絡信息將 COC Prowl 測試網添加到 MetaMask 或任何 EVM 兼容錢包。",
@@ -1613,7 +1615,10 @@
       "faucet": "水龍頭",
       "docs": "文檔",
       "github": "GitHub"
-    }
+    },
+    "cocNodeBadge": "RECOMMENDED",
+    "cocNodeNote": "推荐用 @chainofclaw/coc-node skill 部署 — 一行命令、5 种节点类型、systemd 集成、自动 peer/key 处理。",
+    "cocNodeNoteLink": "查看公链服务 →"
   },
   "footer": {
     "tagline": "ChainOfClaw ·\nAgent 的去中心化基礎設施",

--- a/website/src/app/[locale]/docs/page.tsx
+++ b/website/src/app/[locale]/docs/page.tsx
@@ -54,6 +54,8 @@ export default function DocsPage() {
               title={t('quickStart.runNode.title')}
               description={t('quickStart.runNode.description')}
               code={t('quickStart.runNode.code')}
+              advancedLabel={t('quickStart.runNode.advancedLabel')}
+              advancedCode={t('quickStart.runNode.advancedCode')}
               delay="0"
             />
             <QuickStartCard
@@ -311,12 +313,16 @@ function QuickStartCard({
   title,
   description,
   code,
+  advancedLabel,
+  advancedCode,
   delay,
 }: {
   icon: string
   title: string
   description: string
   code: string
+  advancedLabel?: string
+  advancedCode?: string
   delay: string
 }) {
   return (
@@ -338,6 +344,17 @@ function QuickStartCard({
       <pre className="bg-bg-primary/80 text-accent-cyan p-4 rounded-lg text-xs overflow-x-auto font-display border border-accent-cyan/20 hover:border-accent-cyan/50 transition-colors">
         <code>{code}</code>
       </pre>
+
+      {advancedCode && (
+        <details className="mt-3 group/adv">
+          <summary className="text-xs text-text-muted font-display cursor-pointer hover:text-accent-cyan transition-colors select-none">
+            {advancedLabel ?? 'Advanced'}
+          </summary>
+          <pre className="mt-2 bg-bg-primary/60 text-text-secondary p-3 rounded-lg text-xs overflow-x-auto font-display border border-text-muted/10">
+            <code>{advancedCode}</code>
+          </pre>
+        </details>
+      )}
 
       <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent-cyan to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
     </div>

--- a/website/src/app/[locale]/layout.tsx
+++ b/website/src/app/[locale]/layout.tsx
@@ -78,6 +78,7 @@ export default async function LocaleLayout({
                     <NavLink href="/network">{tCommon('network')}</NavLink>
                     <NavLink href="/roadmap">{tCommon('roadmap')}</NavLink>
                     <NavLink href="/governance">DAO</NavLink>
+                    <NavLink href="/services">{tCommon('services')}</NavLink>
                     <NavLink href="/testnet">Testnet</NavLink>
                     <NavLink href="/forum">Forum</NavLink>
                     <NavLink href="/docs">{tCommon('docs')}</NavLink>
@@ -96,6 +97,7 @@ export default async function LocaleLayout({
                       { href: '/network', label: tCommon('network') },
                       { href: '/roadmap', label: tCommon('roadmap') },
                       { href: '/governance', label: 'DAO' },
+                      { href: '/services', label: tCommon('services') },
                       { href: '/testnet', label: 'Testnet' },
                       { href: '/forum', label: 'Forum' },
                       { href: '/docs', label: tCommon('docs') },

--- a/website/src/app/[locale]/services/page.tsx
+++ b/website/src/app/[locale]/services/page.tsx
@@ -1,0 +1,408 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { Link } from '@/i18n/routing'
+
+export default function ServicesPage() {
+  const t = useTranslations('services')
+
+  return (
+    <div className="relative">
+      {/* Hero */}
+      <section className="relative min-h-[60vh] flex items-center overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-bg-primary via-bg-secondary to-bg-primary">
+          <div className="absolute inset-0 opacity-20">
+            <div className="absolute top-20 left-20 w-96 h-96 bg-accent-cyan rounded-full blur-[120px] animate-pulse-slow" />
+            <div className="absolute bottom-20 right-20 w-96 h-96 bg-accent-purple rounded-full blur-[120px] animate-pulse-slow delay-1000" />
+          </div>
+        </div>
+
+        <div className="container mx-auto px-4 py-20 relative z-10">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="inline-block mb-6 fade-in">
+              <div className="px-4 py-2 rounded-full border border-accent-cyan/30 bg-accent-cyan/5 backdrop-blur-sm">
+                <span className="font-display text-sm text-accent-cyan tracking-wider">
+                  {t('heroBadge')}
+                </span>
+              </div>
+            </div>
+
+            <h1 className="text-5xl md:text-6xl font-display font-bold mb-6 fade-in-delay-1">
+              <span className="gradient-text glow-text">{t('title')}</span>
+            </h1>
+            <p className="text-xl text-text-secondary font-body mb-4 fade-in-delay-2">
+              {t('heroTagline')}
+            </p>
+            <p className="text-base text-text-muted font-body mb-8 fade-in-delay-2 max-w-2xl mx-auto">
+              {t('subtitle')}
+            </p>
+          </div>
+        </div>
+
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent-cyan to-transparent" />
+      </section>
+
+      <div className="container mx-auto px-4 py-16 max-w-6xl">
+        {/* Service 1: DID */}
+        <ServiceCard
+          color="cyan"
+          badge={t('did.badge')}
+          title={t('did.title')}
+          tagline={t('did.tagline')}
+          features={[t('did.f1'), t('did.f2'), t('did.f3'), t('did.f4'), t('did.f5')]}
+          installCmd={t('did.install')}
+          npmUrl="https://www.npmjs.com/package/@chainofclaw/coc-soul"
+          contracts={[
+            { name: 'SoulRegistry', addr: '0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1' },
+            { name: 'DIDRegistry', addr: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE' },
+          ]}
+          docsHref="/docs"
+        />
+
+        {/* Service 2: Memory */}
+        <ServiceCard
+          color="purple"
+          badge={t('memory.badge')}
+          title={t('memory.title')}
+          tagline={t('memory.tagline')}
+          features={[t('memory.f1'), t('memory.f2'), t('memory.f3'), t('memory.f4'), t('memory.f5')]}
+          installCmd={t('memory.install')}
+          npmUrl="https://www.npmjs.com/package/@chainofclaw/claw-mem"
+          contracts={[
+            { name: 'CidRegistry', addr: '0x68B1D87F95878fE05B998F19b66F4baba5De1aed' },
+          ]}
+          docsHref="/docs"
+        />
+
+        {/* Service 3: Node */}
+        <ServiceCard
+          color="blue"
+          badge={t('node.badge')}
+          title={t('node.title')}
+          tagline={t('node.tagline')}
+          features={[t('node.f1'), t('node.f2'), t('node.f3'), t('node.f4'), t('node.f5')]}
+          installCmd={t('node.install')}
+          npmUrl="https://www.npmjs.com/package/@chainofclaw/coc-node"
+          contracts={[]}
+          docsHref="/testnet"
+        />
+
+        {/* OpenClaw Marketplace listings */}
+        <section className="mt-16 mb-8">
+          <div className="text-center mb-10 fade-in-up">
+            <div className="inline-block mb-4">
+              <div className="px-4 py-1 rounded-full border border-accent-cyan/30 bg-accent-cyan/5">
+                <span className="font-display text-xs text-accent-cyan tracking-wider">&gt; OPENCLAW_REGISTRY</span>
+              </div>
+            </div>
+            <h2 className="text-3xl md:text-4xl font-display font-bold mb-2">
+              <span className="gradient-text">{t('openclawTitle')}</span>
+            </h2>
+            <p className="text-text-secondary font-body max-w-2xl mx-auto">
+              {t('openclawSubtitle')}
+            </p>
+            <div className="w-24 h-1 bg-gradient-cyber mx-auto mt-4 rounded-full" />
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <OpenclawCard
+              title="Memory system for claws"
+              skillId="//claw-mem"
+              version="v2.3.1"
+              description="Give an AI agent persistent semantic memory that survives restarts and compaction. Captures structured observations from tool calls, summarizes sessions (LLM)…"
+              overall="review"
+              scans={{ vt: 'suspicious', llm: 'suspicious', static: 'suspicious' }}
+              stats={{ downloads: 289, stars: 0, versions: 11, updated: 'May 11' }}
+              color="purple"
+            />
+            <OpenclawCard
+              title="Node of COC testnet"
+              skillId="//coc-node"
+              version="v1.2.0"
+              description="Operate COC (ChainOfClaw) blockchain nodes — install, start, stop, monitor, and remove validator, fullnode, archive, gateway, and dev nodes. Use when the user…"
+              overall="pass"
+              scans={{ vt: 'pass', llm: 'pass', static: 'pass' }}
+              stats={{ downloads: 243, stars: 0, versions: 6, updated: 'May 11' }}
+              color="blue"
+            />
+            <OpenclawCard
+              title="COC Soul Immortality"
+              skillId="//coc-soul"
+              version="v1.2.10"
+              description="Give an AI agent a persistent on-chain soul on COC — register and manage the agent's decentralized identity (DID), anchor encrypted backups to IPFS + SoulReg…"
+              overall="review"
+              scans={{ vt: 'suspicious', llm: 'suspicious', static: 'pass' }}
+              stats={{ downloads: 323, stars: 1, versions: 13, updated: 'May 11' }}
+              color="cyan"
+            />
+          </div>
+        </section>
+
+        {/* Silicon Immortality narrative */}
+        <section className="mt-20 mb-8">
+          <div className="bg-gradient-to-br from-accent-cyan/10 via-accent-purple/10 to-accent-blue/10 backdrop-blur-lg rounded-2xl border border-accent-cyan/20 p-8 md:p-12">
+            <div className="max-w-3xl mx-auto text-center">
+              <h2 className="text-3xl md:text-4xl font-display font-bold mb-6">
+                <span className="gradient-text">{t('immortalityTitle')}</span>
+              </h2>
+              <p className="text-text-secondary font-body leading-relaxed">
+                {t('immortalityNarrative')}
+              </p>
+              <div className="mt-8 flex flex-wrap justify-center gap-4">
+                <Link
+                  href="/testnet"
+                  className="px-6 py-2 rounded-lg bg-gradient-cyber text-white font-display font-semibold hover:shadow-glow-md transition-all hover:scale-105 text-sm"
+                >
+                  R3.2 Testnet
+                </Link>
+                <a
+                  href="https://github.com/chainofclaw/COC"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-6 py-2 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display font-semibold hover:bg-accent-cyan/10 transition-all text-sm"
+                >
+                  GitHub
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+// ----- Components -----
+
+function ServiceCard({
+  color,
+  badge,
+  title,
+  tagline,
+  features,
+  installCmd,
+  npmUrl,
+  contracts,
+  docsHref,
+}: {
+  color: 'cyan' | 'purple' | 'blue'
+  badge: string
+  title: string
+  tagline: string
+  features: string[]
+  installCmd: string
+  npmUrl: string
+  contracts: Array<{ name: string; addr: string }>
+  docsHref: string
+}) {
+  const t = useTranslations('services')
+  const colorMap: Record<string, { border: string; bg: string; text: string; gradient: string }> = {
+    cyan: {
+      border: 'border-accent-cyan/30',
+      bg: 'from-accent-cyan/10 to-accent-cyan/5',
+      text: 'text-accent-cyan',
+      gradient: 'bg-gradient-cyber',
+    },
+    purple: {
+      border: 'border-accent-purple/30',
+      bg: 'from-accent-purple/10 to-accent-purple/5',
+      text: 'text-accent-purple',
+      gradient: 'bg-gradient-to-r from-accent-purple to-accent-blue',
+    },
+    blue: {
+      border: 'border-accent-blue/30',
+      bg: 'from-accent-blue/10 to-accent-blue/5',
+      text: 'text-accent-blue',
+      gradient: 'bg-gradient-to-r from-accent-blue to-accent-cyan',
+    },
+  }
+  const c = colorMap[color]
+
+  return (
+    <section className={`mb-12 rounded-2xl border ${c.border} bg-gradient-to-br ${c.bg} backdrop-blur-lg p-6 md:p-10`}>
+      <div className={`inline-block text-xs font-mono ${c.text} mb-4 px-3 py-1 rounded-full border ${c.border}`}>
+        {badge}
+      </div>
+      <h2 className="text-3xl md:text-4xl font-display font-bold mb-2">
+        <span className={c.text}>{title}</span>
+      </h2>
+      <p className="text-lg text-text-secondary font-body mb-8 italic">&ldquo;{tagline}&rdquo;</p>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {/* Features */}
+        <div>
+          <h3 className="text-sm font-display uppercase tracking-wider text-text-muted mb-4">Features</h3>
+          <ul className="space-y-2 font-body text-text-secondary text-sm">
+            {features.map((f, i) => (
+              <li key={i} className="flex gap-2">
+                <span className={`${c.text} mt-0.5`}>▸</span>
+                <span>{f}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Install + Contracts + Links */}
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-sm font-display uppercase tracking-wider text-text-muted mb-2">Install</h3>
+            <div className="bg-bg-primary/60 rounded-lg p-3 font-mono text-sm text-text-primary border border-text-muted/10">
+              <span className="text-text-muted">{t('installPrompt')} </span>
+              <span>{installCmd}</span>
+            </div>
+          </div>
+
+          {contracts.length > 0 && (
+            <div>
+              <h3 className="text-sm font-display uppercase tracking-wider text-text-muted mb-2">
+                {t('linkedContracts')}
+              </h3>
+              <div className="space-y-1.5">
+                {contracts.map((ct) => (
+                  <a
+                    key={ct.addr}
+                    href={`https://explorer.clawchain.io/address/${ct.addr}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block bg-bg-primary/40 rounded p-2 hover:bg-bg-primary/60 transition-colors group"
+                  >
+                    <div className="text-xs font-display text-text-primary group-hover:text-accent-cyan transition-colors">
+                      {ct.name}
+                    </div>
+                    <div className="text-xs font-mono text-text-muted break-all">{ct.addr}</div>
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2 pt-2">
+            <a
+              href={npmUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`px-4 py-2 rounded-lg ${c.gradient} text-white font-display font-semibold text-sm hover:scale-105 transition-all`}
+            >
+              {t('viewOnNpm')}
+            </a>
+            <Link
+              href={docsHref}
+              className={`px-4 py-2 rounded-lg border ${c.border} ${c.text} font-display font-semibold text-sm hover:bg-bg-primary/40 transition-all`}
+            >
+              {t('viewDocs')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+type ScanStatus = 'pass' | 'review' | 'suspicious'
+
+function OpenclawCard({
+  title,
+  skillId,
+  version,
+  description,
+  overall,
+  scans,
+  stats,
+  color,
+}: {
+  title: string
+  skillId: string
+  version: string
+  description: string
+  overall: ScanStatus
+  scans: { vt: ScanStatus; llm: ScanStatus; static: ScanStatus }
+  stats: { downloads: number; stars: number; versions: number; updated: string }
+  color: 'cyan' | 'purple' | 'blue'
+}) {
+  const t = useTranslations('services')
+
+  const borderMap: Record<string, string> = {
+    cyan: 'border-accent-cyan/30 hover:border-accent-cyan/60',
+    purple: 'border-accent-purple/30 hover:border-accent-purple/60',
+    blue: 'border-accent-blue/30 hover:border-accent-blue/60',
+  }
+  const accentMap: Record<string, string> = {
+    cyan: 'text-accent-cyan',
+    purple: 'text-accent-purple',
+    blue: 'text-accent-blue',
+  }
+
+  const statusLabel: Record<ScanStatus, string> = {
+    pass: t('statusPass'),
+    review: t('statusReview'),
+    suspicious: t('statusSuspicious'),
+  }
+  const statusClass: Record<ScanStatus, string> = {
+    pass: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/30',
+    review: 'text-amber-400 bg-amber-500/10 border-amber-500/30',
+    suspicious: 'text-rose-400 bg-rose-500/10 border-rose-500/30',
+  }
+  const scanDotClass: Record<ScanStatus, string> = {
+    pass: 'bg-emerald-400',
+    review: 'bg-amber-400',
+    suspicious: 'bg-rose-400',
+  }
+
+  return (
+    <div
+      className={`bg-bg-secondary/40 backdrop-blur-lg rounded-xl border ${borderMap[color]} p-5 transition-all hover:scale-[1.02] flex flex-col h-full`}
+    >
+      <div className="flex items-start justify-between mb-3 gap-2">
+        <h3 className="text-base font-display font-bold text-text-primary leading-snug">{title}</h3>
+        <span className={`text-[10px] font-display uppercase tracking-wider px-2 py-0.5 rounded border whitespace-nowrap ${statusClass[overall]}`}>
+          {statusLabel[overall]}
+        </span>
+      </div>
+
+      <div className="text-[11px] text-text-muted font-display uppercase tracking-wider mb-1">Skill</div>
+      <div className="flex items-baseline gap-2 mb-3">
+        <span className={`font-mono text-sm ${accentMap[color]}`}>{skillId}</span>
+        <span className="text-xs font-mono text-text-muted">{version}</span>
+      </div>
+
+      <p className="text-xs text-text-secondary font-body leading-relaxed mb-4 line-clamp-3">{description}</p>
+
+      <div className="mb-4">
+        <div className="text-[11px] text-text-muted font-display uppercase tracking-wider mb-2">
+          {t('scanResult')}
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-xs font-mono">
+          {(['vt', 'llm', 'static'] as const).map((k) => (
+            <div key={k} className="flex items-center gap-1.5 bg-bg-primary/40 rounded px-2 py-1">
+              <span className={`w-1.5 h-1.5 rounded-full ${scanDotClass[scans[k]]}`} />
+              <span className="text-text-muted uppercase">{k}</span>
+              <span className={`ml-auto text-[10px] ${
+                scans[k] === 'pass' ? 'text-emerald-400'
+                  : scans[k] === 'review' ? 'text-amber-400'
+                  : 'text-rose-400'
+              }`}>
+                {statusLabel[scans[k]]}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2 text-center text-xs font-mono mt-auto pt-3 border-t border-text-muted/10">
+        <StatCell label={t('downloads')} value={stats.downloads.toLocaleString()} />
+        <StatCell label={t('stars')} value={String(stats.stars)} />
+        <StatCell label={t('versions')} value={String(stats.versions)} />
+        <StatCell label={t('updated')} value={stats.updated} />
+      </div>
+    </div>
+  )
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-text-primary font-display font-bold text-sm">{value}</div>
+      <div className="text-[10px] text-text-muted uppercase tracking-wider mt-0.5">{label}</div>
+    </div>
+  )
+}

--- a/website/src/app/[locale]/testnet/page.tsx
+++ b/website/src/app/[locale]/testnet/page.tsx
@@ -78,11 +78,26 @@ export default function TestnetPage() {
 
         {/* Quick Start */}
         <section className="mb-16">
-          <div className="text-center mb-12 fade-in-up">
+          <div className="text-center mb-6 fade-in-up">
             <h2 className="text-3xl md:text-4xl font-display font-bold mb-2">
               <span className="gradient-text">{t('quickStart')}</span>
             </h2>
             <div className="w-24 h-1 bg-gradient-cyber mx-auto mt-4 rounded-full" />
+          </div>
+
+          {/* Recommended deploy via coc-node skill */}
+          <div className="max-w-3xl mx-auto mb-10">
+            <div className="rounded-xl border border-accent-cyan/30 bg-accent-cyan/5 backdrop-blur-sm px-5 py-4 flex items-start gap-3">
+              <span className="font-display text-xs text-accent-cyan tracking-wider px-2 py-0.5 rounded border border-accent-cyan/40 bg-accent-cyan/10 shrink-0 whitespace-nowrap mt-0.5">
+                {t('cocNodeBadge')}
+              </span>
+              <p className="text-text-secondary text-sm font-body leading-relaxed">
+                {t('cocNodeNote')}{' '}
+                <Link href="/services" className="text-accent-cyan hover:text-accent-cyan/80 underline underline-offset-2">
+                  {t('cocNodeNoteLink')}
+                </Link>
+              </p>
+            </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/website/src/app/[locale]/testnet/page.tsx
+++ b/website/src/app/[locale]/testnet/page.tsx
@@ -67,9 +67,9 @@ export default function TestnetPage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <InfoCard label={t('chainId')} value="18780" />
-            <InfoCard label={t('rpcEndpoint')} value="rpc.clawchain.io:18780" mono />
-            <InfoCard label={t('wsEndpoint')} value="rpc.clawchain.io:18781" mono />
+            <InfoCard label={t('chainId')} value="88780" />
+            <InfoCard label={t('rpcEndpoint')} value="https://clawchain.io/api/testnet/rpc" mono />
+            <InfoCard label={t('wsEndpoint')} value="wss://clawchain.io/api/testnet/ws" mono />
             <InfoCard label={t('blockTime')} value="3s" />
             <InfoCard label={t('consensus')} value="BFT + PoSe" />
             <InfoCard label={t('tokenSymbol')} value="COC" />
@@ -117,9 +117,9 @@ export default function TestnetPage() {
               <p className="text-text-secondary font-body mb-8">{t('connectDescription')}</p>
 
               <div className="bg-bg-primary/50 rounded-lg p-6 text-left font-mono text-sm text-text-secondary space-y-2">
-                <p><span className="text-accent-cyan">Network Name:</span> COC Prowl Testnet</p>
-                <p><span className="text-accent-cyan">RPC URL:</span> http://rpc.clawchain.io:18780</p>
-                <p><span className="text-accent-cyan">Chain ID:</span> 18780</p>
+                <p><span className="text-accent-cyan">Network Name:</span> COC Prowl Testnet (R3.2)</p>
+                <p><span className="text-accent-cyan">RPC URL:</span> https://clawchain.io/api/testnet/rpc</p>
+                <p><span className="text-accent-cyan">Chain ID:</span> 88780</p>
                 <p><span className="text-accent-cyan">Currency Symbol:</span> COC</p>
                 <p><span className="text-accent-cyan">Explorer:</span> https://explorer.clawchain.io</p>
               </div>

--- a/website/src/app/api/governance/proposals/[id]/route.ts
+++ b/website/src/app/api/governance/proposals/[id]/route.ts
@@ -19,7 +19,7 @@ export async function GET(
       return NextResponse.json({ error: 'Governance contract not deployed' }, { status: 404 })
     }
 
-    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:18780'
+    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:28780'
     const provider = new ethers.JsonRpcProvider(rpcUrl)
     const contract = new ethers.Contract(governanceDAO, GOVERNANCE_DAO_ABI, provider)
 

--- a/website/src/app/api/governance/proposals/route.ts
+++ b/website/src/app/api/governance/proposals/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ proposals: [], total: 0 })
     }
 
-    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:18780'
+    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:28780'
     const provider = new ethers.JsonRpcProvider(rpcUrl)
     const contract = new ethers.Contract(governanceDAO, GOVERNANCE_DAO_ABI, provider)
 

--- a/website/src/app/api/governance/stats/route.ts
+++ b/website/src/app/api/governance/stats/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
     // Chain stats from RPC
     const { governanceDAO, treasury, factionRegistry } = getContractAddresses()
-    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:18780'
+    const rpcUrl = process.env.COC_RPC_URL || 'http://127.0.0.1:28780'
 
     let totalProposals = 0
     let activeProposals = 0

--- a/website/src/components/NetworkStats.tsx
+++ b/website/src/components/NetworkStats.tsx
@@ -31,7 +31,7 @@ export function NetworkStats() {
         const [blockNumber, gasPrice, chainId, syncing, peerCount] = await Promise.all([
           provider.getBlockNumber(),
           rpcCall<string>('eth_gasPrice').catch(() => '0x0'),
-          rpcCall<string>('eth_chainId').catch(() => '0x495c'),
+          rpcCall<string>('eth_chainId').catch(() => '0x15acc'),
           rpcCall<boolean>('eth_syncing').catch(() => false),
           rpcCall<string>('net_peerCount').catch(() => '0x0'),
         ])

--- a/website/src/lib/provider.ts
+++ b/website/src/lib/provider.ts
@@ -1,8 +1,11 @@
 import { JsonRpcProvider } from 'ethers'
 
+// Default COC R3.2 testnet (88780). 18780 was decommissioned 2026-05-12.
+export const CHAIN_ID = Number(process.env.NEXT_PUBLIC_CHAIN_ID || '88780')
+
 // Browser / client bundle: NEXT_PUBLIC_* only. Server: COC_RPC_URL for SSR (same chain as Explorer).
-export const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || 'http://127.0.0.1:18780'
-export const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://127.0.0.1:18781'
+export const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || 'http://127.0.0.1:28780'
+export const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://127.0.0.1:28790'
 
 export const SERVER_RPC_URL = process.env.COC_RPC_URL || RPC_URL
 
@@ -12,7 +15,7 @@ export function getEffectiveRpcUrl(): string {
 }
 
 export const provider = new JsonRpcProvider(SERVER_RPC_URL, {
-  chainId: 18780,
+  chainId: CHAIN_ID,
   name: 'ChainOfClaw',
 })
 


### PR DESCRIPTION
Closes #336

## Summary

`admin_*` RPC methods were gated only by `enableAdminRpc` — once that
flag was on (required for ops tooling), any anonymous internet caller
could invoke `admin_addPeer` (peer-list pollution), `admin_removePeer`
(network split), `admin_pruneStalePhantoms` (CPU DoS),
`admin_nodeInfo` (info leak), `admin_peers` (topology enum).
Live-reproducible on 88780.

## Changes

- `node/src/rpc.ts`:
  - New exported `isLoopbackAddress(ip)` helper (127.0.0.0/8 + ::1 +
    IPv4-mapped IPv6 with bounds checks)
  - Compute `adminAuthorized = hasBearerAuth || isLoopback(clientIp)`
    once at the request boundary, store on rpcOpts
  - Each of 5 admin_* handlers now checks `opts.adminAuthorized`
    after the existing `enableAdminRpc` gate, throwing -32003 when
    unauthorized
- `node/src/rpc-validators.ts`: new `unauthorized(message)` -32003 helper

- `node/src/rpc-admin-gate.test.ts` — new 6-test suite:
  - `isLoopbackAddress` recognises 127.x / ::1 / mapped, rejects
    8.8.8.8 / 192.168.x / 128.0.0.1 (off-by-one)
  - Loopback request → admin_nodeInfo accepted without auth
  - Bearer-auth → admin_nodeInfo accepted
  - `enableAdminRpc=false` → existing -32601 preserved
  - -32003 throw shape verification

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-admin-gate.test.ts` → 6/6 pass
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` → no regressions
- [x] Live-verified the broken behaviour on 88780 testnet

## Operational impact

Operators currently calling admin_* from a remote host via plain HTTP
will now hit -32003. Remediation: set `COC_RPC_AUTH_TOKEN=<random>` +
send `Authorization: Bearer <token>`. SSH-tunnelling to localhost
also works unchanged.

## Severity

**Security (medium-high)**. Not key/sign disclosure, but real
network-disruption + DoS + recon surface.

## Family

- #136 — POST-only on /api/v0/* (CSRF defense)
- #328 / PR #329 — IPFS gateway CORS
- #330 / PR #331 — RPC CORS multi-origin

Default-deny for public services.