### PR TITLE
fix(rpc): eth_getFilterChanges/Logs return -32000 for missing filter (#342)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3164,6 +3164,34 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#342: eth_getFilterChanges for missing/expired filter returns -32000", async () => {
+    // Pre-fix returned `[]` for any missing filter — long-running indexers
+    // polling past FILTER_TTL_MS (5 min) silently dropped events with no
+    // error to trigger filter re-creation. Geth/erigon return -32000
+    // "filter not found"; mirror that so clients can detect the situation.
+    const r1 = await rpcCallRaw(port, "eth_getFilterChanges", ["0x" + "f".repeat(32)])
+    assert.equal(r1.error?.code, -32000,
+      `missing filter must be -32000, got ${JSON.stringify(r1)}`)
+    assert.match(r1.error!.message, /filter not found/,
+      "error message must say 'filter not found'")
+
+    const r2 = await rpcCallRaw(port, "eth_getFilterLogs", ["0x" + "e".repeat(32)])
+    assert.equal(r2.error?.code, -32000,
+      `getFilterLogs missing filter must be -32000, got ${JSON.stringify(r2)}`)
+    assert.match(r2.error!.message, /filter not found/)
+
+    // Sanity: a real filter still works without error
+    const fid = await rpcCall(port, "eth_newBlockFilter") as string
+    const ok = (await rpcCall(port, "eth_getFilterChanges", [fid])) as unknown[]
+    assert.ok(Array.isArray(ok), "valid filter must still return array")
+    await rpcCall(port, "eth_uninstallFilter", [fid])
+
+    // After uninstall, the same id now misses → -32000
+    const afterUninstall = await rpcCallRaw(port, "eth_getFilterChanges", [fid])
+    assert.equal(afterUninstall.error?.code, -32000,
+      "uninstalled filter must surface as -32000 on subsequent poll")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1169,7 +1169,11 @@ async function handleRpc(
       // a perpetual empty stream that mimics "no new events."
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #342: pre-fix returned `[]` for missing/expired filter — long-
+      // running indexers polling past the 5-minute FILTER_TTL_MS got
+      // silently dropped events with no error to trigger re-creation.
+      // Geth/erigon surface -32000 "filter not found"; mirror that.
+      if (!filter) throw { code: -32000, message: `filter not found: ${id}` }
       // Refresh the filter's last-access timestamp so cleanupExpiredFilters
       // doesn't reap an actively polled subscriber.
       filter.lastAccessedAtMs = Date.now()
@@ -1839,7 +1843,9 @@ async function handleRpc(
       // #196: parity with eth_getFilterChanges / eth_uninstallFilter.
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #342: -32000 for missing/expired filter — matches geth/erigon and
+      // gives indexers a clear signal to re-create the filter.
+      if (!filter) throw { code: -32000, message: `filter not found: ${id}` }
       // Refresh last-access time so active polls keep the filter alive.
       filter.lastAccessedAtMs = Date.now()
       // getFilterLogs is a log-filter-only method: block and pendingTx


### PR DESCRIPTION
Closes #342

## Summary

`eth_getFilterChanges` / `eth_getFilterLogs` returned `result: []` when
the filter ID didn't exist (or had been reaped after the 5-minute
TTL). Long-running indexers polling past TTL silently dropped events
with no error signal to trigger re-creation. Live-reproducible on
88780.

## Changes

- `node/src/rpc.ts`:
  - `eth_getFilterChanges`: missing filter → throw `{code: -32000,
    message: "filter not found: <id>"}` (was `return []`)
  - `eth_getFilterLogs`: same fix
  - `eth_uninstallFilter`: unchanged (boolean return per its
    documented contract)
- `node/src/rpc-extended.test.ts` — new `#342` subtest:
  - getFilterChanges missing id → -32000
  - getFilterLogs missing id → -32000
  - Valid filter still returns array (regression guard)
  - Uninstall + re-poll → -32000

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` → 95/95 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Family

JSON-RPC spec compliance. Sibling of:
- #276 / PR #277 — mempool client-input -32000 mapping
- #286 / PR #287 — eth_call revert -32000
- #332 / PR #333 — replacement-underpriced -32000

Theme: -32000 for client-input / state-mismatch conditions, not
silent empty result.