### PR TITLE
fix(chain-engine): #438 persistent engine rejects stale-nonce txs (parity with in-memory)

### DIFF
--- a/node/src/chain-engine-persistent.test.ts
+++ b/node/src/chain-engine-persistent.test.ts
@@ -257,6 +257,88 @@ test("PersistentChainEngine: transaction deduplication", async () => {
   }
 })
 
+test("#438: PersistentChainEngine.addRawTx rejects stale-nonce txs (parity with in-memory ChainEngine)", async () => {
+  // Live testnet 88780 reproduction (pre-fix):
+  //   1. Send tx with nonce=N, wait for it to mine. On-chain nonce becomes N+1.
+  //   2. Send a different signed tx with nonce=N (or N-1, N-5 — any used value).
+  //   3. eth_sendRawTransaction returns a hash. The tx silently sits in the
+  //      mempool (txByHash shows blockHash:null) forever — it can never confirm.
+  //
+  // The in-memory ChainEngine (chain-engine.ts:181-186) rejects with
+  // "nonce too low: tx nonce X, on-chain nonce Y" before mempool insertion.
+  // The persistent variant (used in production) was missing the same guard,
+  // creating both a DoS surface (mempool pollution) and a UX problem
+  // (clients think the tx was accepted).
+  const tmpDir = mkdtempSync(join(tmpdir(), "coc-engine-test-"))
+
+  try {
+    const evm = await EvmChain.create(2077)
+    const wallet = Wallet.createRandom()
+    await evm.prefund([
+      { address: wallet.address, balanceWei: parseEther("10").toString() },
+    ])
+
+    const engine = new PersistentChainEngine(
+      {
+        dataDir: tmpDir,
+        nodeId: "node1",
+        chainId: 2077,
+        validators: [],
+        finalityDepth: 3,
+        maxTxPerBlock: 100,
+        minGasPriceWei: 1n,
+      },
+      evm
+    )
+    await engine.init()
+
+    // Build + apply tx with nonce 0 so on-chain nonce advances to 1.
+    const tx0 = await wallet.signTransaction({
+      to: Wallet.createRandom().address,
+      value: parseEther("1"),
+      gasLimit: 21000,
+      gasPrice: 1000000000,
+      nonce: 0,
+      chainId: 2077,
+    })
+    await engine.addRawTx(tx0 as `0x${string}`)
+    await engine.proposeNextBlock()
+
+    // Now try a DIFFERENT tx (different recipient → different hash) reusing
+    // nonce 0. Pre-fix this slipped past the dedup check (different hash) and
+    // landed in the mempool silently. Post-fix it must reject with "nonce too
+    // low" before reaching mempool.
+    const stale = await wallet.signTransaction({
+      to: Wallet.createRandom().address,
+      value: parseEther("2"), // different value → different hash
+      gasLimit: 21000,
+      gasPrice: 1000000000,
+      nonce: 0, // same nonce — already used on-chain
+      chainId: 2077,
+    })
+    await assert.rejects(
+      async () => await engine.addRawTx(stale as `0x${string}`),
+      /nonce too low/,
+      "stale-nonce tx must reject, not silently pollute the mempool",
+    )
+
+    // Also pin a sanity case: same-sender at the CORRECT nonce still works.
+    const next = await wallet.signTransaction({
+      to: Wallet.createRandom().address,
+      value: parseEther("1"),
+      gasLimit: 21000,
+      gasPrice: 1000000000,
+      nonce: 1, // current next nonce
+      chainId: 2077,
+    })
+    await engine.addRawTx(next as `0x${string}`)
+
+    await engine.close()
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test("PersistentChainEngine: get transaction by hash", async () => {
   const tmpDir = mkdtempSync(join(tmpdir(), "coc-engine-test-"))
 

--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -612,14 +612,33 @@ export class PersistentChainEngine {
   }
 
   async addRawTx(rawTx: Hex): Promise<MempoolTx> {
-    const tx = this.mempool.addRawTx(rawTx)
+    // #438: pre-check stale nonce BEFORE mempool insertion. The in-memory
+    // ChainEngine (chain-engine.ts:181-186) has this guard, but the
+    // persistent variant (used in production) was missing it — so on
+    // testnet 88780 an attacker could pollute the mempool with txs whose
+    // nonce is already mined: eth_sendRawTransaction would return a hash,
+    // the tx would sit in the pool until evicted, and the user would see
+    // "success" for a tx that can never confirm. Mirror the in-memory
+    // engine's check so behavior is uniform across both backends. Reading
+    // nonce via evm.getNonce hits the live state manager, which reflects
+    // the latest applied block.
+    const decoded = Transaction.from(rawTx)
 
-    // Check if tx already confirmed using nonce store
-    const nonce = `tx:${tx.hash}`
-    if (await this.txNonceStore.isUsed(nonce)) {
-      this.mempool.remove(tx.hash)
+    // Mirror in-memory engine order: hash dedup first (more specific error
+    // for same-tx replay), then stale-nonce check (catches different-tx-same-
+    // -nonce). Both run before mempool insertion so we never accept a tx that
+    // can't make it on-chain.
+    if (await this.txNonceStore.isUsed(`tx:${decoded.hash}`)) {
       throw new Error("tx already confirmed")
     }
+    if (decoded.from) {
+      const onchainNonce = await this.evm.getNonce(decoded.from.toLowerCase() as Hex)
+      if (BigInt(decoded.nonce) < onchainNonce) {
+        throw new Error(`nonce too low: tx nonce ${decoded.nonce}, on-chain nonce ${onchainNonce}`)
+      }
+    }
+
+    const tx = this.mempool.addRawTx(rawTx, decoded)
 
     // Emit pending transaction event
     this.events.emitPendingTx({


### PR DESCRIPTION
Closes #438.

## Why

The in-memory \`ChainEngine\` (\`chain-engine.ts:181-186\`) has had a \`nonce too low\` guard since #156. The persistent variant (wired in production via \`node/src/index.ts:99\`) was missing the same check. Live testnet 88780 reproduces silent acceptance of stale-nonce txs:

\`\`\`
nonce 184 (5 below latest) → SILENT_ACCEPT, returns hash, never confirms
nonce 186 (3 below latest) → SILENT_ACCEPT
nonce 188 (1 below latest) → SILENT_ACCEPT
nonce 189 (legitimate)     → SILENT_ACCEPT, confirms normally
\`\`\`

The txs end up in the mempool with \`blockHash: null\` until TTL eviction. Mempool-pollution DoS surface + dApp UX regression (\"success\" hash for a tx that vanishes).

## Fix

Mirror the in-memory engine's check in \`PersistentChainEngine.addRawTx\`:

\`\`\`ts
const decoded = Transaction.from(rawTx)
if (await this.txNonceStore.isUsed(\\\`tx:\${decoded.hash}\\\`)) {
  throw new Error(\"tx already confirmed\")
}
if (decoded.from) {
  const onchainNonce = await this.evm.getNonce(decoded.from.toLowerCase() as Hex)
  if (BigInt(decoded.nonce) < onchainNonce) {
    throw new Error(\\\`nonce too low: tx nonce \${decoded.nonce}, on-chain nonce \${onchainNonce}\\\`)
  }
}
const tx = this.mempool.addRawTx(rawTx, decoded)
\`\`\`

Hash dedup first (preserves the existing \`tx already confirmed\` error for same-tx replay), then nonce-too-low (catches different-tx-same-stale-nonce). Both run BEFORE mempool insertion so we never burn a slot on a tx that can never be mined.

## Tests

New \`#438\` regression in \`chain-engine-persistent.test.ts\` pins:
- same-tx replay → \`tx already confirmed\` (preserves existing behavior)
- stale-nonce different-tx → \`nonce too low\` (the new guard)
- correct next-nonce tx still accepted (sanity)

\`\`\`
$ node --experimental-strip-types --test node/src/chain-engine-persistent.test.ts
# tests 29 pass 29 fail 0
$ node --experimental-strip-types --test node/src/chain-engine*.test.ts node/src/mempool.test.ts
# tests 59 pass 59 fail 0
\`\`\`

## Test plan

- [x] Persistent engine suite green
- [x] Adjacent engine + mempool suites green
- [ ] CI green
- [ ] After rollout: replay testnet probe → stale nonce returns -32000, not success