### PR TITLE
fix(rpc): #454 receipt logIndex is block-global (geth-spec parity)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -824,7 +824,31 @@ export class EvmChain {
   }
 
   getReceipt(txHash: string): TxReceipt | null {
-    return this.receipts.get(txHash) ?? null
+    const r = this.receipts.get(txHash)
+    if (!r) return null
+    if (!r.logs || r.logs.length === 0) return r
+    // #454: logIndex on receipt logs MUST be block-global per Ethereum
+    // spec ("log index position in the block"). The storage path
+    // (lines 339/423/650 above) writes logs with per-tx logIndex —
+    // restarting at 0 for each tx. Recompute the cumulative offset from
+    // prior receipts in the same block at read time so the public RPC
+    // surface is spec-compliant without rewriting the storage format.
+    let offset = 0
+    const blockReceipts = [...this.receipts.values()]
+      .filter((rr) => rr.blockNumber === r.blockNumber)
+      .sort((a, b) => parseInt(a.transactionIndex, 16) - parseInt(b.transactionIndex, 16))
+    for (const br of blockReceipts) {
+      if (br.transactionHash.toLowerCase() === txHash.toLowerCase()) break
+      offset += (br.logs ?? []).length
+    }
+    if (offset === 0) return r
+    return {
+      ...r,
+      logs: r.logs.map((log, idx) => ({
+        ...log,
+        logIndex: `0x${(offset + idx).toString(16)}`,
+      })),
+    }
   }
 
   getTransaction(txHash: string): TxInfo | null {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3317,6 +3317,95 @@ test("RPC Extended Methods", async (t) => {
     if (receipt.to && got.to) {
       assert.equal(receipt.to, got.to, "receipt.to must equal tx.to byte-for-byte")
     }
+
+  await t.test("#454: receipt logIndex is block-global (running count across all prior txs in block)", async () => {
+    // Per Ethereum spec: "logIndex: log index position in the BLOCK".
+    // Pre-fix every tx's logs restarted logIndex at 0, so a block with
+    // 2 txs each emitting 1 log reported [0, 0] instead of geth-spec
+    // [0, 1]. Indexers / subgraphs keyed on (blockHash, logIndex) saw
+    // duplicate keys and dropped entries.
+    //
+    // Minimal log-emitting contract (no constructor args, runtime emits
+    // one LOG0 then stops). CODECOPY stack order (top first): destOffset,
+    // codeOffset, size — so push size first (bottom), then codeOffset,
+    // then destOffset (top).
+    //   constructor (12 bytes):
+    //     60 06    PUSH1 6     (runtime size, bottom)
+    //     60 0c    PUSH1 12    (code offset where runtime starts)
+    //     60 00    PUSH1 0     (memory dest, top)
+    //     39       CODECOPY    (mem[0..6] = code[12..18])
+    //     60 06    PUSH1 6     (return length)
+    //     60 00    PUSH1 0     (return offset)
+    //     f3       RETURN
+    //   runtime (6 bytes):
+    //     60 00    PUSH1 0     (data length)
+    //     60 00    PUSH1 0     (data offset)
+    //     a0       LOG0
+    //     00       STOP
+    const DEPLOY_BYTECODE = "0x6006600c60003960066000f360006000a000"
+
+    const { Wallet: EW454 } = await import("ethers")
+    const wallet = new EW454(`0x${"0d".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+
+    // Deploy the contract.
+    const deployTx = await wallet.signTransaction({
+      type: 0, to: null, value: 0n, data: DEPLOY_BYTECODE,
+      gasLimit: 500_000n, gasPrice: 1_000_000_000n,
+      nonce: Number(startN), chainId,
+    })
+    const submit454 = async (raw: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await res.json() as { result?: string; error?: { code: number; message: string } }
+    }
+    const deployBody = await submit454(deployTx)
+    assert.ok(deployBody.result, `deploy must succeed: ${JSON.stringify(deployBody)}`)
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+    const deployReceipt = await rpcCall(port, "eth_getTransactionReceipt", [deployBody.result]) as {
+      contractAddress: string
+    }
+    assert.ok(deployReceipt.contractAddress, "deploy must yield contract address")
+    const contractAddr = deployReceipt.contractAddress
+
+    // Submit two txs that each call the contract (each emits 1 LOG0).
+    // They MUST land in the same block for the offset assertion to apply.
+    const call1 = await wallet.signTransaction({
+      type: 0, to: contractAddr, value: 0n, data: "0x",
+      gasLimit: 50_000n, gasPrice: 1_000_000_000n,
+      nonce: Number(startN) + 1, chainId,
+    })
+    const call2 = await wallet.signTransaction({
+      type: 0, to: contractAddr, value: 0n, data: "0x",
+      gasLimit: 50_000n, gasPrice: 1_000_000_000n,
+      nonce: Number(startN) + 2, chainId,
+    })
+    const r1 = await submit454(call1)
+    const r2 = await submit454(call2)
+    assert.ok(r1.result && r2.result, "both calls must submit successfully")
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+
+    const rec1 = await rpcCall(port, "eth_getTransactionReceipt", [r1.result]) as {
+      logs: Array<{ logIndex: string }>
+      blockNumber: string
+    }
+    const rec2 = await rpcCall(port, "eth_getTransactionReceipt", [r2.result]) as {
+      logs: Array<{ logIndex: string }>
+      blockNumber: string
+    }
+
+    assert.equal(rec1.blockNumber, rec2.blockNumber,
+      "both calls must land in the same block (test pre-condition)")
+    assert.equal(rec1.logs.length, 1, "call 1 must emit exactly 1 log")
+    assert.equal(rec2.logs.length, 1, "call 2 must emit exactly 1 log")
+    assert.equal(rec1.logs[0].logIndex, "0x0",
+      `first tx's first log must have logIndex 0x0 (got ${rec1.logs[0].logIndex})`)
+    assert.equal(rec2.logs[0].logIndex, "0x1",
+      `second tx's first log must have logIndex 0x1 (block-global), not 0x0 (per-tx). got ${rec2.logs[0].logIndex} — this is the #454 regression`)
+  })
   })
 
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3790,6 +3790,20 @@ async function formatPersistentReceipt(
     },
   ])
 
