### PR TITLE
fix(rpc): #464 EIP-234 mutex applies to eth_newFilter + eth_subscribe(logs)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -484,6 +484,43 @@ test("RPC Extended Methods", async (t) => {
     assert.match(json.error!.message, /mutually exclusive/i, "message must mention the mutual-exclusivity rule")
   })
 
+  await t.test("#464: eth_newFilter rejects blockHash + fromBlock/toBlock too (sibling of #116)", async () => {
+    // EIP-234's mutex applies to every endpoint that takes a log-filter shape.
+    // #116 fixed eth_getLogs; eth_newFilter and eth_subscribe("logs") were
+    // missed by that audit and silently accepted both fields, taking the
+    // blockHash path and ignoring fromBlock/toBlock. Centralize the check
+    // inside validateLogFilter so all three callsites reject identically.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_newFilter", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: string }
+    }
+    // blockHash + fromBlock → reject
+    const r1 = await probe([{ blockHash: "0x" + "00".repeat(32), fromBlock: "0x0" }])
+    assert.equal(r1.error?.code, -32602,
+      `eth_newFilter blockHash+fromBlock must be -32602 (got ${JSON.stringify(r1)})`)
+    assert.match(r1.error!.message, /mutually exclusive|EIP-234/i)
+
+    // blockHash + toBlock → reject
+    const r2 = await probe([{ blockHash: "0x" + "00".repeat(32), toBlock: "latest" }])
+    assert.equal(r2.error?.code, -32602,
+      `eth_newFilter blockHash+toBlock must be -32602 (got ${JSON.stringify(r2)})`)
+
+    // blockHash + both → reject
+    const r3 = await probe([{ blockHash: "0x" + "00".repeat(32), fromBlock: "0x0", toBlock: "latest" }])
+    assert.equal(r3.error?.code, -32602, "blockHash+fromBlock+toBlock must reject")
+
+    // Sanity: blockHash alone is OK.
+    const ok = await probe([{ blockHash: "0x" + "00".repeat(32) }])
+    assert.ok(ok.result, `blockHash alone must succeed: ${JSON.stringify(ok)}`)
+    // Sanity: fromBlock alone is OK.
+    const ok2 = await probe([{ fromBlock: "0x0", toBlock: "latest" }])
+    assert.ok(ok2.result, `fromBlock+toBlock alone must succeed: ${JSON.stringify(ok2)}`)
+  })
+
   await t.test("#114: eth_getBlockReceipts shape matches eth_getTransactionReceipt", async () => {
     // Pre-fix bug: getBlockReceipts returned a stripped-down 9-field shape
     // (no contractAddress / cumulativeGasUsed / effectiveGasPrice / logsBloom

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -514,6 +514,15 @@ export function validateLogFilter(query: Record<string, unknown>): {
     if (typeof query.blockHash !== "string" || !FILTER_TOPIC_RE.test(query.blockHash)) {
       invalidParams("invalid blockHash: must match /^0x[0-9a-fA-F]{64}$/")
     }
+    // #464: EIP-234 — blockHash is mutually exclusive with fromBlock /
+    // toBlock. eth_getLogs already enforces this at its call site (rpc.ts
+    // line ~1096), but eth_newFilter and eth_subscribe("logs") share the
+    // same filter shape and silently accepted both — taking the blockHash
+    // path and ignoring fromBlock/toBlock. Centralize the check here so
+    // all three callsites reject identically per geth + erigon.
+    if (query.fromBlock !== undefined || query.toBlock !== undefined) {
+      invalidParams("blockHash is mutually exclusive with fromBlock/toBlock (EIP-234)")
+    }
     query.blockHash = (query.blockHash as string).toLowerCase()
   }
   const validateFilterAddr = (raw: unknown, idx: number): Hex => {


### PR DESCRIPTION
Closes #464.

## Why

EIP-234 specifies that \`blockHash\` is mutually exclusive with \`fromBlock\`/\`toBlock\` in log-filter queries. PR #116 enforced this for \`eth_getLogs\` at its call site, but \`eth_newFilter\` and \`eth_subscribe(\"logs\")\` share the same shape via \`validateLogFilter\` and were missed by the audit.

Live testnet 88780:
\`\`\`
eth_newFilter({blockHash, fromBlock})
→ result: 0x78e3...    ← silent accept, fromBlock ignored

geth/erigon:
→ -32602 invalid params
\`\`\`

## Fix

Move the mutex check from eth_getLogs's call site into \`validateLogFilter\`:

\`\`\`ts
if (query.blockHash !== undefined && query.blockHash !== null) {
  // ... shape check ...
  if (query.fromBlock !== undefined || query.toBlock !== undefined) {
    invalidParams(\"blockHash is mutually exclusive with fromBlock/toBlock (EIP-234)\")
  }
  // ...
}
\`\`\`

eth_getLogs's existing inline check stays as defense-in-depth.

## Tests

New \`#464\` in \`rpc-extended.test.ts\` covers:
- eth_newFilter({blockHash, fromBlock}) → -32602
- eth_newFilter({blockHash, toBlock}) → -32602
- eth_newFilter({blockHash, fromBlock, toBlock}) → -32602
- Sanity: blockHash alone OK, fromBlock+toBlock alone OK

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
$ node --experimental-strip-types --test node/src/rpc-validators.test.ts
# tests 103 pass 103 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [x] rpc-validators green (103/103)
- [ ] CI green
- [ ] After rollout: testnet 88780 \`eth_newFilter\` with both fields → -32602

## Related

Same family as #462 (PR #463): \"shared validator missed by audit\" — both are EIP-234/EIP-1898 mutex rules that the central validator didn't enforce.