### PR TITLE
fix(rpc): #458 CORS fail-closed on unmatched Origin (no whitelist leak)

### DIFF
--- a/node/src/rpc-cors.test.ts
+++ b/node/src/rpc-cors.test.ts
@@ -105,7 +105,13 @@ test("#330 RPC CORS — whitelist echoes matched Origin + sets Vary", async (t) 
     "second whitelist entry must echo too")
 })
 
-test("#330 RPC CORS — unknown Origin falls back to first whitelist entry (back-compat)", async (t) => {
+test("#458 RPC CORS — unknown Origin gets NO ACAO header (fail-closed, no whitelist leak)", async (t) => {
+  // #458: pre-fix every non-whitelisted Origin was answered with
+  // Access-Control-Allow-Origin: <first whitelist entry>. Browsers blocked
+  // the response anyway (mismatch), so the practical effect was leaking
+  // the server's preferred origin to every probe (e.g. an attacker scanning
+  // testnets could enumerate which origins each node trusts). CORS-spec
+  // fail-closed pattern: omit the header entirely when Origin isn't allowed.
   const prev = process.env.COC_CORS_ORIGIN
   process.env.COC_CORS_ORIGIN = "https://prod.coc.example,https://staging.coc.example"
   process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
@@ -116,8 +122,28 @@ test("#330 RPC CORS — unknown Origin falls back to first whitelist entry (back
     await close()
   })
   const { headers } = await probe(port, "POST", "https://attacker.example")
+  assert.equal(headers["access-control-allow-origin"], undefined,
+    "unmatched Origin must NOT receive ACAO header (no whitelist leak)")
+  assert.equal(headers["vary"], "Origin",
+    "Vary: Origin still set so caches don't reuse a whitelisted-origin response")
+})
+
+test("#458 RPC CORS — no-Origin request (curl/server-to-server) still gets whitelist[0] back-compat", async (t) => {
+  // For non-browser callers (curl, monitoring, server-to-server) CORS
+  // doesn't apply — emitting a default ACAO is harmless. Pin the legacy
+  // behavior so existing tooling that grep-matches ACAO doesn't break.
+  const prev = process.env.COC_CORS_ORIGIN
+  process.env.COC_CORS_ORIGIN = "https://prod.coc.example,https://staging.coc.example"
+  process.env.COC_RPC_RATE_LIMIT_DISABLED = "1"
+  const { port, close } = await startTestRpc()
+  t.after(async () => {
+    if (prev === undefined) delete process.env.COC_CORS_ORIGIN
+    else process.env.COC_CORS_ORIGIN = prev
+    await close()
+  })
+  const { headers } = await probe(port, "POST") // no Origin
   assert.equal(headers["access-control-allow-origin"], "https://prod.coc.example",
-    "unmatched Origin falls back to first whitelist entry (browser denies cross-origin)")
+    "no-Origin request emits whitelist[0] for back-compat")
 })
 
 test("#330 RPC CORS — OPTIONS preflight returns 204 No Content", async (t) => {
@@ -150,7 +176,8 @@ test("#330 RPC CORS — default (env unset) preserves localhost dev fallback", a
   const r1 = await probe(port, "POST", "http://localhost:3000")
   assert.equal(r1.headers["access-control-allow-origin"], "http://localhost:3000",
     "default env unset must echo localhost:3000 for back-compat")
+  // #458: non-matching Origin no longer leaks the dev default. ACAO is omitted.
   const r2 = await probe(port, "POST", "https://prod.example")
-  assert.equal(r2.headers["access-control-allow-origin"], "http://localhost:3000",
-    "non-matching Origin falls back to default — browser denies cross-origin")
+  assert.equal(r2.headers["access-control-allow-origin"], undefined,
+    "non-matching Origin must NOT leak the configured default (#458 fail-closed)")
 })

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -311,23 +311,41 @@ export function startRpcServer(
     // so intermediate caches don't serve the wrong origin.
     const corsConfig = process.env.COC_CORS_ORIGIN ?? "http://localhost:3000"
     const reqOrigin = typeof req.headers.origin === "string" ? req.headers.origin : null
-    let allowedOrigin: string
+    // #458: when request Origin is provided but NOT in the whitelist, do NOT
+    // emit Access-Control-Allow-Origin. Pre-fix code echoed `whitelist[0]`
+    // (e.g. "http://localhost:3000") regardless of the actual Origin —
+    // browsers saw a mismatch and blocked the response anyway, AND the
+    // server leaked which origin it considered "primary" to every probe.
+    // CORS spec: omit ACAO to fail-closed (browser blocks correctly without
+    // disclosing config).
+    let allowedOrigin: string | null
     if (corsConfig === "*") {
       allowedOrigin = "*"
     } else {
       const whitelist = corsConfig.split(",").map((s) => s.trim()).filter(Boolean)
       if (reqOrigin && whitelist.includes(reqOrigin)) {
+        // Browser request from a whitelisted origin: echo it back.
         allowedOrigin = reqOrigin
-      } else {
-        // Fall back to the first whitelist entry so existing single-origin
-        // dev setups keep working unchanged (back-compat).
+      } else if (!reqOrigin) {
+        // No Origin header (curl, server-to-server, monitoring). CORS
+        // doesn't apply; emit whitelist[0] for back-compat (legacy dev
+        // tooling expects the header).
         allowedOrigin = whitelist[0] ?? "http://localhost:3000"
+      } else {
+        // Origin provided but not whitelisted → fail-closed (omit header).
+        allowedOrigin = null
       }
     }
-    res.setHeader("Access-Control-Allow-Origin", allowedOrigin)
-    if (allowedOrigin !== "*") {
-      // Tell shared caches the response varies by the request Origin —
-      // otherwise the cache may serve the ACAO for origin A to origin B.
+    if (allowedOrigin !== null) {
+      res.setHeader("Access-Control-Allow-Origin", allowedOrigin)
+      if (allowedOrigin !== "*") {
+        // Tell shared caches the response varies by the request Origin —
+        // otherwise the cache may serve the ACAO for origin A to origin B.
+        res.setHeader("Vary", "Origin")
+      }
+    } else {
+      // Still set Vary: Origin so caches don't serve a cached ACAO from a
+      // different origin's earlier (whitelisted) request.
       res.setHeader("Vary", "Origin")
     }
     res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS")


### PR DESCRIPTION
Closes #458.

## Why

\`#330\`'s whitelist-aware CORS implementation echoed \`Access-Control-Allow-Origin: <whitelist[0]>\` for EVERY request — including those with non-whitelisted Origin headers. Two issues:

1. Browsers blocked the response anyway (Origin mismatch), so the fallback never helped.
2. Every untrusted probe disclosed the server's preferred origin (info leak).

Live testnet 88780:
\`\`\`
$ curl -v ...88780 -H \"Origin: https://attacker.example.com\"
< Access-Control-Allow-Origin: http://localhost:3000   ← leaks default
\`\`\`

## Fix

CORS-spec fail-closed pattern:

| Case | ACAO behavior |
|---|---|
| Origin matches whitelist | echo Origin (existing) |
| No Origin header (curl) | whitelist[0] (back-compat) |
| Origin present but unmatched | **omit ACAO entirely** (new) |

\`Vary: Origin\` still set in the omit case so caches don't reuse a whitelisted-origin response.

## Tests

In \`rpc-cors.test.ts\`:
- NEW \`#458 unknown Origin gets NO ACAO\` — pins fail-closed.
- NEW \`#458 no-Origin curl call still gets whitelist[0]\` — pins back-compat.
- UPDATED existing \`#330 default env unset\` — non-matching Origin now expects NO ACAO (was: localhost:3000 leak).

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-cors.test.ts
# tests 6 pass 6 fail 0
\`\`\`

## Test plan

- [x] rpc-cors green (6/6)
- [x] rpc-extended green (104/104)
- [ ] CI green
- [ ] Post-rollout: replay testnet probe → \`Access-Control-Allow-Origin\` header absent for non-whitelisted Origin