### PR TITLE
fix(ipfs-http): restore pubsub control-char check dropped in #429

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1854,3 +1854,36 @@ describe("#324 IPFS gateway honors HTTP Range header", () => {
     assert.equal(res.headers["accept-ranges"], "bytes")
   })
 })
+
+// #312/#313 restoration: PR #429's IPFS rewrite accidentally dropped the
+// control-character check in handlePubsubRoute. Without it, topics like
+// "alpha\x00beta" round-trip through libp2p but cause string-equality
+// subscribers to silently mismatch (publish drops, no error to client).
+describe("#312 pubsub topic rejects control characters", () => {
+  it("POST /api/v0/pubsub/pub with null byte in topic returns 400", async () => {
+    const { IpfsPubsub } = await import("./ipfs-pubsub.ts")
+    const pubsub = new IpfsPubsub({ nodeId: "ctrl-test" })
+    server.attachSubsystems({ pubsub })
+    try {
+      const probes = [
+        "topic%00null",   // NUL
+        "topic%01soh",    // SOH
+        "topic%1F",       // unit separator
+        "topic%7F",       // DEL
+        "%0Atopic",       // leading LF
+        "topic%09tab",    // tab
+      ]
+      for (const arg of probes) {
+        const res = await fetch(`/api/v0/pubsub/pub?arg=${arg}`, { method: "POST", body: new TextEncoder().encode("payload") })
+        assert.equal(res.status, 400, `topic=${arg}: must reject with 400, got ${res.status}`)
+        const body = await res.json() as { error?: string }
+        assert.match(body.error ?? "", /control characters/i, `topic=${arg}: error must mention control characters`)
+      }
+      // Sanity: legal topic still works.
+      const ok = await fetch("/api/v0/pubsub/pub?arg=normal-topic", { method: "POST", body: new TextEncoder().encode("payload") })
+      assert.equal(ok.status, 200, "legal topic must still accept (regression sentinel)")
+    } finally {
+      pubsub.stop()
+    }
+  })
+})

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1520,6 +1520,16 @@ export class IpfsHttpServer {
         return
       }
 
+      // Reject control characters (#312/#313): a NUL byte or other control codes in the
+      // topic round-trip through libp2p but cause subscribers' string-based topic filters
+      // to silently mismatch, masking publish drops. Reapplied after PR #429's rewrite of
+      // the IPFS handler accidentally dropped the original check.
+      if (topic && /[\x00-\x1F\x7F]/.test(topic)) {
+        res.writeHead(400, { "content-type": "application/json" })
+        res.end(JSON.stringify({ error: "topic contains control characters" }))
+        return
+      }
+
       switch (route) {
         case "pub": {
           if (!topic) {


### PR DESCRIPTION
Closes #432.

## Why

Live probe of testnet 88780 IPFS endpoint shows pubsub topics with embedded control bytes (NUL etc.) are silently accepted:

\`\`\`
$ curl -sS -X POST 'http://159.198.44.136:28800/api/v0/pubsub/pub?arg=topic%00null&arg=hello'
{\"ok\":true}
\`\`\`

PR #313 already addressed this on its branch but the change was lost when PR #429 rewrote \`handlePubsubRoute\` to fix the #428 syntax cascade. The length check survived; the control-char check did not.

## Fix

Reapply the original \`/[\\x00-\\x1F\\x7F]/\` check immediately after the length validation, before the route switch. Applies uniformly to \`pub\` / \`sub\` / \`peers\` paths.

## Test

Added \`#312 pubsub topic rejects control characters\` regression in \`node/src/ipfs-http.test.ts\`: six byte probes (NUL/SOH/US/DEL/LF/TAB) + a positive sanity case.

\`\`\`
$ node --experimental-strip-types --test node/src/ipfs-http.test.ts
# tests 95
# pass 95
# fail 0
\`\`\`

## Test plan

- [x] Local unit suite green
- [ ] CI green
- [ ] Replay testnet probe after rollout — \`pub?arg=topic%00null\` returns 400 (not 200)