### PR TITLE
fix(rpc): eth_getBlockReceipts accepts BlockNumberOrHash (#366)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -356,6 +356,38 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(receipts, null)
   })
 
+  await t.test("#366: eth_getBlockReceipts accepts block hash (BlockNumberOrHash)", async () => {
+    // geth's `eth_getBlockReceipts` accepts both a block number/tag
+    // AND a bare 32-byte block hash. Pre-fix our handler only resolved
+    // as block number — passing a 66-char hash got BigInt(hash)
+    // parsed as a giant integer, then `chain.getBlockByNumber(huge)`
+    // returned null, indistinguishable from "no such block."
+    //
+    // Strategy: propose a real block on the fixture chain (the
+    // synthesised genesis at "0x0" isn't indexed by hash since it's
+    // a stub for #112), then fetch by-hash and expect the same
+    // receipts list as by-number.
+    await chain.proposeNextBlock()
+    const blockByNumber = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash: string } | null
+    assert.ok(blockByNumber, "fixture must have block 0x1 after proposeNextBlock")
+    const lowerHash = blockByNumber!.hash
+    assert.match(lowerHash, /^0x[0-9a-fA-F]{64}$/, "block must have a 32-byte hash")
+
+    // Lookup by lowercase hash MUST work (this is the primary fix).
+    const byNumber = await rpcCall(port, "eth_getBlockReceipts", ["0x1"])
+    const byLowerHash = await rpcCall(port, "eth_getBlockReceipts", [lowerHash])
+    assert.notStrictEqual(byLowerHash, null, "eth_getBlockReceipts(<lowercase block hash>) must NOT return null")
+    assert.ok(Array.isArray(byLowerHash), "eth_getBlockReceipts(hash) must return an array (possibly empty)")
+    assert.deepEqual(byLowerHash, byNumber, "by-hash result must match by-number result")
+
+    // Mixed-case hash also works (case-insensitive, mirroring #364 normalization).
+    const mixedHash =
+      "0x" + lowerHash.slice(2).split("").map((c, i) => i % 2 === 0 ? c.toUpperCase() : c).join("")
+    const byMixedHash = await rpcCall(port, "eth_getBlockReceipts", [mixedHash])
+    assert.notStrictEqual(byMixedHash, null, "eth_getBlockReceipts(<mixed-case block hash>) must NOT return null")
+    assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1879,9 +1879,26 @@ async function handleRpc(
       // Strategy: walk block.txs, parse each to derive its hash, then route
       // through the same persistent / evm fallback as eth_getTransactionReceipt
       // so a single receipt formatter is used for both methods.
-      const tag = String((payload.params ?? [])[0] ?? "latest")
-      const num = await resolveBlockNumber(tag, chain)
-      const block = await Promise.resolve(chain.getBlockByNumber(num))
+      //
+      // #366: geth's `eth_getBlockReceipts` accepts `BlockNumberOrHash`
+      // — both a hex/tag block number AND a bare 32-byte block hash.
+      // Pre-fix we only resolved as block number: passing a hash like
+      // `0xb51f36bb…` (66 chars) sailed through `BigInt(hash)` as a
+      // gigantic integer, `chain.getBlockByNumber(huge)` returned null,
+      // and the caller saw `null` indistinguishable from "block hash
+      // doesn't exist." Detect the 66-char hash shape and route to
+      // `getBlockByHash` instead. Indexers that bulk-fetch receipts
+      // by block hash (Etherscan-clones, The Graph, etc.) need this.
+      const rawParam = (payload.params ?? [])[0]
+      let block: Awaited<ReturnType<typeof chain.getBlockByNumber>> | null = null
+      if (typeof rawParam === "string" && /^0x[0-9a-fA-F]{64}$/.test(rawParam)) {
+        // 32-byte block hash — case-insensitive, mirroring #364 normalization.
+        block = await Promise.resolve(chain.getBlockByHash(rawParam.toLowerCase() as Hex))
+      } else {
+        const tag = String(rawParam ?? "latest")
+        const num = await resolveBlockNumber(tag, chain)
+        block = await Promise.resolve(chain.getBlockByNumber(num))
+      }
       if (!block) return null
       const receipts: unknown[] = []
       for (const rawTx of block.txs) {


### PR DESCRIPTION
Fixes #366.

## Summary

- \`eth_getBlockReceipts\` previously ignored block-hash input — passing a 66-char hash got BigInt-parsed as a giant integer, \`getBlockByNumber(huge)\` returned null. geth-typed \`BlockNumberOrHash\` accepts both natively.
- Detect 66-char \`0x\` + 64-hex shape upfront, route to \`chain.getBlockByHash\` with lowercase normalization (mirrors #364) so mixed-case explorer-rendered hashes also work.
- EIP-1898 object form is a separate scope.

## Test plan

- [x] New subtest in \`rpc-extended.test.ts\`: propose a real block, then fetch receipts by-number, by-lowercase-hash, and by-mixed-case-hash; expect all three to deep-equal. 95/95 PASS.
- [x] Live testnet 88780 reproduction matches the issue body (by-number works, by-hash returns null pre-fix).