### PR TITLE
fix(ipfs): mfs.mkdir rejects empty / root arg with 400 (#380)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1591,6 +1591,53 @@ describe("IpfsHttpServer", () => {
       assert.equal(isIpfsAdminAuthorized(reqOk, "203.0.113.7", cfgNoToken), false)
     })
   })
+
+  it("#380: /api/v0/files/mkdir with empty or root arg returns 400 (not silent 200 ok)", async () => {
+    // Pre-fix: the handler passed empty `arg` straight to mfs.mkdir("").
+    // normalizePath("") rewrites it to "/", `dirs.has("/")` is always
+    // true, and the call returns as a silent no-op — the client sees
+    // 200 `{ok:true}` and believes the directory exists. Later
+    // `files/write` into the path fails with "parent directory not
+    // found", masking the original mistake.
+    //
+    // Live testnet 88780 reproduction (pre-fix):
+    //
+    //   $ curl -X POST 'http://node:28800/api/v0/files/mkdir'
+    //   → 200 {"ok":true}
+    //   $ curl -X POST 'http://node:28800/api/v0/files/mkdir?arg='
+    //   → 200 {"ok":true}
+    //   $ curl -X POST 'http://node:28800/api/v0/files/mkdir?arg=/'
+    //   → 200 {"ok":true}    # root is no-op, but still claims success
+    //
+    // kubo's CLI rejects all three with "argument 'path' is required" /
+    // "cannot create root". This test pins parity.
+    const { IpfsMfs } = await import("./ipfs-mfs.ts")
+    const mfs = new IpfsMfs(store, unixfs)
+    server.attachSubsystems({ mfs })
+
+    const probes = [
+      { path: "/api/v0/files/mkdir", label: "no ?arg= at all" },
+      { path: "/api/v0/files/mkdir?arg=", label: "empty ?arg=" },
+      { path: "/api/v0/files/mkdir?arg=/", label: "root ?arg=/" },
+    ]
+    for (const { path, label } of probes) {
+      const res = await fetch(path, { method: "POST" })
+      assert.equal(res.status, 400, `${label}: must be 400, got ${res.status}`)
+      const body = await res.json() as { error?: string; message?: string }
+      assert.equal(body.error, "bad request", `${label}: error must be 'bad request', got ${JSON.stringify(body)}`)
+      assert.match(
+        `${body.message ?? ""}`,
+        /missing path argument|cannot mkdir root/i,
+        `${label}: message must name the missing-path / root problem, got ${JSON.stringify(body)}`,
+      )
+    }
+
+    // Sanity: a real path still works.
+    const okRes = await fetch("/api/v0/files/mkdir?arg=/probe-380", { method: "POST" })
+    assert.equal(okRes.status, 200, "valid path must succeed")
+    const statRes = await fetch("/api/v0/files/stat?arg=/probe-380", { method: "POST" })
+    assert.equal(statRes.status, 200, "directory must actually be created")
+  })
 })
 
 // Phase Q.4 — Reed-Solomon erasure coding integration tests.

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1478,6 +1478,28 @@ export class IpfsHttpServer {
     try {
       switch (route) {
         case "mkdir": {
+          // #380: pre-fix the handler passed empty `arg` (when no ?arg= was
+          // supplied) straight to mfs.mkdir(""). normalizePath("") rewrites
+          // it to "/", `dirs.has("/")` is always true, and the call returns
+          // as a silent no-op — leaving the client a 200 `{ok:true}`
+          // response indicating a directory that doesn't exist. The client
+          // later `files/write`s into the path and fails with
+          // "parent directory not found", masking the original mistake.
+          //
+          // kubo's CLI rejects empty / root with
+          //   Error: argument "path" is required
+          // Reject both shapes at the HTTP boundary so silent-success is
+          // impossible.
+          if (arg.length === 0) {
+            res.writeHead(400, { "content-type": "application/json" })
+            res.end(JSON.stringify({ error: "bad request", message: "missing path argument" }))
+            break
+          }
+          if (arg === "/" || arg === "") {
+            res.writeHead(400, { "content-type": "application/json" })
+            res.end(JSON.stringify({ error: "bad request", message: "cannot mkdir root path" }))
+            break
+          }
           const parents = url.query?.parents === "true"
           await this.mfs.mkdir(arg, { parents })
           res.writeHead(200, { "content-type": "application/json" })


### PR DESCRIPTION
Closes #380.

## Summary

`/api/v0/files/mkdir` returned `200 {"ok":true}` when no `?arg=`
was supplied or when the path resolved to root. The handler passed
empty string to `mfs.mkdir("")`; `normalizePath("")` rewrites that
to `/`, `dirs.has("/")` is always true, so mkdir returns
immediately. The client gets a success response describing a
directory that doesn't exist — and the next `files/write` into
that path fails with "parent directory not found", masking the
original mistake.

## Live testnet 88780 reproduction (pre-fix)

```
$ curl -X POST 'http://199.192.16.79:28800/api/v0/files/mkdir'
→ 200 {"ok":true}
$ curl -X POST 'http://199.192.16.79:28800/api/v0/files/mkdir?arg='
→ 200 {"ok":true}
$ curl -X POST 'http://199.192.16.79:28800/api/v0/files/mkdir?arg=/'
→ 200 {"ok":true}    # root no-op, but still claims success
```

kubo's CLI rejects all three with `argument "path" is required` /
`cannot create root`.

## Fix

Validate at the HTTP boundary that `arg` is non-empty and not just
`/`. Return `400 {"error":"bad request","message":"missing path argument"}`
(or `"cannot mkdir root path"`).

## Test plan

- [x] New regression test in `node/src/ipfs-http.test.ts` (#380 subtest)
  - Probes: no ?arg=, empty ?arg=, ?arg=/
  - Each must return 400 with `error: "bad request"`
  - Sanity: `?arg=/probe-380` still creates the directory
- [x] Verified fail-without-fix: `git stash push node/src/ipfs-http.ts` →
      test fails (`200 !== 400`)
- [x] Full ipfs-http suite: `node --test node/src/ipfs-http.test.ts` → 51/51 PASS

## Real-world impact

Client-side state machines using ipfs-http-client to build
directory trees (test fixtures, snapshot uploads, MFS mirroring
tools) get silently-broken trees if their `mkdir` call serialised
an empty path. Pre-fix the failure mode was "your /a/b/c/file
isn't found after upload"; post-fix the first mkdir fails at the
boundary with a clear message.