### PR TITLE
fix(rpc): #440 map every mempool/chain rejection to -32000 (not -32603)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2835,6 +2835,91 @@ test("RPC Extended Methods", async (t) => {
       `error must preserve "replacement tx gas price too low" surface, got: ${JSON.stringify(replBody)}`)
   })
 
+  await t.test("#440: eth_sendRawTransaction maps every mempool/chain rejection to -32000 (not -32603)", async () => {
+    // Live testnet 88780 reproduction: bursting 100 concurrent same-sender
+    // txs (per-sender cap = 64) returned 100× -32603 "exceeds max pending
+    // tx limit (64)". ethers.js wraps -32603 as opaque "could not coalesce
+    // error", so callers see neither the cause nor an actionable code.
+    //
+    // Per geth, every well-formed-tx-but-server-won't-accept condition
+    // maps to -32000. Per JSON-RPC, every replay/format problem maps to
+    // -32602. Anything left becomes generic -32603. Pin the canonical map
+    // so wallets + indexers can branch on error.code reliably.
+    const { Wallet } = await import("ethers")
+
+    const submit = async (rawTx: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [rawTx] }),
+      })
+      return await res.json() as { error?: { code: number; message: string }; result?: string }
+    }
+
+    // -32602: wrong chain id (replay protection — definitely a client error).
+    const wallet440a = new Wallet(`0x${"04".repeat(32)}`)
+    await evm.prefund([{ address: wallet440a.address, balanceWei: "1000000000000000000" }])
+    const startNonce440a = await evm.getNonce(wallet440a.address.toLowerCase() as `0x${string}`)
+    const wrongChain = await wallet440a.signTransaction({
+      type: 0,
+      to: `0x${"02".repeat(20)}`,
+      value: 1n,
+      nonce: Number(startNonce440a),
+      gasPrice: 1_000_000_000n,
+      gasLimit: 21_000n,
+      chainId: chainId + 1, // wrong!
+    })
+    {
+      const r = await submit(wrongChain)
+      assert.equal(r.error?.code, -32602,
+        `wrong-chain-id must be -32602 (invalid params), got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /invalid chain ID/i)
+    }
+
+    // -32000: stale nonce (the #438 family — chain-engine throws "nonce too low")
+    const wallet440b = new Wallet(`0x${"05".repeat(32)}`)
+    await evm.prefund([{ address: wallet440b.address, balanceWei: "1000000000000000000" }])
+    const sign440b = (nonce: number) => wallet440b.signTransaction({
+      type: 0, to: `0x${"02".repeat(20)}`, value: 1n, nonce,
+      gasPrice: 1_000_000_000n, gasLimit: 21_000n, chainId,
+    })
+    // Mine the first tx so on-chain nonce advances.
+    const first440b = await sign440b(0)
+    {
+      const r = await submit(first440b)
+      assert.ok(r.result, `setup tx must mine: ${JSON.stringify(r)}`)
+    }
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+    const stale440b = await sign440b(0) // same nonce, now stale
+    {
+      const r = await submit(stale440b)
+      // Either "nonce too low" (#438 wired) or "tx already confirmed"
+      // (#438 hash dedup path); both must map to -32000.
+      assert.equal(r.error?.code, -32000,
+        `stale-nonce must be -32000, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /nonce too low|tx already confirmed/i)
+    }
+
+    // -32000: intrinsic gas too low (gasLimit < 21000 floor).
+    const wallet440c = new Wallet(`0x${"06".repeat(32)}`)
+    await evm.prefund([{ address: wallet440c.address, balanceWei: "1000000000000000000" }])
+    const lowGas = await wallet440c.signTransaction({
+      type: 0,
+      to: `0x${"02".repeat(20)}`,
+      value: 1n,
+      nonce: Number(await evm.getNonce(wallet440c.address.toLowerCase() as `0x${string}`)),
+      gasPrice: 1_000_000_000n,
+      gasLimit: 100n, // way below 21000
+      chainId,
+    })
+    {
+      const r = await submit(lowGas)
+      assert.equal(r.error?.code, -32000,
+        `intrinsic-gas-too-low must be -32000, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /intrinsic gas too low/i)
+    }
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1076,14 +1076,40 @@ async function handleRpc(
         if (isEthersShapeError) {
           invalidParams("invalid raw transaction: failed to decode")
         }
-        // #332: mempool.addRawTx throws plain Error("replacement tx gas price
-        // too low: ...") when a same-nonce replacement doesn't clear the 10%
-        // bump threshold. Pre-fix this surfaced as -32603 "internal error"
-        // even though it's a clean client-input rejection — the caller just
-        // needs to retry with a higher gas price. Map to -32000 to match
-        // geth's "replacement transaction underpriced" convention.
+        // #332 + #440: mempool/chain-engine throws plain Error for every
+        // client-side rejection (replacement underpriced, mempool full, account
+        // quota exceeded, stale nonce, wrong chain id, etc.). Pre-fix they all
+        // surfaced as -32603 "internal error" — ethers.js wraps -32603 as the
+        // opaque "could not coalesce error", breaking ALL programmatic error
+        // handling on the client side. Geth uses -32000 for these (per its
+        // server-error namespace) and -32602 for input-shape errors. Map both
+        // here so callers see actionable codes.
         const msg = parseErr instanceof Error ? parseErr.message : String(parseErr)
-        if (/^replacement tx gas price too low/i.test(msg)) {
+
+        // -32602 invalid params: tx content fails replay/format pre-checks.
+        if (
+          /^invalid chain ID: expected/i.test(msg) ||
+          /^invalid tx: missing sender/i.test(msg) ||
+          /^blob transactions \(type 3\) are not supported/i.test(msg)
+        ) {
+          invalidParams(msg)
+        }
+
+        // -32000 server-side rejection: tx well-formed but the node won't
+        // accept it right now (pool capacity, account quota, nonce, gas).
+        // Same code geth uses for "transaction underpriced", "txpool is full",
+        // "exceeds account quota", "nonce too low", "intrinsic gas too low",
+        // "already known", "gas limit exceeded", etc.
+        if (
+          /^replacement tx gas price too low/i.test(msg) ||
+          /exceeds max pending tx limit/i.test(msg) ||
+          /^mempool is full$/i.test(msg) ||
+          /^nonce too low:/i.test(msg) ||
+          /^tx already confirmed$/i.test(msg) ||
+          /^intrinsic gas too low:/i.test(msg) ||
+          /^gasLimit exceeds maximum:/i.test(msg) ||
+          /is poisoned \(hung block execution/i.test(msg)
+        ) {
           throw { code: -32000, message: msg }
         }
         throw parseErr


### PR DESCRIPTION
Closes #440.

## Why

\`eth_sendRawTransaction\` currently returns \`-32603\` (\"internal error\") for nearly every client-side rejection. ethers.js wraps \`-32603\` as \`could not coalesce error\`, so callers see neither the cause nor an actionable code.

Live testnet 88780 reproduction — 100 concurrent same-sender txs against the per-sender cap (64):

\`\`\`
result: ok=0 error_kinds:
  100 × -32603 sender 0xf39f... exceeds max pending tx limit (64)
\`\`\`

ethers.js v6 collapses all 100 into \`ProviderError: could not coalesce error\`. Wallets, indexers, and dApps can't branch.

## Fix

Extend the existing #332 pattern (\"replacement tx gas price too low\" → -32000) to the full set of mempool / chain-engine rejections:

| Message | New code |
|---|---|
| invalid chain ID, invalid tx: missing sender, blob tx not supported | -32602 |
| replacement underpriced (already #332) | -32000 |
| exceeds max pending tx limit, mempool is full, nonce too low, tx already confirmed, intrinsic gas too low, gasLimit exceeds maximum, tx poisoned | -32000 |

Mirrors geth's convention: -32000 for \"server won't accept this well-formed tx\", -32602 for \"this tx is malformed/replay-violating.\"

## Tests

New \`#440\` regression in \`rpc-extended.test.ts\` covers 3 representative paths:
- wrong chain id → -32602
- stale nonce → -32000
- intrinsic gas too low → -32000

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: testnet 88780 burst test → -32000 with actionable message instead of -32603 \"could not coalesce error\"

## Related

- #332 (original mapping for replacement underpriced) — already merged
- #438 (PersistentChainEngine stale-nonce check) — open as PR #439. \"nonce too low\" message landing as -32000 depends on either of these PRs being applied (the test exercises both paths).