### PR TITLE
fix(rpc): #446 receipt effectiveGasPrice computes correct EIP-1559 value (min(maxFee, baseFee+maxPriority))

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2784,6 +2784,82 @@ test("RPC Extended Methods", async (t) => {
       "contract T must be in compile output")
   })
 
+  await t.test("#446: eth_getTransactionReceipt computes effectiveGasPrice correctly for EIP-1559 (type 2) txs", async () => {
+    // Live testnet 88780 reproduction:
+    //   maxFeePerGas         = 0xa00000000    (42.95 Gwei)
+    //   maxPriorityFeePerGas = 0x10000000     (0.27 Gwei)
+    //   block baseFeePerGas  = 0x3b9aca00     (1 Gwei)
+    //   expected effective   = min(maxFee, baseFee + maxPrio) = 0x4b9aca00
+    //   pre-fix actual       = 0xa00000000   ← maxFeePerGas, wrong by 33×
+    //
+    // formatPersistentReceipt was setting effectiveGasPrice = parsed.gasPrice
+    // from formatRawTransaction, which for type-2 txs falls back to
+    // maxFeePerGas (ethers normalizes parsed.gasPrice = undefined for
+    // EIP-1559). Indexers, block explorers, and fee-rebate calculators
+    // saw the wrong number for every type-2 tx on COC.
+    const { Wallet, parseEther } = await import("ethers")
+    const wallet = new Wallet(`0x${"09".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: parseEther("10").toString() }])
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+
+    const maxPriority = 200_000_000n     // 0.2 Gwei
+    const maxFee = 50_000_000_000n        // 50 Gwei — way above baseFee+priority
+
+    const tx1559 = await wallet.signTransaction({
+      type: 2,
+      to: `0x${"0a".repeat(20)}`,
+      value: 1n,
+      nonce: Number(startN),
+      maxFeePerGas: maxFee,
+      maxPriorityFeePerGas: maxPriority,
+      gasLimit: 50_000n,
+      chainId,
+    })
+
+    const submit = async (raw: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await res.json() as { result?: string; error?: { code: number; message: string } }
+    }
+    const getReceipt = async (hash: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionReceipt", params: [hash] }),
+      })
+      return await res.json() as { result?: Record<string, unknown> }
+    }
+
+    const r = await submit(tx1559)
+    assert.ok(r.result, `EIP-1559 submit must succeed: ${JSON.stringify(r)}`)
+
+    // Force a block so the tx persists; needed for formatPersistentReceipt
+    // path. The in-memory cache has a separate correctly-computed
+    // effectiveGasPrice — this test specifically pins the persisted path.
+    if (chain.proposeNextBlock) {
+      await chain.proposeNextBlock()
+    }
+
+    const rec = await getReceipt(r.result!)
+    assert.ok(rec.result, `receipt must be present after mining: ${JSON.stringify(rec)}`)
+    assert.equal(rec.result!.type, "0x2", "type must be 0x2 for EIP-1559 receipt")
+
+    const effective = BigInt(String(rec.result!.effectiveGasPrice))
+    // effectiveGasPrice MUST NOT equal maxFeePerGas (the bug's signature).
+    assert.notEqual(
+      effective, maxFee,
+      `effectiveGasPrice must NOT equal maxFeePerGas (${maxFee}); got ${effective} — this is the #446 regression`,
+    )
+    // Sanity: effective must be ≤ maxFeePerGas.
+    assert.ok(
+      effective <= maxFee,
+      `effectiveGasPrice (${effective}) must be ≤ maxFeePerGas (${maxFee})`,
+    )
+  })
+
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {
     // mempool.addRawTx throws plain Error("replacement tx gas price too
     // low: need at least X, got Y") when a same-nonce replacement does

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3730,10 +3730,44 @@ async function formatPersistentReceipt(
       logIndex: toRpcQuantity(idx),
       removed: false,
     })),
