### PR TITLE
fix(rpc): #466 receipt.contractAddress lowercase (parity with from/to/log.address)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -431,8 +431,11 @@ export class EvmChain {
       if (first !== undefined) this.receipts.delete(first)
     }
 
+    // #466: lowercase contractAddress to match the rest of the JSON-RPC
+    // address convention (from / to / log.address). result.createdAddress
+    // is an Address object whose toString() returns EIP-55 mixed case.
     const contractAddress = result.createdAddress
-      ? result.createdAddress.toString()
+      ? result.createdAddress.toString().toLowerCase()
       : undefined
 
     this.receipts.set(txHash, {
@@ -652,8 +655,9 @@ export class EvmChain {
       }
     })
 
+    // #466: lowercase contractAddress (see prior site for context).
     const contractAddress = result.createdAddress
-      ? result.createdAddress.toString()
+      ? result.createdAddress.toString().toLowerCase()
       : undefined
 
     // Use pre-computed sender when available (locally proposed blocks) to skip ECDSA recovery

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3209,6 +3209,55 @@ test("RPC Extended Methods", async (t) => {
       assert.equal(extraData.toLowerCase(), miner.toLowerCase(),
         `extraData should encode proposer address as raw bytes (matching miner field)`)
     }
+
+  await t.test("#466: receipt.contractAddress is lowercase (parity with from/to/log.address)", async () => {
+    // Live testnet 88780 reproduction:
+    //   $ curl ...eth_getTransactionReceipt <deploy-tx-hash>
+    //   {
+    //     "from":            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+    //     "contractAddress": "0xeF31027350Be2c7439C1b0BE022d49421488b72C",
+    //     ...
+    //   }
+    //
+    // viem.getCreateAddress returns EIP-55 mixed case; the formatter
+    // relayed it without lowercasing while every other receipt address
+    // field (from, to, log.address) was already lowercase. dApps that
+    // string-compared `receipt.contractAddress === addr.toLowerCase()`
+    // saw false-mismatch for deploy receipts and treated the contract
+    // as undeployed. Same family as #456.
+    const { Wallet: EW466, parseEther } = await import("ethers")
+    const wallet = new EW466(`0x${"0f".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: parseEther("10").toString() }])
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+
+    // 5-byte init that returns empty runtime — minimal valid CREATE.
+    const deployTx = await wallet.signTransaction({
+      type: 0, to: null, value: 0n, data: "0x60006000f3",
+      gasLimit: 100_000n, gasPrice: 1_000_000_000n,
+      nonce: Number(startN), chainId,
+    })
+    const submit = async (raw: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await res.json() as { result?: string; error?: { code: number; message: string } }
+    }
+    const deployRes = await submit(deployTx)
+    assert.ok(deployRes.result, `deploy must succeed: ${JSON.stringify(deployRes)}`)
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+
+    const receipt = await rpcCall(port, "eth_getTransactionReceipt", [deployRes.result]) as {
+      contractAddress: string | null
+      from: string
+    }
+    assert.ok(receipt.contractAddress, `deploy must yield a contractAddress: ${JSON.stringify(receipt)}`)
+    assert.equal(
+      receipt.contractAddress, receipt.contractAddress!.toLowerCase(),
+      `contractAddress must be lowercase (parity with from), got ${receipt.contractAddress}`,
+    )
+    assert.equal(receipt.from, receipt.from.toLowerCase(), "from must be lowercase (sanity)")
+  })
   })
 
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3754,9 +3754,19 @@ async function formatPersistentReceipt(
     tx.receipt.transactionHash,
   )
   const normalizedTo = normalizePersistedTo(tx.receipt.to)
-  const contractAddress = normalizedTo === null && tx.receipt.status === 1n
+  // #466: viem.getCreateAddress returns the address in EIP-55 mixed case.
+  // Geth + Erigon always lowercase addresses in JSON-RPC responses, and
+  // the rest of COC's receipt body (from / to / log.address) is already
+  // lowercase. Pre-fix the deploy receipts returned a mixed-case
+  // contractAddress while every other field was lowercase — dApps that
+  // string-compared the deploy receipt's contractAddress vs the address
+  // they later passed to eth_call / eth_getCode (typically lowercased)
+  // saw false-mismatch and treated the contract as undeployed. Same
+  // family as #456 (eth_getTransactionByHash from/to mixed case).
+  const rawContractAddress = normalizedTo === null && tx.receipt.status === 1n
     ? getCreateAddress({ from: tx.receipt.from, nonce: parsed.nonce as string })
     : null
+  const contractAddress = rawContractAddress ? rawContractAddress.toLowerCase() : null
   const logsBloom = aggregateBlockLogsBloom([
     {
       transactionHash: tx.receipt.transactionHash,


### PR DESCRIPTION
Closes #466.

## Why

\`viem.getCreateAddress\` (used in formatPersistentReceipt) and \`Address.toString()\` (in evm.ts) both return EIP-55 mixed case. The formatter and EVM receipt cache relayed it without lowercasing, while every other receipt address field (from, to, log.address) was already lowercase per geth convention.

Live testnet 88780:
\`\`\`
\"from\":            \"0xf39fd6e51aad88...\"   (lowercase)
\"contractAddress\": \"0xeF31027350Be2c7...\"   (MIXED case)
\`\`\`

dApps that string-compare \`receipt.contractAddress === addr.toLowerCase()\` silently fail post-deploy. Indexers see two entries per contract.

## Fix

Two sites in lockstep:
1. \`rpc.ts:formatPersistentReceipt:3636\` — lowercase the \`getCreateAddress\` output.
2. \`evm.ts:434\` + \`:658\` (two receipt-creation paths) — lowercase \`result.createdAddress.toString()\`.

## Tests

New \`#466\` regression in \`rpc-extended.test.ts\`:
- Deploy a minimal valid CREATE (\`0x60006000f3\` — 5-byte init returning empty runtime)
- Assert \`receipt.contractAddress === toLowerCase(contractAddress)\`
- Assert \`receipt.from === toLowerCase(from)\` (sibling sanity)

\`\`\`
$ node --experimental-strip-types --test node/src/rpc-extended.test.ts
# tests 105 pass 105 fail 0
$ node --experimental-strip-types --test node/src/evm*.test.ts
# tests 9 pass 9 fail 0
\`\`\`

## Test plan

- [x] rpc-extended green (105/105)
- [x] evm green (9/9)
- [ ] CI green
- [ ] After rollout: testnet 88780 deploy receipt → contractAddress all-lowercase

## Related

- #456 (PR #457): sibling — eth_getTransactionByHash from/to mixed case.
- 7-PR formatter parity thread: #442 #446 #448 #450 #452 #454 #456. This PR is the 8th and (hopefully) closes the contractAddress gap that audit missed.