### PR TITLE
fix(rpc): #404 3 block-tag handlers silent-coerce array/bool to fake tag

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2364,6 +2364,64 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok3.error, undefined, "empty object filter must succeed")
   })
 
+  await t.test("#404: 3 block-tag handlers reject non-string tags (no silent String() coercion)", async () => {
+    // Pre-fix `String((payload.params ?? [])[0] ?? "latest")` collapsed
+    // `12345` → "12345" and `["0x64"]` → "0x64", letting both flow
+    // through parseBlockTag → real block lookup. Sibling of #250
+    // (eth_getBlockByNumber) and #256 (3 other block-tag handlers).
+    // The three handlers that missed that migration are:
+    //   - eth_getBlockReceipts (#114 added block-hash support but kept String())
+    //   - eth_getBlockTransactionCountByNumber
+    //   - eth_feeHistory[1] (newestBlock)
+    // Each handler should reject non-string/non-number shapes at -32602.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // Each handler with the same anti-pattern. true/false collapse to
+    // "true"/"false" pre-fix; ["0x1"] collapses to "0x1"; {} → "[object Object]"
+    // (already rejected so used as the *correct* control case).
+    const cases: Array<{ method: string; paramAt: 0 | 1 }> = [
+      { method: "eth_getBlockReceipts", paramAt: 0 },
+      { method: "eth_getBlockTransactionCountByNumber", paramAt: 0 },
+      { method: "eth_feeHistory", paramAt: 1 },
+    ]
+    for (const { method, paramAt } of cases) {
+      const make = (badTag: unknown): unknown[] => {
+        if (method === "eth_feeHistory") return ["0x4", badTag, [25]]
+        return paramAt === 0 ? [badTag] : [null, badTag]
+      }
+      // ["0x64"] is the most damning — pre-fix returned a real-looking
+      // result for block 100 instead of -32602.
+      const rArray = await probe(method, make(["0x64"]))
+      assert.equal(rArray.error?.code, -32602,
+        `${method}(["0x64"]) must be -32602, got ${JSON.stringify(rArray)}`)
+      // booleans must reject too
+      const rBool = await probe(method, make(true))
+      assert.equal(rBool.error?.code, -32602,
+        `${method}(true) must be -32602, got ${JSON.stringify(rBool)}`)
+      // {} stays rejected — control case
+      const rObj = await probe(method, make({}))
+      assert.equal(rObj.error?.code, -32602,
+        `${method}({}) must be -32602, got ${JSON.stringify(rObj)}`)
+      // Sanity: a well-formed string tag still works.
+      const rOk = await probe(method, make("latest"))
+      assert.equal(rOk.error, undefined,
+        `${method}("latest") must succeed, got ${JSON.stringify(rOk)}`)
+      // Numbers MUST work — parseBlockTag accepts them (kubo/clients
+      // sometimes send raw integers for "block N"). This is the part
+      // that String() coercion turned into a problem: number-as-input
+      // is valid, but bare arrays/booleans are not.
+      const rNum = await probe(method, make(0))
+      assert.equal(rNum.error, undefined,
+        `${method}(0 numeric) must succeed, got ${JSON.stringify(rNum)}`)
+    }
+  })
+
   await t.test("#248: coc_erasureStatus rejects non-string manifest CID", async () => {
     // Pre-fix `String((payload.params ?? [])[0] ?? "")` silently coerced
     // 123 → "123", true → "true", {} → "[object Object]" and forwarded

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1726,6 +1726,17 @@ async function handleRpc(
       // the raw input through so parseBlockTag's invalidParams branch
       // catches every non-string/non-number shape. Same fix as #250.
       const num = await resolveBlockNumber((payload.params ?? [])[0], chain)
+  })
+
+      // #404: pre-fix `String((payload.params ?? [])[0] ?? "latest")`
+      // collapsed `12345` to "12345" and `["0x64"]` to "0x64", letting
+      // both silently flow through parseBlockTag → real block lookup
+      // instead of -32602. Same anti-pattern as #250 (eth_getBlockByNumber)
+      // and #256 (3 other block-tag handlers). parseBlockTag accepts
+      // unknown and rejects non-string / non-number shapes — pass the
+      // raw param through.
+      const height = await Promise.resolve(chain.getHeight())
+      const num = parseBlockTag((payload.params ?? [])[0], height)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
@@ -1827,6 +1838,12 @@ async function handleRpc(
       // === "1500"` silently coerce a single-element array to block 1500.
       // Pass raw through resolveBlockNumber so non-string/non-number shapes
       // hit parseBlockTag's invalidParams branch. Same fix as #250.
+  })
+
+      // #404: pre-fix `String((payload.params ?? [])[1] ?? "latest")`
+      // silently coerced `100` to "100" and `["0x64"]` to "0x64"
+      // (#256/#250 anti-pattern). Pass the raw param so parseBlockTag
+      // rejects non-string / non-number shapes at -32602.
       const newestBlock = (payload.params ?? [])[1]
       // #224: `as number[]` was a TS runtime no-op so an object/string/
       // bool silently passed through (`{}.length === undefined`
@@ -2055,6 +2072,16 @@ async function handleRpc(
       // #256: pre-fix `String((params)[0] ?? "latest")` made `String([1500])
       // === "1500"` silently coerce a single-element array to block 1500.
       // Pass raw through resolveBlockNumber. Same fix as #250.
+  })
+
+      // #404: pre-fix `String((payload.params ?? [])[0] ?? "latest")`
+      // collapsed `12345` to "12345" and `["0x64"]` to "0x64", letting
+      // both silently flow through parseBlockTag → real block #100 lookup
+      // and clients got back the empty-receipts answer (the bug below
+      // returns `[]` for any block with 0 txs). Same anti-pattern as
+      // #250 (eth_getBlockByNumber) and #256 (3 other block-tag handlers).
+      // resolveBlockNumber accepts unknown and parseBlockTag rejects
+      // non-string / non-number shapes — pass the raw param through.
       const num = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       if (!block) return null


### PR DESCRIPTION
Closes #404.

## Summary

- `eth_getBlockReceipts`, `eth_getBlockTransactionCountByNumber`, and
  `eth_feeHistory`'s `newestBlock` still used the pre-#250 anti-pattern
  `String((payload.params ?? [])[N] ?? \"latest\")`, collapsing arrays
  and numbers silently to real block lookups. Sibling of #250 / #256 /
  #294 — these three got missed by the earlier migrations.
- Drop `String()` from all three sites. parseBlockTag accepts
  `unknown` and rejects non-string/non-number shapes — pass the raw
  param through.

## Files

- `node/src/rpc.ts` — three handlers, raw-param plumbing.
- `node/src/rpc-extended.test.ts` — `#404` regression covering
  bool / single-element-array / object × all three handlers, plus
  well-formed string + integer sanity cases.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — PASS
- [x] Sanity: `git stash node/src/rpc.ts` → `#404` `not ok` → restore → PASS