### PR TITLE
fix(rpc): admin_addPeer rejects non-http(s) URL schemes (#392)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2300,6 +2300,67 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#392: admin_addPeer rejects non-http(s) URL schemes (no deceptive true)", async () => {
+    // Pre-fix admin_addPeer only checked `new URL(peerUrl)` succeeded,
+    // accepting ftp://, file://, javascript:, data:, ws://, ldap:// —
+    // all returned `result:true` while peer-discovery's normalizePeer
+    // (peer-discovery.ts:451) silently dropped them downstream. The
+    // mismatch made the API deceptive: a caller saw success but the
+    // peer was never added.
+    //
+    // Live testnet 88780 reproduction (pre-fix, with admin RPC on):
+    //
+    //   $ admin_addPeer("ftp://evil.com/")     → 200 {"result":true}
+    //   $ admin_addPeer("file:///etc/passwd")  → 200 {"result":true}
+    //   $ admin_addPeer("javascript:alert(1)") → 200 {"result":true}
+    //   # All accepted at API, all silently dropped by normalizePeer.
+    //
+    // Worse, the `file://` case suggests a confused caller about what
+    // this method does; an attacker probing for an SSRF surface would
+    // see "true" and assume their URL was added.
+    const adminPort = port + 3000
+    const adminServer = startRpcServer(
+      "127.0.0.1", adminPort, chainId, evm, chain, p2p,
+      undefined, undefined, "admin-test", undefined,
+      undefined,
+      { enableAdminRpc: true },
+    )
+    try {
+      const probe = async (url: string) => {
+        const r = await fetch(`http://127.0.0.1:${adminPort}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "admin_addPeer", params: [url, "peer-x"] }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      // Each must fail with -32602; pre-fix all returned result:true.
+      const badSchemes = [
+        "ftp://evil.com/",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "data:text/plain,hello",
+        "ws://1.2.3.4/",
+        "ldap://attacker.com/",
+      ]
+      for (const url of badSchemes) {
+        const r = await probe(url)
+        assert.equal(r.error?.code, -32602,
+          `admin_addPeer(${url}) must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /scheme|http:|https:/i,
+          `error must mention scheme requirement, got: ${r.error!.message}`)
+        assert.notEqual(r.result, true, "must not return true for rejected scheme")
+      }
+      // http: and https: still accepted (sanity).
+      for (const url of ["http://1.2.3.4:30303/", "https://example.com/"]) {
+        const r = await probe(url)
+        assert.notEqual(r.error?.code, -32602, `${url}: must pass scheme validation`)
+      }
+    } finally {
+      adminServer.close()
+    }
+  })
+
   await t.test("#242: DID handlers reject non-string DID/agentId/credentialId (no silent coercion)", async () => {
     // Pre-fix 7 DID/identity handlers used `String((payload.params ?? [])[0] ?? "")`.
     // String(123)="123", String(true)="true", String({})="[object Object]" — all

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2663,8 +2663,20 @@ async function handleRpc(
       }
       const peerUrl = peerUrlRaw
       const peerId = (peerIdRaw ?? `peer-${Date.now()}`) as string
-      try { new URL(peerUrl) } catch {
-        invalidParams("invalid peer URL")
+      // #392: pre-fix only `new URL(...)` succeeded, accepting any scheme
+      // — ftp://, file://, javascript:, data:, ws://, ldap:// all passed.
+      // Downstream `normalizePeer` (peer-discovery.ts:451) silently
+      // dropped non-http(s) URLs, but the API returned `true` regardless,
+      // making the call deceptive — client thinks the peer was added but
+      // it wasn't. Worse, `file://` URLs landing here suggest a confused
+      // caller about what this API does. Reject non-http(s) at the
+      // boundary so the API contract matches downstream behaviour.
+      const parsedPeerUrl = (() => {
+        try { return new URL(peerUrl) }
+        catch { invalidParams("invalid peer URL") }
+      })()
+      if (parsedPeerUrl.protocol !== "http:" && parsedPeerUrl.protocol !== "https:") {
+        invalidParams(`invalid peer URL scheme: ${parsedPeerUrl.protocol} (must be http: or https:)`)
       }
       if (!/^[a-zA-Z0-9\-_.:]+$/.test(peerId)) {
         invalidParams("invalid peer ID: only alphanumeric, hyphens, underscores, dots, colons allowed")


### PR DESCRIPTION
Closes #392.

## Summary

`admin_addPeer` accepted ANY URL scheme — ftp://, file://,
javascript:, data:, ws://, ldap:// — and returned `result:true`.
Downstream `normalizePeer` silently dropped non-http(s) URLs, so
the peer was never actually added. API was deceptive.

## Live testnet 88780 reproduction (pre-fix)

```
$ admin_addPeer("ftp://evil.com/")      → {"result":true}
$ admin_addPeer("file:///etc/passwd")   → {"result":true}
$ admin_addPeer("javascript:alert(1)")  → {"result":true}
$ admin_addPeer("data:text/plain,h")    → {"result":true}
$ admin_addPeer("ws://1.2.3.4/")        → {"result":true}
$ admin_addPeer("ldap://attacker/")     → {"result":true}
$ coc_getPeers  # none of these appear
```

## Fix

Validate `parsedPeerUrl.protocol` at the RPC boundary. Anything
other than `http:` / `https:` returns -32602 with a clear
"must be http: or https:" message.

## Test plan

- [x] New regression `#392` in `node/src/rpc-extended.test.ts`
  - 6 non-http schemes (ftp, file, javascript, data, ws, ldap)
    each must be -32602
  - Error message names the scheme and the allowed values
  - http://, https:// still pass shape validation (sanity)
- [x] Verified fail-without-fix: `git stash push node/src/rpc.ts`
      → test fails (all 6 returned result:true pre-fix)
- [x] Full rpc-extended suite: 95/95 PASS

## Real-world impact

Operations tools that expected `admin_addPeer → true` to mean
"peer was added" finally see that signal. Pre-fix the silent
downstream drop made "why isn't my new peer connecting"
hard to debug.