### PR TITLE
fix(ipfs): #416 pubsub/peers accepts empty topic + all routes accept control chars

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1272,6 +1272,42 @@ describe("IpfsHttpServer", () => {
     assert.equal(legacyRes.status, 200, `legacy ?dest= cp must still succeed, got ${legacyRes.status}`)
   })
 
+  it("#416: /api/v0/pubsub/peers rejects empty topic + all routes reject control chars in topic", async () => {
+    // Pre-fix `pubsub/peers` had no empty-topic guard (the sibling
+    // `pub` and `sub` cases did), so `?arg=` flowed through and
+    // returned `{Strings:[], count:0}` — same as a real topic with
+    // no subscribers, so the caller couldn't tell their topic was
+    // missing. Separately, all three routes accepted topics with
+    // null bytes / ASCII control chars, which kubo's pubsub rejects
+    // as malformed UTF-8 routing keys.
+    const { IpfsPubsub } = await import("./ipfs-pubsub.ts")
+    const pubsub = new IpfsPubsub()
+    server.attachSubsystems({ pubsub })
+    // (a) pubsub/peers with empty topic now rejects with 400
+    const emptyPeers = await fetch("/api/v0/pubsub/peers?arg=", { method: "POST" })
+    assert.equal(emptyPeers.status, 400, "pubsub/peers with empty topic must be 400")
+    const emptyPeersBody = await emptyPeers.json() as { error?: string }
+    assert.match(emptyPeersBody.error ?? "", /missing topic/i, "error must name missing topic")
+    // (b) control char (null byte) rejected on every pubsub route
+    for (const route of ["pub", "sub", "peers"]) {
+      const url = `/api/v0/pubsub/${route}?arg=${encodeURIComponent("topic with-null")}`
+      const r = await fetch(url, { method: "POST" })
+      assert.equal(r.status, 400,
+        `pubsub/${route} with null byte must be 400, got ${r.status}`)
+      const body = await r.json() as { error?: string }
+      assert.match(body.error ?? "", /control character|invalid topic/i,
+        `pubsub/${route} error must name the topic`)
+    }
+    // (c) sanity: well-formed topic still accepted on pub + peers
+    const okPub = await fetch("/api/v0/pubsub/pub?arg=valid-topic", { method: "POST" })
+    assert.equal(okPub.status, 200, "well-formed pub must be 200")
+    const okPeers = await fetch("/api/v0/pubsub/peers?arg=valid-topic", { method: "POST" })
+    assert.equal(okPeers.status, 200, "well-formed peers must be 200")
+    const okPeersBody = await okPeers.json() as { Strings: string[]; count: number }
+    assert.deepEqual(okPeersBody.Strings, [], "no peers means empty array")
+    assert.equal(typeof okPeersBody.count, "number")
+  })
+
   it("#210: /api/v0/erasure/status maps ErasureError codes to 4xx (no 500 leak)", async () => {
     // Pre-fix the outer catch in IpfsHttpServer only mapped
     // ErasureError "invalid_params" → 400 and "not_found" → 404. The

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1810,6 +1810,18 @@ export class IpfsHttpServer {
         res.end(JSON.stringify({ error: "topic too long (max 512 chars)" }))
         return
       }
+      // #416: topic must not contain null bytes / control chars. Pre-fix
+      // a `topic` like "valid\x00trailing" silently flowed into pubsub
+      // subscribers (and any downstream store keyed on the string). Per
+      // kubo topics are non-empty UTF-8 with no control characters; line
+      // up so a buggy client learns about the malformed topic instead of
+      // pub-ing or peer-counting a partially-named topic.
+      const topicHasControlChar = topic.length > 0 && /[\x00-\x1f]/.test(topic)
+      if (topicHasControlChar) {
+        res.writeHead(400, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "invalid topic: must not contain control characters" }))
+        return
+      }
 
       // #312: reject control characters in topic name. Pre-fix, a topic
       // like `evil\0null` was accepted by pub AND sub; pubsub/ls then
@@ -1907,6 +1919,18 @@ export class IpfsHttpServer {
           break
         }
         case "peers": {
+          // #416: pre-fix the empty-topic case fell through and called
+          // `getSubscribers("")` which always returns 0 — same response
+          // as a real topic with no peers, so a client probing
+          // `pubsub/peers?arg=` couldn't tell their topic was missing.
+          // The sibling `pub` and `sub` cases reject empty topic with
+          // 400; line `peers` up so all three pubsub routes share the
+          // same contract.
+          if (!topic) {
+            res.writeHead(400, { "content-type": "application/json" })
+            res.end(JSON.stringify({ error: "missing topic" }))
+            break
+          }
           const count = this.pubsub.getSubscribers(topic)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ Strings: [], count }))


### PR DESCRIPTION
Closes #416.

## Summary

- \`pubsub/peers\` lacked the empty-topic guard that \`pub\` and \`sub\`
  already had — \`?arg=\` returned a misleading \"no subscribers\" answer
  indistinguishable from real empty topics.
- All three pubsub routes accepted topics with null bytes / ASCII
  control chars (\`\\x00-\\x1f\`). Length cap #284 bounded memory but
  didn't reject malformed UTF-8 routing keys.
- Add empty-topic guard to \`peers\` and a centralized control-char
  rejection before the route dispatch so the three routes share the
  same shape contract.

## Files

- \`node/src/ipfs-http.ts\` — empty-topic guard for \`peers\`, central
  control-char rejection for all pubsub routes.
- \`node/src/ipfs-http.test.ts\` — \`#416\` regression covering all
  three routes × control-char + \`peers\`-only empty topic +
  well-formed sanity.

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-http.test.ts\` — PASS
- [x] Sanity: \`git stash node/src/ipfs-http.ts\` → \`#416\` \`not ok\` → restore → PASS