### PR TITLE
fix(rpc): #462 EIP-1898 rejects {blockHash, blockNumber} together (spec violation)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -618,6 +618,17 @@ test("RPC Extended Methods", async (t) => {
     const malformed = await probe({ blockHash: "0xnot-a-hash" })
     assert.equal(malformed.error?.code, -32602, `malformed blockHash must be -32602 (got ${JSON.stringify(malformed)})`)
     assert.match(malformed.error?.message ?? "", /invalid blockHash/i)
+
+    // #462: EIP-1898 explicitly forbids both blockNumber AND blockHash in
+    // the same object. Pre-fix the blockHash branch ran first and silently
+    // ignored an accompanying blockNumber field — clients could submit
+    // both shapes and get an answer keyed on whichever happened to win.
+    // Geth + Erigon reject with -32602. Match them.
+    const both = await probe({ blockHash, blockNumber: "0x1" })
+    assert.equal(both.error?.code, -32602,
+      `EIP-1898 forbids blockHash+blockNumber together; must be -32602 (got ${JSON.stringify(both)})`)
+    assert.match(both.error?.message ?? "", /EIP-1898 forbids|blockNumber and blockHash/i,
+      `error message must reference the spec rule, got: ${both.error?.message}`)
   })
 
   await t.test("txpool_status returns pool stats", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2997,6 +2997,18 @@ async function resolveHistoricalExecutionContext(
 
   // EIP-1898 object form #1: {blockHash: "0x…", requireCanonical?: bool}.
   if (typeof input === "object" && input !== null && "blockHash" in input) {
+    // #462: EIP-1898 explicitly says "the parameters MUST not include both
+    // blockNumber and blockHash". Pre-fix the blockHash branch ran first
+    // and silently ignored an accompanying blockNumber field — clients
+    // could (intentionally or accidentally) submit both shapes and get
+    // an answer keyed on whichever happened to win. Geth + Erigon reject
+    // this with -32602. Reject upfront before the lookup.
+    if ("blockNumber" in (input as Record<string, unknown>)) {
+      throw {
+        code: -32602,
+        message: "invalid block parameter: EIP-1898 forbids blockNumber and blockHash together",
+      }
+    }
     const rawHash = (input as Record<string, unknown>).blockHash
     if (typeof rawHash !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(rawHash)) {
       throw { code: -32602, message: "invalid blockHash: must match /^0x[0-9a-fA-F]{64}$/" }


### PR DESCRIPTION
Closes #462.

## Why

EIP-1898 explicitly states: *\"the parameters MUST not include both blockNumber and blockHash\"*. Pre-fix \`resolveHistoricalExecutionContext\` ran the blockHash branch first and silently ignored an accompanying blockNumber. Clients could submit conflicting fields and get an answer keyed on the silent winner.

Live testnet 88780:
\`\`\`
eth_call({...}, {blockHash, blockNumber: 0x100})
→ result: 0x...bb    ← silent accept, blockNumber ignored
\`\`\`

Geth + Erigon reject with -32602. COC silently accepts.

## Fix

\`\`\`ts
if (\"blockNumber\" in input) {
  throw {
    code: -32602,
    message: \"invalid block parameter: EIP-1898 forbids blockNumber and blockHash together\",
  }
}
\`\`\`

## Tests

\`#462\` extends the existing \`#368\` EIP-1898 test in \`rpc-extended.test.ts\`:
- probe({blockHash, blockNumber}) → -32602
- error message references the spec rule

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 104 pass 104 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (104/104)
- [ ] CI green
- [ ] After rollout: testnet 88780 \`eth_call\` with both fields → -32602 (was: silent accept)

## Related

- #368 (already merged): introduced EIP-1898 BlockNumberOrHash support. This PR closes the mutex gap that audit missed.
- #432 / #436 family: validate-before-silent-accept anti-pattern. Same pattern, different endpoint.