### PR TITLE
fix(p2p): 405 response sets Content-Length: 0 + Allow header (#378)

### DIFF
--- a/node/src/p2p-405-head.test.ts
+++ b/node/src/p2p-405-head.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #378 regression: non-POST requests to the P2P HTTP gossip server
+ * must return 405 with explicit `Content-Length: 0` so HEAD requests
+ * terminate immediately instead of hanging until the keep-alive
+ * timeout fires.
+ *
+ * Same pattern as #376 (RPC server) — pre-fix
+ * `res.writeHead(405); res.end()` defaulted to chunked
+ * Transfer-Encoding. For HEAD requests, Node suppresses the body but
+ * still advertises chunked, so the client waits for a terminating
+ * chunk that never arrives, hanging until the 5 s keepAliveTimeout
+ * fires.
+ *
+ * Live testnet 88780 reproduction (pre-fix):
+ *
+ *   $ time curl -X HEAD http://199.192.16.79:29780/
+ *   → 6.48 s  (5 s keep-alive + RTT)
+ *
+ * Real-world impact: deployments that expose the P2P port to a load
+ * balancer (e.g. for cross-region replication health checks) face
+ * the same socket-pool exhaustion as #376.
+ *
+ * Fix sets `Content-Length: 0` + `Allow: POST` (RFC 7231 §6.5.5)
+ * on the 405 so HEAD / GET / PUT / DELETE all terminate immediately.
+ */
+
+import test from "node:test"
+import assert from "node:assert/strict"
+import http from "node:http"
+import { P2PNode } from "./p2p.ts"
+import type { Hex, ChainSnapshot } from "./blockchain-types.ts"
+
+test("#378: HEAD request to P2P server returns 405 with Content-Length: 0 (no hang)", async (t) => {
+  const port = 29900 + Math.floor(Math.random() * 100)
+  const p2p = new P2PNode(
+    {
+      bind: "127.0.0.1",
+      port,
+      peers: [],
+      nodeId: "test-378",
+      enableDiscovery: false,
+    },
+    {
+      onTx: async () => {},
+      onBlock: async () => {},
+      onSnapshotRequest: () =>
+        ({ height: 0, latestHash: "0x0" as Hex, blocks: [] }) as unknown as ChainSnapshot,
+      getHeight: () => 0n,
+    },
+  )
+  p2p.start()
+  t.after(async () => {
+    await p2p.stop()
+  })
+  await new Promise<void>((r) => setTimeout(r, 50))
+
+  // Probe HEAD — must return 405 with Content-Length: 0 and Allow header,
+  // and the request must complete in well under 5 s (the keep-alive
+  // timeout). Pre-fix this would hang for ~5 s waiting for a chunked
+  // terminator that Node had suppressed for HEAD.
+  const start = Date.now()
+  const result = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>(
+    (resolve, reject) => {
+      const req = http.request(
+        { hostname: "127.0.0.1", port, method: "HEAD", path: "/" },
+        (res) => {
+          res.on("data", () => {})
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers }))
+        },
+      )
+      req.on("error", reject)
+      req.setTimeout(3000, () => {
+        req.destroy(new Error("HEAD hang — pre-fix bug shape"))
+        reject(new Error("HEAD hang — pre-fix bug shape"))
+      })
+      req.end()
+    },
+  )
+  const elapsed = Date.now() - start
+
+  assert.equal(result.status, 405, "HEAD must return 405 Method Not Allowed")
+  assert.equal(
+    result.headers["content-length"],
+    "0",
+    "Content-Length must be 0 (no body to wait for)",
+  )
+  assert.match(
+    String(result.headers["allow"] ?? ""),
+    /POST/i,
+    "RFC 7231 §6.5.5: 405 must include Allow header listing supported methods",
+  )
+  assert.ok(
+    elapsed < 1000,
+    `HEAD must terminate quickly (got ${elapsed} ms — pre-fix hung ~5 s on keep-alive timeout)`,
+  )
+
+  // GET also rejected with 405, same shape.
+  const getResult = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>(
+    (resolve, reject) => {
+      const req = http.request(
+        { hostname: "127.0.0.1", port, method: "GET", path: "/wire" },
+        (res) => {
+          res.on("data", () => {})
+          res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers }))
+        },
+      )
+      req.on("error", reject)
+      req.setTimeout(3000, () => reject(new Error("GET hang")))
+      req.end()
+    },
+  )
+  assert.equal(getResult.status, 405)
+  assert.match(String(getResult.headers["allow"] ?? ""), /POST/i)
+
+  // PUT and DELETE too — proves the fix is method-agnostic.
+  for (const method of ["PUT", "DELETE"]) {
+    const r = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>(
+      (resolve, reject) => {
+        const req = http.request(
+          { hostname: "127.0.0.1", port, method, path: "/" },
+          (res) => {
+            res.on("data", () => {})
+            res.on("end", () =>
+              resolve({ status: res.statusCode ?? 0, headers: res.headers }),
+            )
+          },
+        )
+        req.on("error", reject)
+        req.setTimeout(3000, () => reject(new Error(`${method} hang`)))
+        req.end()
+      },
+    )
+    assert.equal(r.status, 405, `${method} must return 405`)
+    assert.equal(r.headers["content-length"], "0", `${method} must set Content-Length: 0`)
+  }
+})

