### PR TITLE
fix(ipfs): /api/v0/pin/ls validates type filter (kubo parity) (#388)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -829,6 +829,67 @@ describe("IpfsHttpServer", () => {
     assert.equal(denied.status, 404)
   })
 
+  it("#388: /api/v0/pin/ls validates ?type= filter (kubo parity)", async () => {
+    // Pre-fix the handler ignored `type=` entirely:
+    //   - `type=bogus` → 200 with the full pin set (no filter applied)
+    //   - `type=indirect` → 200 with recursive-typed pins (wrong filter)
+    // Tools that partition by pin type (browser-IPFS, audit scripts)
+    // saw nonsense results. Kubo validates type ∈ {direct, indirect,
+    // recursive, all}; we now match that, and since COC's blockstore
+    // only tracks recursive pins, direct/indirect always returns empty.
+    //
+    // Live testnet 88780 reproduction:
+    //   $ curl -X POST 'http://node:28800/api/v0/pin/ls?type=bogus'
+    //   → 200 {"Keys":{... all pins, type-filter ignored ...}}
+    //   $ curl -X POST 'http://node:28800/api/v0/pin/ls?type=indirect'
+    //   → 200 {"Keys":{... all pins typed "recursive" ...}}
+    // Post-fix both reject with 400 / return empty as appropriate.
+
+    // Seed at least one pin.
+    const data = new TextEncoder().encode("hello-388")
+    const meta = await unixfs.addFile("p388.txt", data)
+    const pinRes = await fetch(`/api/v0/pin/add?arg=${meta.cid}`, { method: "POST" })
+    assert.equal(pinRes.status, 200)
+
+    // type=bogus → 400 invalid type
+    const bogusRes = await fetch("/api/v0/pin/ls?type=bogus")
+    assert.equal(bogusRes.status, 400, `type=bogus must be 400, got ${bogusRes.status}`)
+    const bogusBody = await bogusRes.json() as { error?: string; message?: string }
+    assert.match(
+      `${bogusBody.error} ${bogusBody.message ?? ""}`,
+      /invalid type|recursive/i,
+      `error must explain allowed values, got ${JSON.stringify(bogusBody)}`,
+    )
+
+    // type=recursive → returns full set
+    const recRes = await fetch("/api/v0/pin/ls?type=recursive")
+    assert.equal(recRes.status, 200)
+    const recBody = await recRes.json() as { Keys: Record<string, unknown> }
+    assert.ok(meta.cid in recBody.Keys, "recursive type returns the recursive pin")
+
+    // type=all → returns full set (default)
+    const allRes = await fetch("/api/v0/pin/ls?type=all")
+    assert.equal(allRes.status, 200)
+    const allBody = await allRes.json() as { Keys: Record<string, unknown> }
+    assert.ok(meta.cid in allBody.Keys, "type=all returns the pin")
+
+    // type=direct → empty (COC has no direct pins)
+    const directRes = await fetch("/api/v0/pin/ls?type=direct")
+    assert.equal(directRes.status, 200)
+    const directBody = await directRes.json() as { Keys: Record<string, unknown> }
+    assert.equal(Object.keys(directBody.Keys).length, 0, "COC has no direct pins → must be empty")
+
+    // type=indirect → empty
+    const indirectRes = await fetch("/api/v0/pin/ls?type=indirect")
+    assert.equal(indirectRes.status, 200)
+    const indirectBody = await indirectRes.json() as { Keys: Record<string, unknown> }
+    assert.equal(Object.keys(indirectBody.Keys).length, 0, "COC has no indirect pins → must be empty")
+
+    // pin/ls?arg=<cid>&type=direct → 404 (cid is recursive, not direct)
+    const cidDirectRes = await fetch(`/api/v0/pin/ls?arg=${meta.cid}&type=direct`)
+    assert.equal(cidDirectRes.status, 404, "cid lookup with wrong type returns 404")
+  })
+
   it("POST /api/v0/add accepts a 10 MB payload (regression: 10MB PUT was rejected by the 10MB exact cap)", async () => {
     const boundary = "----TenMbBoundary"
     const payload = Buffer.alloc(10 * 1024 * 1024, 0x61) // 10 MB of 'a'

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -590,6 +590,9 @@ export class IpfsHttpServer {
         // #372: batch filter — pin/ls with multiple args returns per-CID
         // status (kubo semantics).
         await this.handlePinLs(res, allQueryValues(url.query.arg))
+  })
+
+        await this.handlePinLs(res, argParam, firstQueryValue(url.query?.type))
         return
       }
       if (url.pathname === "/api/v0/pin/rm") {
@@ -1384,6 +1387,24 @@ export class IpfsHttpServer {
       resolvedType = type as AllowedType
     }
 
+  })
+
+    // #388: kubo's `/api/v0/pin/ls?type=<filter>` validates the filter
+    // string against {direct, indirect, recursive, all}. Pre-fix this
+    // handler ignored the `type` param entirely, so `type=bogus`
+    // silently returned the full pin set as if no filter were applied,
+    // and `type=indirect` returned recursive-typed pins. Tools that
+    // partition their UI by pin type (browser-IPFS, pin-management
+    // scripts) were broken on COC.
+    //
+    // COC's blockstore only tracks recursive pins, so the filter logic
+    // is straightforward: direct/indirect → empty, recursive/all → full
+    // set. Unknown values reject with 400.
+    const validTypes = new Set(["direct", "indirect", "recursive", "all"])
+    const resolvedType = type === undefined || type === "" ? "all" : type
+    if (!validTypes.has(resolvedType)) {
+      throw new HttpError(400, "invalid type", `pin type must be one of: ${[...validTypes].join(", ")}`)
+    }
     const pins = await this.store.listPins()
     if (cid !== undefined) {
       // Match the kubo `/api/v0/pin/ls?arg=<cid>` semantics: 404 when the
@@ -1411,6 +1432,13 @@ export class IpfsHttpServer {
     const pins = await this.store.listPins()
     if (cids.length === 0) {
       // No filter — return entire pin set (unchanged from pre-fix).
+  })
+
+      // #388: cid is recursive-typed. If caller asked for direct/indirect,
+      // the answer is "not in that bucket" → 404 (matches kubo).
+      if (resolvedType === "direct" || resolvedType === "indirect") {
+        throw new HttpError(404, "not pinned", `cid is recursive, not ${resolvedType}`)
+      }
       res.writeHead(200, { "content-type": "application/json" })
       res.end(JSON.stringify({ Keys: pins.reduce((acc, c) => {
         acc[c] = { Type: "recursive" }
@@ -1442,6 +1470,16 @@ export class IpfsHttpServer {
     }
     res.writeHead(200, { "content-type": "application/json" })
     res.end(JSON.stringify({ Keys: out }))
+  })
+
+    // #388: bulk listing — direct/indirect always empty on COC (no such
+    // pin types exist); recursive/all returns the full pin set.
+    const filteredPins = resolvedType === "direct" || resolvedType === "indirect" ? [] : pins
+    res.writeHead(200, { "content-type": "application/json" })
+    res.end(JSON.stringify({ Keys: filteredPins.reduce((acc, c) => {
+      acc[c] = { Type: "recursive" }
+      return acc
+    }, {} as Record<string, { Type: string }>) }))
   }
 
   private metaPath(): string {


### PR DESCRIPTION
Closes #388.

## Summary

`/api/v0/pin/ls` ignored the `?type=` query parameter entirely.
`type=bogus` returned the full pin set, `type=indirect` returned
recursive-typed pins — silently wrong filter results. kubo validates
`type ∈ {direct, indirect, recursive, all}` and returns 400 otherwise.

## Live testnet 88780 reproduction (pre-fix)

```
$ curl -X POST 'http://199.192.16.79:28800/api/v0/pin/ls?type=bogus'
→ 200 {"Keys":{ … all pins, filter ignored … }}
$ curl -X POST 'http://199.192.16.79:28800/api/v0/pin/ls?type=indirect'
→ 200 {"Keys":{ … recursive pins under wrong filter … }}
```

## Fix

Strict validation at the HTTP boundary. COC's blockstore only
tracks recursive pins, so direct/indirect → empty Keys set;
recursive/all → full pin set; anything else → 400. Per-CID
mismatch (e.g. `pin/ls?arg=<recursive-cid>&type=direct`) → 404.

## Test plan

- [x] New regression `#388` in `node/src/ipfs-http.test.ts`
  - 6 subtests: bogus (400), recursive (full), all (full),
    direct (empty), indirect (empty), per-CID mismatch (404)
- [x] Verified fail-without-fix: `git stash push node/src/ipfs-http.ts` →
      test fails (200 vs 400 for bogus, full set vs empty for direct)
- [x] Full ipfs-http suite: 51/51 PASS