### PR TITLE
fix(rpc): normalize hash params to lowercase (#364)

### DIFF
--- a/node/src/rpc-validators.test.ts
+++ b/node/src/rpc-validators.test.ts
@@ -280,6 +280,22 @@ describe("requireTxHashParam (#150)", () => {
     const e = captureThrow(() => requireTxHashParam([null], 0))
     assert.equal(e.code, -32602)
   })
+
+  test("#364: normalizes mixed-case to lowercase for Map.get parity", () => {
+    // ETH JSON-RPC hashes are case-INsensitive — geth accepts both
+    // `0xABCD…` and `0xabcd…`. Pre-fix the downstream `chain.blockByHash
+    // .get(hash)` / `txByHash.get(hash)` used the as-received case, so
+    // `0xBBAD…` returned null indistinguishable from "no such tx" even
+    // when the lowercased equivalent existed.
+    const mixed  = "0xBBaD93Ae799eCB20E5A0Dd43Dc1211Bb4141572399cD0E23E40F9B92388B3D31"
+    const lower  = "0xbbad93ae799ecb20e5a0dd43dc1211bb4141572399cd0e23e40f9b92388b3d31"
+    assert.equal(requireTxHashParam([mixed], 0), lower)
+    // All-caps must also normalize.
+    const upper = "0xBBAD93AE799ECB20E5A0DD43DC1211BB4141572399CD0E23E40F9B92388B3D31"
+    assert.equal(requireTxHashParam([upper], 0), lower)
+    // Already-lowercased passes through unchanged.
+    assert.equal(requireTxHashParam([lower], 0), lower)
+  })
 })
 
 describe("requireBlockHashParam (#166)", () => {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -181,6 +181,17 @@ export function requireAddressParam(params: unknown[], index: number, name = "ad
  * like "0x123" slipped through and the downstream tx lookup returned
  * null ("tx not found"). Clients couldn't distinguish a typo from a
  * tx that doesn't exist on-chain.
+ *
+ * #364: ETH JSON-RPC hashes are case-INsensitive — geth accepts both
+ * `0xABCD…` and `0xabcd…` for the same hash. Our `chain.blockByHash`
+ * / `blockIndex.getBlockByHash` / tx-by-hash lookups go through
+ * `Map.get(hash)` keyed by the lowercase-computed digest, so a
+ * client passing the mixed-case form (common when copy-pasting
+ * from block explorers like Etherscan-clone UIs that render hashes
+ * with uppercase letters for readability) got `null` indistinguishable
+ * from "no such block/tx." Normalize to lowercase here so every
+ * caller of `requireTxHashParam` / `requireBlockHashParam` sees the
+ * canonical form regardless of client casing.
  */
 export function requireTxHashParam(params: unknown[], index: number, name = "transaction hash"): Hex {
   const value = (params ?? [])[index]
@@ -190,7 +201,7 @@ export function requireTxHashParam(params: unknown[], index: number, name = "tra
   if (!HASH_RE.test(value as string)) {
     invalidParams(`invalid ${name}: must match /^0x[0-9a-fA-F]{64}$/`)
   }
-  return value as Hex
+  return (value as string).toLowerCase() as Hex
 }
 
 /**


### PR DESCRIPTION
Fixes #364.

## Summary

- ETH JSON-RPC hashes are case-INsensitive (geth-compatible). Our \`requireTxHashParam\` / \`requireBlockHashParam\` returned the as-received case, and \`chain.blockByHash.get(hash)\` / \`txByHash.get(hash)\` did strict-case Map lookup → mixed-case hashes silently returned null.
- Live testnet 88780 reproduction confirmed for \`eth_getBlockByHash\`, \`eth_getTransactionByHash\` (and by inheritance \`eth_getTransactionReceipt\`, \`debug_traceTransaction\`, etc).
- One-line normalize-to-lowercase at the validator boundary, matching what \`validateLogFilter\` already does for \`blockHash\` / addresses / topics.

## Test plan

- [x] \`node --experimental-strip-types --test node/src/rpc-validators.test.ts\` — 89/89 PASS (3 new subtests covering mixed→lower, all-caps→lower, idempotent lower).
- [x] \`node --experimental-strip-types --test node/src/rpc-extended.test.ts node/src/rpc.test.ts\` — 99/99 PASS (no regressions).
- [x] Live testnet 88780 reproduction matches the issue body.