### PR TITLE
fix(rpc): eth_getFilterLogs rejects non-log filter with -32602 (#390)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -332,10 +332,47 @@ test("RPC Extended Methods", async (t) => {
     // semantics (empty initial, no errors on poll).
   })
 
-  await t.test("#94: eth_getFilterLogs on a block filter returns [] (not log results)", async () => {
-    const fid = (await rpcCall(port, "eth_newBlockFilter")) as string
-    const result = (await rpcCall(port, "eth_getFilterLogs", [fid])) as unknown[]
-    assert.deepEqual(result, [], "getFilterLogs on a non-log filter must return []")
+  await t.test("#390: eth_getFilterLogs rejects non-log filter with -32602 (was silent [] pre-fix)", async () => {
+    // Pre-fix the handler returned `[]` for block/pendingTx filters with
+    // a misleading "match kubo/geth" comment. Geth actually returns
+    // "filter not found" when typ != LogsSubscription
+    // (filters/api.go: GetFilterLogs). Polling clients that hit the
+    // wrong method saw "no logs" forever instead of an error pointing
+    // at the type mismatch.
+    //
+    // Block filter case:
+    const blockFid = (await rpcCall(port, "eth_newBlockFilter")) as string
+    const r1 = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getFilterLogs", params: [blockFid] }),
+    })
+    const body1 = await r1.json() as { error?: { code: number; message: string } }
+    assert.ok(body1.error, "block filter must reject (not return [])")
+    assert.equal(body1.error!.code, -32602, `expected -32602, got ${body1.error!.code}`)
+    assert.match(body1.error!.message, /block filter|log filter/i, `message must name the type mismatch, got: ${body1.error!.message}`)
+
+    // Pending-tx filter case:
+    const ptxFid = (await rpcCall(port, "eth_newPendingTransactionFilter")) as string
+    const r2 = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "eth_getFilterLogs", params: [ptxFid] }),
+    })
+    const body2 = await r2.json() as { error?: { code: number; message: string } }
+    assert.ok(body2.error, "pendingTx filter must reject (not return [])")
+    assert.equal(body2.error!.code, -32602)
+    assert.match(body2.error!.message, /pendingTx filter|log filter/i)
+
+    // Log filter case (sanity: still works):
+    const logFid = (await rpcCall(port, "eth_newFilter", [{ fromBlock: "0x0" }])) as string
+    const r3 = await rpcCall(port, "eth_getFilterLogs", [logFid])
+    assert.ok(Array.isArray(r3), "log filter still works")
+
+    // Missing filter case (sanity: #342 unchanged, returns []):
+    const missing = "0x" + "00".repeat(16)
+    const r4 = await rpcCall(port, "eth_getFilterLogs", [missing])
+    assert.deepEqual(r4, [], "missing filter returns [] (#342 contract)")
   })
 
   await t.test("eth_getFilterLogs returns array", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1896,11 +1896,18 @@ async function handleRpc(
       if (!filter) throw { code: -32000, message: `filter not found: ${id}` }
       // Refresh last-access time so active polls keep the filter alive.
       filter.lastAccessedAtMs = Date.now()
-      // getFilterLogs is a log-filter-only method: block and pendingTx
-      // filters have no historical "logs" to return. Match the kubo/geth
-      // behaviour of returning [] rather than confusing the caller with
-      // garbage from an unintended code path.
-      if (filter.kind && filter.kind !== "log") return []
+      // #390: pre-fix `return []` for non-log filters silently masked a
+      // client-side bug (wrong method for filter type). The comment
+      // claimed "match geth" but geth actually returns
+      // "filter not found" when the filter's typ != LogsSubscription
+      // (filters/api.go: GetFilterLogs). Polling clients that hit the
+      // wrong method see "no logs" forever instead of an error pointing
+      // at the type mismatch. Reject with -32602 + a message that names
+      // the filter's actual kind so the client can switch to the right
+      // poll method (`eth_getFilterChanges` works for any kind).
+      if (filter.kind && filter.kind !== "log") {
+        invalidParams(`eth_getFilterLogs requires a log filter, got ${filter.kind} filter — use eth_getFilterChanges instead`)
+      }
       const height = await Promise.resolve(chain.getHeight())
       const end = filter.toBlock ?? height
       if (end - filter.fromBlock > MAX_LOG_BLOCK_RANGE) {


### PR DESCRIPTION
Closes #390.

## Summary

`eth_getFilterLogs` returned `[]` for block/pendingTx filters,
silently masking client-side bugs. Inline comment claimed kubo/geth
parity, but geth actually returns "filter not found" when
`f.typ != LogsSubscription` (filters/api.go: GetFilterLogs).

## Live testnet 88780 reproduction (pre-fix)

```
$ eth_newBlockFilter           → "0x432db346…"
$ eth_getFilterLogs(blockFid)  → 200 {"result": []}
```

Polling client sees "no logs" forever, never learning it used the
wrong method.

## Fix

Reject with -32602 naming both the actual filter kind and the
correct alternative method:

  `eth_getFilterLogs requires a log filter, got block filter —
   use eth_getFilterChanges instead`

Missing-filter case (#342 — returns []) is preserved. Only the
type-mismatch path becomes an error.

## Test plan

- [x] New regression `#390` in `node/src/rpc-extended.test.ts`
  - block filter → -32602 with "block filter" / "log filter" in message
  - pendingTx filter → -32602 with "pendingTx filter" / "log filter"
  - log filter → still returns array (sanity)
  - missing filter → still returns `[]` (preserves #342 contract)
- [x] Replaces obsolete `#94` test which asserted the old wrong-behavior
- [x] Verified fail-without-fix: `git stash push node/src/rpc.ts` → test fails
- [x] Full rpc-extended suite: 94/94 PASS