### PR TITLE
fix(metrics+p2p): #414 HEAD on /metrics /health fall through to 404 (sibling of #410)

### DIFF
--- a/node/src/metrics-server.ts
+++ b/node/src/metrics-server.ts
@@ -34,7 +34,15 @@ export function startMetricsServer(
   timer.unref()
 
   const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-    if (req.url === "/metrics" && req.method === "GET") {
+    // #414: HEAD must mirror GET on read-only endpoints. Pre-fix the
+    // bare GET method gate let HEAD probes (Prometheus blackbox_exporter
+    // with method=HEAD, k8s livenessProbe httpHeaders HEAD) fall through
+    // to the 404 catch-all and the monitor flagged the service down.
+    // Sibling of #410 (faucet) and #376/#382. Node auto-suppresses the
+    // body for HEAD when Content-Length is set, so the same handler
+    // serves both verbs unchanged.
+    const isReadMethod = req.method === "GET" || req.method === "HEAD"
+    if (req.url === "/metrics" && isReadMethod) {
       try {
         await metrics.collect()
         const body = metrics.serialize()
@@ -47,7 +55,7 @@ export function startMetricsServer(
         res.writeHead(500, { "Content-Type": "text/plain" })
         res.end("metrics collection error\n")
       }
-    } else if (req.url === "/health") {
+    } else if (req.url === "/health" && isReadMethod) {
       res.writeHead(200, { "Content-Type": "text/plain" })
       res.end("ok\n")
     } else {

--- a/node/src/p2p.ts
+++ b/node/src/p2p.ts
@@ -473,7 +473,15 @@ export class P2PNode {
     if (this.server) return
     this.startedAtMs = Date.now()
     const server = http.createServer(async (req, res) => {
-      if (req.method === "GET" && req.url === "/health") {
+      // #414: HEAD must mirror GET on read-only endpoints. Pre-fix the
+      // bare GET method gate let HEAD probes (Prometheus, k8s
+      // livenessProbe httpHeaders HEAD) fall through to other branches
+      // and finally the 405 catch-all. Sibling of #410 / #376 / #382.
+      // Node auto-suppresses the body for HEAD when Content-Length is
+      // set, so the same handler serves both verbs unchanged. Only the
+      // /health endpoint widens here — the other P2P GET routes need
+      // request-body or signed-challenge inputs that HEAD never sends.
+      if ((req.method === "GET" || req.method === "HEAD") && req.url === "/health") {
         res.writeHead(200, { "content-type": "application/json" })
         res.end(serializeJson({ ok: true, ts: Date.now() }))
         return

--- a/runtime/lib/agent-metrics-server.test.ts
+++ b/runtime/lib/agent-metrics-server.test.ts
@@ -8,9 +8,18 @@ function httpGet(
   port: number,
   path: string,
 ): Promise<{ statusCode: number; body: string; contentType: string }> {
+  return httpRequest(host, port, path, "GET")
+}
+
+function httpRequest(
+  host: string,
+  port: number,
+  path: string,
+  method: string,
+): Promise<{ statusCode: number; body: string; contentType: string }> {
   return new Promise((resolve, reject) => {
     const req = request(
-      { host, port, path, method: "GET" },
+      { host, port, path, method },
       (res) => {
         const chunks: Buffer[] = []
         res.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
@@ -55,6 +64,36 @@ describe("agent-metrics-server", () => {
       const missingResp = await httpGet(handle.bind, handle.port, "/not-found")
       assert.equal(missingResp.statusCode, 404)
       assert.equal(missingResp.body, "not found\n")
+    } finally {
+      await handle.stop()
+    }
+  })
+
+  it("#414: HEAD on /metrics and /health returns 200 (uptime-monitor parity)", async () => {
+    // Pre-fix the bare GET method gate let HEAD probes fall through to
+    // the 404 catch-all (Prometheus blackbox_exporter with method=HEAD,
+    // k8s livenessProbe httpHeaders HEAD). Sibling of #410 / #376 /
+    // #382. Per HTTP/1.1 §9.4 HEAD must mirror GET on every read
+    // endpoint; Node auto-suppresses the body when Content-Length is
+    // set so the same handler serves both verbs.
+    const handle = await startAgentMetricsServer({
+      bind: "127.0.0.1",
+      port: 0,
+      getPrometheus: () => "coc_agent_pending_v1 0\n",
+    })
+    try {
+      // HEAD /metrics → 200 (body suppressed by Node)
+      const metricsHead = await httpRequest(handle.bind, handle.port, "/metrics", "HEAD")
+      assert.equal(metricsHead.statusCode, 200, "HEAD /metrics must be 200")
+      assert.match(metricsHead.contentType, /text\/plain/, "HEAD /metrics content-type must match")
+      // Per HTTP/1.1 §9.4, HEAD response has no body. Node auto-suppresses.
+      assert.equal(metricsHead.body, "", "HEAD /metrics must have empty body")
+      // HEAD /health → 200
+      const healthHead = await httpRequest(handle.bind, handle.port, "/health", "HEAD")
+      assert.equal(healthHead.statusCode, 200, "HEAD /health must be 200")
+      // HEAD /not-found → 404 (catch-all unchanged for non-read verbs / unknown URLs)
+      const missingHead = await httpRequest(handle.bind, handle.port, "/not-found", "HEAD")
+      assert.equal(missingHead.statusCode, 404, "HEAD on unknown URL stays 404")
     } finally {
       await handle.stop()
     }

--- a/runtime/lib/agent-metrics-server.ts
+++ b/runtime/lib/agent-metrics-server.ts
@@ -19,7 +19,14 @@ export async function startAgentMetricsServer(
   options: AgentMetricsServerOptions,
 ): Promise<AgentMetricsServerHandle> {
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-    if (req.method === "GET" && req.url === "/metrics") {
+    // #414: HEAD must mirror GET on read-only endpoints. Pre-fix the
+    // bare GET method gate let HEAD probes fall through to the 404
+    // catch-all (Prometheus blackbox_exporter with method=HEAD,
+    // k8s livenessProbe httpHeaders HEAD). Sibling of #410 / #376 /
+    // #382. Node auto-suppresses the body for HEAD when Content-Length
+    // is set, so handlers serve both verbs unchanged.
+    const isReadMethod = req.method === "GET" || req.method === "HEAD"
+    if (isReadMethod && req.url === "/metrics") {
       const body = options.getPrometheus()
       res.writeHead(200, {
         "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
@@ -29,7 +36,7 @@ export async function startAgentMetricsServer(
       return
     }
 
-    if (req.method === "GET" && req.url === "/health") {
+    if (isReadMethod && req.url === "/health") {
       res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" })
       res.end("ok\n")
       return


### PR DESCRIPTION
Closes #414.

## Summary

- Three more servers (\`node/src/metrics-server.ts\`,
  \`runtime/lib/agent-metrics-server.ts\`, \`node/src/p2p.ts\`)
  gated read-side endpoints on \`req.method === \"GET\"\` strictly,
  so HEAD probes fell through to the 404 catch-all — same anti-pattern
  as the faucet fix in #410.
- Widen the method gate to accept \`GET || HEAD\` for the read
  endpoints. Node auto-suppresses the body for HEAD when
  Content-Length is set, so handlers serve both verbs unchanged.
- \`node/src/p2p.ts\` widens only \`/health\` — the other P2P GET
  routes (chain-snapshot / state-snapshot / peers / identity-proof /
  node-info) need request-body or signed-challenge inputs HEAD never
  carries.

## Files

- \`node/src/metrics-server.ts\` — \`isReadMethod\` for /metrics, /health.
- \`runtime/lib/agent-metrics-server.ts\` — same.
- \`node/src/p2p.ts\` — /health only.
- \`runtime/lib/agent-metrics-server.test.ts\` — \`#414\` regression
  spins up a real server, asserts HEAD on /metrics + /health → 200,
  HEAD on unknown URL stays 404.

## Test plan

- [x] \`node --experimental-strip-types --test runtime/lib/agent-metrics-server.test.ts\` — PASS
- [x] \`node --experimental-strip-types --test node/src/p2p.test.ts\` — PASS (no regression)
- [x] Sanity: \`git stash runtime/lib/agent-metrics-server.ts\` → \`#414\` \`not ok\` → restore → PASS