+  // #454: logIndex MUST be block-global (running count across all prior
+  // txs' logs in this block), not per-tx-local. Spec: ethereum.org JSON-RPC
+  // "logIndex: log index position in the BLOCK". Pre-fix, every tx's logs
+  // restarted at 0 (`.map((log, idx) => ...)` with idx 0-based), so a
+  // block with 3 txs each emitting 2 logs reported logIndex sequence
+  // [0,1, 0,1, 0,1] instead of geth-spec [0,1, 2,3, 4,5]. Indexers /
+  // subgraphs that key on (blockHash, logIndex) saw duplicate keys and
+  // dropped entries.
+  let logIndexOffset = 0
+  for (const r of receipts) {
+    if (r.transactionHash.toLowerCase() === tx.receipt.transactionHash.toLowerCase()) break
+    logIndexOffset += (r.logs ?? []).length
+  }
+
   return {
     transactionHash: tx.receipt.transactionHash,
     transactionIndex: transactionIndex !== null ? toRpcQuantity(transactionIndex) : "0x0",
@@ -3809,7 +3823,7 @@ async function formatPersistentReceipt(
       blockHash: tx.receipt.blockHash,
       transactionHash: tx.receipt.transactionHash,
       transactionIndex: transactionIndex !== null ? toRpcQuantity(transactionIndex) : "0x0",
-      logIndex: toRpcQuantity(idx),
+      logIndex: toRpcQuantity(logIndexOffset + idx),
       removed: false,
     })),
     // #446: prefer the stored effectiveGasPrice (already computed correctly by


### PR DESCRIPTION
Closes #454.

## Why

Per Ethereum JSON-RPC spec, \`logIndex\` is the position in the BLOCK. COC restarts it at 0 per tx, so a block with multiple log-emitting txs produces duplicate (blockHash, logIndex) pairs. Indexers / subgraphs / analytics that key on this combo silently drop entries.

## Live reproduction (test bytecode in #454)

\`\`\`
rec1.logs[0].logIndex → 0x0 ✓
rec2.logs[0].logIndex → 0x0 ✗  (should be 0x1, block-global)
\`\`\`

## Fix

Recompute at the RPC boundary in two places (so storage format is preserved):

1. \`formatPersistentReceipt\`: walk block receipts, accumulate \`logIndexOffset\` until the target tx.
2. \`evm.getReceipt\`: iterate the in-memory receipt cache filtered by blockNumber, sort by transactionIndex, compute offset for the requested tx, return a copy with corrected log entries.

## Tests

New \`#454\` regression in \`rpc-extended.test.ts\` deploys a minimal LOG0-emitting contract (hand-rolled 18-byte bytecode), calls it twice in the same block, asserts:
- rec1.logs[0].logIndex == 0x0
- rec2.logs[0].logIndex == 0x1 (block-global)
- both calls land in the same block (test pre-condition)

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
$ node --experimental-strip-types --test node/src/evm*.test.ts node/src/rpc.test.ts
# tests 14 pass 14 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [x] EVM + rpc.test green (14/14)
- [ ] CI green
- [ ] After rollout: testnet 88780 — deploy LOG0 contract, call twice, verify rec2.logs[0].logIndex == 0x1

## Related

The persistent storage layer (\`chain-engine-persistent.ts:1208\`) also stores per-tx \`logIndex\` in \`IndexedLog\` for \`eth_getLogs\` filtering. That path isn't addressed here because rewriting historical indexed-log keys requires a migration; the RPC boundary fix corrects the **observable** behavior with no migration. A follow-up PR can address the indexed-log path if needed.