--- a/node/src/p2p.ts
+++ b/node/src/p2p.ts
@@ -633,7 +633,23 @@ export class P2PNode {
       }
 
       if (req.method !== "POST") {
-        res.writeHead(405)
+        // #378: parity with rpc.ts #376 — pre-fix `res.writeHead(405);
+        // res.end()` left Content-Length unset. Node defaulted to
+        // chunked Transfer-Encoding, and for HEAD requests it
+        // suppresses the body but still advertises chunked, so the
+        // client waited for a terminating chunk that never arrived
+        // and hung until the 5 s keepAliveTimeout fired. Load balancer
+        // health probes (AWS ALB / GCP LB / K8s readinessProbe) commonly
+        // default to HEAD — each probe stalls 5 s, exhausting the
+        // keep-alive socket pool and destabilising the health window.
+        //
+        // Set Content-Length: 0 + Allow: POST so HEAD/GET/PUT/DELETE
+        // terminate immediately. RFC 7231 §6.5.5 also requires Allow
+        // on 405 responses.
+        res.writeHead(405, {
+          "allow": "POST",
+          "content-length": "0",
+        })
         res.end()
         return
       }


### PR DESCRIPTION
Closes #378.

## Summary

P2P HTTP gossip server had the same HEAD-hang bug as the RPC server
(fixed by #376). Pre-fix `res.writeHead(405); res.end()` left
Content-Length unset, so Node defaulted to chunked Transfer-Encoding.
For HEAD requests, Node suppresses the body but still advertises
chunked, so the client waits for a terminating chunk that never
arrives, hanging until the 5 s keepAliveTimeout fires.

## Live testnet 88780 reproduction

```
$ time curl -X HEAD http://199.192.16.79:29780/
→ 6.48 s  (5 s keep-alive + RTT)
```

## Fix

Set `Content-Length: 0` + `Allow: POST` on the 405 so HEAD/GET/PUT/DELETE
all terminate immediately. RFC 7231 §6.5.5 also requires `Allow` on
405 responses.

## Test plan

- [x] New regression test `node/src/p2p-405-head.test.ts`
  - HEAD returns 405 with `Content-Length: 0` + `Allow: POST`, elapsed < 1 s
  - GET / PUT / DELETE same shape (proves method-agnostic)
- [x] Verified fail-without-fix: `git stash push node/src/p2p.ts` →
      test fails with `undefined !== '0'` (assertion on Content-Length)
- [x] Full p2p suite: `node --test node/src/p2p.test.ts node/src/p2p-405-head.test.ts` → 11/11 PASS
- [x] Probe latency drops from ~6.5 s to <100 ms on live testnet

## Parallel to #376

This is the second of two HEAD-hang fixes:
- #376 fixed `rpc.ts` (port 28780)
- #378 fixes `p2p.ts` (port 29780) — same pattern, same fix shape