### PR TITLE
fix(rpc): #448 extraData encodes proposer as raw address bytes (≤32-byte consensus cap)

### DIFF
--- a/node/src/chain-events.ts
+++ b/node/src/chain-events.ts
@@ -100,7 +100,12 @@ export async function formatNewHeadsNotification(event: BlockEvent): Promise<Rec
     receiptsRoot: headerView.receiptsRoot,
     miner: block.proposer.startsWith("0x") ? block.proposer : "0x0000000000000000000000000000000000000000",
     difficulty: "0x0",
-    extraData: `0x${Buffer.from(block.proposer, "utf-8").toString("hex")}`,
+    // #448: encode proposer as address bytes (20 bytes), not ASCII string.
+    // See rpc.ts:formatBlockResponse for context. Falls back to UTF-8
+    // (truncated to 32 bytes) when proposer isn't a hex address.
+    extraData: /^0x[0-9a-fA-F]{40}$/.test(block.proposer)
+      ? block.proposer.toLowerCase()
+      : `0x${Buffer.from(block.proposer, "utf-8").toString("hex").slice(0, 64)}`,
     gasLimit: "0x1c9c380",
     gasUsed: `0x${headerView.gasUsed.toString(16)}`,
     timestamp: `0x${Math.floor(block.timestampMs / 1000).toString(16)}`,

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2860,6 +2860,62 @@ test("RPC Extended Methods", async (t) => {
     )
   })
 
