### PR TITLE
fix(ipfs-http): repo/gc and block/rm require loopback or admin token (#344)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -7,7 +7,7 @@ import { randomBytes } from "node:crypto"
 import http from "node:http"
 import { IpfsBlockstore } from "./ipfs-blockstore.ts"
 import { UnixFsBuilder } from "./ipfs-unixfs.ts"
-import { IpfsHttpServer } from "./ipfs-http.ts"
+import { IpfsHttpServer, isIpfsAdminAuthorized } from "./ipfs-http.ts"
 import type { CidString } from "./ipfs-types.ts"
 
 // The IPFS HTTP server uses a module-level rate limiter (100 req/min/IP).
@@ -1237,6 +1237,61 @@ describe("IpfsHttpServer", () => {
       opaque[2] = 0
       const { ct } = await addAndFetch(opaque, "blob.bin")
       assert.equal(ct, "application/octet-stream")
+  })
+
+  // #344: repo/gc and block/rm were callable by any anonymous internet
+  // client — repo/gc thrashes disk with GC scans + can wipe in-flight
+  // unpinned blocks; block/rm deletes arbitrary blocks (including
+  // pinned ones, since removeBlock unpins as part of removal). Restrict
+  // to loopback by default; opt-in via X-COC-IPFS-Admin-Token header.
+  describe("#344 IPFS admin endpoint auth gate", () => {
+    it("repo/gc from loopback (default test client) succeeds", async () => {
+      // Test client connects to 127.0.0.1 → loopback path → no token needed
+      const res = await fetch("/api/v0/repo/gc", { method: "POST" })
+      assert.equal(res.status, 200, "loopback caller must succeed by default")
+    })
+
+    it("block/rm from loopback (default test client) succeeds", async () => {
+      // Upload a block first
+      const data = new TextEncoder().encode("delete me")
+      const meta = await unixfs.addFile("x.bin", data)
+      const res = await fetch(`/api/v0/block/rm?arg=${meta.cid}`, { method: "POST" })
+      assert.equal(res.status, 200, "loopback block/rm must succeed by default")
+    })
+
+    it("isIpfsAdminAuthorized: loopback variants accepted", () => {
+      const baseCfg = { bind: "0.0.0.0", port: 0, storageDir: "/tmp" }
+      const fakeReq = { headers: {} } as http.IncomingMessage
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "127.0.0.1", baseCfg), true)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "127.255.255.255", baseCfg), true)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "::1", baseCfg), true)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "::ffff:127.0.0.1", baseCfg), true)
+    })
+
+    it("isIpfsAdminAuthorized: non-loopback rejected without token", () => {
+      const baseCfg = { bind: "0.0.0.0", port: 0, storageDir: "/tmp" }
+      const fakeReq = { headers: {} } as http.IncomingMessage
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "8.8.8.8", baseCfg), false)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "192.168.1.5", baseCfg), false)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "209.74.64.88", baseCfg), false)
+      // 128.0.0.1 must NOT match the 127.x loopback regex (off-by-one guard)
+      assert.equal(isIpfsAdminAuthorized(fakeReq, "128.0.0.1", baseCfg), false)
+    })
+
+    it("isIpfsAdminAuthorized: non-loopback with matching token accepted", () => {
+      const cfgWithToken = { bind: "0.0.0.0", port: 0, storageDir: "/tmp", adminAuthToken: "secret-token-xyz" }
+      // matching token
+      const reqOk = { headers: { "x-coc-ipfs-admin-token": "secret-token-xyz" } } as unknown as http.IncomingMessage
+      assert.equal(isIpfsAdminAuthorized(reqOk, "203.0.113.7", cfgWithToken), true)
+      // wrong token rejected
+      const reqBad = { headers: { "x-coc-ipfs-admin-token": "wrong-token" } } as unknown as http.IncomingMessage
+      assert.equal(isIpfsAdminAuthorized(reqBad, "203.0.113.7", cfgWithToken), false)
+      // missing header rejected
+      const reqMissing = { headers: {} } as http.IncomingMessage
+      assert.equal(isIpfsAdminAuthorized(reqMissing, "203.0.113.7", cfgWithToken), false)
+      // header present but config token unset → still loopback-only
+      const cfgNoToken = { bind: "0.0.0.0", port: 0, storageDir: "/tmp" }
+      assert.equal(isIpfsAdminAuthorized(reqOk, "203.0.113.7", cfgNoToken), false)
     })
   })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -130,6 +130,49 @@ function validateAddParams(query: Record<string, string | string[] | undefined>)
         `${key}: expected boolean (true/false/0/1), got '${raw}'`)
     }
   }
