### PR TITLE
fix(rpc): #432 DID/governance handlers validate before backend-config short-circuit

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1226,10 +1226,74 @@ test("RPC Extended Methods", async (t) => {
     }
     // (c) coc_resolveDid / coc_getDIDDocument on a node without DID config
     // → -32601 method not available (not -32603 internal-error).
+    // #432: shape-valid args still hit the -32601 path (DID resolver not
+    // configured); garbage input (empty params) gets -32602 via the new
+    // validate-before-config-check ordering.
     for (const method of ["coc_resolveDid", "coc_getDIDDocument"]) {
-      const j = await probeError(method, [])
+      const j = await probeError(method, ["did:coc:agent-shape-valid"])
       assert.ok(j.error)
-      assert.equal(j.error!.code, -32601, `${method} must be -32601 when not configured, got ${j.error!.code}`)
+      assert.equal(j.error!.code, -32601, `${method} with valid shape must be -32601 when not configured, got ${j.error!.code}`)
+    }
+  })
+
+  await t.test("#432: DID/governance handlers validate input BEFORE the backend-not-configured check", async () => {
+    // Pre-fix the `if (!didResolver) methodNotFound(...)` /
+    // `if (!hasGovernance) methodNotFound(...)` short-circuit ran BEFORE
+    // `requireStringParam` in 10 handlers. On every read-only fullnode
+    // (the entire testnet 88780 RPC surface) garbage input got the
+    // misleading -32601 "not configured" instead of -32602 "invalid
+    // params". Same anti-pattern as #424 (reward handlers).
+    //
+    // This fixture has no didResolver / didDataProvider / governance
+    // configured (the default test shape), so these handlers HIT the
+    // backend-config check in the wild. With the fix, garbage gets
+    // -32602 first; shape-valid input gets -32601 after.
+    const probeError = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { result?: unknown; error?: { code: number; message: string } }
+    }
+    // (a) Single-string-arg handlers: empty/numeric/boolean → -32602
+    const stringArgMethods = [
+      "coc_resolveDid",
+      "coc_getDIDDocument",
+      "coc_getAgentCapabilities",
+      "coc_getDelegations",
+      "coc_getAgentLineage",
+      "coc_getVerificationMethods",
+      "coc_getCredentialAnchor",
+    ]
+    for (const method of stringArgMethods) {
+      for (const bad of [[], [null], [42], [true], [{}], [[1, 2]]]) {
+        const j = await probeError(method, bad)
+        assert.ok(j.error, `${method}(${JSON.stringify(bad)}) must error`)
+        assert.equal(j.error!.code, -32602,
+          `${method}(${JSON.stringify(bad)}) must be -32602 (was -32601 pre-fix), got ${j.error!.code}`)
+      }
+      // Shape-valid → -32601 (backend not configured)
+      const ok = await probeError(method, ["agent-shape-valid"])
+      assert.equal(ok.error?.code, -32601,
+        `${method}("agent-shape-valid") must be -32601 (not configured), got ${JSON.stringify(ok)}`)
+    }
+    // (b) coc_getDaoProposal: proposalId is string. Same garbage shapes.
+    for (const bad of [[], [null], [42], [true], [""]]) {
+      const j = await probeError("coc_getDaoProposal", bad)
+      assert.equal(j.error?.code, -32602,
+        `coc_getDaoProposal(${JSON.stringify(bad)}) must be -32602, got ${j.error?.code}`)
+    }
+    const okDao = await probeError("coc_getDaoProposal", ["valid-id"])
+    assert.equal(okDao.error?.code, -32601,
+      `coc_getDaoProposal("valid-id") must be -32601 (governance not enabled), got ${JSON.stringify(okDao)}`)
+    // (c) coc_submitProposal / coc_voteProposal: first param must be object.
+    for (const method of ["coc_submitProposal", "coc_voteProposal"]) {
+      for (const bad of [[], [null], ["not-object"], [42], [[1, 2]]]) {
+        const j = await probeError(method, bad)
+        assert.equal(j.error?.code, -32602,
+          `${method}(${JSON.stringify(bad)}) must be -32602, got ${j.error?.code}`)
+      }
     }
   })
 

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2118,17 +2118,19 @@ async function handleRpc(
       // §5.1, -32603 is for server faults; "feature not enabled on
       // this node" is a method-availability concern → -32601. Same
       // class as #132 (unknown-method fallback fix).
-      if (!hasGovernance(chain)) {
-        methodNotFound("coc_submitProposal: governance module not enabled on this node")
-      }
       // #220: pre-fix `(payload.params ?? [])[0] as Record<string,string>`
       // was a no-op cast. With params=[] or params=[null] the first param
       // was undefined/null; the next line then accessed `.proposer` and
       // threw a V8 TypeError ("Cannot read properties of undefined/null
       // (reading 'proposer')") which leaked through the outer catch.
+      // #432: validate input BEFORE governance-module check so garbage
+      // gets -32602 even on read-only fullnodes (same anti-pattern as #424).
       const rawParams = (payload.params ?? [])[0]
       if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
         invalidParams("invalid params: expected non-null object as first param")
+      }
+      if (!hasGovernance(chain)) {
+        methodNotFound("coc_submitProposal: governance module not enabled on this node")
       }
       const proposalParams = rawParams as Record<string, string>
       // Only the local node can submit proposals via RPC
