### PR TITLE
fix(rpc): #452 synthesised genesis block matches non-genesis shape (Cancun fields + empty-trie roots)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1053,6 +1053,63 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(zeroTag.hash, earliest!.hash)
   })
 
+  await t.test("#452: synthesised genesis block matches non-genesis block shape (Cancun fields + empty-trie roots)", async () => {
+    // Pre-fix:
+    //   - transactionsRoot / receiptsRoot were ZERO_HASH instead of the
+    //     canonical empty-trie root (rlp(empty) keccak). Geth/erigon use
+    //     EMPTY_TRIE_ROOT for empty blocks; some validity checkers reject
+    //     zero roots, and shape diff vs block 1 broke ethers' block parser.
+    //   - withdrawals / withdrawalsRoot / blobGasUsed / excessBlobGas /
+    //     parentBeaconBlockRoot were missing entirely; every post-Cancun
+    //     block on the chain has them. Shape bifurcation broke clients.
+    //   - `uncles` was emitted only on genesis; non-genesis blocks omit it.
+    //   - `finalized` was missing; genesis is by definition finalized.
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block")
+    const genesis = await rpcCall(port, "eth_getBlockByNumber", ["earliest", false]) as Record<string, unknown>
+    const block1 = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+
+    // 1. Empty-trie roots, not zero hash.
+    const EMPTY_TRIE_ROOT = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+    assert.equal(
+      genesis.transactionsRoot, EMPTY_TRIE_ROOT,
+      "genesis transactionsRoot must be EMPTY_TRIE_ROOT (not zero hash) — required for spec-strict validators",
+    )
+    assert.equal(
+      genesis.receiptsRoot, EMPTY_TRIE_ROOT,
+      "genesis receiptsRoot must be EMPTY_TRIE_ROOT",
+    )
+
+    // 2. Cancun post-fork fields must be present on genesis (so the
+    // response shape matches block 1+ — bifurcation breaks block parsers).
+    assert.equal(genesis.blobGasUsed, "0x0", "genesis.blobGasUsed must be present (matches Cancun blocks)")
+    assert.equal(genesis.excessBlobGas, "0x0", "genesis.excessBlobGas must be present")
+    assert.deepEqual(genesis.withdrawals, [], "genesis.withdrawals must be present (empty)")
+    assert.equal(
+      genesis.withdrawalsRoot, EMPTY_TRIE_ROOT,
+      "genesis.withdrawalsRoot must be present (empty trie root)",
+    )
+    assert.equal(
+      genesis.parentBeaconBlockRoot, "0x" + "0".repeat(64),
+      "genesis.parentBeaconBlockRoot must be present (zero hash)",
+    )
+    assert.equal(genesis.finalized, true, "genesis must be finalized=true (it's the oldest block)")
+
+    // 3. Field-set parity with non-genesis (no `uncles` only on genesis).
+    assert.ok(!("uncles" in genesis), "uncles must NOT be on genesis (chain is post-PoW)")
+    assert.ok(!("uncles" in block1), "uncles must NOT be on non-genesis either (consistency)")
+
+    // 4. Genesis must declare every field block 1 does. Difference set must
+    // be empty modulo totalDifficulty (some chains omit it on later blocks).
+    const block1Keys = new Set(Object.keys(block1))
+    const genesisKeys = new Set(Object.keys(genesis))
+    const missingFromGenesis = [...block1Keys].filter((k) => !genesisKeys.has(k))
+    assert.deepEqual(
+      missingFromGenesis, [],
+      `genesis missing keys present in block 1: ${missingFromGenesis.join(", ")} (shape bifurcation)`,
+    )
+  })
+
   await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
     const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
     assert.ok(Array.isArray(peers), "must return an array")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3858,10 +3858,24 @@ async function classifyMempoolPendingQueued(
  * already uses on the wire (parentHash = 0x000…000, timestamp = 0). Empty txs,
  * empty proposer, default 30M gasLimit. Hash is all-zeros — the same value
  * block 1 carries as parentHash, so chain integrity checks line up.
+ *
+ * #452: shape must match non-genesis blocks (formatBlockResponse) so client
+ * libraries don't bifurcate on field set. Specifically:
+ *   - transactionsRoot / receiptsRoot use the empty-trie root (the canonical
+ *     keccak of rlp(empty)), not zero hash — geth, parity, erigon all use
+ *     this for empty blocks; some block-validity checkers reject zero roots.
+ *   - withdrawals / withdrawalsRoot / blobGasUsed / excessBlobGas /
+ *     parentBeaconBlockRoot were missing entirely — every post-Cancun block
+ *     in the chain has them, so genesis must too.
+ *   - uncles[] was emitted only for genesis; non-genesis blocks omit it.
+ *     Drop it for consistency (we're a post-PoW chain).
+ *   - finalized field was missing — genesis is by definition finalized.
  */
 function formatGenesisBlock(includeTx: boolean) {
   const ZERO_HASH = `0x${"0".repeat(64)}`
   const ZERO_ADDR = `0x${"0".repeat(40)}`
+  // keccak256(rlp([])) — the canonical empty Merkle Patricia Trie root.
+  const EMPTY_TRIE_ROOT = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
   return {
     number: "0x0",
     hash: ZERO_HASH,
@@ -3869,21 +3883,26 @@ function formatGenesisBlock(includeTx: boolean) {
     nonce: "0x0000000000000000",
     sha3Uncles: ZERO_HASH,
     logsBloom: `0x${"0".repeat(512)}`,
-    transactionsRoot: ZERO_HASH,
+    transactionsRoot: EMPTY_TRIE_ROOT,
     stateRoot: ZERO_HASH,
-    receiptsRoot: ZERO_HASH,
+    receiptsRoot: EMPTY_TRIE_ROOT,
     miner: ZERO_ADDR,
     difficulty: "0x0",
     totalDifficulty: "0x0",
     extraData: "0x",
+    mixHash: ZERO_HASH,
     size: "0x0",
     gasLimit: "0x1c9c380",
     gasUsed: "0x0",
     timestamp: "0x0",
-    transactions: includeTx ? [] : [],
-    uncles: [],
-    mixHash: ZERO_HASH,
     baseFeePerGas: "0x0",
+    withdrawals: [],
+    withdrawalsRoot: EMPTY_TRIE_ROOT,
+    blobGasUsed: "0x0",
+    excessBlobGas: "0x0",
+    parentBeaconBlockRoot: ZERO_HASH,
+    finalized: true,
+    transactions: includeTx ? [] : [],
   }
 }
 


### PR DESCRIPTION
Closes #452.

## Why

\`formatGenesisBlock\` returned a different shape than \`formatBlockResponse\`:

1. \`transactionsRoot\` / \`receiptsRoot\` were \`ZERO_HASH\` instead of the canonical empty-trie root (\`0x56e81f...3b421\`).
2. 5 Cancun fields missing: \`withdrawals\`, \`withdrawalsRoot\`, \`blobGasUsed\`, \`excessBlobGas\`, \`parentBeaconBlockRoot\`.
3. \`uncles: []\` was only on genesis; non-genesis correctly omits it (post-PoW chain).
4. \`finalized\` field missing; genesis is by definition finalized.

ethers, viem, hardhat block parsers see different shape for genesis vs block 1, breaking fork-detection. Spec-strict validators reject zero-rooted genesis.

## Fix

- Use EMPTY_TRIE_ROOT for empty roots.
- Add the 5 Cancun fields with zero/empty defaults.
- Add \`finalized: true\`.
- Remove \`uncles\`.
- Field ordering reshuffled to match formatBlockResponse.

## Tests

New \`#452\` regression in \`rpc-extended.test.ts\` pins:
- transactionsRoot / receiptsRoot are EMPTY_TRIE_ROOT
- 5 Cancun fields present with right defaults
- \`finalized: true\` on genesis
- \`uncles\` NOT on genesis (consistency with block 1)
- genesis carries every key block 1 has

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: \`eth_getBlockByNumber earliest\` returns shape matching \`eth_getBlockByNumber 0x1\`