### PR TITLE
fix(rpc): txpool separates pending vs queued by nonce contiguity (#386)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -635,6 +635,73 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(typeof content.queued === "object")
   })
 
+  await t.test("#386: txpool_status / txpool_content classify gap-nonce txs as queued (not pending)", async () => {
+    // Pre-fix: txpool_status hardcoded `queued: "0x0"` and txpool_content
+    // returned `queued: {}` regardless of nonce gaps. A tx with nonce=5
+    // while account onchain nonce was 0 reported as pending, so wallet
+    // stuck-tx detection (which polls txpool_content and waits for the
+    // tx to move from queued → pending) never triggered.
+    //
+    // Live testnet 88780 repro: deployer had a tx with nonce=300 in the
+    // mempool while onchain nonce was 187. Pre-fix txpool_content showed
+    // it under "pending"; post-fix it correctly appears under "queued".
+    //
+    // Fix mirrors geth's separation: contiguous-from-onchain → pending,
+    // gapped/future → queued.
+    const { Wallet: EthersWallet, Transaction: EthersTransaction } = await import("ethers")
+    const TEST_PK = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+    const wallet = new EthersWallet(TEST_PK)
+    const senderAddr = wallet.address.toLowerCase()
+
+    // Clear any pre-existing test txs first by getting baseline.
+    const baselineNonce = await rpcCall(port, "eth_getTransactionCount", [wallet.address, "latest"]) as string
+    const startNonce = parseInt(baselineNonce, 16)
+
+    // Sign two txs: one contiguous (startNonce) and one gapped (startNonce + 5).
+    function sign(nonce: number): string {
+      const tx = EthersTransaction.from({
+        to: "0x0000000000000000000000000000000000000001",
+        value: "0x1",
+        nonce,
+        gasLimit: "0x5208",
+        gasPrice: "0x3b9aca00",
+        chainId,
+        data: "0x",
+      })
+      const sig = wallet.signingKey.sign(tx.unsignedHash)
+      const clone = tx.clone()
+      clone.signature = sig
+      return clone.serialized
+    }
+    await rpcCall(port, "eth_sendRawTransaction", [sign(startNonce)])
+    await rpcCall(port, "eth_sendRawTransaction", [sign(startNonce + 5)])
+
+    const status = await rpcCall(port, "txpool_status") as { pending: string; queued: string }
+    const pendingCount = parseInt(status.pending, 16)
+    const queuedCount = parseInt(status.queued, 16)
+    assert.ok(pendingCount >= 1, `txpool_status.pending must count contiguous tx (got ${pendingCount})`)
+    assert.ok(queuedCount >= 1, `txpool_status.queued must count gap tx (got ${queuedCount}, pre-fix was always 0)`)
+
+    const content = await rpcCall(port, "txpool_content") as {
+      pending: Record<string, Record<string, { nonce: string }>>
+      queued: Record<string, Record<string, { nonce: string }>>
+    }
+    const pendingForSender = content.pending[senderAddr] ?? {}
+    const queuedForSender = content.queued[senderAddr] ?? {}
+    assert.ok(
+      String(startNonce) in pendingForSender,
+      `nonce ${startNonce} (contiguous) must be in pending, got pending=${JSON.stringify(Object.keys(pendingForSender))} queued=${JSON.stringify(Object.keys(queuedForSender))}`,
+    )
+    assert.ok(
+      String(startNonce + 5) in queuedForSender,
+      `nonce ${startNonce + 5} (gap) must be in queued, got pending=${JSON.stringify(Object.keys(pendingForSender))} queued=${JSON.stringify(Object.keys(queuedForSender))}`,
+    )
+    assert.ok(
+      !(String(startNonce + 5) in pendingForSender),
+      `gap nonce ${startNonce + 5} must NOT appear in pending`,
+    )
+  })
+
   await t.test("coc_nodeInfo returns node metadata", async () => {
     const info = await rpcCall(port, "coc_nodeInfo")
     assert.ok(typeof info === "object")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1919,31 +1919,30 @@ async function handleRpc(
       return receipts
     }
     case "txpool_status": {
-      const stats = chain.mempool.stats()
+      // #386: pre-fix hardcoded queued:"0x0" miscounted gap/future-nonce
+      // txs as pending. Geth's txpool_status separates contiguous-from-
+      // onchain (pending) vs gapped/future (queued) so stuck-tx detection
+      // works. Bucket per-sender by walking nonces from each sender's
+      // onchain nonce.
+      const allTxs = chain.mempool.getAll()
+      const { pendingCount, queuedCount } = await classifyMempoolPendingQueued(allTxs, evm)
       return {
-        pending: `0x${stats.size.toString(16)}`,
-        queued: "0x0",
+        pending: `0x${pendingCount.toString(16)}`,
+        queued: `0x${queuedCount.toString(16)}`,
       }
     }
     case "txpool_content": {
+      // #386: same pending vs queued split as txpool_status. Pre-fix lumped
+      // every tx into `pending` (queued stayed {}) so ethers/wagmi/web3.js
+      // stuck-tx detection — which polls txpool_content and checks if the
+      // tx moved from queued → pending — never triggered. Live-testnet
+      // repro: a tx with nonce=300 sat in mempool while account onchain
+      // nonce was 187; pre-fix txpool_content reported it as pending,
+      // post-fix it reports as queued (correct — the 188..299 gap blocks
+      // it from execution).
       const allTxs = chain.mempool.getAll()
-      const pending: Record<string, Record<string, unknown>> = {}
-      for (const mtx of allTxs) {
-        const sender = mtx.from
-        if (!pending[sender]) pending[sender] = {}
-        const parsed = Transaction.from(mtx.rawTx)
-        pending[sender][mtx.nonce.toString()] = {
-          hash: mtx.hash,
-          nonce: `0x${mtx.nonce.toString(16)}`,
-          from: mtx.from,
-          to: parsed.to ?? null,
-          value: `0x${(parsed.value ?? 0n).toString(16)}`,
-          gas: `0x${mtx.gasLimit.toString(16)}`,
-          gasPrice: `0x${mtx.gasPrice.toString(16)}`,
-          input: parsed.data ?? "0x",
-        }
-      }
-      return { pending, queued: {} }
+      const { pending, queued } = await splitMempoolPendingQueued(allTxs, evm)
+      return { pending, queued }
     }
     case "coc_getTransactionsByAddress": {
       // #120: validate address shape so typos surface as -32602 instead
@@ -3660,6 +3659,84 @@ async function formatPersistentReceipt(
     contractAddress,
     type: String((parsed as Record<string, unknown>).type ?? "0x0"),
   }
+}
+
+/**
+ * #386: split mempool txs into geth-compatible "pending" (contiguous
+ * from onchain nonce) vs "queued" (gap/future). Caches per-sender
+ * onchain nonce since multiple txs from the same sender share it.
+ *
+ * Returns the two buckets pre-shaped for `txpool_content`. Sort each
+ * sender's txs by nonce, then walk from the sender's onchain nonce —
+ * the contiguous run is "pending", everything after a gap is "queued".
+ */
+async function splitMempoolPendingQueued(
+  allTxs: ReturnType<IChainEngine["mempool"]["getAll"]>,
+  evm: EvmChain,
+): Promise<{
+  pending: Record<string, Record<string, unknown>>
+  queued: Record<string, Record<string, unknown>>
+}> {
+  const pending: Record<string, Record<string, unknown>> = {}
+  const queued: Record<string, Record<string, unknown>> = {}
+  const bySender = new Map<string, typeof allTxs>()
+  for (const mtx of allTxs) {
+    const arr = bySender.get(mtx.from) ?? []
+    arr.push(mtx)
+    bySender.set(mtx.from, arr)
+  }
+  for (const [sender, senderTxs] of bySender) {
+    senderTxs.sort((a, b) => (a.nonce < b.nonce ? -1 : a.nonce > b.nonce ? 1 : 0))
+    const onchainNonce = await evm.getNonce(sender)
+    let expected = onchainNonce
+    for (const mtx of senderTxs) {
+      const parsed = Transaction.from(mtx.rawTx)
+      const entry = {
+        hash: mtx.hash,
+        nonce: `0x${mtx.nonce.toString(16)}`,
+        from: mtx.from,
+        to: parsed.to ?? null,
+        value: `0x${(parsed.value ?? 0n).toString(16)}`,
+        gas: `0x${mtx.gasLimit.toString(16)}`,
+        gasPrice: `0x${mtx.gasPrice.toString(16)}`,
+        input: parsed.data ?? "0x",
+      }
+      const bucket = mtx.nonce === expected ? pending : queued
+      if (!bucket[sender]) bucket[sender] = {}
+      bucket[sender][mtx.nonce.toString()] = entry
+      if (mtx.nonce === expected) expected++
+    }
+  }
+  return { pending, queued }
+}
+
+/** #386: count-only variant for `txpool_status`. Same partition logic. */
+async function classifyMempoolPendingQueued(
+  allTxs: ReturnType<IChainEngine["mempool"]["getAll"]>,
+  evm: EvmChain,
+): Promise<{ pendingCount: number; queuedCount: number }> {
+  let pendingCount = 0
+  let queuedCount = 0
+  const bySender = new Map<string, bigint[]>()
+  for (const mtx of allTxs) {
+    const arr = bySender.get(mtx.from) ?? []
+    arr.push(mtx.nonce)
+    bySender.set(mtx.from, arr)
+  }
+  for (const [sender, nonces] of bySender) {
+    nonces.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    const onchainNonce = await evm.getNonce(sender)
+    let expected = onchainNonce
+    for (const nonce of nonces) {
+      if (nonce === expected) {
+        pendingCount++
+        expected++
+      } else {
+        queuedCount++
+      }
+    }
+  }
+  return { pendingCount, queuedCount }
 }
 
 /**


### PR DESCRIPTION
Closes #386.

## Summary

`txpool_status` hardcoded `queued: "0x0"` and `txpool_content`
hardcoded `queued: {}`. Both reported every mempool tx as pending,
regardless of nonce gaps. ethers/wagmi/web3.js stuck-tx detection
polls `txpool_content` and waits for a tx to move queued → pending,
but pre-fix nothing ever appeared in queued so the detection never
triggered.

## Live testnet 88780 reproduction (pre-fix)

```
$ eth_getTransactionCount(0xf39…266, "latest") → "0xbb" (187)
$ txpool_content
→ pending: { "0xf39…266": { "300": { nonce=0x12c, … } } }
→ queued:  {}                  # 113-tx gap, mis-classified
```

## Fix

Two new helpers:
- `splitMempoolPendingQueued` for txpool_content
- `classifyMempoolPendingQueued` for txpool_status (count-only)

Both walk per-sender txs sorted by nonce, starting from the sender's
onchain nonce. Contiguous run is pending; the first gap and
everything after is queued. Each sender's onchain nonce is read
once per call.

## Test plan

- [x] New regression `#386` in `node/src/rpc-extended.test.ts`
  - Signs two txs: nonce=N (contiguous), nonce=N+5 (gap)
  - txpool_status: pending ≥ 1, queued ≥ 1 (was always 0)
  - txpool_content: nonce N in pending, nonce N+5 in queued, NOT in pending
- [x] Verified fail-without-fix: `git stash push node/src/rpc.ts` →
      test fails (`gap nonce N+5 must NOT appear in pending`)
- [x] Full rpc-extended suite: 95/95 PASS
- [x] Full rpc suite: 5/5 PASS

## Real-world impact

- Wallet UIs (MetaMask "tx pending too long") now correctly identify stuck txs
- Ops dashboards alerting on `txpool_status.queued > threshold` can fire
- ethers/wagmi/web3.js polling-based confirmations behave correctly