### PR TITLE
fix(ipfs): reject /api/v0/add params that change CID shape (#354)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -355,6 +355,66 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(new Uint8Array(await r7.buffer()), content)
   })
 
+  it("#353: /api/v0/add rejects unsupported kubo params with 400 (not silent ignore)", async () => {
+    // Pre-fix the server hard-codes cid-version=1 / sha2-256 /
+    // chunker=size-262144 / raw-leaves=false, but accepted any
+    // value for these params and produced its default CID
+    // regardless. A client requesting `cid-version=0` got a v1
+    // `bafy...` CID back and their content-address verification
+    // silently broke — they expected `Qm...` (v0).
+    const boundary = "----T353"
+    const mkBody = () => [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="x.txt"',
+      "Content-Type: application/octet-stream",
+      "",
+      "x",
+      `--${boundary}--`,
+      "",
+    ].join("\r\n")
+    const post = async (qs: string) => fetch(`/api/v0/add?${qs}`, {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body: mkBody(),
+    })
+
+    // Hash-shape params that demand a value we don't produce.
+    for (const qs of [
+      "cid-version=0",
+      "cid-version=2",
+      "cid-version=999",
+      "hash=blake2b-256",
+      "hash=sha3-256",
+      "chunker=size-1024",
+      "chunker=rabin-512-1024-2048",
+      "chunker=buzhash",
+    ]) {
+      const r = await post(qs)
+      assert.equal(r.status, 400, `${qs}: expected 400 (got ${r.status})`)
+      const body = await r.json() as { error: string; message?: string }
+      assert.equal(body.error, "unsupported_param", qs)
+    }
+
+    // Boolean opt-ins we don't honor.
+    for (const key of ["raw-leaves", "wrap-with-directory", "nocopy", "inline", "trickle"]) {
+      const r = await post(`${key}=true`)
+      assert.equal(r.status, 400, `${key}=true: expected 400 (got ${r.status})`)
+      // Case-insensitive `1` form also rejects.
+      const r2 = await post(`${key}=1`)
+      assert.equal(r2.status, 400, `${key}=1: expected 400 (got ${r2.status})`)
+    }
+
+    // Garbage boolean value must reject too (kubo flag parser does).
+    const rg = await post("raw-leaves=maybe")
+    assert.equal(rg.status, 400, "raw-leaves=maybe: expected 400")
+
+    // Defaults must still work (no params + matching values).
+    const ok = await post("cid-version=1&hash=sha2-256&chunker=size-262144&raw-leaves=false&trickle=false")
+    assert.equal(ok.status, 200, "matching-defaults must succeed")
+    const okBody = await ok.json() as { Hash: string }
+    assert.ok(okBody.Hash?.startsWith("bafy"), "should still return v1 bafy CID")
+  })
+
   it("#180: /api/v0/add?erasure=N+M rejects N or M above MAX_DATA/PARITY_SHARDS with 400 (not 500)", async () => {
     // Pre-fix parseErasureSpec only checked the lower bound (n>=1,
     // m>=1). Values above MAX_DATA_SHARDS / MAX_PARITY_SHARDS (24

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -72,6 +72,66 @@ function isNotFoundError(err: unknown): boolean {
   return /not\s*found|no such|ENOENT/i.test(msg)
 }
 
+/**
+ * #353: /api/v0/add silently ignored kubo params that materially change
+ * the resulting CID (cid-version, hash, chunker, raw-leaves, trickle,
+ * wrap-with-directory, inline, nocopy). A client requesting
+ * `cid-version=0` got back a `bafy...` v1 CID; the upload succeeded,
+ * the client recomputed its expected v0 `Qm...` digest, and the two
+ * never matched — content-addressed verification silently broke.
+ *
+ * This server's UnixFS builder is hard-coded to: cid-version=1 (raw
+ * dag-pb), hash=sha2-256, chunker=size-262144 (256 KiB), unixfs-
+ * wrapped leaves (i.e. raw-leaves=false), balanced layout (trickle=
+ * false), no directory wrap. Reject any client request that demands
+ * a different shape so they can fall back / retry with the right
+ * settings instead of pinning a CID that doesn't match their hash.
+ *
+ * Benign params (pin, progress, silent, quieter, quiet, fscache,
+ * stdin-name, only-hash, hash-fun-code) are passed through — they
+ * either don't change the CID or the response shape we already
+ * emit (single newline-terminated JSON object) is a strict subset
+ * of kubo's progress stream.
+ */
+function validateAddParams(query: Record<string, string | string[] | undefined>): void {
+  const exactDefault = (key: string, expected: string): void => {
+    const raw = firstQueryValue(query[key])
+    if (raw !== undefined && raw !== expected) {
+      throw new HttpError(400, "unsupported_param",
+        `${key}: only '${expected}' is supported (got '${raw}')`)
+    }
+  }
+
+  exactDefault("cid-version", "1")
+  exactDefault("hash", "sha2-256")
+  exactDefault("chunker", "size-262144")
+
+  // Booleans we don't honor — accept "false" / absent, reject "true".
+  // Case-insensitive to match kubo's go-flag parser.
+  const booleanRejectsTrue = [
+    "raw-leaves",
+    "wrap-with-directory",
+    "nocopy",
+    "inline",
+    "trickle",
+  ]
+  for (const key of booleanRejectsTrue) {
+    const raw = firstQueryValue(query[key])
+    if (raw === undefined) continue
+    const norm = raw.toLowerCase()
+    if (norm === "true" || norm === "1") {
+      throw new HttpError(400, "unsupported_param",
+        `${key}: not supported by this server (only 'false' / unset)`)
+    }
+    // Reject obvious garbage like "maybe", "yes". kubo's flag parser
+    // accepts true/false/0/1 (case-insensitive) and 400s on the rest.
+    if (norm !== "false" && norm !== "0") {
+      throw new HttpError(400, "unsupported_param",
+        `${key}: expected boolean (true/false/0/1), got '${raw}'`)
+    }
+  }
+}
+
 export interface IpfsServerConfig {
   bind: string
   port: number
@@ -220,6 +280,12 @@ export class IpfsHttpServer {
       // `string | string[]` Node's url-parser actually returns).
       const argParam = firstQueryValue(url.query.arg)
       if (url.pathname === "/api/v0/add") {
+        // #353: reject unsupported kubo params *before* we read the
+        // multipart body — a client requesting cid-version=0 should
+        // get a fast 400 with `unsupported_param`, not a successful
+        // upload + a v1 CID they can't reconcile against their v0
+        // expectation.
+        validateAddParams(url.query as Record<string, string | string[] | undefined>)
         await this.handleAdd(req, res, firstQueryValue(url.query.erasure))
         return
       }


### PR DESCRIPTION
Fixes #354.

## Summary

- `/api/v0/add` silently ignored kubo params that change the produced CID (`cid-version`, `hash`, `chunker`, `raw-leaves`, `wrap-with-directory`, `nocopy`, `inline`, `trickle`). Server is hard-coded to v1+sha256+256KiB+unixfs-leaves+balanced — clients requesting anything else got the default CID back with HTTP 200 and broken content-address verification.
- New `validateAddParams(query)` runs at dispatch before multipart parsing and rejects with `400 unsupported_param` (matching values / absence still pass).

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 51/51 PASS (1 new subtest, ~12 unsupported-param assertions).
- [x] Live testnet 88780 reproduction: every probed param returned 200+default CID pre-fix.