### PR TITLE
fix(pose-http): 30s body-read timeout closes slowloris connections (#348)

### DIFF
--- a/node/src/pose-http.test.ts
+++ b/node/src/pose-http.test.ts
@@ -366,6 +366,49 @@ test("#176: malformed JSON body returns generic error without V8 SyntaxError lea
   }
 })
 
+test("#348: pose-http body read timeout closes slowloris connection", async () => {
+  // Parity with #346 RPC body timeout — pre-fix pose-http had no body
+  // inactivity timer, so an attacker sending `Content-Length: N` headers
+  // and 0 body bytes held a request slot until Node's default ~5min
+  // requestTimeout, draining the PoSe handler pool.
+  const pose = createTestEngine()
+  const { port, close } = await startTestServer(pose)
+  try {
+    const net = await import("node:net")
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.default.createConnection(port, "127.0.0.1")
+      const start = Date.now()
+      let closed = false
+      socket.on("connect", () => {
+        // Headers say content-length:1000 but we never send body.
+        socket.write(
+          "POST /pose/challenge HTTP/1.1\r\n" +
+          "Host: 127.0.0.1\r\n" +
+          "Content-Type: application/json\r\n" +
+          "Content-Length: 1000\r\n" +
+          "\r\n"
+        )
+      })
+      socket.on("close", () => {
+        closed = true
+        const elapsed = Date.now() - start
+        // Production timeout is 30s; CI watchdog at 45s catches stuck-forever.
+        assert.ok(elapsed < 45_000, `server-side timer must close socket within 45s; got ${elapsed}ms`)
+        resolve()
+      })
+      socket.on("error", () => { closed = true; resolve() })
+      setTimeout(() => {
+        if (!closed) {
+          socket.destroy()
+          reject(new Error("server failed to close slowloris socket within 45s"))
+        }
+      }, 45_000).unref()
+    })
+  } finally {
+    close()
+  }
+})
+
 function hashStable(value: unknown): `0x${string}` {
   return `0x${keccak256Hex(Buffer.from(stableStringify(value), "utf8"))}` as `0x${string}`
 }

--- a/node/src/pose-http.ts
+++ b/node/src/pose-http.ts
@@ -326,11 +326,23 @@ export function handlePoseRequest(
   let body = ""
   let bodySize = 0
   let aborted = false
+  // #348: parity with #346 (RPC body timeout) — pose-http had no inactivity
+  // / total read timeout. `Content-Length: N` + 0 body bytes tied up the
+  // /pose/challenge or /pose/receipt request slot until Node's default
+  // 5-minute requestTimeout. Slowloris DoS surface.
+  const READ_TIMEOUT_MS = 30_000
+  const readTimer = setTimeout(() => {
+    if (aborted) return
+    aborted = true
+    req.destroy(new Error("pose body read timeout"))
+  }, READ_TIMEOUT_MS).unref()
+
   req.on("data", (chunk: Buffer | string) => {
     if (aborted) return
     bodySize += typeof chunk === "string" ? chunk.length : chunk.byteLength
     if (bodySize > MAX_POSE_BODY) {
       aborted = true
+      clearTimeout(readTimer)
       jsonResponse(res, 413, { error: "body too large" })
       req.destroy()
       return
@@ -338,6 +350,7 @@ export function handlePoseRequest(
     body += chunk
   })
   req.on("end", async () => {
+    clearTimeout(readTimer)
     if (aborted) return
     try {
       const parsedBody = JSON.parse(body || "{}")


### PR DESCRIPTION
Closes #348

## Summary

`pose-http.ts:329` had no body inactivity / total read timeout. Same
slowloris DoS surface as #346 but on the PoSe HTTP routes
(`/pose/challenge` / `/pose/receipt`). Mirror the IPFS-side
30s timeout that's been in place for ages.

## Changes

- `node/src/pose-http.ts`: 30s `setTimeout` wrapping the body reader
  → marks aborted + `req.destroy()` on fire. Cleared on `end` /
  body-limit / socket-error. `.unref()` so dangling timers don't pin
  the event loop.

- `node/src/pose-http.test.ts` — new `#348` subtest:
  - Raw socket sends `POST /pose/challenge` headers with
    `Content-Length: 1000` + 0 body bytes
  - Server-side timer fires within 45s (production 30s + CI slack)

## Test plan

- [x] `node --experimental-strip-types --test node/src/pose-http.test.ts` → 16/16 pass at 30.6s (matches 30s production timeout)

## Family

- #346 / PR #347 — sibling RPC body timeout
- #292 / PR #293 — pose-http / coc-node body size cap
- `ipfs-http.ts readBody` — pre-existing 30s timeout

Theme: bound worst-case resource cost per accepted request across
every public-network HTTP boundary.