### PR TITLE
fix(ipfs-http): multipart parser respects RFC 2046 CRLF-anchored boundary (#338)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1072,6 +1072,83 @@ describe("IpfsHttpServer", () => {
       const getRes = await fetch(`/ipfs/${cid}`)
       const headRes = await fetch(`/ipfs/${cid}`, { method: "HEAD" })
       assert.equal(headRes.status, getRes.status, "HEAD and GET must agree on status code (RFC 7231)")
+  })
+
+  // #338: multipart parser used raw.split("--" + boundary) without RFC
+  // 2046's mandatory CRLF prefix — file content containing the boundary
+  // string anywhere silently truncated the upload. CID then pointed to
+  // partial data. Data-integrity bug. Verify boundary-in-content uploads
+  // round-trip byte-exact.
+  describe("#338 multipart parser CRLF-anchored boundary", () => {
+    it("file content containing the boundary string is preserved", async () => {
+      const boundary = "----TestBoundary338"
+      // File data deliberately includes the boundary substring (no CRLF
+      // prefix — RFC says this is NOT a delimiter).
+      const content = Buffer.from(`hello --${boundary} embedded mid-file payload`)
+      const body = Buffer.concat([
+        Buffer.from(`--${boundary}\r\n`),
+        Buffer.from(`Content-Disposition: form-data; name="file"; filename="x.bin"\r\n`),
+        Buffer.from(`Content-Type: application/octet-stream\r\n\r\n`),
+        content,
+        Buffer.from(`\r\n--${boundary}--\r\n`),
+      ])
+      const res = await fetch("/api/v0/add", {
+        method: "POST",
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body: body.toString("binary"),
+      })
+      assert.equal(res.status, 200)
+      const json = await res.json() as { Hash: string; Size: string }
+      assert.equal(Number(json.Size), content.length,
+        `upload must preserve full ${content.length} bytes including boundary substring, got Size=${json.Size}`)
+      // Cat back and verify byte-exact
+      const cat = await fetch(`/api/v0/cat?arg=${json.Hash}`)
+      const got = await cat.buffer()
+      assert.deepEqual(new Uint8Array(got), new Uint8Array(content),
+        "round-tripped content must match original byte-for-byte")
+    })
+
+    it("malformed mid-content `--boundary` without CRLF prefix is ignored", async () => {
+      // Subtle variant: boundary appears mid-content with no CRLF prefix,
+      // only a space prefix. Pre-fix split here too; post-fix should not.
+      const boundary = "----TestB338Subtle"
+      const content = Buffer.from(`prefix --${boundary} foo  --${boundary} bar suffix`)
+      const body = Buffer.concat([
+        Buffer.from(`--${boundary}\r\n`),
+        Buffer.from(`Content-Disposition: form-data; name="file"; filename="x.bin"\r\n`),
+        Buffer.from(`Content-Type: application/octet-stream\r\n\r\n`),
+        content,
+        Buffer.from(`\r\n--${boundary}--\r\n`),
+      ])
+      const res = await fetch("/api/v0/add", {
+        method: "POST",
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body: body.toString("binary"),
+      })
+      assert.equal(res.status, 200)
+      const json = await res.json() as { Hash: string; Size: string }
+      assert.equal(Number(json.Size), content.length,
+        `multiple boundary substrings mid-content must not truncate; expected ${content.length}, got ${json.Size}`)
+    })
+
+    it("well-formed multipart still works (regression guard)", async () => {
+      const boundary = "----RegressionBoundary"
+      const content = Buffer.from("ordinary file content, no boundary substring")
+      const body = Buffer.concat([
+        Buffer.from(`--${boundary}\r\n`),
+        Buffer.from(`Content-Disposition: form-data; name="file"; filename="r.bin"\r\n`),
+        Buffer.from(`Content-Type: application/octet-stream\r\n\r\n`),
+        content,
+        Buffer.from(`\r\n--${boundary}--\r\n`),
+      ])
+      const res = await fetch("/api/v0/add", {
+        method: "POST",
+        headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+        body: body.toString("binary"),
+      })
+      assert.equal(res.status, 200)
+      const json = await res.json() as { Hash: string; Size: string }
+      assert.equal(Number(json.Size), content.length, "normal upload byte count must match")
     })
   })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1659,6 +1659,61 @@ async function readBody(req: http.IncomingMessage, maxSize = DEFAULT_MAX_UPLOAD_
   }
 }
 
