### PR TITLE
fix(ipfs-http): #426 cat/MFS offset+length accept values over MAX_SAFE_INTEGER

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -384,6 +384,21 @@ describe("IpfsHttpServer", () => {
     const r7 = await fetch(`/api/v0/cat?arg=${meta.cid}`, { method: "POST" })
     assert.equal(r7.status, 200)
     assert.deepEqual(new Uint8Array(await r7.buffer()), content)
+    // (h) #426: offset > MAX_SAFE_INTEGER must reject. Pre-fix
+    // `Number.isInteger(1e21)` returned true after precision loss and the
+    // handler responded with 200 + empty body (indistinguishable from
+    // "valid offset past EOF"). 21-digit integer overflows MAX_SAFE_INTEGER.
+    const r8 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=999999999999999999999`, { method: "POST" })
+    assert.equal(r8.status, 400, "offset over MAX_SAFE_INTEGER must reject (was silent 200 + empty)")
+    assert.match((await r8.json() as { error: string }).error, /invalid offset/)
+    // (i) #426: same for length
+    const r9 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=0&length=999999999999999999999`, { method: "POST" })
+    assert.equal(r9.status, 400, "length over MAX_SAFE_INTEGER must reject")
+    assert.match((await r9.json() as { error: string }).error, /invalid length/)
+    // (j) #426 sanity: MAX_SAFE_INTEGER itself is at the boundary and accepted
+    const r10 = await fetch(`/api/v0/cat?arg=${meta.cid}&offset=${Number.MAX_SAFE_INTEGER}`, { method: "POST" })
+    assert.equal(r10.status, 200, "MAX_SAFE_INTEGER must still accept (boundary)")
+    assert.equal((await r10.buffer()).length, 0)
   })
 
   it("#353: /api/v0/add rejects unsupported kubo params with 400 (not silent ignore)", async () => {
@@ -787,6 +802,13 @@ describe("IpfsHttpServer", () => {
     // Sanity: valid offset + count still works.
     const ok = await fetch("/api/v0/files/read?arg=/probe&offset=0&count=5", { method: "POST" })
     assert.equal(ok.status, 200, "valid offset/count must succeed")
+    // #426: MFS read offset/count must reject values over MAX_SAFE_INTEGER
+    // (sibling of the cat-handler hazard). Pre-fix `Number.isInteger`
+    // accepted `1e21` after precision loss.
+    const huge = await fetch("/api/v0/files/read?arg=/probe&offset=999999999999999999999", { method: "POST" })
+    assert.equal(huge.status, 400, "MFS read offset over MAX_SAFE_INTEGER must reject")
+    const huge2 = await fetch("/api/v0/files/read?arg=/probe&count=999999999999999999999", { method: "POST" })
+    assert.equal(huge2.status, 400, "MFS read count over MAX_SAFE_INTEGER must reject")
   })
 
   it("#232: /api/v0/files/* path traversal returns 400 (not 500 'internal error')", async () => {

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -913,11 +913,19 @@ export class IpfsHttpServer {
     // by kubo's spec but the handler ignored them, returning the full
     // file regardless. Worse, malformed values (negative, non-numeric)
     // silently passed through. Validate + slice now.
+    // #426: `Number.isFinite(n) && Number.isInteger(n)` accepted values
+    // over `MAX_SAFE_INTEGER` (e.g. `offset=999999999999999999999`).
+    // `Number("999…")` → 1e21, and `Number.isInteger(1e21)` is true
+    // because the precision-lost value happens to be an integer in
+    // JS-number space, just not the integer the user wrote.
+    // `buf.subarray(1e21)` then returns an empty slice and the request
+    // comes back as `HTTP 200` + empty body — indistinguishable from
+    // "valid offset past EOF". Tighten to `Number.isSafeInteger`.
     let offset = 0
     let length: number | undefined
     if (range?.offset !== undefined) {
       const n = Number(range.offset)
-      if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+      if (!Number.isSafeInteger(n) || n < 0) {
         res.writeHead(400, { "content-type": "application/json" })
         res.end(JSON.stringify({ error: "invalid offset: must be a non-negative integer" }))
         return
@@ -926,7 +934,7 @@ export class IpfsHttpServer {
     }
     if (range?.length !== undefined) {
       const n = Number(range.length)
-      if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+      if (!Number.isSafeInteger(n) || n < 0) {
         res.writeHead(400, { "content-type": "application/json" })
         res.end(JSON.stringify({ error: "invalid length: must be a non-negative integer" }))
         return
@@ -1327,16 +1335,20 @@ export class IpfsHttpServer {
           // either surfaced as 500 "internal error" or returned surprising
           // data. Match the (already correct) handleCat rule so MFS read
           // and unixfs cat share the same kubo-compatible shape contract.
+          // #426: same MAX_SAFE_INTEGER hazard as the cat handler — values
+          // like `999999999999999999999` slipped through because
+          // `Number.isInteger(1e21)` is true after precision loss. Tighten
+          // to `Number.isSafeInteger`.
           if (offsetRaw !== undefined) {
             const n = Number(offsetRaw)
-            if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+            if (!Number.isSafeInteger(n) || n < 0) {
               throw new HttpError(400, "invalid offset")
             }
             opts.offset = n
           }
           if (countRaw !== undefined) {
             const n = Number(countRaw)
-            if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+            if (!Number.isSafeInteger(n) || n < 0) {
               throw new HttpError(400, "invalid count")
             }
             opts.count = n


### PR DESCRIPTION
## Summary

\`handleCat\` and the MFS \`/api/v0/files/read\` route validated offset/length/count with \`Number.isFinite(n) && Number.isInteger(n)\`. That accepts values over \`MAX_SAFE_INTEGER\`:

\`Number("999999999999999999999")\` → \`1e21\`, and \`Number.isInteger(1e21)\` is \`true\` because the precision-lost value happens to be an integer in JS-number space — just not the integer the user wrote. \`buf.subarray(1e21)\` then returns an empty slice, so the client gets \`HTTP 200\` + empty body, indistinguishable from "valid offset past EOF".

Same anti-pattern family as #398 (which fixed JSON-RPC \`id\` validation by switching to \`Number.isSafeInteger\`).

## Live testnet 88780 reproduction (pre-fix)

\`\`\`
$ curl -sw "%{http_code}\n" -X POST \
    "http://159.198.44.136:28800/api/v0/cat?arg=<cid>&offset=999999999999999999999" \
    -o /tmp/out
→ 200             (silent success)
$ wc -c < /tmp/out
0                 (empty body — no way to tell input was rejected)
\`\`\`

## Fix

Replace \`Number.isFinite(n) && Number.isInteger(n)\` with \`Number.isSafeInteger(n)\` in all four sites:
- \`handleCat\` offset/length
- MFS \`files/read\` route offset/count

Values over \`MAX_SAFE_INTEGER\` now return \`400 invalid offset\` / \`400 invalid count\`. \`Number.MAX_SAFE_INTEGER\` itself still passes (boundary).

## Test plan

- [x] New regression \`#426\` in \`node/src/ipfs-http.test.ts\`
  - cat offset=999…(21 digits) → 400 (was: 200 + empty)
  - cat length=999…(21 digits) → 400
  - cat offset=MAX_SAFE_INTEGER → 200 + empty (boundary still works)
  - MFS read offset/count over MAX_SAFE_INTEGER → 400
- [x] Fail-without-fix verified: \`git checkout HEAD~1 -- node/src/ipfs-http.ts\` → 2 test failures; restore → 94/94 pass
- [x] Full ipfs-http suite: 94/94 pass

## Real-world impact

Any tooling that probes large random offsets (S3-style range reads ported to IPFS, fuzzing harnesses, indexers scanning byte ranges) gets indistinguishable success vs. genuine-EOF responses. Post-fix the boundary is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)