### PR TITLE
fix(rpc): #436 governance handlers validate before backend-config short-circuit

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -802,6 +802,69 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(proposals.length, 0)
   })
 
+  await t.test("#436: coc_getProposals/getDaoProposals/getFaction validate input BEFORE backend-config short-circuit", async () => {
+    // Same family as #432 / PR #431 but for the 3 handlers that return
+    // a successful empty result (`[]` or `null`) instead of methodNotFound
+    // when governance is off. Pre-fix, garbage input shapes silently got
+    // the empty result on every read-only fullnode (the entire testnet 88780
+    // RPC surface) — clients could not tell "I sent garbage" from
+    // "no proposals exist." Validation must run unconditionally at the
+    // RPC boundary; the config check only selects between "real lookup"
+    // and "empty result" AFTER input passes shape validation.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+
+    // coc_getProposals — non-string filter must reject even without governance.
+    for (const bad of [true, false, 42, {}, [1, 2]]) {
+      const r = await probe("coc_getProposals", [bad])
+      assert.equal(r.error?.code, -32602,
+        `coc_getProposals(${JSON.stringify(bad)}) must be -32602 (not silent []), got ${JSON.stringify(r)}`)
+    }
+    // Sanity: valid shape returns [] (not error) without governance.
+    {
+      const r = await probe("coc_getProposals", [])
+      assert.equal(r.error, undefined, `coc_getProposals([]) without governance must return empty array, got ${JSON.stringify(r)}`)
+      assert.deepEqual(r.result, [])
+    }
+
+    // coc_getDaoProposals — non-string/non-object filter must reject.
+    for (const bad of [true, false, 42, [1, 2]]) {
+      const r = await probe("coc_getDaoProposals", [bad])
+      assert.equal(r.error?.code, -32602,
+        `coc_getDaoProposals(${JSON.stringify(bad)}) must be -32602 (not silent []), got ${JSON.stringify(r)}`)
+    }
+    // Bad nested shape must also reject.
+    {
+      const r = await probe("coc_getDaoProposals", [{ status: 42 }])
+      assert.equal(r.error?.code, -32602,
+        `coc_getDaoProposals({status:42}) must reject, got ${JSON.stringify(r)}`)
+    }
+    {
+      const r = await probe("coc_getDaoProposals", [])
+      assert.equal(r.error, undefined, `coc_getDaoProposals([]) without governance must return empty array`)
+      assert.deepEqual(r.result, [])
+    }
+
+    // coc_getFaction — non-string / non-0x-prefix address must reject.
+    for (const bad of [[], [null], [42], [true], [{}], [[1, 2]], ["not-0x-prefixed"]]) {
+      const r = await probe("coc_getFaction", bad)
+      assert.equal(r.error?.code, -32602,
+        `coc_getFaction(${JSON.stringify(bad)}) must be -32602 (not silent null), got ${JSON.stringify(r)}`)
+    }
+    // Sanity: valid address shape returns null (not error) without governance.
+    {
+      const r = await probe("coc_getFaction", ["0x0000000000000000000000000000000000000001"])
+      assert.equal(r.error, undefined, `coc_getFaction(valid_address) without governance must return null`)
+      assert.equal(r.result, null)
+    }
+  })
+
   await t.test("unsupported method throws error", async () => {
     await assert.rejects(
       () => rpcCall(port, "eth_nonExistentMethod"),

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2217,7 +2217,9 @@ async function handleRpc(
       }
     }
     case "coc_getProposals": {
-      if (!hasGovernance(chain)) return []
+      // #436: validate shape BEFORE backend-config short-circuit so
+      // garbage input returns -32602, not a silent `[]`. Same family
+      // as #432 / PR #431 (which fixed the methodNotFound variant).
       // #226: pre-fix `as string | undefined` was a runtime no-op so
       // bool/number/object/array silently slipped through and the
       // `validStatuses.includes(...)` always returned false → silent
@@ -2230,6 +2232,7 @@ async function handleRpc(
       if (typeof rawStatusFilter === "string" && rawStatusFilter !== "" && !validStatuses.includes(rawStatusFilter)) {
         invalidParams(`invalid status filter: must be one of ${validStatuses.join(", ")}`)
       }
+      if (!hasGovernance(chain)) return []
       const filter = typeof rawStatusFilter === "string" && rawStatusFilter !== "" ? rawStatusFilter as "pending" | "approved" | "rejected" | "expired" : undefined
       const proposals = chain.governance.getProposals(filter)
       return proposals.map((p) => ({
@@ -2281,9 +2284,9 @@ async function handleRpc(
       return { id: proposal.id, status: proposal.status, votes: Object.fromEntries(proposal.votes) }
     }
     case "coc_getDaoProposals": {
-      if (!hasGovernance(chain)) return []
-      const gov2 = chain.governance
-      if (!gov2.getProposals) return []
+      // #436: validate shape BEFORE backend-config short-circuit (same
+      // family as #432 / PR #431). Without this, garbage filter shapes
+      // silently get `[]` instead of -32602 on read-only nodes.
       // #226: pre-fix the `as` cast was a runtime no-op so booleans,
       // numbers, and arrays silently bypassed both string/object
       // branches → all filters undefined → silent "return all" path.
@@ -2320,6 +2323,9 @@ async function handleRpc(
       if (statusFilter2 && !validStatuses2.includes(statusFilter2)) {
         invalidParams(`invalid status filter: must be one of ${validStatuses2.join(", ")}`)
       }
+      if (!hasGovernance(chain)) return []
+      const gov2 = chain.governance
+      if (!gov2.getProposals) return []
       const sFilter = statusFilter2 && validStatuses2.includes(statusFilter2) ? statusFilter2 : undefined
       let results = gov2.getProposals(sFilter)
       if (typeFilter) results = results.filter((p: { type: string }) => p.type === typeFilter)
@@ -2360,11 +2366,14 @@ async function handleRpc(
       return { balance: `0x${treasury2.toString(16)}` }
     }
     case "coc_getFaction": {
-      if (!hasGovernance(chain)) return null
+      // #436: validate shape BEFORE backend-config short-circuit (same
+      // family as #432 / PR #431). Without this, garbage address shapes
+      // silently get `null` instead of -32602 on read-only nodes.
       const address = (payload.params ?? [])[0]
       if (typeof address !== "string" || !address.startsWith("0x")) {
         invalidParams("invalid address: expected hex string")
       }
+      if (!hasGovernance(chain)) return null
       const factionInfo = chain.governance.getFaction?.(address)
       if (!factionInfo) return null
       return {


### PR DESCRIPTION
Closes #436.

## Why

3 governance read handlers (\`coc_getProposals\`, \`coc_getDaoProposals\`, \`coc_getFaction\`) run \`if (!hasGovernance) return [...]\` BEFORE input shape validation. On read-only fullnodes (= the entire testnet 88780 RPC surface), garbage input silently returns a successful empty result instead of -32602.

Live testnet 88780 reproduction:

\`\`\`
coc_getProposals([true])            → []   ← should be -32602
coc_getDaoProposals([{status:42}])  → []   ← should be -32602
coc_getFaction([42])                → null ← should be -32602
\`\`\`

Same family as #432 / PR #431. PR #431 covered the 10 handlers that fall back to \`methodNotFound\`. These 3 fall back to a successful empty result and were missed.

## Fix

Move shape validation above the backend-config guard in all 3 handlers. Validation runs unconditionally; the config check still selects between \"real lookup\" and \"empty result\" AFTER input passes shape validation.

## Test

New \`#436\` regression in \`rpc-extended.test.ts\`:
- coc_getProposals × 5 garbage shapes → -32602
- coc_getDaoProposals × 5 garbage shapes → -32602
- coc_getFaction × 7 garbage shapes → -32602
- 3 sanity cases: valid shape still returns empty result without governance

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended suite green (105/105)
- [ ] CI green
- [ ] Replay testnet probe after rollout — garbage input returns -32602, not silent empty