### PR TITLE
fix(rpc): synthesise genesis state for earliest/0x0 queries (#384)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -920,6 +920,39 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(zeroTag.hash, earliest!.hash)
   })
 
+  await t.test("#384: state-query RPCs at \"earliest\"/\"0x0\" return zero/empty (not 'block not found')", async () => {
+    // Pre-fix: eth_getBlockByNumber("earliest") synthesised a genesis
+    // block (#112) but every state-query RPC threw `-32001 block not
+    // found: earliest` because resolveHistoricalExecutionContext lacked
+    // the parallel synthesis path. ethers/viem/web3.js wallets that
+    // probe genesis state during initialisation (balance check, chainId
+    // smoke test, fork-detection) hit the error and failed to connect.
+    //
+    // Fix mirrors #112: when block 0 is requested but the chain has
+    // no persisted block 0 and height ≥ 1, return the empty default —
+    // zero balance / no code / nonce 0 / zero storage — matching what
+    // geth and anvil return for genesis state queries.
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block so height ≥ 1")
+    const sampleAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    for (const tag of ["earliest", "0x0"]) {
+      const bal = await rpcCall(port, "eth_getBalance", [sampleAddr, tag])
+      assert.equal(bal, "0x0", `eth_getBalance(${tag}) must return 0x0, got ${JSON.stringify(bal)}`)
+      const code = await rpcCall(port, "eth_getCode", [sampleAddr, tag])
+      assert.equal(code, "0x", `eth_getCode(${tag}) must return 0x, got ${JSON.stringify(code)}`)
+      const nonce = await rpcCall(port, "eth_getTransactionCount", [sampleAddr, tag])
+      assert.equal(nonce, "0x0", `eth_getTransactionCount(${tag}) must return 0x0, got ${JSON.stringify(nonce)}`)
+      const storage = await rpcCall(port, "eth_getStorageAt", [sampleAddr, "0x0", tag])
+      assert.equal(storage, `0x${"0".repeat(64)}`, `eth_getStorageAt(${tag}) must return 32-byte zero, got ${JSON.stringify(storage)}`)
+      const callRet = await rpcCall(port, "eth_call", [{ to: sampleAddr, data: "0x" }, tag])
+      assert.equal(callRet, "0x", `eth_call(${tag}) must return 0x (no code), got ${JSON.stringify(callRet)}`)
+    }
+    // Sanity: non-genesis tags still go through the normal path. Use
+    // "latest" — should not throw.
+    const balLatest = await rpcCall(port, "eth_getBalance", [sampleAddr, "latest"])
+    assert.match(String(balLatest), /^0x[0-9a-f]+$/, "eth_getBalance(latest) still works")
+  })
+
   await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
     const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
     assert.ok(Array.isArray(peers), "must return an array")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -796,8 +796,12 @@ async function handleRpc(
       // #122: validate at the boundary so a typo gives -32602 instead of
       // -32603 with the raw input echoed back from the EVM.
       const address = requireAddressParam(payload.params ?? [], 0)
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[1], chain)
-      const balance = await evm.getBalance(address, stateRoot)
+      const ctx = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: at synthetic genesis (no persisted block 0) every account
+      // has balance 0 — short-circuit so ethers/viem init probes don't
+      // hit "block not found".
+      if (ctx.syntheticGenesis) return "0x0"
+      const balance = await evm.getBalance(address, ctx.stateRoot)
       return `0x${balance.toString(16)}`
     }
     case "eth_getTransactionCount": {
@@ -810,8 +814,10 @@ async function handleRpc(
         const pendingNonce = chain.mempool.getPendingNonce(address as Hex, onchainNonce)
         return `0x${pendingNonce.toString(16)}`
       }
-      const stateRoot = await resolveHistoricalStateRoot(tag, chain)
-      const nonce = await evm.getNonce(address, stateRoot)
+      const ctx = await resolveHistoricalExecutionContext(tag, chain)
+      // #384: synthetic genesis → nonce 0.
+      if (ctx.syntheticGenesis) return "0x0"
+      const nonce = await evm.getNonce(address, ctx.stateRoot)
       return `0x${nonce.toString(16)}`
     }
     case "eth_getTransactionReceipt": {
@@ -949,8 +955,10 @@ async function handleRpc(
     }
     case "eth_getCode": {
       const codeAddr = requireAddressParam(payload.params ?? [], 0)
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[1], chain)
-      return await evm.getCode(codeAddr, stateRoot)
+      const ctx = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: synthetic genesis → no code deployed yet.
+      if (ctx.syntheticGenesis) return "0x"
+      return await evm.getCode(codeAddr, ctx.stateRoot)
     }
     case "eth_call": {
       // #172: reject non-object first param upfront — runtime type
@@ -973,6 +981,8 @@ async function handleRpc(
       // surfaces as -32603 with V8 message leak (data).
       validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: synthetic genesis has no contracts to call — return empty.
+      if (executionContext.syntheticGenesis) return "0x"
       const callResult = await evm.callRaw({
         from: callParams.from,
         to,
@@ -1008,8 +1018,10 @@ async function handleRpc(
       if (!/^0x[0-9a-fA-F]{1,64}$/.test(storageSlot)) {
         invalidParams(`invalid storage slot: must match /^0x[0-9a-fA-F]{1,64}$/`)
       }
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[2], chain)
-      return await evm.getStorageAt(storageAddr, storageSlot, stateRoot)
+      const ctx = await resolveHistoricalExecutionContext((payload.params ?? [])[2], chain)
+      // #384: synthetic genesis has empty storage everywhere.
+      if (ctx.syntheticGenesis) return `0x${"0".repeat(64)}`
+      return await evm.getStorageAt(storageAddr, storageSlot, ctx.stateRoot)
     }
     case "eth_getProof": {
       const proofAddr = requireAddressParam(payload.params ?? [], 0)
@@ -3023,10 +3035,21 @@ async function resolveHistoricalStateRoot(input: unknown, chain: IChainEngine): 
   return (await resolveHistoricalExecutionContext(input, chain)).stateRoot
 }
 
+/**
+ * #384: when state queries (eth_getBalance/Code/TxCount/StorageAt/call)
+ * request block 0 ("earliest" / "0x0" / EIP-1898 {blockNumber:"0x0"})
+ * but the chain has produced blocks since (height>=1), return this
+ * flag so the caller can short-circuit to the zero/empty default —
+ * mirroring #112's synthetic genesis for eth_getBlockByNumber so
+ * ethers/viem/web3.js wallets that probe genesis state during init
+ * don't get a misleading "block not found: earliest" error.
+ */
+export type HistoricalExecutionContext = { stateRoot?: string; syntheticGenesis?: boolean } & ExecutionContext
+
 async function resolveHistoricalExecutionContext(
   input: unknown,
   chain: IChainEngine,
-): Promise<{ stateRoot?: string } & ExecutionContext> {
+): Promise<HistoricalExecutionContext> {
   if (
     input === undefined ||
     input === null ||
@@ -3136,6 +3159,14 @@ async function resolveHistoricalExecutionContext(
   const blockNumber = parseBlockTag(input, height)
   const block = await Promise.resolve(chain.getBlockByNumber(blockNumber))
   if (!block) {
+    // #384: chain has no persisted block 0 (production starts at height 1),
+    // but #112 synthesises one for eth_getBlockByNumber("earliest"). Mirror
+    // that here so state queries at "earliest"/"0x0" return the empty
+    // default (zero balance / no code) instead of "block not found",
+    // matching geth's behaviour at chain start.
+    if (blockNumber === 0n && height >= 1n) {
+      return { blockNumber: 0n, syntheticGenesis: true }
+    }
     throw { code: -32001, message: `block not found: ${String(input)}` }
   }
   if (!block.stateRoot) {


### PR DESCRIPTION
Closes #384.

## Summary

`eth_getBlockByNumber("earliest")` synthesises a genesis block
(per #112) because the chain starts producing at height 1 with
no persisted block 0. But the state-query RPCs lack the parallel
synthesis path — they throw `-32001 block not found: earliest`.

## Live testnet 88780 reproduction (pre-fix)

```
$ curl -X POST … eth_getBalance(addr, "earliest")
→ -32001 "block not found: earliest"

$ curl -X POST … eth_getBlockByNumber("earliest")
→ 200 OK with synthesised genesis block        # asymmetric!
```

## Fix

`resolveHistoricalExecutionContext` now mirrors `eth_getBlockByNumber`'s
synthesis: when blockNumber resolves to 0n but no real block 0 exists
and chain.height ≥ 1, return `{ blockNumber: 0n, syntheticGenesis: true }`.
Each state-query handler checks the flag and short-circuits to the
empty default:

- `eth_getBalance` → `"0x0"`
- `eth_getCode` → `"0x"`
- `eth_getTransactionCount` → `"0x0"`
- `eth_getStorageAt` → 32-byte zero hex
- `eth_call` → `"0x"`

Matches geth/anvil behaviour for chains with empty genesis allocs.

## Test plan

- [x] New regression `#384` in `node/src/rpc-extended.test.ts`
  - Probes all 5 state-query RPCs at both `"earliest"` and `"0x0"`
  - Each must return the empty default (not throw -32001)
  - Sanity: `"latest"` still works through the normal path
- [x] Verified fail-without-fix: `git stash push node/src/rpc.ts` →
      test fails with `-32001 block not found: earliest` (5 assertions × 2 tags)
- [x] Full rpc-extended suite: 95/95 PASS
- [x] Full rpc suite: 5/5 PASS

## Real-world impact

ethers v6 / viem / wagmi all probe `earliest` balance during their
initial RPC handshake (live-node detection, fork-detection). Pre-fix
any wallet/dapp hitting the COC testnet on first connect saw the
-32001 error and refused to proceed. Post-fix they get the
geth-equivalent zero default and move on to `latest` queries.