### PR TITLE
fix(chain-engine): #444 reject insufficient-funds tx at submission (geth ErrInsufficientFunds)

### DIFF
--- a/node/src/chain-engine-persistent.test.ts
+++ b/node/src/chain-engine-persistent.test.ts
@@ -332,7 +332,74 @@ test("#438: PersistentChainEngine.addRawTx rejects stale-nonce txs (parity with 
       chainId: 2077,
     })
     await engine.addRawTx(next as `0x${string}`)
+    await engine.close()
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
 
+test("#444: addRawTx rejects insufficient-funds tx at submission (parity with geth ErrInsufficientFunds)", async () => {
+  // Live testnet 88780 reproduction:
+  //   const w = new Wallet('0x' + '42'.repeat(32))  // fresh, 0 balance
+  //   const signed = await w.signTransaction({
+  //     to: '0x70997970...', value: 1n, gasLimit: 21000n,
+  //     gasPrice: 0x77359400n, nonce: 0, chainId: 88780,
+  //   })
+  //   await provider.send('eth_sendRawTransaction', [signed])
+  //   → returns success hash; pending nonce advances 0→1
+  //   await provider.send('eth_getTransactionByHash', [hash])
+  //   → present in mempool with blockHash:null forever
+  //
+  // Phase H3's affordability check inside pickForBlock prevents the tx
+  // from being included in a block, but pre-fix nothing rejected it at
+  // submission. Clients see a success hash for a tx that will never
+  // execute, and the mempool fills with permanently-unfundable txs (a
+  // DoS surface using throwaway wallets).
+  const tmpDir = mkdtempSync(join(tmpdir(), "coc-engine-test-"))
+  try {
+    const evm = await EvmChain.create(2077)
+    // Wallet is intentionally NOT prefunded.
+    const wallet = Wallet.createRandom()
+    const engine = new PersistentChainEngine(
+      {
+        dataDir: tmpDir,
+        nodeId: "node1",
+        chainId: 2077,
+        validators: [],
+        finalityDepth: 3,
+        maxTxPerBlock: 100,
+        minGasPriceWei: 1n,
+      },
+      evm
+    )
+    await engine.init()
+
+    const tx = await wallet.signTransaction({
+      to: Wallet.createRandom().address,
+      value: parseEther("1"),
+      gasLimit: 21_000,
+      gasPrice: 1_000_000_000,
+      nonce: 0,
+      chainId: 2077,
+    })
+    await assert.rejects(
+      async () => await engine.addRawTx(tx as `0x${string}`),
+      /insufficient funds for gas \* price \+ value/i,
+      "0-balance sender must reject at submission, not silently fill mempool",
+    )
+
+    // Once funded, the same shape (different nonce since wallet is single-shot)
+    // must succeed — pin the positive case so the check stays narrow.
+    await evm.prefund([{ address: wallet.address, balanceWei: parseEther("10").toString() }])
+    const tx2 = await wallet.signTransaction({
+      to: Wallet.createRandom().address,
+      value: parseEther("1"),
+      gasLimit: 21_000,
+      gasPrice: 1_000_000_000,
+      nonce: 0,
+      chainId: 2077,
+    })
+    await engine.addRawTx(tx2 as `0x${string}`)
     await engine.close()
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })

--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -640,6 +640,28 @@ export class PersistentChainEngine {
 
     const tx = this.mempool.addRawTx(rawTx, decoded)
 
+    // #444: sender balance must cover the upfront cost (gas + value) at
+    // submission time. Phase H3 already checks affordability inside
+    // pickForBlock (mempool.ts:411-432), but pre-fix nothing rejected an
+    // unfundable tx at INSERTION — eth_sendRawTransaction returned a hash
+    // for a 0-balance sender, the tx sat in the mempool until block-pick
+    // time noticed it couldn't pay, and clients saw "success" for txs that
+    // can never execute. Same family as the #438 nonce gap. Mirror geth's
+    // pre-mempool ErrInsufficientFunds for parity.
+    const effectiveGasPrice = tx.maxFeePerGas > 0n
+      ? tx.maxFeePerGas
+      : tx.gasPrice
+    const upfrontCost = effectiveGasPrice * tx.gasLimit + tx.value
+    if (upfrontCost > 0n) {
+      const senderBalance = await this.evm.getBalance(tx.from)
+      if (senderBalance < upfrontCost) {
+        this.mempool.remove(tx.hash)
+        throw new Error(
+          `insufficient funds for gas * price + value: address ${tx.from} have ${senderBalance} want ${upfrontCost}`,
+        )
+      }
+    }
+
     // Emit pending transaction event
     this.events.emitPendingTx({
       hash: tx.hash,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1133,6 +1133,13 @@ async function handleRpc(
         ) {
           throw { code: -32000, message: msg }
         }
+        // #444: insufficient-funds rejection at addRawTx time. Geth uses
+        // -32000 for "insufficient funds for gas * price + value" so
+        // ethers.js surfaces it as an actionable error rather than the
+        // opaque -32603 "could not coalesce" wrapper.
+        if (/^insufficient funds for gas \* price \+ value/i.test(msg)) {
+          throw { code: -32000, message: msg }
+        }
         throw parseErr
       }
       await p2p.receiveTx(raw)


### PR DESCRIPTION
Closes #444.

## Why

Phase H3 wired an affordability check inside \`mempool.pickForBlock\`, but nothing checks at INSERTION. Wallets submitting from 0-balance senders see \`eth_sendRawTransaction\` return a success hash and the pending nonce advance — the tx then sits in the mempool forever (only block-pick on proposer nodes ever evicts it).

Live testnet 88780 reproduction:
\`\`\`
fresh wallet, balance 0 → tx submission returns hash 0xa1d3...
→ eth_getTransactionByHash returns the tx, blockHash:null
→ pending nonce advances to 1
→ tx never confirms
\`\`\`

DoS surface (cheap-to-throw wallets pollute the mempool) + UX regression (dApps hang on \"pending\"). Same family as #438 — pre-mempool validation gap.

## Fix

Add geth-style \`ErrInsufficientFunds\` check in \`PersistentChainEngine.addRawTx\`:

\`\`\`ts
const effectiveGasPrice = tx.maxFeePerGas > 0n ? tx.maxFeePerGas : tx.gasPrice
const upfrontCost = effectiveGasPrice * tx.gasLimit + tx.value
if (upfrontCost > 0n) {
  const senderBalance = await this.evm.getBalance(tx.from)
  if (senderBalance < upfrontCost) {
    this.mempool.remove(tx.hash)
    throw new Error(\`insufficient funds for gas * price + value: address \${tx.from} have \${senderBalance} want \${upfrontCost}\`)
  }
}
\`\`\`

Mapped to \`-32000\` in \`rpc.ts\` (extends #332 / #440).

## Tests

New \`#444\` regression in \`chain-engine-persistent.test.ts\`:
- 0-balance wallet submits → \`insufficient funds for gas * price + value\` (matches the regex pattern ethers uses to surface this)
- same wallet prefunded → tx accepted (positive sanity)

\`\`\`
$ node --experimental-strip-types --test node/src/chain-engine-persistent.test.ts
# tests 29 pass 29 fail 0
$ node --experimental-strip-types --test \\
    node/src/chain-engine.test.ts \\
    node/src/chain-engine-persistent.test.ts \\
    node/src/mempool.test.ts
# tests 68 pass 68 fail 0
\`\`\`

## Test plan

- [x] Persistent engine + mempool suites green
- [ ] CI green
- [ ] After rollout: testnet 88780 probe → 0-balance wallet gets \`-32000 insufficient funds\` instead of success hash

## Related

- #438 (PR #439): stale-nonce pre-mempool check. Sibling fix — together they close the two main mempool-pollution vectors (\"already-used nonce\", \"can't afford\").
- #332 / #440 (PR #441): error code mapping for mempool/chain rejections. The new \`insufficient funds\` message is added to the -32000 map.