### PR TITLE
fix(rpc): #424 reward handlers validate before backend-config short-circuit

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2939,6 +2939,61 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okC.error, undefined, `well-shaped getRewardClaim must succeed: ${JSON.stringify(okC)}`)
   })
 
+  await t.test("#424: coc_getRewardManifest / coc_getRewardClaim validate epochId/nodeId before the rewardManifestDir short-circuit", async () => {
+    // Pre-fix the handler ran `if (!rewardManifestDir) return null` BEFORE
+    // `requireIntegerParam` / `requireStringParam`, so any node where the
+    // manifest dir wasn't configured (every read-only fullnode on
+    // testnet 88780) silently returned `null` for garbage epochId
+    // (`"1"`, `true`, `[1]`). Clients couldn't tell "input invalid" from
+    // "feature not configured". Validation belongs at the boundary —
+    // backend configuration is irrelevant to input shape.
+    //
+    // Spin up a second RPC server WITHOUT `rewardManifestDir` (the
+    // unconfigured shape). Same validation rules must apply.
+    const port2 = port + 1000
+    const server2 = startRpcServer("127.0.0.1", port2, chainId, evm, chain, p2p, undefined, undefined, undefined, undefined, {
+      // intentionally omit rewardManifestDir → unconfigured backend
+      getBftEquivocations: () => [],
+    })
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      const probe = async (method: string, params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${port2}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      // Garbage epochId must still be -32602, NOT silent null,
+      // even though the backend has no manifest dir configured.
+      for (const bad of [true, false, "1", "5", [1], {}, 1.5, -1]) {
+        const m = await probe("coc_getRewardManifest", [bad])
+        assert.equal(m.error?.code, -32602,
+          `unconfigured backend: getRewardManifest(${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(m)}`)
+        const c = await probe("coc_getRewardClaim", [bad, `0x${"22".repeat(32)}`])
+        assert.equal(c.error?.code, -32602,
+          `unconfigured backend: getRewardClaim(${JSON.stringify(bad)}, ...) must be -32602, got ${JSON.stringify(c)}`)
+      }
+      // Garbage nodeId on otherwise valid epoch must also reject.
+      for (const bad of [123, true, {}, [1]]) {
+        const r = await probe("coc_getRewardClaim", [7, bad])
+        assert.equal(r.error?.code, -32602,
+          `unconfigured backend: getRewardClaim(7, ${JSON.stringify(bad)}) must be -32602, got ${JSON.stringify(r)}`)
+      }
+      // Sanity: VALID input on unconfigured backend returns null (the
+      // documented behaviour when no manifest dir is configured).
+      const okM = await probe("coc_getRewardManifest", [7])
+      assert.equal(okM.error, undefined, `valid input must not error, got ${JSON.stringify(okM)}`)
+      assert.equal(okM.result, null, "valid input + unconfigured dir → null")
+      const okC = await probe("coc_getRewardClaim", [7, `0x${"22".repeat(32)}`])
+      assert.equal(okC.error, undefined, `valid input must not error, got ${JSON.stringify(okC)}`)
+      assert.equal(okC.result, null, "valid input + unconfigured dir → null")
+    } finally {
+      await new Promise<void>((resolve) => server2.close(() => resolve()))
+    }
+  })
+
   await t.test("#254: coc_getTransactionsByAddress rejects non-integer limit/offset and non-boolean reverse", async () => {
     // Pre-fix `Number((params)[1] ?? 50)` silently coerced `true`→1, `"5"`→5,
     // `[3]`→3, `{}`→NaN→fallback. `(params[2] !== false)` accepted every

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2697,10 +2697,16 @@ async function handleRpc(
       }
     }
     case "coc_getRewardManifest": {
+      // #252: reject non-integer epochId (was: Number(true)→1, Number([1])→1, Number("1")→1)
+      // #424: validate BEFORE short-circuiting on missing rewardManifestDir.
+      // Pre-fix the dir check ran first, so on any node where the manifest
+      // dir wasn't configured (every read-only fullnode on testnet 88780)
+      // garbage epochId (`"1"`, `true`, `[1]`) silently returned `null` —
+      // indistinguishable from "valid id, no manifest". Validation belongs
+      // at the boundary, regardless of backend configuration.
+      const epochId = requireIntegerParam(payload.params ?? [], 0, "epochId")
       const rewardManifestDir = typeof opts?.rewardManifestDir === "string" ? opts.rewardManifestDir : ""
       if (!rewardManifestDir) return null
-      // #252: reject non-integer epochId (was: Number(true)→1, Number([1])→1, Number("1")→1)
-      const epochId = requireIntegerParam(payload.params ?? [], 0, "epochId")
       const manifest = readBestRewardManifest(rewardManifestDir, epochId)
       if (!manifest) return null
       return {
@@ -2716,14 +2722,17 @@ async function handleRpc(
       }
     }
     case "coc_getRewardClaim": {
-      const rewardManifestDir = typeof opts?.rewardManifestDir === "string" ? opts.rewardManifestDir : ""
-      if (!rewardManifestDir) return null
       // #252: reject non-integer epochId and non-string nodeId
+      // #424: same as coc_getRewardManifest — validate at the boundary
+      // before checking backend configuration so garbage input never
+      // returns silent `null`.
       const epochId = requireIntegerParam(payload.params ?? [], 0, "epochId")
       const nodeId = requireStringParam(payload.params ?? [], 1, "nodeId")
       if (!/^0x[0-9a-fA-F]+$/.test(nodeId)) {
         invalidParams("invalid nodeId")
       }
+      const rewardManifestDir = typeof opts?.rewardManifestDir === "string" ? opts.rewardManifestDir : ""
+      if (!rewardManifestDir) return null
       const manifest = readBestRewardManifest(rewardManifestDir, epochId)
       if (!manifest) return null
       return lookupRewardClaim(manifest, nodeId)


### PR DESCRIPTION
Closes #424.

## Summary

`coc_getRewardManifest` and `coc_getRewardClaim` ran
`if (!rewardManifestDir) return null` BEFORE the `requireIntegerParam`
/ `requireStringParam` validators. On every read-only fullnode
(no manifest dir configured — which is the entire testnet 88780 RPC
surface), garbage input silently returned `null` instead of `-32602`.
Same silent-fallback anti-pattern #252 / #254 / #258 / #260 fixed
elsewhere.

## Live testnet 88780 reproduction (pre-fix)

```
curl …coc_getRewardManifest(["1"])    → {"result":null}     # garbage
curl …coc_getRewardManifest([true])   → {"result":null}     # garbage
curl …coc_getRewardManifest([1.5])    → {"result":null}     # garbage
curl …coc_getRewardManifest([7])      → {"result":null}     # valid (unconfigured)
```

Indistinguishable. The same garbage shapes returned `-32602` on a
relayer node where the manifest dir IS configured — inconsistent
across deployment shapes.

## Fix

Move `requireIntegerParam` / `requireStringParam` ABOVE the
`if (!rewardManifestDir) return null` guard. Validation now runs
unconditionally at the RPC boundary; the dir check only selects
between "real lookup" and "null because unconfigured" AFTER input
passes shape validation.

## Test plan

- [x] New regression `#424` in `node/src/rpc-extended.test.ts`
  - Spins up a SECOND server WITHOUT `rewardManifestDir` (mirrors
    testnet 88780 fullnode shape)
  - Asserts garbage epochId/nodeId → `-32602` (was: null)
  - Asserts valid input → `null` (unchanged — documented behaviour
    for unconfigured backend)
- [x] Fail-without-fix verified: `git stash push node/src/rpc.ts` →
      `not ok 95 - #424`; restore → 97/97 PASS
- [x] No regression in #252 / #254 — the configured-backend tests
      still pass since validation still runs first

🤖 Generated with [Claude Code](https://claude.com/claude-code)