### PR TITLE
fix(rpc): #450 txpool_content carries full EIP-1559/EIP-2930 fields (parity with eth_getTransactionByHash)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -702,6 +702,76 @@ test("RPC Extended Methods", async (t) => {
     )
   })
 
+  await t.test("#450: txpool_content entries carry full EIP-1559/EIP-2930 fields (parity with eth_getTransactionByHash)", async () => {
+    // Live testnet 88780 reproduction:
+    //   $ curl ...txpool_content
+    //   {
+    //     "queued": {
+    //       "0xf39f...": {
+    //         "411": {
+    //           "hash": "0xf6094f...", "nonce": "0x19b", "from": "0xf39f...",
+    //           "to": "0x70997970...", "value": "0x1", "gas": "0x5208",
+    //           "gasPrice": "0x77359400", "input": "0x"
+    //           // MISSING: maxFeePerGas, maxPriorityFeePerGas, accessList,
+    //           //          type, chainId, v, r, s, blockHash, blockNumber,
+    //           //          transactionIndex
+    //         }
+    //       }
+    //     }
+    //   }
+    //
+    // splitMempoolPendingQueued was hand-rolling a per-entry literal with
+    // legacy fields only. Indexers that compare in-pool vs mined-tx shape
+    // (etherscan-clones, mempool dashboards) saw mismatched fields. Reuse
+    // formatRawTransaction so the entries match eth_getTransactionByHash.
+    const { Wallet: EW, Transaction: ET } = await import("ethers")
+    const wallet = new EW(`0x${"0b".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const startNonce = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+
+    // Send an EIP-1559 tx with a gap nonce so it lands in `queued`.
+    const tx1559 = ET.from({
+      type: 2,
+      to: `0x${"0c".repeat(20)}`,
+      value: 1n,
+      nonce: Number(startNonce) + 3, // gap → queued bucket
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 100_000_000n,
+      gasLimit: 50_000n,
+      chainId,
+      data: "0x",
+    })
+    const sig = wallet.signingKey.sign(tx1559.unsignedHash)
+    const clone = tx1559.clone()
+    clone.signature = sig
+    const raw = clone.serialized
+    await rpcCall(port, "eth_sendRawTransaction", [raw])
+
+    const content = await rpcCall(port, "txpool_content") as {
+      pending: Record<string, Record<string, Record<string, unknown>>>
+      queued: Record<string, Record<string, Record<string, unknown>>>
+    }
+    const senderAddr = wallet.address.toLowerCase()
+    const queuedForSender = content.queued[senderAddr] ?? {}
+    const entry = queuedForSender[String(Number(startNonce) + 3)]
+    assert.ok(entry, `EIP-1559 tx must appear in queued bucket: ${JSON.stringify(Object.keys(queuedForSender))}`)
+
+    // The full set of fields that geth's txpool_content includes (parity
+    // with eth_getTransactionByHash):
+    assert.equal(entry.type, "0x2", `type must be 0x2 for EIP-1559, got ${entry.type}`)
+    assert.equal(entry.maxFeePerGas, "0x77359400", `maxFeePerGas must be present`)
+    assert.equal(entry.maxPriorityFeePerGas, "0x5f5e100", `maxPriorityFeePerGas must be present`)
+    assert.equal(entry.chainId, `0x${chainId.toString(16)}`)
+    // Mempool txs report null for these three (per geth):
+    assert.equal(entry.blockHash, null, "blockHash null for mempool")
+    assert.equal(entry.blockNumber, null, "blockNumber null for mempool")
+    assert.equal(entry.transactionIndex, null, "transactionIndex null for mempool")
+    // Signature fields must be present:
+    assert.ok(typeof entry.v === "string", `v must be present, got ${entry.v}`)
+    assert.ok(typeof entry.r === "string", `r must be present, got ${entry.r}`)
+    assert.ok(typeof entry.s === "string", `s must be present, got ${entry.s}`)
+  })
+
   await t.test("coc_nodeInfo returns node metadata", async () => {
     const info = await rpcCall(port, "coc_nodeInfo")
     assert.ok(typeof info === "object")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3799,16 +3799,20 @@ async function splitMempoolPendingQueued(
     const onchainNonce = await evm.getNonce(sender)
     let expected = onchainNonce
     for (const mtx of senderTxs) {
-      const parsed = Transaction.from(mtx.rawTx)
-      const entry = {
+      // #450: reuse formatRawTransaction so txpool_content entries have
+      // the same shape as eth_getTransactionByHash — including type,
+      // maxFeePerGas, maxPriorityFeePerGas, accessList (#442/#443), chainId,
+      // v/r/s. Pre-fix the bespoke literal omitted every EIP-1559 / EIP-2930
+      // field, breaking indexers that expect parity with mined-tx output.
+      // Block context is omitted (mempool txs): formatRawTransaction emits
+      // blockHash: null, blockNumber: null, transactionIndex: null.
+      const entry = formatRawTransaction(mtx.rawTx as Hex) ?? {
         hash: mtx.hash,
         nonce: `0x${mtx.nonce.toString(16)}`,
         from: mtx.from,
-        to: parsed.to ?? null,
-        value: `0x${(parsed.value ?? 0n).toString(16)}`,
         gas: `0x${mtx.gasLimit.toString(16)}`,
         gasPrice: `0x${mtx.gasPrice.toString(16)}`,
-        input: parsed.data ?? "0x",
+        input: "0x",
       }
       const bucket = mtx.nonce === expected ? pending : queued
       if (!bucket[sender]) bucket[sender] = {}


### PR DESCRIPTION
Closes #450.

## Why

\`splitMempoolPendingQueued\` hand-rolled a per-entry literal with legacy fields only. Every EIP-1559/EIP-2930 tx in the mempool was missing 11 fields (type, maxFeePerGas, maxPriorityFeePerGas, accessList, chainId, v, r, s, blockHash, blockNumber, transactionIndex). Indexers comparing in-pool vs mined-tx shape saw mismatched output.

Live testnet 88780:
\`\`\`
queued: { 0xf39f...: { 411: {
  hash, nonce, from, to, value, gas, gasPrice, input  // only 8 fields
}}}
\`\`\`

## Fix

Reuse \`formatRawTransaction\` (the same shared formatter used by \`eth_getTransactionByHash\`). Shape parity is now automatic — when fields are added or fixed (e.g. \`accessList\` in PR #443, \`effectiveGasPrice\` in PR #447), \`txpool_content\` benefits transitively.

The hand-rolled literal is kept as a defensive fallback for truly unparseable raw bytes.

## Tests

New \`#450\` regression in \`rpc-extended.test.ts\` pins:
- \`type=0x2\` present on EIP-1559 entries
- \`maxFeePerGas\` / \`maxPriorityFeePerGas\` present
- \`chainId\` present
- \`v\`/\`r\`/\`s\` signature components present
- \`blockHash\`/\`blockNumber\`/\`transactionIndex\` are null (per geth)

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: testnet 88780 \`txpool_content\` → entry shape matches \`eth_getTransactionByHash\`

## Related

- #442 (PR #443): formatRawTransaction adds accessList — stacks with this PR so accessList flows into txpool_content
- #446 (PR #447): effectiveGasPrice fix in the same formatter family