### PR TITLE
fix(rpc): #396 eth_getUncle* handlers skip arg-shape validation

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -235,6 +235,61 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(count, "0x0")
   })
 
+  await t.test("#396: eth_getUncleCountByBlockHash rejects non-hash arg with -32602", async () => {
+    // Pre-fix the handler returned the no-uncle stub ("0x0") regardless
+    // of the param shape, so a non-string / non-hex hash silently came
+    // back as "no uncles" instead of -32602. Geth validates the hash
+    // shape first — clients that send garbage learn about misuse instead
+    // of receiving a "valid hash, no uncle" answer they could act on.
+    const garbageCases = [
+      { params: [12345], desc: "number" },
+      { params: [{}], desc: "object" },
+      { params: ["not-a-hash"], desc: "non-hex string" },
+      { params: ["0x123"], desc: "wrong-length hex" },
+      { params: [], desc: "missing arg" },
+    ]
+    for (const tc of garbageCases) {
+      const res = await rpcCallRaw(port, "eth_getUncleCountByBlockHash", tc.params)
+      assert.ok(res.error, `${tc.desc}: expected error, got result ${JSON.stringify(res)}`)
+      assert.strictEqual(
+        res.error.code,
+        -32602,
+        `${tc.desc}: expected code -32602, got ${res.error.code}`,
+      )
+    }
+    // Valid 32-byte hash still returns "0x0"
+    const valid = await rpcCall(port, "eth_getUncleCountByBlockHash", [
+      "0x" + "0".repeat(64),
+    ])
+    assert.strictEqual(valid, "0x0")
+  })
+
+  await t.test("#396: eth_getUncleByBlockHashAndIndex rejects non-hash and non-hex index", async () => {
+    // Same anti-pattern: the index param flowed straight to the null
+    // return without shape validation. Match the *byHash sibling so
+    // negative / non-hex indices surface as -32602.
+    const res1 = await rpcCallRaw(port, "eth_getUncleByBlockHashAndIndex", ["not-a-hash", "0x0"])
+    assert.strictEqual(res1.error?.code, -32602)
+    const res2 = await rpcCallRaw(port, "eth_getUncleByBlockHashAndIndex", [
+      "0x" + "0".repeat(64),
+      "not-hex",
+    ])
+    assert.strictEqual(res2.error?.code, -32602)
+    // Valid args still return null (no uncles on COC chain).
+    const valid = await rpcCall(port, "eth_getUncleByBlockHashAndIndex", [
+      "0x" + "0".repeat(64),
+      "0x0",
+    ])
+    assert.strictEqual(valid, null)
+  })
+
+  await t.test("#396: eth_getUncleByBlockNumberAndIndex rejects non-string tag", async () => {
+    const res = await rpcCallRaw(port, "eth_getUncleByBlockNumberAndIndex", [{}, "0x0"])
+    assert.strictEqual(res.error?.code, -32602)
+    const valid = await rpcCall(port, "eth_getUncleByBlockNumberAndIndex", ["0x0", "0x0"])
+    assert.strictEqual(valid, null)
+  })
+
   await t.test("eth_protocolVersion returns version", async () => {
     const version = await rpcCall(port, "eth_protocolVersion")
     assert.ok(typeof version === "string")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1741,11 +1741,34 @@ async function handleRpc(
       })
     }
     case "eth_getUncleCountByBlockHash":
-    case "eth_getUncleCountByBlockNumber":
-    case "eth_getUncleByBlockHashAndIndex":
-    case "eth_getUncleByBlockNumberAndIndex":
-      // COC uses PoSe consensus with no uncle blocks
+    case "eth_getUncleByBlockHashAndIndex": {
+      // #396: pre-fix returned the no-uncle stub ("0x0" / null) without
+      // ever inspecting the args, so non-hex / non-string block hashes
+      // silently came back as "has no uncles" instead of -32602. Geth
+      // validates the hash shape first and rejects malformed inputs
+      // regardless of whether the chain supports uncles. Validate the
+      // hash here so spec-violating clients learn about misuse — same
+      // class as #166 (block-hash-shape validation).
+      requireBlockHashParam(payload.params ?? [], 0)
+      if (payload.method === "eth_getUncleByBlockHashAndIndex") {
+        // Second param is the uncle index; validate shape too (#198).
+        requireIndexParam(payload.params ?? [], 1, "uncle index")
+      }
       return payload.method.includes("Count") ? "0x0" : null
+    }
+    case "eth_getUncleCountByBlockNumber":
+    case "eth_getUncleByBlockNumberAndIndex": {
+      // #396: same pre-fix anti-pattern as the *byHash siblings — the
+      // block tag was never validated, so a non-string param silently
+      // got the no-uncle stub. Match geth: parseBlockTag enforces shape.
+      const tag = (payload.params ?? [])[0]
+      const height = await Promise.resolve(chain.getHeight())
+      parseBlockTag(tag, height)
+      if (payload.method === "eth_getUncleByBlockNumberAndIndex") {
+        requireIndexParam(payload.params ?? [], 1, "uncle index")
+      }
+      return payload.method.includes("Count") ? "0x0" : null
+    }
     case "eth_getWork":
       // PoW stub — COC uses PoSe consensus, no mining
       return ["0x" + "0".repeat(64), "0x" + "0".repeat(64), "0x" + "0".repeat(64)]


### PR DESCRIPTION
Closes #396.

## Summary

- All four `eth_getUncle*` handlers share a single short-circuit return
  that fires before `payload.params` is inspected, so malformed shapes
  (`non-string hash`, `object as block tag`, `non-hex index`) silently
  receive the no-uncle stub instead of `-32602`. The rest of the
  `eth_getBlock*` family already rejects the same shapes (#166 / #198).
- Wrap each case in the existing validators
  (`requireBlockHashParam` / `parseBlockTag` / `requireIndexParam`)
  before returning the stub. Valid requests still return `"0x0"` / `null`.

## Files

- `node/src/rpc.ts` — split the merged cases by signature; validate
  args before returning the stub.
- `node/src/rpc-extended.test.ts` — 3 new regression tests asserting
  `-32602` for malformed shapes and the stub for valid args.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — all subtests PASS
- [x] Sanity check: `git stash node/src/rpc.ts` → 3 new tests turn `not ok` → restore → tests PASS