### PR TITLE
fix(http): RPC + IPFS + coc-node set headersTimeout/requestTimeout (#350)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -353,6 +353,16 @@ export class IpfsHttpServer {
         } catch { /* connection already closed */ }
       }
     })
+    // #350: server-level slowloris protection — bound header / total
+    // request / keep-alive idle times so an attacker can't pin the
+    // request handler pool just by sending slow bytes. Mirrors p2p.ts's
+    // long-standing values (10s/30s/5s). The body-level inactivity
+    // timeout in readBody (30s) defends the same threat lower in the
+    // stack; both layers are intentional defense-in-depth.
+    server.headersTimeout = 10_000
+    server.requestTimeout = 30_000
+    server.keepAliveTimeout = 5_000
+
     server.on("connection", (socket) => {
       this.sockets.add(socket)
       socket.on("close", () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -471,6 +471,15 @@ export function startRpcServer(
     })
   })
 
+  // #350: server-level slowloris protection — same values p2p.ts has
+  // had since 2026-Q1. Defense-in-depth on top of the body-level
+  // inactivity timer (#346): even if the body reader's 30s fires too
+  // late or doesn't fire (e.g. handshake-stage attack), the HTTP server
+  // itself caps headers / total request / keep-alive idle.
+  server.headersTimeout = 10_000
+  server.requestTimeout = 30_000
+  server.keepAliveTimeout = 5_000
+
   server.listen(port, bind, () => {
     log.info("listening", { bind, port })
   })

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -350,6 +350,12 @@ const server = http.createServer((req, res) => {
   return json(res, 404, { error: "not found" });
 });
 
+// #350: server-level slowloris protection — same values p2p.ts has
+// had for ages. Bounds headers / total request / keep-alive idle.
+server.headersTimeout = 10_000;
+server.requestTimeout = 30_000;
+server.keepAliveTimeout = 5_000;
+
 server.listen(port, bind, () => {
   log.info("listening", { bind, port });
 });


### PR DESCRIPTION
Closes #350

## Summary

`p2p.ts` has long set slowloris-protection timeouts
(headersTimeout=10s, requestTimeout=30s, keepAliveTimeout=5s). The
RPC, IPFS, and coc-node HTTP servers didn't — they inherited Node
defaults (60s/5min/5s), leaving the **header-stage slowloris** vector
wide open even after #346/#348 closed the body-stage gap.

## Changes

- `node/src/rpc.ts` — set the three timeouts before `server.listen()`
- `node/src/ipfs-http.ts` — same three timeouts before `server.listen()`
- `runtime/coc-node.ts` — same three timeouts before `server.listen()`

No new tests — these are passive HTTP server properties; existing
tests cover normal request behaviour and #346/#348's body-level
slowloris tests cover the inactivity side. Server-level timeouts are
already test-covered via p2p.ts's existing fixtures (same values).

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc.test.ts node/src/ipfs-http.test.ts` → 55/55 pass

## Family

- `p2p.ts:798-800` — pattern source
- #346 / PR #347 — RPC body inactivity timer
- #348 / PR #349 — PoSe body inactivity timer

Theme: bound worst-case resource cost per accepted request at every
HTTP boundary, on every relevant axis.