### PR TITLE
fix(ipfs-http): 404/405 responses set Content-Length so HEAD doesn't hang (#382)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1638,6 +1638,67 @@ describe("IpfsHttpServer", () => {
     const statRes = await fetch("/api/v0/files/stat?arg=/probe-380", { method: "POST" })
     assert.equal(statRes.status, 200, "directory must actually be created")
   })
+
+  it("#382: HEAD requests on IPFS HTTP do not hang (Content-Length set on 404/405)", async () => {
+    // Pre-fix the IPFS HTTP server's catch-all 404 (line 202) and
+    // /api/v0/* non-POST 405 (line 212) used `res.writeHead(X);
+    // res.end([body])` which committed headers before body length
+    // was known. Node defaulted to chunked Transfer-Encoding. For
+    // HEAD requests, Node suppresses the body but still advertises
+    // chunked — the client waits for a terminating chunk that never
+    // arrives, hanging until the 5 s keepAliveTimeout fires.
+    //
+    // Live testnet 88780 reproduction (pre-fix):
+    //
+    //   $ time curl -X HEAD http://node:28800/api/v0/version
+    //   → 6.47 s
+    //   $ time curl -X HEAD http://node:28800/foo
+    //   → 6.48 s
+    //
+    // Same pattern as #376 (rpc.ts) / #378 (p2p.ts). Fix sets
+    // Content-Length explicitly so HEAD/GET terminate identically.
+    const probes = [
+      { path: "/foo", expectedStatus: 404, label: "404 catch-all (non-/api/v0, non-/ipfs)" },
+      { path: "/api/v0/version", expectedStatus: 405, label: "405 for HEAD on POST-only /api/v0/*" },
+      { path: "/api/v0/cat?arg=bafybeibpm6rvk2zrrwakx3xj2xpjcd66kifv46s4te3evt7d42ybellahm", expectedStatus: 405, label: "405 for HEAD on /api/v0/cat" },
+    ]
+    for (const { path, expectedStatus, label } of probes) {
+      const start = Date.now()
+      const result = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>(
+        (resolve, reject) => {
+          const url = new URL(path, baseUrl)
+          const req = http.request(
+            {
+              hostname: url.hostname,
+              port: url.port,
+              method: "HEAD",
+              path: url.pathname + url.search,
+            },
+            (r) => {
+              r.on("data", () => {})
+              r.on("end", () => resolve({ status: r.statusCode ?? 0, headers: r.headers }))
+            },
+          )
+          req.on("error", reject)
+          req.setTimeout(3000, () => {
+            req.destroy(new Error(`HEAD hang on ${path} — pre-fix bug shape`))
+            reject(new Error(`HEAD hang on ${path}`))
+          })
+          req.end()
+        },
+      )
+      const elapsed = Date.now() - start
+      assert.equal(result.status, expectedStatus, `${label}: status`)
+      assert.ok(
+        result.headers["content-length"] !== undefined,
+        `${label}: Content-Length must be set (got headers: ${JSON.stringify(result.headers)})`,
+      )
+      assert.ok(
+        elapsed < 1000,
+        `${label}: HEAD must terminate quickly (got ${elapsed} ms — pre-fix hung ~5 s)`,
+      )
+    }
+  })
 })
 
 // Phase Q.4 — Reed-Solomon erasure coding integration tests.

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -475,7 +475,14 @@ export class IpfsHttpServer {
       }
 
       if (!url.pathname?.startsWith("/api/v0/")) {
-        res.writeHead(404)
+        // #382: bare `res.writeHead(404); res.end()` triggers Node's
+        // chunked Transfer-Encoding because headers commit before body
+        // length is known. HEAD requests then wait for a terminating
+        // chunk that Node suppresses, hanging the client for the full
+        // 5 s keep-alive timeout. Same pattern as #376 (rpc.ts) / #378
+        // (p2p.ts) — set Content-Length: 0 explicitly so HEAD/GET
+        // terminate immediately.
+        res.writeHead(404, { "content-length": "0" })
         res.end()
         return
       }
