### PR TITLE
fix(ipfs-mfs): files/stat returns CID + cumulativeSize for directories

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -169,6 +169,45 @@ test("MFS: stat returns directory info", async () => {
   }
 })
 
+test("#434: stat on directory returns non-empty CID + cumulativeSize, matches flush()", async () => {
+  // Pre-fix stat() hard-coded hash:"" and cumulativeSize:0 for every directory.
+  // Kubo's files/stat returns the dir's content-addressed CID and a non-zero
+  // cumulative size for non-empty dirs — clients (and our own ls vs stat
+  // consumers) rely on the CID being present to chase the DAG. Pin both fields.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.mkdir("/d")
+    await mfs.write("/d/a.txt", new TextEncoder().encode("hello"), { create: true })
+    await mfs.write("/d/b.txt", new TextEncoder().encode("world!"), { create: true })
+
+    const stat = await mfs.stat("/d")
+    assert.strictEqual(stat.type, "directory")
+    assert.ok(stat.hash && stat.hash.length > 0, `directory stat must return a non-empty CID, got ${JSON.stringify(stat)}`)
+    assert.strictEqual(stat.cumulativeSize, 5 + 6, "cumulativeSize must sum immediate-child sizes (5 + 6 = 11)")
+    assert.strictEqual(stat.blocks, 2, "blocks must reflect entry count")
+
+    // stat() and flush() must agree on the same CID for the same dir.
+    const flushed = await mfs.flush("/d")
+    assert.strictEqual(stat.hash, flushed, "stat() and flush() must return the same CID")
+  } finally {
+    cleanup()
+  }
+})
+
+test("#434: stat on empty directory returns non-empty CID + zero cumulativeSize", async () => {
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.mkdir("/empty")
+    const stat = await mfs.stat("/empty")
+    assert.strictEqual(stat.type, "directory")
+    assert.ok(stat.hash && stat.hash.length > 0, "empty directory must still get a CID (empty-listing CID)")
+    assert.strictEqual(stat.cumulativeSize, 0)
+    assert.strictEqual(stat.blocks, 0)
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: flush returns CID", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -339,10 +339,19 @@ export class IpfsMfs {
     // Check if it's a directory
     const dir = this.dirs.get(normalized)
     if (dir) {
+      // kubo's files/stat returns the directory's content-addressed CID,
+      // not an empty string. Reuse flush()'s listing-based CID build so
+      // stat and flush agree on the same hash for the same directory.
+      // CumulativeSize is the sum of immediate-child sizes — a coarse
+      // approximation of kubo's dag-pb cumulative size, but non-zero so
+      // clients can spot the dir has content.
+      const hash = await this.flush(normalized)
+      let cumulativeSize = 0
+      for (const entry of dir.entries.values()) cumulativeSize += entry.size
       return {
-        hash: "",
+        hash,
         size: 0,
-        cumulativeSize: 0,
+        cumulativeSize,
         type: "directory",
         blocks: dir.entries.size,
       }


### PR DESCRIPTION
Closes #434.

## Why

Live testnet 88780 shows \`files/stat\` returns empty \`Hash\` and \`CumulativeSize:0\` for directories, even when \`files/ls\` (and \`files/flush\`) on the same path return real CIDs. Clients that use \`stat\` as a directory-CID source silently get nothing.

## Fix

\`IpfsMfs.stat()\` now reuses \`flush()\`'s listing-based CID build for directories and sums immediate-child sizes for \`cumulativeSize\`. stat and flush now agree on the same hash for the same directory.

## Tests

Two new regressions in \`node/src/ipfs-mfs.test.ts\`:
- populated directory: non-empty \`hash\`, summed \`cumulativeSize\`, stat() === flush() invariant
- empty directory: still gets a CID (empty-listing CID), \`cumulativeSize=0\`

\`\`\`
$ node --experimental-strip-types --test node/src/ipfs-mfs.test.ts
# tests 17  pass 17  fail 0
\`\`\`

## Test plan

- [x] MFS suite green
- [x] HTTP suite still green (94/94)
- [ ] CI green
- [ ] After rollout: replay testnet probe → \`stat\` and \`flush\` return same CID