### PR TITLE
fix(rpc): cap inner topic OR-set in eth_getLogs (#266) (re-#267)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2260,6 +2260,46 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#266: eth_getLogs caps inner topic OR-set (defense-in-depth against O(blocks×logs×topics) amplification)", async () => {
+    // validateLogFilter caps the OUTER topics array at 4 (matching the EVM's
+    // 4-indexed-topics-per-log limit) but the INNER array (the OR-set for
+    // that topic slot) was unbounded. Sibling to MAX_FILTER_ADDRESSES=100;
+    // same family as #264 (eth_getProof storage keys cap).
+    const probe = async (innerN: number) => {
+      const inner = Array.from({ length: innerN }, (_, i) =>
+        `0x${i.toString(16).padStart(64, "0")}`,
+      )
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "eth_getLogs",
+          params: [{ topics: [inner] }],
+        }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // 33 inner topics → over the new 32 cap, reject
+    const r33 = await probe(33)
+    assert.equal(r33.error?.code, -32602,
+      `inner topics=33 must be -32602, got ${JSON.stringify(r33)}`)
+    assert.match(r33.error!.message, /inner topic.*too large/i,
+      `error must reference inner cap, got ${JSON.stringify(r33)}`)
+    // 1000 inner topics → same
+    const r1000 = await probe(1000)
+    assert.equal(r1000.error?.code, -32602, `inner topics=1000 must be -32602`)
+    // 32 inner topics (at cap) → should NOT be a shape-rejection
+    const r32 = await probe(32)
+    assert.notEqual(r32.error?.code, -32602,
+      `inner topics=32 (at cap) must pass shape, got ${JSON.stringify(r32)}`)
+    // 1 inner topic → fine
+    const r1 = await probe(1)
+    assert.notEqual(r1.error?.code, -32602,
+      `inner topics=1 must pass shape, got ${JSON.stringify(r1)}`)
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -457,6 +457,10 @@ const FILTER_ADDR_RE = /^0x[0-9a-fA-F]{40}$/
 const FILTER_TOPIC_RE = /^0x[0-9a-fA-F]{64}$/
 const MAX_FILTER_ADDRESSES = 100
 const MAX_FILTER_TOPICS = 4
+// #266: cap the inner (per-position) topic OR-set so a single query
+// can't amplify into O(blocks × logs × inner_topics) work. Sibling of
+// MAX_FILTER_ADDRESSES — geth caps total inner topics at ~32 too.
+const MAX_INNER_TOPIC_VALUES = 32
 
 /**
  * Validate + normalize the address/topic/blockHash fields of a log
@@ -520,6 +524,14 @@ export function validateLogFilter(query: Record<string, unknown>): {
     topics = (query.topics as unknown[]).map((t, i) => {
       if (t === null || t === undefined) return null
       if (Array.isArray(t)) {
+        // #266: cap inner OR-set so a single query can't amplify into
+        // worst-case O(blocks × logs × inner_topics) work. Same family
+        // as MAX_FILTER_ADDRESSES — without this cap, a 10K-entry inner
+        // array is accepted and per-log matching iterates it for every
+        // log in the (up to 10K-block) range. Symmetric with #264.
+        if (t.length > MAX_INNER_TOPIC_VALUES) {
+          invalidParams(`inner topic array at index ${i} too large: ${t.length} > ${MAX_INNER_TOPIC_VALUES}`)
+        }
         return t.map((tt, j) => {
           if (typeof tt !== "string" || !FILTER_TOPIC_RE.test(tt)) {
             invalidParams(`invalid filter topic at index ${i}[${j}]: must match /^0x[0-9a-fA-F]{64}$/ or null`)


### PR DESCRIPTION
Re-opening — earlier rebase attempt accidentally pushed wrong HEAD, closing #267. Branch content restored to e025304. Same code, same tests.