### PR TITLE
fix(ipfs): #420 MFS cp/mv with src===dest silently 200 ok

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1736,6 +1736,16 @@ export class IpfsHttpServer {
           // IS in the alternation. /files/mv with that shape fell through
           // to 500 + ERROR log. Same regex-mismatch family as #232/#268.
           /^cannot (remove|operate on|copy|move)/i.test(msg) ||
+  })
+
+          /^cannot (remove|operate on|copy)/i.test(msg) ||
+          // #420: cp/mv with src===dest pre-fix silently returned 200
+          // ok (line 239 of ipfs-mfs.ts said `return` for same-path).
+          // After tightening to throw, the message starts with
+          // "source and destination are the same:" — neither
+          // /^cannot/ nor any other existing alternation catches it,
+          // so without this regex the new error would leak as 500.
+          /^source and destination are the same/i.test(msg) ||
           /must be/i.test(msg) ||
           /^missing /i.test(msg) ||
           /^write would exceed/i.test(msg) ||

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -342,6 +342,32 @@ test("#418: normalizePath rejects whitespace-only path components", async () => 
     const entries = await mfs.ls("/")
     assert.ok(entries.some((e) => e.name === " leading-space"),
       "non-whitespace-only names with spaces still allowed")
+  })
+
+test("#420: mv with src===dest rejects instead of silent no-op", async () => {
+  // Pre-fix `mv("/a", "/a")` silently returned (line 239 of mfs.ts:
+  // `if (srcNorm === destNorm) return`), masking client typos where
+  // someone meant to rename /a → /b but typed /a → /a. POSIX `mv` +
+  // kubo MFS both reject; align so a buggy client (variable
+  // confusion, accidental copy-paste) learns about misuse.
+  // Live on 88780: `files/mv?arg=/cp-test&arg=/cp-test` returned
+  // `{"ok":true}` status=200.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/file.txt", new TextEncoder().encode("data"), { create: true })
+    await assert.rejects(
+      () => mfs.mv("/file.txt", "/file.txt"),
+      /source and destination are the same/,
+    )
+    // Sanity: file is still present after the rejected mv.
+    const data = await mfs.read("/file.txt")
+    assert.strictEqual(new TextDecoder().decode(data), "data",
+      "rejected mv must leave source intact")
+    // Sanity: real rename still works.
+    await mfs.mv("/file.txt", "/renamed.txt")
+    await assert.rejects(() => mfs.read("/file.txt"), /not found/)
+    const data2 = await mfs.read("/renamed.txt")
+    assert.strictEqual(new TextDecoder().decode(data2), "data")
   } finally {
     cleanup()
   }
@@ -474,6 +500,28 @@ test("#418: write rejects whitespace-only path components", async () => {
       () => mfs.write("\t", new TextEncoder().encode("data"), { create: true }),
       /whitespace-only/,
     )
+  })
+
+test("#420: cp with src===dest rejects instead of silent no-op", async () => {
+  // Same silent-no-op class as mv. POSIX `cp /a /a` is "same file"
+  // error; kubo MFS rejects too.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/file.txt", new TextEncoder().encode("data"), { create: true })
+    await assert.rejects(
+      () => mfs.cp("/file.txt", "/file.txt"),
+      /source and destination are the same/,
+    )
+    // Sanity: file is still present after the rejected cp.
+    const data = await mfs.read("/file.txt")
+    assert.strictEqual(new TextDecoder().decode(data), "data",
+      "rejected cp must leave source intact")
+    // Sanity: real copy still works.
+    await mfs.cp("/file.txt", "/copy.txt")
+    const orig = await mfs.read("/file.txt")
+    const copy = await mfs.read("/copy.txt")
+    assert.strictEqual(new TextDecoder().decode(orig), "data")
+    assert.strictEqual(new TextDecoder().decode(copy), "data")
   } finally {
     cleanup()
   }

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -266,8 +266,16 @@ export class IpfsMfs {
     const srcNorm = normalizePath(source)
     const destNorm = normalizePath(dest)
 
-    // No-op when source and destination are identical
-    if (srcNorm === destNorm) return
+    // #420: pre-fix `if (srcNorm === destNorm) return` silently
+    // succeeded for `mv /a /a`, masking client typos. POSIX `mv` and
+    // kubo's MFS reject same-path mv with an error; do the same so
+    // a buggy client (variable confusion, accidental copy-paste)
+    // learns about misuse instead of getting a 200 ok for what they
+    // probably meant to be a real rename. Same class as #380 / #418
+    // silent-success in MFS.
+    if (srcNorm === destNorm) {
+      throw new Error(`source and destination are the same: ${srcNorm}`)
+    }
 
     // Prevent moving a directory into its own subtree
     if (destNorm.startsWith(srcNorm + "/")) {
@@ -337,8 +345,15 @@ export class IpfsMfs {
     const srcNorm = normalizePath(source)
     const destNorm = normalizePath(dest)
 
-    // No-op when source and destination are identical
-    if (srcNorm === destNorm) return
+    // #420: pre-fix `if (srcNorm === destNorm) return` silently
+    // succeeded for `cp /a /a`, masking client typos. POSIX `cp` and
+    // kubo's MFS reject same-path cp with an error; do the same so a
+    // buggy client (variable confusion, accidental copy-paste) learns
+    // about misuse instead of getting a 200 ok for what they probably
+    // meant to be a real copy.
+    if (srcNorm === destNorm) {
+      throw new Error(`source and destination are the same: ${srcNorm}`)
+    }
 
     // Prevent copying a directory into its own subtree (infinite recursion)
     if (destNorm.startsWith(srcNorm + "/")) {


### PR DESCRIPTION
Closes #420.

## Summary

- \`mv /a /a\` and \`cp /a /a\` silently returned ok (line 239 / 288
  in ipfs-mfs.ts said \`if (srcNorm === destNorm) return\`). POSIX +
  kubo both reject same-path operations as client errors.
- Throw \`source and destination are the same: <path>\` in both
  paths.
- Extend ipfs-http.ts catch regex with \`^source and destination are
  the same\` so the HTTP layer maps to 400 (same location as #270 /
  #268 / #232 sibling fixes).

## Files

- \`node/src/ipfs-mfs.ts\` — throw in cp + mv same-path branches.
- \`node/src/ipfs-http.ts\` — add regex alternation for 400 mapping.
- \`node/src/ipfs-mfs.test.ts\` — \`#420\` regression on cp + mv
  same-path, source-untouched after rejection, real rename/copy
  sanity.

## Test plan

- [x] \`node --experimental-strip-types --test node/src/ipfs-mfs.test.ts\` — PASS (15/15)
- [x] Sanity: \`git stash node/src/ipfs-mfs.ts\` → both \`#420\` tests \`not ok\` → restore → PASS

Same class as #380 / #418 silent-success in MFS.