+  await t.test("#448: eth_getBlockByNumber extraData is 20-byte address (not 42-byte ASCII string)", async () => {
+    // Live testnet 88780 reproduction:
+    //   $ curl ...eth_getBlockByNumber latest
+    //   {
+    //     "miner":     "0xde4e7889aa9007318ff261b1ee675f1305153590",
+    //     "extraData": "0x307864653465373838396161393030373331386666323631623165653637356631333035313533353930"
+    //   }
+    //   ↑ 84 hex chars after 0x = 42 bytes — exceeds Ethereum's 32-byte
+    //     extraData cap (consensus rule)
+    //   ↑ ASCII decodes to the proposer address rendered as TEXT STRING:
+    //     bytes.fromhex("307864...3530") = "0xde4e7889aa9007318ff261b1ee675f1305153590"
+    //
+    // formatBlockResponse used Buffer.from(proposer, "utf-8").toString("hex")
+    // which encodes each ASCII character of the "0x..." string. The result
+    // is wasteful AND a consensus-rule violation. External spec-strict
+    // block validators (L2 fraud-proof generators, geth-strict block import)
+    // reject any header with extraData > 32 bytes.
+    const res = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getBlockByNumber", params: ["latest", false] }),
+    })
+    const body = await res.json() as { result?: Record<string, unknown> }
+    assert.ok(body.result, "latest block must exist")
+    const extraData = String(body.result!.extraData ?? "")
+    const miner = String(body.result!.miner ?? "")
+
+    // 1. extraData must be ≤ 32 bytes (Ethereum consensus rule).
+    const extraBytes = (extraData.length - 2) / 2
+    assert.ok(extraBytes <= 32,
+      `extraData must be ≤ 32 bytes (Ethereum consensus rule), got ${extraBytes} bytes: ${extraData}`)
+
+    // 2. extraData must NOT be the ASCII rendering of the address.
+    // The pre-fix output, decoded as latin1, would start with "0x".
+    if (extraData.length > 2) {
+      const decoded = Buffer.from(extraData.slice(2), "hex").toString("latin1")
+      assert.ok(!decoded.startsWith("0x"),
+        `extraData must not be ASCII-encoded hex string (bug signature). Decoded as latin1: "${decoded}"`)
+    }
+
+    // 3. When proposer is a 20-byte hex address (production case),
+    // extraData should equal the proposer byte-for-byte (which equals
+    // miner when miner is hex). When proposer is a test-fixture node ID
+    // (e.g. "node-1"), miner falls back to the zero address but extraData
+    // still encodes the proposer as UTF-8 bytes (truncated to ≤32 bytes).
+    //
+    // Either way, the 32-byte cap (assertion 1) and the "no ASCII-encoded
+    // 0x..." check (assertion 2) catch the original bug. Skip the
+    // byte-for-byte equality check when miner is the zero address.
+    if (miner !== "0x0000000000000000000000000000000000000000"
+      && /^0x[0-9a-fA-F]{40}$/.test(miner)) {
+      assert.equal(extraData.toLowerCase(), miner.toLowerCase(),
+        `extraData should encode proposer address as raw bytes (matching miner field)`)
+    }
+  })
+
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {
     // mempool.addRawTx throws plain Error("replacement tx gas price too
     // low: need at least X, got Y") when a same-nonce replacement does

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3934,7 +3934,20 @@ async function formatBlock(block: Awaited<ReturnType<IChainEngine["getBlockByNum
     miner: block.proposer.startsWith("0x") ? block.proposer : "0x0000000000000000000000000000000000000000",
     difficulty: "0x0",
     totalDifficulty: "0x0",
-    extraData: `0x${Buffer.from(block.proposer, "utf-8").toString("hex")}`,
+    // #448: encode extraData as the proposer's address BYTES (20 bytes),
+    // not the ASCII representation of the hex string. Pre-fix
+    // `Buffer.from(block.proposer, "utf-8").toString("hex")` encoded the
+    // 42-char "0x..." string char-by-char, producing 42 BYTES of extraData
+    // — both wasteful AND a violation of Ethereum's 32-byte extraData cap
+    // (consensus rule). External spec-strict validators (L2 fraud-proof
+    // generators, geth-strict block import) rejected COC blocks.
+    //
+    // When proposer is a 20-byte hex address, use it directly. Otherwise
+    // (test fixtures, non-address node IDs) fall back to UTF-8 encoding
+    // but truncate to 32 bytes to stay within the consensus cap.
+    extraData: /^0x[0-9a-fA-F]{40}$/.test(block.proposer)
+      ? block.proposer.toLowerCase()
+      : `0x${Buffer.from(block.proposer, "utf-8").toString("hex").slice(0, 64)}`,
     mixHash: "0x" + "0".repeat(64),
     size: `0x${blockSize.toString(16)}`,
     gasLimit: `0x${BLOCK_GAS_LIMIT.toString(16)}`,


### PR DESCRIPTION
Closes #448.

## Why

\`formatBlockResponse\` + \`chain-events\` newHeads formatter both use:

\`\`\`ts
extraData: \`0x\${Buffer.from(block.proposer, \"utf-8\").toString(\"hex\")}\`
\`\`\`

When \`block.proposer\` is the 42-char hex address (production case), each ASCII char gets encoded to 2 hex bytes → **42 bytes** of extraData, violating Ethereum's 32-byte cap (yellow paper §4.3.4). The bytes decode back to the proposer's address as a TEXT STRING.

Live testnet 88780:
\`\`\`
miner:     0xde4e7889aa9007318ff261b1ee675f1305153590  (20 bytes raw)
extraData: 0x307864...3530  (84 hex chars = 42 bytes — violates ≤32 cap)
\`\`\`

External spec-strict validators (geth import, L2 fraud-proof generators, light-client verifiers) reject any header > 32 bytes extraData.

## Fix

When proposer is a 20-byte hex address, use it directly. Else fall back to UTF-8 encoding (truncated to 32 bytes):

\`\`\`ts
extraData: /^0x[0-9a-fA-F]{40}\$/.test(block.proposer)
  ? block.proposer.toLowerCase()
  : \`0x\${Buffer.from(block.proposer, \"utf-8\").toString(\"hex\").slice(0, 64)}\`
\`\`\`

Both formatters fixed in lockstep (\`rpc.ts\` + \`chain-events.ts\`).

## Tests

New \`#448\` regression in \`rpc-extended.test.ts\` pins:
1. extraData ≤ 32 bytes (consensus cap)
2. extraData bytes don't decode to ASCII \"0x...\" (bug signature)
3. when proposer is a hex address, extraData equals miner byte-for-byte

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: re-probe testnet 88780 → \`extraData.length\` ≤ 66 chars (32 bytes + 0x), miner-equal