-    effectiveGasPrice: String((parsed as Record<string, unknown>).gasPrice ?? "0x0"),
+    // #446: prefer the stored effectiveGasPrice (already computed correctly by
+    // evm.ts:404-413 during block execution). Fall back to recomputing from
+    // the parsed tx + block baseFee only when the stored field is absent
+    // (older blocks or non-EVM-produced receipts).
+    effectiveGasPrice: tx.receipt.effectiveGasPrice
+      && tx.receipt.effectiveGasPrice !== "0x0"
+      ? tx.receipt.effectiveGasPrice
+      : toRpcQuantity(computeEffectiveGasPrice(parsed, block?.baseFee ?? 0n)),
     contractAddress,
     type: String((parsed as Record<string, unknown>).type ?? "0x0"),
   }
+}
+
+/**
+ * Receipt `effectiveGasPrice` per EIP-1559:
+ *   - Legacy (type 0) / EIP-2930 (type 1): gasPrice (whatever the tx signed).
+ *   - EIP-1559 (type 2): min(maxFeePerGas, baseFeePerGas + maxPriorityFeePerGas).
+ *
+ * #446: pre-fix the receipt formatter set effectiveGasPrice = parsed.gasPrice,
+ * which for type-2 txs that ethers normalizes to maxFeePerGas. Live testnet
+ * 88780 reproduction: tx with maxFee=0xa00000000 (42.95 Gwei), maxPriority=
+ * 0x10000000 (0.27 Gwei), baseFee=0x3b9aca00 (1 Gwei) reported
+ * effectiveGasPrice=0xa00000000 instead of the correct 0x4b9aca00
+ * (~1.27 Gwei) — a 33x overstatement. Block explorers, gas tracking, and
+ * fee-rebate calculations all see the wrong number.
+ */
+function computeEffectiveGasPrice(
+  parsed: Record<string, unknown>,
+  baseFeePerGas: bigint,
+): bigint {
+  const txType = Number(parsed.type ?? "0x0")
+  if (txType === 2) {
+    const maxFee = BigInt(String(parsed.maxFeePerGas ?? "0x0"))
+    const maxPrio = BigInt(String(parsed.maxPriorityFeePerGas ?? "0x0"))
+    const dynamic = baseFeePerGas + maxPrio
+    return maxFee < dynamic ? maxFee : dynamic
+  }
+  return BigInt(String(parsed.gasPrice ?? "0x0"))
 }
 
 /**


### PR DESCRIPTION
Closes #446.

## Why

\`formatPersistentReceipt\` was overwriting the stored (correctly-computed) \`effectiveGasPrice\` with \`parsed.gasPrice\` from \`formatRawTransaction\`. For type-2 (EIP-1559) txs, ethers v6 leaves \`parsed.gasPrice\` undefined, so the formatter fell back to \`maxFeePerGas\`. Every EIP-1559 receipt reported maxFeePerGas instead of the actual paid price.

Live testnet 88780:
\`\`\`
tx maxFeePerGas      = 0xa00000000   (42.95 Gwei)
tx maxPriorityFee    = 0x10000000    (0.27 Gwei)
block baseFeePerGas  = 0x3b9aca00    (1 Gwei)
expected effective   = 0x4b9aca00    (1.27 Gwei)
actual effective     = 0xa00000000   ← maxFeePerGas (33× too high)
\`\`\`

## Fix

\`\`\`ts
effectiveGasPrice: tx.receipt.effectiveGasPrice && tx.receipt.effectiveGasPrice !== \"0x0\"
  ? tx.receipt.effectiveGasPrice              // EVM-computed, already correct
  : toRpcQuantity(computeEffectiveGasPrice(parsed, block?.baseFee ?? 0n))
\`\`\`

New helper \`computeEffectiveGasPrice\` does the EIP-1559 \`min(maxFee, baseFee + maxPriority)\` for type-2; returns \`parsed.gasPrice\` unchanged for legacy / EIP-2930.

## Tests

New \`#446\` regression in \`rpc-extended.test.ts\`:
- EIP-1559 tx with \`maxFee >> baseFee + priority\` → receipt's effective != maxFee
- effective ≤ maxFee (sanity)

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Impact (post-rollout)

Block explorers, indexers, fee-rebate calculators, gas dashboards see the actual paid price for type-2 txs (no longer 33× inflated).

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: re-probe testnet 88780 → receipt.effectiveGasPrice ≠ tx.maxFeePerGas

## Related

- #442 (PR #443): EIP-2930/EIP-1559 \`accessList\` field. Same family — type-1/2 tx response field correctness.