### PR TITLE
fix(ipfs): accept arg=/ipfs/<cid> kubo path form (#370)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -146,6 +146,45 @@ describe("IpfsHttpServer", () => {
     assert.equal(res.status, 400)
   })
 
+  it("#370: /api/v0/cat accepts arg=/ipfs/<cid> path form (kubo default)", async () => {
+    // kubo CLI and js-ipfs default to the `/ipfs/<cid>` path form for
+    // the `arg` parameter. Pre-fix our `isValidCid` rejected any string
+    // containing `/`, so every kubo-default call surfaced as 400
+    // "invalid cid" — silently breaking official-client interop.
+    const data = new TextEncoder().encode("hello-prefix")
+    const meta = await unixfs.addFile("p.txt", data)
+    const cid = meta.cid
+
+    // Both path forms must produce the same bytes as the bare-CID form.
+    const r1 = await fetch(`/api/v0/cat?arg=${cid}`)
+    assert.equal(r1.status, 200)
+    const buf1 = await r1.buffer()
+    assert.deepEqual(new Uint8Array(buf1), data, "bare CID baseline")
+
+    const r2 = await fetch(`/api/v0/cat?arg=${encodeURIComponent("/ipfs/" + cid)}`)
+    assert.equal(r2.status, 200, "/ipfs/<cid> path form must succeed")
+    const buf2 = await r2.buffer()
+    assert.deepEqual(new Uint8Array(buf2), data)
+
+    // Same prefix works for /api/v0/get + /api/v0/block/get + /api/v0/pin/ls
+    // since the strip happens at the dispatcher boundary, not per-route.
+    await store.pin(cid)
+    const r3 = await fetch(`/api/v0/pin/ls?arg=${encodeURIComponent("/ipfs/" + cid)}`)
+    assert.equal(r3.status, 200, "/ipfs/<cid> on pin/ls must succeed")
+    const pinBody = await r3.json() as { Keys: Record<string, { Type: string }> }
+    assert.ok(pinBody.Keys[cid], "pin should be returned")
+
+    // Variant: "ipfs/<cid>" without leading slash (permissive).
+    const r4 = await fetch(`/api/v0/cat?arg=${encodeURIComponent("ipfs/" + cid)}`)
+    assert.equal(r4.status, 200, "ipfs/<cid> without leading / must succeed")
+
+    // /ipns/<key> is NOT supported and the prefix must NOT be stripped —
+    // a plain CID lookup would silently succeed if we stripped /ipns/
+    // and the remaining text happened to look like a CID. Force 400.
+    const r5 = await fetch(`/api/v0/cat?arg=${encodeURIComponent("/ipns/some-name")}`)
+    assert.equal(r5.status, 400, "/ipns/<key> must still 400 (not supported)")
+  })
+
   it("POST /api/v0/block/put and GET /api/v0/block/get round-trip", async () => {
     const data = new TextEncoder().encode("raw block data")
     const putRes = await fetch("/api/v0/block/put", {

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -66,6 +66,32 @@ function nthQueryValue(raw: string | string[] | undefined, n: number): string | 
   return n === 0 ? raw : undefined
 }
 
+/**
+ * #370: kubo's `/api/v0/*` endpoints accept the `arg` parameter as
+ * either a bare CID (`bafy…`) OR a path-form `/ipfs/<cid>[/<subpath>]`.
+ * The kubo CLI default and js-ipfs both emit the path form. Pre-fix
+ * our `isValidCid` rejected any string containing `/` so every
+ * `arg=/ipfs/<cid>` call surfaced as `400 invalid cid` — silently
+ * breaking interop with the official client tooling.
+ *
+ * Strip a leading `/ipfs/` (or `ipfs/` without leading slash for
+ * permissiveness) so the remaining string is the bare CID and falls
+ * through the normal `isValidCid` check. Subpaths under directory
+ * CIDs aren't supported here (we don't expose directory navigation),
+ * so any string containing `/` after the strip still fails `isValidCid`
+ * with the same clean 400.
+ *
+ * IPNS (`/ipns/<key>`) is NOT supported on this server; the prefix
+ * stays intact so `isValidCid` returns false with a clean "invalid cid"
+ * instead of pretending the IPNS name is a CID.
+ */
+function stripIpfsPathPrefix(arg: string | undefined): string | undefined {
+  if (arg === undefined) return undefined
+  if (arg.startsWith("/ipfs/")) return arg.slice(6)
+  if (arg.startsWith("ipfs/")) return arg.slice(5)
+  return arg
+}
+
 function isNotFoundError(err: unknown): boolean {
   if (err && typeof err === "object" && "code" in err && (err as { code: unknown }).code === "ENOENT") return true
   const msg = String(err instanceof Error ? err.message : err)
@@ -446,7 +472,12 @@ export class IpfsHttpServer {
       // #192: coalesce dup query params at the dispatcher boundary so
       // route handlers always receive `string | undefined` (not the
       // `string | string[]` Node's url-parser actually returns).
-      const argParam = firstQueryValue(url.query.arg)
+      //
+      // #370: also normalize kubo's path-form CID arg
+      // (`arg=/ipfs/<cid>`) to the bare CID at the boundary so each
+      // route's `isValidCid` check accepts both forms. kubo CLI and
+      // js-ipfs both default to the path form.
+      const argParam = stripIpfsPathPrefix(firstQueryValue(url.query.arg))
       if (url.pathname === "/api/v0/add") {
         // #353: reject unsupported kubo params *before* we read the
         // multipart body — a client requesting cid-version=0 should


### PR DESCRIPTION
Fixes #370.

## Summary

- kubo CLI / js-ipfs default to \`arg=/ipfs/<cid>\` for every API call. Our \`isValidCid\` rejected any \`/\` so every call surfaced as \"invalid cid\" without any hint that the prefix was the cause.
- Strip leading \`/ipfs/\` (or \`ipfs/\`) at the dispatcher boundary — one transform covers cat/get/pin/block/object/erasure-status etc.
- Subpath under directory CID falls through to existing isValidCid rejection. \`/ipns/<key>\` is NOT stripped (IPNS not implemented).

## Test plan

- [x] New subtest covering /ipfs/ prefix, ipfs/ no-slash variant, /ipns/ rejection, parity across cat/pin-ls. 51/51 PASS.
- [x] Verified test FAILS on un-fixed code via \`git stash push node/src/ipfs-http.ts\` (50 pass / 1 fail).
- [x] Live testnet 88780 reproduction matches issue body.