### PR TITLE
fix(rpc): #408 coc_getTransactionsByAddress silent-clamps limit/offset

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -534,6 +534,47 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(Array.isArray(ok), "valid address must return an array")
   })
 
+  await t.test("#408: coc_getTransactionsByAddress rejects limit/offset silent clamping", async () => {
+    // Pre-fix `Math.min(Math.max(rawLimit, 1), 10_000)` silently
+    // clamped `limit=0` → 1 (so clients asking for zero results got
+    // one back), `limit=-5` → 1, and `offset=-10` → 0 (no error).
+    // The sibling #254 fix rejected NaN/Infinity but not these.
+    // Reject upfront so clients with off-by-one paging logic don't
+    // act on silently-realigned results.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "coc_getTransactionsByAddress", params,
+        }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // limit edge cases
+    for (const badLimit of [0, -1, -100, 1.5, 10_001]) {
+      const r = await probe([validAddr, badLimit, true, 0])
+      assert.equal(r.error?.code, -32602,
+        `limit=${badLimit} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /limit/i, "error must name limit")
+    }
+    // offset edge cases
+    for (const badOffset of [-1, -100, 1.5, 100_001]) {
+      const r = await probe([validAddr, 50, true, badOffset])
+      assert.equal(r.error?.code, -32602,
+        `offset=${badOffset} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /offset/i, "error must name offset")
+    }
+    // Sanity: valid limit/offset still works
+    const okValid = await probe([validAddr, 50, true, 0])
+    assert.equal(okValid.error, undefined, "valid limit=50 offset=0 must work")
+    assert.ok(Array.isArray(okValid.result), "must return array")
+    // Sanity: omitted limit/offset still uses defaults (no error)
+    const okDefaults = await probe([validAddr])
+    assert.equal(okDefaults.error, undefined, "default limit/offset must work")
+  })
+
   await t.test("#118: eth_getStorageAt rejects malformed slots with -32602", async () => {
     // Pre-fix: invalid slots either leaked the evm's padded hex back
     // ("0x000…-1") or silently returned zero. Now each malformed shape

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2142,6 +2142,34 @@ async function handleRpc(
       const limit = optionalIntegerParam(payload.params ?? [], 1, "limit", 50, { min: 1, max: 10_000 })
       const reverse = optionalBooleanParam(payload.params ?? [], 2, "reverse", true)
       const offset = optionalIntegerParam(payload.params ?? [], 3, "offset", 0, { min: 0, max: 100_000 })
+  })
+
+      const rawAddr = String((payload.params ?? [])[0] ?? "")
+      if (!/^0x[0-9a-fA-F]{40}$/.test(rawAddr)) {
+        invalidParams("invalid address: must match /^0x[0-9a-fA-F]{40}$/")
+      }
+      const addr = rawAddr.toLowerCase() as Hex
+      // #408: pre-fix `Math.min(Math.max(rawLimit, 1), 10_000)` silently
+      // clamped `limit=0` → 1 (so clients asking for zero results got
+      // one back), `limit=-5` → 1, and `limit=1.5` → 1.5 (preserved
+      // because Math.max doesn't truncate). Same for offset: `-10` →
+      // 0 instead of -32602. The sibling #254 fix rejected NaN/Infinity
+      // but not these — clients with off-by-one paging logic get
+      // silently mis-aligned results. Reject upfront so spec-violating
+      // clients learn about misuse instead of acting on the wrong page.
+      const rawLimit = (payload.params ?? [])[1]
+      const limitVal = rawLimit === undefined || rawLimit === null ? 50 : Number(rawLimit)
+      if (!Number.isInteger(limitVal) || limitVal < 1 || limitVal > 10_000) {
+        invalidParams("invalid limit: must be an integer in [1, 10000]")
+      }
+      const limit = limitVal
+      const reverse = (payload.params ?? [])[2] !== false
+      const rawOffset = (payload.params ?? [])[3]
+      const offsetVal = rawOffset === undefined || rawOffset === null ? 0 : Number(rawOffset)
+      if (!Number.isInteger(offsetVal) || offsetVal < 0 || offsetVal > 100_000) {
+        invalidParams("invalid offset: must be an integer in [0, 100000]")
+      }
+      const offset = offsetVal
 
       if (typeof chain.getTransactionsByAddress === "function") {
         const txs = await chain.getTransactionsByAddress(addr, { limit, reverse, offset })


### PR DESCRIPTION
Closes #408.

## Summary

- `Math.min(Math.max(rawLimit, 1), 10_000)` silently rewrote `limit=0
  →1`, `limit=-5→1`, `limit=20000→10000`; `Math.max(rawOffset, 0)`
  did the same for negative offsets and `Math.min(..., 100_000)` for
  oversized ones. `Number.isFinite` (#254) rejected NaN but not these
  in-range boundary violations.
- Replace silent clamping with `Number.isInteger` + range check that
  emits `-32602` upfront. Same anti-pattern as #218 / #220 / #254.

## Files

- `node/src/rpc.ts` — strict validation in `coc_getTransactionsByAddress`.
- `node/src/rpc-extended.test.ts` — \`#408\` regression covering
  `limit ∈ {0, -1, -100, 1.5, 10001}`, `offset ∈ {-1, -100, 1.5, 100001}`
  must each be `-32602`, plus the default and well-formed sanity cases.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — PASS
- [x] Sanity: `git stash node/src/rpc.ts` → \`#408\` `not ok` → restore → PASS