@@ -2171,15 +2173,16 @@ async function handleRpc(
     }
     case "coc_voteProposal": {
       // #234: same -32601 mapping as coc_submitProposal.
-      if (!hasGovernance(chain)) {
-        methodNotFound("coc_voteProposal: governance module not enabled on this node")
-      }
       // #220: same null-check as coc_submitProposal — params=[] / [null]
       // pre-fix bubbled "Cannot read properties of null (reading 'voterId')"
       // through the outer catch as a -32603 V8 leak.
+      // #432: validate input BEFORE governance-module check (same as #424).
       const voteRaw = (payload.params ?? [])[0]
       if (!voteRaw || typeof voteRaw !== "object" || Array.isArray(voteRaw)) {
         invalidParams("invalid params: expected non-null object as first param")
+      }
+      if (!hasGovernance(chain)) {
+        methodNotFound("coc_voteProposal: governance module not enabled on this node")
       }
       const voteParams = voteRaw as Record<string, unknown>
       // Only the local node can vote via RPC
@@ -2244,12 +2247,16 @@ async function handleRpc(
     }
     case "coc_getDaoProposal": {
       // #234: same -32601 mapping as coc_submitProposal.
-      if (!hasGovernance(chain)) {
-        methodNotFound("coc_getDaoProposal: governance module not enabled on this node")
-      }
+      // #432: validate proposalId BEFORE governance-module check so
+      // garbage input (number, boolean, missing) gets -32602 even on
+      // read-only fullnodes where governance isn't enabled. Same
+      // anti-pattern as #424 (reward handlers).
       const proposalId = (payload.params ?? [])[0]
       if (typeof proposalId !== "string" || !proposalId) {
         invalidParams("invalid proposal id: expected non-empty string")
+      }
+      if (!hasGovernance(chain)) {
+        methodNotFound("coc_getDaoProposal: governance module not enabled on this node")
       }
       const gov = chain.governance
       const proposal = gov.getProposal(proposalId)
@@ -2788,56 +2795,64 @@ async function handleRpc(
     }
     // ── DID Identity Layer ──────────────────────────────────────
     case "coc_resolveDid": {
+      // #432: validate input BEFORE backend-config check so garbage params
+      // (numbers, booleans, objects, missing) get -32602 even on nodes
+      // where the DID resolver isn't configured. Pre-fix the
+      // `if (!didResolver) -32601` ran first, masking input-shape errors
+      // behind a misleading "method not found" on every read-only fullnode.
+      // Same anti-pattern as #424 (reward handlers).
+      const did = requireStringParam(payload.params ?? [], 0, "DID")
       const didResolver = opts?.didResolver as { resolve: (did: string) => Promise<{ didDocument: unknown; didResolutionMetadata: unknown }> } | undefined
       if (!didResolver) methodNotFound("DID resolver not configured on this node (requires soulRegistryAddress + didRegistryAddress)")
-      // #242: pre-fix `String(... ?? "")` silently coerced numbers/bools/
-      // objects to "123"/"true"/"[object Object]" — bogus identifiers
-      // that downstream resolvers couldn't tell apart from real DIDs.
-      // Same anti-pattern as #120/#220/#226/#240.
-      const did = requireStringParam(payload.params ?? [], 0, "DID")
       return didResolver.resolve(did)
     }
     case "coc_getDIDDocument": {
+      // #432: same — validate before backend-config check.
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const didResolver = opts?.didResolver as { resolve: (did: string) => Promise<{ didDocument: unknown }> } | undefined
       if (!didResolver) methodNotFound("DID resolver not configured on this node")
-      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const result = await didResolver.resolve(`did:coc:${agentId}`)
       return result.didDocument ?? null
     }
     case "coc_getAgentCapabilities": {
+      // #432: same — validate before backend-config check.
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const didProvider = opts?.didDataProvider
       if (!didProvider) methodNotFound("DID data provider not configured on this node")
-      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const bitmask = await didProvider.getCapabilities(agentId)
       // Import inline to avoid top-level dependency
       const { capabilityBitmaskToNames } = await import("./did/did-types.ts")
       return { capabilities: capabilityBitmaskToNames(bitmask), bitmask }
     }
     case "coc_getDelegations": {
+      // #432: same — validate before backend-config check.
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const didProvider = opts?.didDataProvider
       if (!didProvider) methodNotFound("DID data provider not configured on this node")
-      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getFullDelegations(agentId)
     }
     case "coc_getAgentLineage": {
+      // #432: same — validate before backend-config check.
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getLineage) methodNotFound("DID data provider not configured on this node")
-      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getLineage(agentId)
     }
     case "coc_getVerificationMethods": {
+      // #432: same — validate before backend-config check.
+      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getVerificationMethods) methodNotFound("DID data provider not configured on this node")
-      const agentId = requireStringParam(payload.params ?? [], 0, "agentId")
       return didProvider.getVerificationMethods(agentId)
     }
     case "coc_getCredentialAnchor": {
       // Checks the on-chain credential anchor only: existence, revocation, expiry.
       // Does NOT verify VC content, signatures, or proofs — use verifiable-credentials.ts
       // for full credential verification.
+      // #432: same — validate before backend-config check.
+      const credentialId = requireStringParam(payload.params ?? [], 0, "credentialId")
       const didProvider = opts?.didDataProvider
       if (!didProvider?.getCredentialAnchor) methodNotFound("DID data provider not configured on this node")
-      const credentialId = requireStringParam(payload.params ?? [], 0, "credentialId")
       return didProvider.getCredentialAnchor(credentialId)
     }
     default:


