### PR TITLE
fix(rpc): #456 formatRawTransaction lowercases from/to (parity with receipt + geth)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3209,6 +3209,7 @@ test("RPC Extended Methods", async (t) => {
       assert.equal(extraData.toLowerCase(), miner.toLowerCase(),
         `extraData should encode proposer address as raw bytes (matching miner field)`)
     }
+  })
 
   await t.test("#466: receipt.contractAddress is lowercase (parity with from/to/log.address)", async () => {
     // Live testnet 88780 reproduction:
@@ -3258,6 +3259,64 @@ test("RPC Extended Methods", async (t) => {
     )
     assert.equal(receipt.from, receipt.from.toLowerCase(), "from must be lowercase (sanity)")
   })
+
+  await t.test("#456: eth_getTransactionByHash returns from/to in lowercase (parity with receipt + geth)", async () => {
+    // Live testnet 88780 reproduction:
+    //   eth_getTransactionReceipt → from = "0xf39fd6e51aad88..."   (lowercase)
+    //   eth_getTransactionByHash  → from = "0xf39Fd6e51aad88..."   (EIP-55 mixed)
+    //   eth_getBlockByNumber      → miner = "0xde4e7889aa..."     (lowercase)
+    //
+    // ethers v6 Transaction.from() returns parsed.from/to in EIP-55
+    // checksum case; formatRawTransaction relayed it untouched. Geth +
+    // Erigon always lowercase addresses in JSON-RPC responses; the rest
+    // of COC's API (receipts, block.miner, eth_getLogs, eth_getBalance)
+    // also lowercases. dApps that string-compare `tx.from === receipt.from`
+    // fail for every non-all-lowercase address.
+    const { Wallet: EW456 } = await import("ethers")
+    const wallet = new EW456(`0x${"0e".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+    // Use any 20-byte address. ethers.Transaction.from(rawTx).to returns
+    // it in EIP-55 mixed case post-parse, so the normalization in
+    // formatRawTransaction is what the test pins.
+    const to = "0xabcdef0123456789abcdef0123456789abcdef01"
+
+    const tx = await wallet.signTransaction({
+      type: 0, to, value: 1n,
+      nonce: Number(startN),
+      gasPrice: 1_000_000_000n, gasLimit: 21_000n,
+      chainId,
+    })
+    const submitRes = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [tx] }),
+    })
+    const submitBody = await submitRes.json() as { result?: string }
+    assert.ok(submitBody.result, `submit must succeed: ${JSON.stringify(submitBody)}`)
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+
+    const got = await rpcCall(port, "eth_getTransactionByHash", [submitBody.result]) as {
+      from: string
+      to: string | null
+    }
+    assert.ok(got, "tx must be findable by hash")
+    assert.equal(got.from, got.from.toLowerCase(),
+      `eth_getTransactionByHash from must be lowercase, got ${got.from}`)
+    if (got.to) {
+      assert.equal(got.to, got.to.toLowerCase(),
+        `eth_getTransactionByHash to must be lowercase, got ${got.to}`)
+    }
+
+    // Cross-check: receipt for the same tx returns matching from/to.
+    const receipt = await rpcCall(port, "eth_getTransactionReceipt", [submitBody.result]) as {
+      from: string
+      to: string | null
+    }
+    assert.equal(receipt.from, got.from,
+      `receipt.from must equal tx.from byte-for-byte (post-lowercase): receipt=${receipt.from} tx=${got.from}`)
+    if (receipt.to && got.to) {
+      assert.equal(receipt.to, got.to, "receipt.to must equal tx.to byte-for-byte")
+    }
   })
 
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3666,6 +3666,13 @@ function formatRawTransaction(
 ): Record<string, unknown> | null {
   try {
     const parsed = Transaction.from(rawTx)
+    // #456: ethers v6 returns EIP-55 mixed-case for parsed.from/to. Geth +
+    // Erigon emit addresses lowercased in JSON-RPC responses, and the rest
+    // of COC's API (receipts, block.miner, eth_getLogs) already lowercases.
+    // Pre-fix eth_getTransactionByHash returned mixed case while
+    // eth_getTransactionReceipt returned lowercase for the SAME tx — same-
+    // -value comparisons across endpoints failed string-equality checks
+    // in dApps/wallets/indexers. Lowercase both fields to match.
     // #442: include accessList for EIP-2930 (type 1) and EIP-1559 (type 2)
     // transactions. Pre-fix every type-1/2 tx returned by
     // eth_getTransactionByHash / eth_getBlockByNumber omitted the field,
@@ -3680,8 +3687,8 @@ function formatRawTransaction(
       : (parsed.type === 1 || parsed.type === 2 ? [] : undefined)
     return {
       hash: parsed.hash,
-      from: parsed.from,
-      to: toRpcHexOrNull(parsed.to ?? null),
+      from: parsed.from ? parsed.from.toLowerCase() : parsed.from,
+      to: toRpcHexOrNull(parsed.to ? parsed.to.toLowerCase() : (parsed.to ?? null)),
       nonce: toRpcQuantity(parsed.nonce),
       value: toRpcQuantity(parsed.value ?? 0n),
       gas: toRpcQuantity(parsed.gasLimit ?? 21_000n),


### PR DESCRIPTION
Closes #456.

## Why

\`formatRawTransaction\` relayed \`parsed.from\` / \`parsed.to\` from ethers (which returns them in EIP-55 mixed case) without lowercasing. Result: same tx returns different casing from different endpoints:

\`\`\`
eth_getTransactionReceipt → 0xf39fd6e5...   (lowercase)
eth_getTransactionByHash  → 0xf39Fd6e5...   (mixed)
eth_getBlockByNumber.miner → lowercase
eth_getLogs.address        → lowercase
\`\`\`

dApps that compare addresses via string equality fail; indexers see two entries per address.

## Fix

\`\`\`ts
from: parsed.from ? parsed.from.toLowerCase() : parsed.from,
to:   toRpcHexOrNull(parsed.to ? parsed.to.toLowerCase() : (parsed.to ?? null)),
\`\`\`

The shared formatter benefits 4+ endpoints (txByHash, txByBlockHashAndIndex, txByBlockNumberAndIndex, txpool_content, block formatter full=true).

## Tests

New \`#456\` regression in \`rpc-extended.test.ts\`:
- \`eth_getTransactionByHash from/to\` are lowercase
- \`receipt.from === tx.from\` byte-for-byte (cross-endpoint parity)

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [ ] CI green
- [ ] After rollout: testnet 88780 \`eth_getTransactionByHash\` lowercases match \`receipt.from\`

## Related

This is the 7th formatter-shape consistency fix in the campaign (#442 #446 #448 #450 #452 #454 #456). Together they bring COC's RPC output into geth/erigon parity.