### PR TITLE
fix(rpc): #398 reject fractional ids and numeric ids past MAX_SAFE_INTEGER

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2008,6 +2008,50 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okStr.error, undefined, "id as string must be allowed")
   })
 
+  await t.test("#398: reject fractional ids and numeric ids past Number.MAX_SAFE_INTEGER", async () => {
+    // §4 — "Numbers SHOULD NOT contain fractional parts" AND values
+    // past 2^53-1 silently lose precision through V8 JSON.parse
+    // (a client sending id 9007199254740993 got back 9007199254740992,
+    // off by one) so clients tracking sequential 64-bit ids can't
+    // correlate the response. Number.isSafeInteger catches both.
+    // The pre-fix `Number.isFinite` accepted both.
+    const probe = async (body: Record<string, unknown>) => {
+      // Build the body manually so we can keep a giant numeric id as
+      // raw JSON (JSON.stringify would coerce through Number first).
+      const idRaw = body.__rawId as string | undefined
+      const json = idRaw !== undefined
+        ? `{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":${idRaw}}`
+        : JSON.stringify(body)
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: json,
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown; id?: unknown }
+    }
+    // Fractional id rejected
+    const fractional = await probe({ jsonrpc: "2.0", id: 1.5, method: "eth_chainId" })
+    assert.equal(fractional.error?.code, -32600, "id=1.5 must be -32600")
+    assert.match(fractional.error!.message, /id must be/i)
+    // 2^53 (one past MAX_SAFE_INTEGER) rejected
+    const overSafe = await probe({ jsonrpc: "2.0", __rawId: "9007199254740993", method: "eth_chainId" })
+    assert.equal(overSafe.error?.code, -32600, "id past MAX_SAFE_INTEGER must be -32600")
+    // 50-digit integer (massive precision loss) rejected
+    const huge = await probe({ jsonrpc: "2.0", __rawId: "12345678901234567890123456789012345678901234567890", method: "eth_chainId" })
+    assert.equal(huge.error?.code, -32600, "50-digit id must be -32600")
+    // Negative integer in safe range still works (spec doesn't ban negatives)
+    const neg = await probe({ jsonrpc: "2.0", id: -1, method: "eth_chainId" })
+    assert.equal(neg.error, undefined, "negative safe-integer id must work")
+    assert.equal(neg.id, -1, "id must echo verbatim")
+    // Exactly Number.MAX_SAFE_INTEGER allowed
+    const max = await probe({ jsonrpc: "2.0", id: Number.MAX_SAFE_INTEGER, method: "eth_chainId" })
+    assert.equal(max.error, undefined, "MAX_SAFE_INTEGER id must work")
+    // String ids of any length allowed (escape hatch for 64-bit clients)
+    const longStr = await probe({ jsonrpc: "2.0", id: "9999999999999999999", method: "eth_chainId" })
+    assert.equal(longStr.error, undefined, "long string id must work")
+    assert.equal(longStr.id, "9999999999999999999", "string id echoed verbatim")
+  })
+
   await t.test("#218: coc_submitProposal rejects malformed stakeAmount without leaking V8 BigInt error", async () => {
     // Pre-fix `BigInt(proposalParams.stakeAmount)` threw a V8 SyntaxError
     // when stakeAmount was an object/array/non-digit-string and the

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -667,11 +667,21 @@ async function handleOne(
   // Pre-fix objects, arrays, bools were silently echoed back, which
   // either crashed strict-typed client response parsers or masked
   // bugs on the caller side.
+  // #398: §4 — "Numbers SHOULD NOT contain fractional parts" AND any
+  // numeric id beyond Number.MAX_SAFE_INTEGER silently lost precision
+  // through V8's JSON.parse (e.g. id 9007199254740993 came back as
+  // 9007199254740992, off by one), which broke RPC response-correlation
+  // for clients using sequential 64-bit ids. `Number.isSafeInteger`
+  // catches both classes in one predicate: rejects floats AND ids
+  // outside [-(2^53-1), 2^53-1]. String ids of any length stay allowed
+  // for clients that need larger correlation tokens.
   if ("id" in payload) {
     const id = (payload as JsonRpcRequest).id
-    const idOk = id === null || typeof id === "string" || (typeof id === "number" && Number.isFinite(id))
+    const idOk = id === null
+      || typeof id === "string"
+      || (typeof id === "number" && Number.isSafeInteger(id))
     if (!idOk) {
-      return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id must be string, number, or null" } }
+      return { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request: id must be a safe integer, string, or null (no fractions, no precision-losing ints)" } }
     }
     // #316: bound the string-id surface. Pre-fix:
     //   - 5000-char id flowed straight back into every response (1:1 echo

--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -552,6 +552,39 @@ describe("WebSocket RPC", () => {
     }
   })
 
+  it("#398: WS reject fractional ids and numeric ids past MAX_SAFE_INTEGER", async () => {
+    // Parity with HTTP RPC #398. Pre-fix Number.isFinite let both
+    // through, and the id silently lost precision through V8 JSON.parse.
+    // Same correlation-breaking class as the HTTP path; tighten WS to
+    // Number.isSafeInteger.
+    const ws = await connectWs(WS_PORT)
+    try {
+      const probeRaw = (rawJson: string): Promise<{ error?: { code: number; message: string }; result?: unknown; id?: unknown }> =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error("probe timeout")), 2000)
+          const handler = (data: Buffer | string) => {
+            clearTimeout(timer)
+            ws.removeListener("message", handler)
+            try { resolve(JSON.parse(data.toString())) } catch (e) { reject(e) }
+          }
+          ws.on("message", handler)
+          ws.send(rawJson)
+        })
+      // Fractional id rejected.
+      const fractional = await probeRaw('{"jsonrpc":"2.0","id":1.5,"method":"eth_chainId","params":[]}')
+      assert.equal(fractional.error?.code, -32600, "id=1.5 must be -32600")
+      // 2^53 (one past MAX_SAFE_INTEGER) rejected.
+      const overSafe = await probeRaw('{"jsonrpc":"2.0","id":9007199254740993,"method":"eth_chainId","params":[]}')
+      assert.equal(overSafe.error?.code, -32600, "id past MAX_SAFE_INTEGER must be -32600")
+      // Valid id still works.
+      const ok = await probeRaw('{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}')
+      assert.equal(ok.error, undefined, "well-formed id must work")
+      assert.equal(ok.id, 1, "id echoed verbatim")
+    } finally {
+      ws.close()
+    }
+  })
+
   it("#208: eth_subscribe/eth_unsubscribe reject malformed params (no silent String() coercion)", async () => {
     // Pre-fix `String(params[0] ?? "")` silently coerced any input.
     // For subscribe: `[["newHeads"]]` joined the single-element array

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -406,12 +406,19 @@ export class WsRpcServer {
     }
     if ("id" in payload) {
       const id = payload.id
-      const idOk = id === null || typeof id === "string" || (typeof id === "number" && Number.isFinite(id))
+      // #398: same as HTTP RPC — reject fractional ids ("Numbers SHOULD
+      // NOT contain fractional parts", §4) AND numeric ids beyond
+      // Number.MAX_SAFE_INTEGER (silently lose precision through V8
+      // JSON.parse). Without this, a WS client tracking sequential 64-bit
+      // ids gets back an off-by-one echo and can't correlate the response.
+      const idOk = id === null
+        || typeof id === "string"
+        || (typeof id === "number" && Number.isSafeInteger(id))
       if (!idOk) {
         this.send(ws, {
           jsonrpc: "2.0",
           id: null,
-          error: { code: -32600, message: "invalid request: id must be string, number, or null" },
+          error: { code: -32600, message: "invalid request: id must be a safe integer, string, or null (no fractions, no precision-losing ints)" },
         })
         return
       }


### PR DESCRIPTION
Closes #398.

## Summary

- JSON-RPC §4 says \"Numbers SHOULD NOT contain fractional parts\", and
  any numeric id past `Number.MAX_SAFE_INTEGER` silently loses
  precision through V8's `JSON.parse` (id `9007199254740993` → echoed
  back as `9007199254740992`). Pre-fix `Number.isFinite` accepted both.
- Tighten the HTTP + WS RPC predicate to `Number.isSafeInteger`, which
  catches fractional ids AND ids outside `[-(2^53-1), 2^53-1]` in one
  check. String ids of any length stay allowed for clients needing
  bigger correlation tokens.

## Files

- `node/src/rpc.ts` — HTTP envelope validation.
- `node/src/websocket-rpc.ts` — WS envelope validation (same shape).
- `node/src/rpc-extended.test.ts` — \`#398\` regression test (fractional,
  past-safe-integer, 50-digit, negative, max-safe, long-string).
- `node/src/websocket-rpc.test.ts` — \`#398\` WS parity test.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — PASS
- [x] `node --experimental-strip-types --test node/src/websocket-rpc.test.ts` — PASS
- [x] Sanity: `git stash node/src/rpc.ts` → \`#398\` HTTP test `not ok` → restore → PASS