### PR TITLE
fix(rpc): cap tx-field hex magnitudes to bound BigInt O(n²) DoS (#352)

### DIFF
--- a/node/src/rpc-validators.test.ts
+++ b/node/src/rpc-validators.test.ts
@@ -458,6 +458,45 @@ describe("validateTxCallFields (#148)", () => {
   test("accepts empty data (0x)", () => {
     validateTxCallFields({ data: "0x" })
   })
+
+  test("#352: rejects gas hex over 16-digit uint64 cap (BigInt O(n²) DoS)", () => {
+    const overlong = "0x" + "a".repeat(17) // 19 chars total > 18 cap
+    const e = captureThrow(() => validateTxCallFields({ gas: overlong }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /gas too large.*uint64/)
+  })
+
+  test("#352: rejects nonce hex over 16-digit uint64 cap", () => {
+    const overlong = "0x" + "f".repeat(20)
+    const e = captureThrow(() => validateTxCallFields({ nonce: overlong }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /nonce too large.*uint64/)
+  })
+
+  test("#352: rejects value hex over 64-digit uint256 cap", () => {
+    const overlong = "0x" + "1".repeat(65)
+    const e = captureThrow(() => validateTxCallFields({ value: overlong }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /value too large.*uint256/)
+  })
+
+  test("#352: rejects 100k-char hex gas (CPU DoS payload)", () => {
+    const huge = "0x" + "a".repeat(100_000)
+    const e = captureThrow(() => validateTxCallFields({ gas: huge }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /gas too large/)
+  })
+
+  test("#352: accepts exactly uint256-max value (regression guard)", () => {
+    const max256 = "0x" + "f".repeat(64)
+    validateTxCallFields({ value: max256 })
+    validateTxCallFields({ gasPrice: max256 })
+  })
+
+  test("#352: accepts exactly uint64-max gas (regression guard)", () => {
+    const max64 = "0x" + "f".repeat(16)
+    validateTxCallFields({ gas: max64, nonce: max64 })
+  })
 })
 
 describe("validateLogFilter", () => {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -308,18 +308,53 @@ const HEX_QUANTITY_RE = /^0x[0-9a-fA-F]+$/
 const HEX_DATA_RE = /^0x([0-9a-fA-F]{2})*$/
 
 /**
+ * #352: per-field hex max-length caps. The pre-fix shape regex
+ * `^0x[0-9a-fA-F]+$` was unbounded — a client could pass `gas: "0x" +
+ * "a".repeat(100_000)` and the downstream `BigInt(...)` ran O(n²) on a
+ * 50KB hex blob, blocking the event loop ~1s per request. With 10
+ * concurrent such calls, the entire single-threaded V8 event loop
+ * saturates. RPC body cap (1 MB) bounds the total payload, but a
+ * single 1 MB call with 16 large fields can still cost > 5s of pure
+ * BigInt allocation.
+ *
+ * Per Ethereum types:
+ *   - gas, nonce          : uint64 → at most 16 hex digits (+ "0x")
+ *   - value, gasPrice,
+ *     maxFeePerGas,
+ *     maxPriorityFeePerGas: uint256 → at most 64 hex digits (+ "0x")
+ *
+ * Add a small slack ("+2") to allow the "0x" prefix.
+ */
+const TX_HEX_FIELD_CAPS: Record<string, number> = {
+  value: 64 + 2,
+  gas: 16 + 2,
+  gasPrice: 64 + 2,
+  maxFeePerGas: 64 + 2,
+  maxPriorityFeePerGas: 64 + 2,
+  nonce: 16 + 2,
+}
+
+/**
  * #148: validate the numeric/data fields of an eth_call / estimateGas /
  * sendTransaction-shaped object. Pre-fix, malformed `value`/`gas`/etc
  * either flowed through to the EVM (which silently treated non-hex as
  * 0) or surfaced as -32603 internal-error with the V8 message leaked.
  * Rejects each field at the boundary with -32602.
+ *
+ * #352: each numeric field now also has a magnitude (hex-length) cap
+ * so a giant hex blob can't trigger O(n²) BigInt conversion.
  */
 export function validateTxCallFields(callParams: Record<string, unknown>): void {
-  for (const field of ["value", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas"] as const) {
+  for (const field of ["value", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas", "nonce"] as const) {
     const v = callParams[field]
     if (v === undefined || v === null || v === "") continue
     if (typeof v !== "string" || !HEX_QUANTITY_RE.test(v)) {
       invalidParams(`invalid ${field}: must match /^0x[0-9a-fA-F]+$/`)
+    }
+    const maxLen = TX_HEX_FIELD_CAPS[field]
+    if (maxLen !== undefined && v.length > maxLen) {
+      const bits = field === "gas" || field === "nonce" ? 64 : 256
+      invalidParams(`${field} too large: ${v.length} chars > ${maxLen} (uint${bits} max)`)
     }
   }
   const data = callParams.data


### PR DESCRIPTION
Closes #352

## Summary

`validateTxCallFields` enforced hex shape but no magnitude cap. A
client passing `gas: "0x" + "a".repeat(100_000)` triggered 1.1s of
single-threaded BigInt allocation per request. 10 concurrent calls
saturate the V8 event loop. CPU-DoS surface. Live-reproducible on 88780.

## Changes

- `node/src/rpc-validators.ts`:
  - Per-field max-length caps:
    - `gas`, `nonce` → 16 hex + "0x" (uint64)
    - `value`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas` →
      64 hex + "0x" (uint256)
  - Reject with -32602 `"<field> too large: <n> chars > <max>
    (uint<bits> max)"` before any BigInt conversion
  - Added `nonce` to the validated field list (missed pre-fix)
- `node/src/rpc-validators.test.ts` — 6 new subtests:
  - gas/nonce overlong (uint64 cap) → -32602
  - value overlong (uint256 cap) → -32602
  - 100k-char gas (CPU DoS payload) → -32602
  - Exactly uint256-max / uint64-max accepted (regression guards)

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-validators.test.ts` → 94/94 pass
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` → 94/94 pass (no regression)
- [x] Live-verified the 1.1s wall-time on 88780

## Family

- #288 / PR #289 — sibling sync-compile DoS
- #264 / PR #265 — sibling unbounded-array DoS
- #292 / PR #293 — sibling body-size DoS bound

Theme: cap per-request CPU at validation boundary, never trust
downstream BigInt / EVM to bound user-controlled hex magnitude.