### PR TITLE
fix(rpc): validateTxCallFields rejects illegal EIP-1559 field combos (#394)

### DIFF
--- a/node/src/rpc-validators.test.ts
+++ b/node/src/rpc-validators.test.ts
@@ -437,11 +437,23 @@ describe("requireStringParam (#242)", () => {
 })
 
 describe("validateTxCallFields (#148)", () => {
-  test("accepts all hex quantity fields", () => {
+  test("accepts all hex quantity fields (legacy-only)", () => {
+    // #394: legacy and EIP-1559 fee fields can't coexist — pre-fix the
+    // test mixed all three (gasPrice + maxFeePerGas + maxPriorityFeePerGas).
+    // After the EIP-1559 combination check, those combinations now reject,
+    // so this sanity case covers legacy-only.
     validateTxCallFields({
       value: "0x10",
       gas: "0x5208",
       gasPrice: "0x1",
+      data: "0xabcd",
+    })
+  })
+
+  test("accepts all hex quantity fields (EIP-1559)", () => {
+    validateTxCallFields({
+      value: "0x10",
+      gas: "0x5208",
       maxFeePerGas: "0x2",
       maxPriorityFeePerGas: "0x1",
       data: "0xabcd",
@@ -512,6 +524,50 @@ describe("validateTxCallFields (#148)", () => {
   test("#352: accepts exactly uint64-max gas (regression guard)", () => {
     const max64 = "0x" + "f".repeat(16)
     validateTxCallFields({ gas: max64, nonce: max64 })
+  })
+
+  test("#394: rejects gasPrice + maxFeePerGas combo (legacy/1559 mix)", () => {
+    const e = captureThrow(() =>
+      validateTxCallFields({ gasPrice: "0x1", maxFeePerGas: "0x2" }),
+    )
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /both gasPrice and \(maxFeePerGas or maxPriorityFeePerGas\)/i)
+  })
+
+  test("#394: rejects gasPrice + maxPriorityFeePerGas combo", () => {
+    const e = captureThrow(() =>
+      validateTxCallFields({ gasPrice: "0x1", maxPriorityFeePerGas: "0x1" }),
+    )
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /both gasPrice and/i)
+  })
+
+  test("#394: rejects maxFeePerGas < maxPriorityFeePerGas (tip > total)", () => {
+    const e = captureThrow(() =>
+      validateTxCallFields({ maxFeePerGas: "0x1", maxPriorityFeePerGas: "0x100" }),
+    )
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /maxPriorityFeePerGas.*>.*maxFeePerGas/i)
+  })
+
+  test("#394: accepts maxFeePerGas >= maxPriorityFeePerGas (sane EIP-1559 tx)", () => {
+    validateTxCallFields({ maxFeePerGas: "0x100", maxPriorityFeePerGas: "0x10" })
+    validateTxCallFields({ maxFeePerGas: "0x10", maxPriorityFeePerGas: "0x10" })
+  })
+
+  test("#394: accepts legacy-only (gasPrice without maxFee)", () => {
+    validateTxCallFields({ gasPrice: "0x3b9aca00" })
+  })
+
+  test("#394: accepts EIP-1559-only (maxFee without gasPrice)", () => {
+    validateTxCallFields({ maxFeePerGas: "0x3b9aca00", maxPriorityFeePerGas: "0x1" })
+  })
+
+  test("#394: empty string EIP-1559 fields don't trigger combo check", () => {
+    // value="" / null are common from ethers serialization for optional fields;
+    // they should be treated as "field absent" for combo validation.
+    validateTxCallFields({ gasPrice: "0x1", maxFeePerGas: "" })
+    validateTxCallFields({ gasPrice: "", maxFeePerGas: "0x1", maxPriorityFeePerGas: "0x1" })
   })
 })
 

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -447,6 +447,33 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
       invalidParams("invalid data: must match /^0x([0-9a-fA-F]{2})*$/")
     }
   }
+  // #394: EIP-1559 field combinations. Pre-fix each field was shape-
+  // validated in isolation but the relationship between them wasn't
+  // checked, so eth_call / eth_estimateGas / eth_sendTransaction
+  // accepted illegal combos that geth (and any tx parser) would
+  // reject downstream:
+  //
+  //   {gasPrice: 0x1, maxFeePerGas: 0x2}          → legacy + 1559 mix
+  //   {maxFeePerGas: 0x1, maxPriorityFeePerGas: 0x100} → tip > total
+  //
+  // The simulation path silently returned a result; a wallet that
+  // built the same tx and then called eth_sendRawTransaction got a
+  // surprise error. Match geth's eth_call by rejecting both shapes
+  // upfront with a clear message.
+  const hasLegacy = typeof callParams.gasPrice === "string" && callParams.gasPrice !== ""
+  const hasMaxFee = typeof callParams.maxFeePerGas === "string" && callParams.maxFeePerGas !== ""
+  const hasMaxTip = typeof callParams.maxPriorityFeePerGas === "string" && callParams.maxPriorityFeePerGas !== ""
+  if (hasLegacy && (hasMaxFee || hasMaxTip)) {
+    invalidParams("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+  }
+  if (hasMaxFee && hasMaxTip) {
+    // Compare without leading zeros: BigInt() handles arbitrary length.
+    const maxFee = BigInt(callParams.maxFeePerGas as string)
+    const maxTip = BigInt(callParams.maxPriorityFeePerGas as string)
+    if (maxTip > maxFee) {
+      invalidParams(`maxPriorityFeePerGas (${maxTip}) > maxFeePerGas (${maxFee})`)
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #394.

## Summary

`validateTxCallFields` shape-validated each fee field but didn't
check relationships. Two illegal combos slipped through:

- `gasPrice` mixed with `maxFeePerGas` / `maxPriorityFeePerGas`
- `maxFeePerGas < maxPriorityFeePerGas` (tip exceeds total fee cap)

Geth rejects both. COC silently produced a result, so wallets that
simulated successfully then saw broadcast fail with confusing
"transaction underpriced" errors from the RLP parser.

## Fix

Two combination checks in `validateTxCallFields` after the per-field
shape validation:

```ts
if (hasLegacy && (hasMaxFee || hasMaxTip)) {
  invalidParams("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
}
if (hasMaxFee && hasMaxTip) {
  if (BigInt(maxTip) > BigInt(maxFee)) {
    invalidParams(`maxPriorityFeePerGas (${maxTip}) > maxFeePerGas (${maxFee})`)
  }
}
```

Empty-string and undefined fields treated as absent so ethers'
optional-field serialization that emits `gasPrice: ""` alongside
EIP-1559 fields still works.

## Test plan

- [x] 6 new subtests in `rpc-validators.test.ts`: combo rejection,
      tip > fee, legacy-only sanity, EIP-1559-only sanity, empty-string
      doesn't trigger
- [x] Updated existing "accepts all hex quantity fields" — pre-fix it
      asserted accepting the illegal mix; split into legacy-only +
      EIP-1559-only sanity cases
- [x] Verified fail-without-fix: 3 subtests fail pre-fix
- [x] 96/96 validators + 99/99 rpc / rpc-extended PASS