+  })
+
+ * #344: gate state-destroying IPFS admin operations (repo/gc, block/rm)
+ * behind either loopback origin OR a configured X-COC-IPFS-Admin-Token
+ * header. Pre-fix every anonymous internet caller could destroy data.
+ *
+ * Mirrors the RPC admin gate (#336): defaults to loopback-only so
+ * unconfigured production deployments are secure-by-default; operators
+ * who need remote access set COC_IPFS_ADMIN_TOKEN and pass it via
+ * X-COC-IPFS-Admin-Token header.
+ */
+export function isIpfsAdminAuthorized(
+  req: http.IncomingMessage,
+  clientIp: string,
+  cfg: IpfsServerConfig,
+): boolean {
+  // 1) Loopback always allowed (typical operator workflow via SSH tunnel
+  //    or local CLI).
+  const stripped = clientIp.startsWith("::ffff:") ? clientIp.slice(7) : clientIp
+  if (stripped === "::1" || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(stripped)) return true
+  // 2) Configured admin token via header. Constant-time comparison so the
+  //    token length isn't a timing oracle.
+  if (cfg.adminAuthToken) {
+    const headerRaw = req.headers["x-coc-ipfs-admin-token"]
+    const provided = typeof headerRaw === "string" ? headerRaw : ""
+    return safeStringEq(provided, cfg.adminAuthToken)
+  }
+  return false
+}
+
+function safeStringEq(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    // Still iterate one of the strings so the timing leak is bounded
+    // by the longer of the two — not by the shorter, which would
+    // disclose length cheaply.
+    let acc = 1
+    const longer = a.length > b.length ? a : b
+    for (let i = 0; i < longer.length; i++) acc |= 1
+    return acc === 0
+  }
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
 }
 
 export interface IpfsServerConfig {
@@ -137,6 +180,12 @@ export interface IpfsServerConfig {
   port: number
   storageDir: string
   nodeId?: string
+  /**
+   * #344: optional Bearer-token (via X-COC-IPFS-Admin-Token header) that
+   * authorizes destructive ops (repo/gc, block/rm) from non-loopback
+   * origins. When unset, those ops are loopback-only (secure default).
+   */
+  adminAuthToken?: string
   /**
    * Phase C3.1: the uploader blocks on replication results and gets a
    * warning header when fewer than `minReplicas` peers acknowledged the
@@ -457,10 +506,30 @@ export class IpfsHttpServer {
         return
       }
       if (url.pathname === "/api/v0/block/rm") {
+        // #344: block/rm destroys arbitrary blocks (pinned ones too:
+        // removeBlock unpins as part of removal). Pre-fix any anonymous
+        // internet caller could enumerate pin/ls and then block/rm each
+        // CID to wipe the node's content. Restrict to loopback / configured
+        // admin token so the operator workflow (chaos drill, manual cleanup)
+        // still works without exposing the surface publicly.
+        if (!isIpfsAdminAuthorized(req, clientIp, this.cfg)) {
+          res.writeHead(403, { "content-type": "application/json" })
+          res.end(JSON.stringify({ error: "forbidden", message: "block/rm requires loopback or X-COC-IPFS-Admin-Token" }))
+          return
+        }
         await this.handleBlockRm(res, argParam)
         return
       }
       if (url.pathname === "/api/v0/repo/gc") {
+        // #344: same auth gate as block/rm. repo/gc walks the entire pin
+        // set under a blockstore lock — concurrent reads/writes block
+        // during the scan. Unauth'd repeated GC = persistent disk thrash
+        // + every in-flight unpinned block gets swept.
+        if (!isIpfsAdminAuthorized(req, clientIp, this.cfg)) {
+          res.writeHead(403, { "content-type": "application/json" })
+          res.end(JSON.stringify({ error: "forbidden", message: "repo/gc requires loopback or X-COC-IPFS-Admin-Token" }))
+          return
+        }
         await this.handleRepoGc(res)
         return
       }


### PR DESCRIPTION
Closes #344

## Summary

`/api/v0/repo/gc` and `/api/v0/block/rm` were callable from any
anonymous internet client. repo/gc thrashes disk + sweeps in-flight
unpinned blocks; block/rm deletes arbitrary blocks (including pinned).
Live-reproducible on 88780.

## Changes

- `node/src/ipfs-http.ts`:
  - New exported `isIpfsAdminAuthorized(req, clientIp, cfg)` helper —
    loopback always allowed, plus optional `X-COC-IPFS-Admin-Token`
    header compared in constant time against `cfg.adminAuthToken`
  - New `IpfsServerConfig.adminAuthToken?: string` opt (driven by
    `COC_IPFS_ADMIN_TOKEN` env in the wiring layer)
  - `repo/gc` and `block/rm` handlers gated on this — return 403
    Forbidden with structured JSON on unauth'd remote calls

- `node/src/ipfs-http.test.ts` — new `#344` describe block, 5 subtests:
  - Loopback repo/gc / block/rm succeed (default test client)
  - `isIpfsAdminAuthorized` unit: loopback variants (127.x/8, ::1, mapped)
  - Unit: non-loopback rejected (8.8.8.8 / 192.168.x / 128.0.0.1)
  - Unit: token matches / wrong / missing / config unset

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 55/55 pass
- [x] Live-verified the broken behaviour on 88780 testnet

## Operational impact

Operators calling repo/gc / block/rm from a remote host via plain
HTTP will now hit 403. Remediation: SSH-tunnel to localhost, or set
`COC_IPFS_ADMIN_TOKEN=<random>` + `X-COC-IPFS-Admin-Token: <token>`.
Public-API endpoints (add, pin/*, files/*) unchanged.

## Severity

**Security (high)**. Pre-fix attacker could destroy all IPFS content
on a node via `pin/ls` + `block/rm` loop. Bigger blast radius than
#336 because IPFS holds user data.

## Family

- #136 — POST-only CSRF on /api/v0/*
- #280 / PR #281 — pin/add DoS
- #336 / PR #337 — sibling admin_* RPC auth gate

Theme: state-destroying endpoints default-deny on public deployments.