### PR DESCRIPTION
## Summary

10 handlers (\`coc_resolveDid\`, \`coc_getDIDDocument\`, \`coc_getAgentCapabilities\`, \`coc_getDelegations\`, \`coc_getAgentLineage\`, \`coc_getVerificationMethods\`, \`coc_getCredentialAnchor\`, \`coc_getDaoProposal\`, \`coc_submitProposal\`, \`coc_voteProposal\`) ran the \`if (!didResolver) methodNotFound(...)\` / \`if (!hasGovernance) methodNotFound(...)\` short-circuit BEFORE the input validators.

On every read-only fullnode where the DID resolver / governance module isn't configured — the entire testnet 88780 RPC surface — garbage input shapes silently returned \`-32601 method not found\` instead of \`-32602 invalid params\`. Clients couldn't tell "I sent garbage" from "the feature isn't available on this node" — same silent-fallback anti-pattern that #424 fixed for the reward handlers.

## Live testnet 88780 reproduction (pre-fix)

\`\`\`
curl …coc_getDaoProposal([42])   → -32601 governance module not enabled
curl …coc_getDaoProposal([])     → -32601 (same)
curl …coc_getDelegations([true]) → -32601 DID data provider not configured
curl …coc_getAgentLineage([42])  → -32601 (same)
\`\`\`

Indistinguishable. Compare to a configured node where the same garbage would correctly come back as \`-32602\` — inconsistent across deployment shapes.

## Fix

Move \`requireStringParam\` (and the object-shape check for the proposal handlers) ABOVE the backend-config guard in all 10 handlers. Validation runs unconditionally at the RPC boundary; the config check only selects between "real lookup" and "-32601 unavailable" AFTER input passes shape validation.

## Test plan

- [x] New \`#432\` regression in \`rpc-extended.test.ts\`
  - 7 single-string-arg DID handlers × 6 garbage shapes ([], [null], [42], [true], [{}], [[1,2]]) → -32602
  - coc_getDaoProposal × 5 garbage shapes → -32602
  - coc_submitProposal + coc_voteProposal × 5 garbage shapes → -32602
  - Sanity: shape-valid input still returns -32601 (not configured)
- [x] Updated existing \`#108\` test for new ordering (shape-valid input now used for the -32601 check)
- [x] Full rpc-extended suite: 105/105 pass

## Real-world impact

DID-aware clients (wallets, agent frameworks) probe \`coc_resolveDid\` / \`coc_getDIDDocument\` during init. Pre-fix any client passing a non-string DID (number, object, missing) got \`-32601\` and assumed the chain didn't support DIDs — they fell back to no-DID mode. Post-fix they get \`-32602\` and know to fix their request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)