### PR TITLE
fix(rpc): coc_erasureStatus instanceof undefined leaks V8 message via -32603 (#358)

### DIFF
--- a/node/src/erasure-status-bridge.test.ts
+++ b/node/src/erasure-status-bridge.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+/**
+ * #358 regression: `index.ts`'s `getErasureStatus` closure dynamically
+ * imported `ErasureError` from `./ipfs-erasure-reader.ts`, but that
+ * module only *imports* the class (from `./ipfs-erasure.ts`) without
+ * re-exporting it. The destructured `ErasureError` resolved to
+ * `undefined` at runtime, and the subsequent `err instanceof
+ * ErasureError` check threw V8 TypeError
+ * "Right-hand side of 'instanceof' is not an object" — caught by the
+ * outer RPC layer and surfaced as `-32603 internal error` with the
+ * V8 message leaked through.
+ *
+ * Live testnet 88780 reproduction (pre-fix):
+ *   curl -d '{"jsonrpc":"2.0","id":1,"method":"coc_erasureStatus",
+ *            "params":["not-a-cid"]}' http://node:28780
+ *   → {"error":{"code":-32603,"message":"Right-hand side of
+ *      'instanceof' is not an object"}}
+ *
+ * Lock the export contract so a future refactor doesn't reintroduce
+ * the broken destructure.
+ */
+test("#358: ErasureError must be importable from ipfs-erasure.ts for instanceof checks", async () => {
+  const erasure = await import("./ipfs-erasure.ts") as Record<string, unknown>
+  assert.equal(typeof erasure.ErasureError, "function",
+    "ipfs-erasure.ts MUST export ErasureError as a constructor — index.ts depends on it for the getErasureStatus closure's err-typing branch")
+
+  // Sanity: instanceof works against the real export (i.e. our fix
+  // actually catches typed errors instead of crashing on undefined RHS).
+  const Klass = erasure.ErasureError as new (code: string, msg: string) => Error & { code: string }
+  const e = new Klass("invalid_cid", "test")
+  assert.ok(e instanceof Klass,
+    "the dynamically-imported ErasureError must satisfy instanceof against itself")
+})
+
+test("#358: simulating the pre-fix bug shape — `err instanceof undefined` throws V8 TypeError", () => {
+  // Pin the V8 error message so the issue description stays accurate
+  // and future maintainers see why the dynamic-import fix matters.
+  const Undef = undefined as unknown as new (...args: unknown[]) => unknown
+  const err = new Error("any error")
+  let caught: unknown
+  try {
+    // @ts-expect-error — we're deliberately reproducing the bug shape.
+    const _ = err instanceof Undef
+  } catch (e) {
+    caught = e
+  }
+  assert.ok(caught instanceof TypeError, "instanceof against undefined RHS must throw TypeError")
+  assert.match(
+    (caught as Error).message,
+    /Right-hand side of 'instanceof' is not (an object|callable)/,
+    "V8 message must match the one leaked through the RPC -32603 reply pre-fix"
+  )
+})

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1334,7 +1334,17 @@ startRpcServer(
       // #108: RPC bridge for the existing /api/v0/erasure/status handler.
       // Resolve the CID into an ErasureManifest (throws if it's not one
       // or the blocks are missing), then compute per-stripe availability.
-      const { resolveCid, erasureStatus, ErasureError } = await import("./ipfs-erasure-reader.ts")
+      // #358: pre-fix the dynamic import destructured `ErasureError`
+      // from `./ipfs-erasure-reader.ts`, but that module *imports*
+      // ErasureError (from ./ipfs-erasure.ts) without re-exporting it.
+      // So `ErasureError` resolved to `undefined` at runtime, and the
+      // `err instanceof ErasureError` check below threw V8 TypeError
+      // "Right-hand side of 'instanceof' is not an object" — caught
+      // by the RPC layer and surfaced as -32603 with the V8 message
+      // leaked through. Import ErasureError directly from its real
+      // owning module instead.
+      const { resolveCid, erasureStatus } = await import("./ipfs-erasure-reader.ts")
+      const { ErasureError } = await import("./ipfs-erasure.ts")
       try {
         const resolved = await resolveCid(cid, ipfsStore)
         if (resolved.kind !== "erasure" || !resolved.manifest) {


### PR DESCRIPTION
Fixes #358.

## Summary

- \`coc_erasureStatus\` leaked \`-32603 \"Right-hand side of 'instanceof' is not an object\"\` for any invalid CID.
- Root cause: \`index.ts\`'s dynamic import destructured \`ErasureError\` from \`./ipfs-erasure-reader.ts\` (which imports but does not re-export it), resolving the class to \`undefined\`. The subsequent \`err instanceof undefined\` check threw V8 TypeError, surfaced as -32603.
- Fix: import \`ErasureError\` directly from \`./ipfs-erasure.ts\`. Two-line dynamic-import change.

## Test plan

- [x] \`node --experimental-strip-types --test node/src/erasure-status-bridge.test.ts\` — 2/2 PASS (regression test pinning both the export contract and the V8 TypeError shape).
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts\` — 94/94 PASS (existing #248 string-validator tests still green).
- [x] Live testnet 88780 reproduction matches the issue body.