### PR TITLE
fix(ipfs): #418 MFS normalizePath accepts whitespace-only path components

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -312,6 +312,36 @@ test("#306: write to NEW file with offset pads with zeros (sparse-style)", async
       assert.strictEqual(read[i], 0, `byte ${i} must be zero (zero-padded prefix)`)
     }
     assert.strictEqual(new TextDecoder().decode(read.slice(100)), "TAIL")
+  })
+
+test("#418: normalizePath rejects whitespace-only path components", async () => {
+  // Pre-fix `mkdir " "` (single space), `mkdir "\t\t"`, `mkdir "   "`
+  // silently created directories named with whitespace under root —
+  // a sibling silent-success class to the #380 empty-arg case. Reject
+  // in normalizePath so every MFS route (mkdir, write, cp, mv, stat,
+  // ls, rm) inherits the check instead of duplicating it per-route.
+  // Live on 88780: `curl -X POST $IPFS/api/v0/files/mkdir?arg=%20`
+  // returned `{"ok":true}` and `files/ls /` showed a directory named " ".
+  const { mfs, cleanup } = await createMfs()
+  try {
+    // Single-space component → reject
+    await assert.rejects(() => mfs.mkdir(" "), /whitespace-only/)
+    // Tab-only component → reject
+    await assert.rejects(() => mfs.mkdir("\t\t"), /whitespace-only/)
+    // Multi-space component → reject
+    await assert.rejects(() => mfs.mkdir("   "), /whitespace-only/)
+    // Whitespace component nested in a path → reject
+    await assert.rejects(() => mfs.mkdir("/valid/ /child", { parents: true }), /whitespace-only/)
+    // Mixed-whitespace component → reject
+    await assert.rejects(() => mfs.mkdir(" \t "), /whitespace-only/)
+    // Sanity: normal directory names with leading/trailing whitespace
+    // are NOT rejected (the validator only catches *entirely*
+    // whitespace components — to avoid breaking legitimately-named
+    // entries like "hello world.txt" or " filename").
+    await mfs.mkdir(" leading-space")
+    const entries = await mfs.ls("/")
+    assert.ok(entries.some((e) => e.name === " leading-space"),
+      "non-whitespace-only names with spaces still allowed")
   } finally {
     cleanup()
   }
@@ -429,6 +459,21 @@ test("#306: existing-file overwrite at offset preserves tail (regression for old
     const read = await mfs.read("/o.bin")
     assert.strictEqual(new TextDecoder().decode(read), "ABCXYZGHIJ",
       "overwrite at offset must preserve bytes before+after the written slice")
+  })
+
+test("#418: write rejects whitespace-only path components", async () => {
+  // Same class as mkdir — write would otherwise create files named
+  // " " or "\t" under root.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await assert.rejects(
+      () => mfs.write(" ", new TextEncoder().encode("data"), { create: true }),
+      /whitespace-only/,
+    )
+    await assert.rejects(
+      () => mfs.write("\t", new TextEncoder().encode("data"), { create: true }),
+      /whitespace-only/,
+    )
   } finally {
     cleanup()
   }

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -505,6 +505,18 @@ function normalizePath(path: string): string {
     if (part === ".." || part === ".") {
       throw new Error(`path traversal not allowed: ${path}`)
     }
+    // #418: non-root path components must contain at least one
+    // non-whitespace character. Pre-fix `arg=%20` (single space)
+    // and `arg=%09` (tab) silently created directories / files named
+    // " " or "\t" under root — same class of silent garbage as the
+    // #380 empty-arg case the previous fix already rejected for
+    // mkdir. Reject in the shared normalizer so every MFS route
+    // (mkdir, write, cp, mv, stat, ls, rm) inherits the check
+    // instead of duplicating it per-route. Skip the root slot
+    // (parts[0] is always "" by construction).
+    if (part !== "" && /^\s+$/.test(part)) {
+      throw new Error(`invalid path: component cannot be whitespace-only: ${JSON.stringify(part)}`)
+    }
   }
   return path
 }


### PR DESCRIPTION
Closes #418.

## Summary

- Sibling to #380 (empty \`?arg=\` rejected). \`arg=%20\` (single
  space), \`arg=%09\` (tab), and any whitespace-only path component
  flowed through \`normalizePath\` unchanged, then mkdir/write
  created a directory or file named \" \" / \"\\t\" / \"   \".
- Tighten the check in \`normalizePath\` so every MFS route inherits
  the rejection — single source of truth. Only rejects components
  that are *entirely* whitespace; legitimately-named entries like
  \" filename.txt\" still pass.

## Files

- \`node/src/ipfs-mfs.ts\` — add whitespace-only component check in
  \`normalizePath\`.
- \`node/src/ipfs-mfs.test.ts\` — \`#418\` regression covering
  single-space, tab-only, multi-space, mixed-whitespace, and nested
  component cases plus a leading-space sanity case.

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-mfs.test.ts\` — PASS (15/15)
- [x] Sanity: \`git stash node/src/ipfs-mfs.ts\` → both \`#418\` tests \`not ok\` → restore → PASS

## Notes

- Route-level catch in \`ipfs-http.ts\` already maps \`^invalid /\`
  wording to 400 (since #232), so HTTP-side surfaces as
  \`400 bad request\` without further changes.
- Does NOT reject leading / trailing whitespace, only fully
  whitespace components.