+/**
+ * #338: RFC 2046 §5.1.1-compliant multipart split.
+ *
+ * Pre-fix used `raw.split("--" + boundary)` which split on the boundary
+ * substring ANYWHERE in the body — file content containing those bytes
+ * silently truncated the upload. The CID then pointed to partial data
+ * and the user didn't know.
+ *
+ * Per RFC 2046, the delimiter is one of:
+ *   - Initial:    "--" + boundary                  (allowed at start of body)
+ *   - Encapsulating:  CRLF + "--" + boundary + CRLF
+ *   - Closing:    CRLF + "--" + boundary + "--"
+ *
+ * The CRLF prefix on subsequent boundaries (RFC §5.1.1: "The body
+ * must therefore include an additional CRLF preceding the boundary
+ * delimiter line") is the bit that turns a substring match into a
+ * delimiter match. Match it.
+ *
+ * Returns the indices of each part's start (after the leading
+ * CRLF/initial-marker) so the caller can extract the slice.
+ */
+function findMultipartParts(raw: Buffer, boundary: string): Array<{ start: number; end: number }> {
+  const delim = Buffer.from(`--${boundary}`, "binary")
+  const crlfDelim = Buffer.from(`\r\n--${boundary}`, "binary")
+  const parts: Array<{ start: number; end: number }> = []
+  // First boundary may start at byte 0 OR be preceded by CRLF; check both.
+  let cursor = 0
+  if (raw.length >= delim.length && raw.compare(delim, 0, delim.length, 0, delim.length) === 0) {
+    cursor = delim.length
+  } else {
+    const firstIdx = raw.indexOf(crlfDelim)
+    if (firstIdx === -1) return parts
+    cursor = firstIdx + crlfDelim.length
+  }
+  while (cursor < raw.length) {
+    // After the delimiter, we expect either CRLF (next part), "--"
+    // (close boundary), or nothing-recognized (malformed → stop).
+    if (raw[cursor] === 0x2d /* '-' */ && raw[cursor + 1] === 0x2d /* '-' */) {
+      // Close boundary — no more parts.
+      break
+    }
+    // Require CRLF after delimiter for regular boundary.
+    if (raw[cursor] !== 0x0d /* '\r' */ || raw[cursor + 1] !== 0x0a /* '\n' */) {
+      // Not a valid delimiter trail; bail.
+      break
+    }
+    const partStart = cursor + 2
+    const nextDelimIdx = raw.indexOf(crlfDelim, partStart)
+    if (nextDelimIdx === -1) break
+    parts.push({ start: partStart, end: nextDelimIdx })
+    cursor = nextDelimIdx + crlfDelim.length
+  }
+  return parts
+}
+
 async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?: string; bytes: Uint8Array }> {
   const contentType = req.headers["content-type"] ?? ""
   // Limit boundary length to prevent split amplification DoS
@@ -1668,22 +1723,21 @@ async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?
     return { bytes: raw }
   }
 
-  const boundary = `--${boundaryMatch[1]}`
+  const boundary = boundaryMatch[1]
   const raw = Buffer.from(await readBody(req))
-  const parts = raw.toString("binary").split(boundary)
-  for (const part of parts) {
-    if (!part || part === "--\r\n") continue
-    // Use indexOf to split only at the FIRST \r\n\r\n (body may contain \r\n\r\n)
-    const separatorIdx = part.indexOf("\r\n\r\n")
-    if (separatorIdx === -1) continue
-    const headerRaw = part.slice(0, separatorIdx)
-    let body = part.slice(separatorIdx + 4)
+  const parts = findMultipartParts(raw, boundary)
+  for (const { start, end } of parts) {
+    const part = raw.subarray(start, end)
+    // Headers/body separator is the FIRST \r\n\r\n inside the part.
+    const sepIdx = part.indexOf("\r\n\r\n")
+    if (sepIdx === -1) continue
+    const headerRaw = part.subarray(0, sepIdx).toString("binary")
+    const body = part.subarray(sepIdx + 4)
     const filenameMatch = /filename="([^"]+)"/.exec(headerRaw)
     const rawFilename = filenameMatch ? filenameMatch[1] : undefined
     // Strip path components to prevent directory traversal in metadata
     const filename = rawFilename ? rawFilename.replace(/.*[/\\]/, "").slice(0, 255) || undefined : undefined
-    if (body.endsWith("\r\n")) body = body.slice(0, -2)
-    return { filename, bytes: Buffer.from(body, "binary") }
+    return { filename, bytes: new Uint8Array(body) }
   }
 
   return { bytes: new Uint8Array() }


### PR DESCRIPTION
Closes #338

## Summary

`readMultipartFile()` used `raw.split(boundary)` which matched the
boundary substring anywhere in the body. File content containing the
boundary string silently truncated the upload — the user got a CID for
a partial file with no error. Live-reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts`:
  - New `findMultipartParts(raw, boundary)` helper that scans for the
    RFC 2046 delimiter `CRLF + "--" + boundary` (initial boundary may
    skip the CRLF; subsequent + closing boundaries require it).
  - Returns part-body ranges so the outer reader can `subarray()`
    without binary-string round-tripping.
  - Recognises three trail forms after delimiter: `--` (close), `CRLF`
    (next part), anything else (malformed, bail conservatively).

- `node/src/ipfs-http.test.ts` — new `#338` describe block:
  - File content with embedded boundary substring → byte-exact round-trip
  - Multiple boundary substrings mid-content → all preserved
  - Well-formed multipart upload still works (regression guard)

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 53/53 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Severity

**Data integrity (medium)**. Silent truncation, no error surface. Same
class as #302/#304/#306 MFS data-integrity bugs.

## Family

- #92 — block/put multipart parsing
- #136 — POST-only CSRF lock
- #192 — dup-arg coalescing

Theme: respect RFC framing at HTTP boundary; don't trust ad-hoc string ops.