### PR TITLE
fix(rpc): #422 eth_getBlockByHash(ZERO_HASH) returns synthesised genesis

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1118,6 +1118,44 @@ test("RPC Extended Methods", async (t) => {
     assert.match(String(balLatest), /^0x[0-9a-f]+$/, "eth_getBalance(latest) still works")
   })
 
+  await t.test("#422: eth_getBlockByHash(ZERO_HASH) returns the same synthesised genesis (parity with eth_getBlockByNumber)", async () => {
+    // Pre-fix: eth_getBlockByNumber("0x0") synthesised a genesis block
+    // with hash = all-zeros (#112). Block 1's parentHash carried the
+    // same all-zeros value. But eth_getBlockByHash lacked the
+    // symmetric synthesis path — a client that grabbed block 1,
+    // followed parentHash, and called `provider.getBlock(parentHash)`
+    // got `null` and broke. Mirror #112 so both lookups agree.
+    //
+    // Live testnet 88780 reproduction (pre-fix):
+    //   getBlockByNumber("0x0")  → hash 0x000…000 (synthesised)
+    //   getBlockByHash(0x000…000) → null   (asymmetric!)
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block so height ≥ 1")
+    const ZERO_HASH = "0x" + "0".repeat(64)
+    const byNum = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
+    assert.equal(byNum.hash, ZERO_HASH, "synthesised genesis hash must be all-zeros (sanity)")
+    const byHash = await rpcCall(port, "eth_getBlockByHash", [ZERO_HASH, false]) as Record<string, unknown> | null
+    assert.ok(byHash !== null, "eth_getBlockByHash(ZERO_HASH) must not be null when synth-genesis is on")
+    assert.equal(byHash!.number, "0x0", "by-hash genesis must have number 0x0")
+    assert.equal(byHash!.hash, ZERO_HASH, "by-hash genesis hash must match by-number")
+    assert.equal(byHash!.parentHash, ZERO_HASH)
+    assert.deepEqual(byHash!.transactions, [])
+    // Sanity: a non-zero hash that doesn't exist still returns null
+    const fakeHash = "0x" + "ab".repeat(32)
+    const nullResult = await rpcCall(port, "eth_getBlockByHash", [fakeHash, false])
+    assert.equal(nullResult, null, "non-zero non-existent hash must still return null")
+    // Sanity: includeTx=true also works through synthesis
+    const byHashWithTx = await rpcCall(port, "eth_getBlockByHash", [ZERO_HASH, true]) as Record<string, unknown>
+    assert.ok(byHashWithTx !== null)
+    assert.deepEqual(byHashWithTx.transactions, [])
+    // Symmetric reachability: block 1's parentHash points to the
+    // synthesised genesis and a client can follow it.
+    const block1 = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+    assert.equal(block1.parentHash, ZERO_HASH, "block 1 parentHash anchors to synth genesis (sanity)")
+    const parent = await rpcCall(port, "eth_getBlockByHash", [block1.parentHash, false]) as Record<string, unknown>
+    assert.ok(parent !== null, "client following block1.parentHash must reach the genesis (not null)")
+  })
+
   await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
     const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
     assert.ok(Array.isArray(peers), "must return an array")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -905,6 +905,23 @@ async function handleRpc(
       // #260: same Boolean(...) silent-coercion bug as eth_getBlockByNumber.
       const includeTx = optionalBooleanParam(payload.params ?? [], 1, "includeTx", false)
       const block = await Promise.resolve(chain.getBlockByHash(hash))
+      // #422: eth_getBlockByNumber("0x0") synthesises a genesis block
+      // (per #112) with hash = all-zeros. Block 1's parentHash carries
+      // the same all-zeros value. But eth_getBlockByHash never had the
+      // symmetric synthesis path — a client that grabbed block 1,
+      // followed parentHash, and called `provider.getBlock(parentHash)`
+      // got `null` and broke. Mirror #112: if the lookup hash is the
+      // all-zeros synthesis hash AND chain.height ≥ 1 AND no real
+      // block-0 is persisted, return the same synthesised genesis.
+      if (!block && /^0x0+$/.test(hash) && hash.length === 66) {
+        const height = await Promise.resolve(chain.getHeight())
+        if (height >= 1n) {
+          const realBlockZero = await Promise.resolve(chain.getBlockByNumber(0n))
+          if (!realBlockZero) {
+            return formatGenesisBlock(includeTx)
+          }
+        }
+      }
       return formatBlock(block, includeTx, chain, evm)
     }
     case "eth_gasPrice": {


### PR DESCRIPTION
Closes #422.

## Summary

`eth_getBlockByNumber("0x0")` synthesises a genesis block (per #112)
with `hash = 0x000…000`. Block 1's `parentHash` carries the same
all-zeros value. But `eth_getBlockByHash` lacked the symmetric
synthesis path — a client that walked `block1.parentHash` and called
`provider.getBlock(parentHash)` got `null` and broke.

## Live testnet 88780 reproduction (pre-fix)

```
$ curl … eth_getBlockByNumber(["0x0",false])
→ hash 0x000…000           # synthesised, OK

$ curl … eth_getBlockByHash(["0x000…000",false])
→ null                       # asymmetric!

$ curl … eth_getBlockByNumber(["0x1",false])
→ parentHash 0x000…000      # client follows this → null
```

## Fix

`eth_getBlockByHash` now mirrors `eth_getBlockByNumber`: when the
lookup hash is all-zeros AND `chain.height ≥ 1` AND no real block 0
is persisted, return `formatGenesisBlock(includeTx)`. Both shapes
now agree, and `block1.parentHash` is followable to the genesis.

## Test plan

- [x] New regression `#422` in `node/src/rpc-extended.test.ts`
  - by-hash(ZERO_HASH) matches by-number("0x0") field-by-field
  - non-zero non-existent hash still returns null
  - `includeTx=true` works through the synthesis
  - block 1's parentHash → genesis (not null)
- [x] Fail-without-fix verified: `git stash push node/src/rpc.ts` →
      `not ok 51 - #422`; restore → pass
- [x] Full rpc-extended suite: 97/97 PASS

## Real-world impact

ethers v6 / viem / wagmi all walk `parentHash` during fork-detection
and reorg-recovery. Pre-fix any such tooling stalled at block 1.
Post-fix the parent chain is fully traversable on chainId 88780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)