@@ -486,8 +493,18 @@ export class IpfsHttpServer {
       // visited webpage trigger state-changing operations (pin/add,
       // block/rm, repo/gc) against a victim's local IPFS daemon.
       if (req.method !== "POST") {
-        res.writeHead(405, { "allow": "POST", "content-type": "application/json" })
-        res.end(JSON.stringify({ error: "method not allowed: /api/v0/* requires POST" }))
+        // #382: pre-fix the body was passed to res.end() after writeHead
+        // had already committed headers, so Node defaulted to chunked
+        // encoding (no Content-Length). HEAD requests then hung 5 s on
+        // keep-alive waiting for the chunked terminator. Compute the body
+        // first and set Content-Length so HEAD/GET behave identically.
+        const body405 = JSON.stringify({ error: "method not allowed: /api/v0/* requires POST" })
+        res.writeHead(405, {
+          "allow": "POST",
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body405)),
+        })
+        res.end(body405)
         return
       }
 
@@ -627,8 +644,16 @@ export class IpfsHttpServer {
         return
       }
 
-      res.writeHead(404)
-      res.end(JSON.stringify({ error: "not found" }))
+      // #382: same chunked-without-terminator HEAD hang. Compute body
+      // first + Content-Length so HEAD requests terminate immediately.
+      {
+        const body404 = JSON.stringify({ error: "not found" })
+        res.writeHead(404, {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body404)),
+        })
+        res.end(body404)
+      }
       } catch (err) {
         // #180: defensively map ErasureError to 4xx — the inline
         // handleCat path already does this for read-side ErasureError,


### PR DESCRIPTION
Closes #382.

## Summary

Three response sites in the IPFS HTTP server used the
`res.writeHead(X, headers); res.end([body])` pattern. writeHead
commits headers before body length is known, so Node defaults to
chunked Transfer-Encoding. For HEAD requests Node suppresses the
body but still advertises chunked — the client waits for a
terminating chunk that never arrives, hanging until the 5 s
keepAliveTimeout fires.

Same systemic pattern as #376 (rpc.ts) / #378 (p2p.ts).

## Live testnet 88780 reproduction

```
$ time curl -X HEAD http://199.192.16.79:28800/api/v0/version
→ 6.47 s  (5 s keep-alive + RTT)
$ time curl -X HEAD http://199.192.16.79:28800/foo
→ 6.48 s
```

## Fix

Three sites in `node/src/ipfs-http.ts`:

1. **L202 — catch-all 404** (non-`/api/v0/`, non-`/ipfs/`):
   added `content-length: 0`. Empty body, HEAD terminates.

2. **L212 — 405 for non-POST `/api/v0/*`**: compute body length
   first, set `content-length` in writeHead so HEAD/GET behave
   identically.

3. **L306 — 404 catch-all at dispatch end**: same fix as L212.

## Test plan

- [x] New regression test `#382` in `node/src/ipfs-http.test.ts`
  - 3 probes: catch-all 404, /api/v0/version 405, /api/v0/cat 405
  - Each must have `Content-Length` set and complete in < 1 s
- [x] Verified fail-without-fix: `git stash push node/src/ipfs-http.ts`
      → test fails with hang/missing Content-Length
- [x] Full ipfs-http suite: `node --test node/src/ipfs-http.test.ts` → 51/51 PASS

## Real-world impact

Load balancers / monitoring probes (AWS ALB, GCP LB, K8s
readinessProbe, Datadog APM) commonly use HEAD as a cheap health
check. Each probe to the IPFS port (28800) stalls ~5 s pre-fix,
exhausting the keep-alive socket pool — identical failure mode
as #376/#378.

## Family

Third in the HEAD-hang series:
- #376 fixed `rpc.ts` (port 28780)
- #378 fixed `p2p.ts` (port 29780)
- #382 fixes `ipfs-http.ts` (port 28800) — same fix shape across
  three sites