### PR TITLE
fix(rpc): EIP-2930 accessList shape validation in eth_call/estimateGas/sendTx (#473)

### DIFF
--- a/node/src/rpc-validators.test.ts
+++ b/node/src/rpc-validators.test.ts
@@ -569,6 +569,82 @@ describe("validateTxCallFields (#148)", () => {
     validateTxCallFields({ gasPrice: "0x1", maxFeePerGas: "" })
     validateTxCallFields({ gasPrice: "", maxFeePerGas: "0x1", maxPriorityFeePerGas: "0x1" })
   })
+
+  test("#473: accepts well-shaped accessList (EIP-2930)", () => {
+    const addr = "0x" + "a".repeat(40)
+    const key = "0x" + "1".repeat(64)
+    validateTxCallFields({
+      accessList: [
+        { address: addr, storageKeys: [] },
+        { address: addr, storageKeys: [key, key] },
+      ],
+    })
+    validateTxCallFields({ accessList: [] })          // empty array is valid
+    validateTxCallFields({ accessList: undefined })   // absent is valid
+    validateTxCallFields({ accessList: null })        // null is treated as absent
+  })
+
+  test("#473: rejects non-array accessList", () => {
+    const e = captureThrow(() => validateTxCallFields({ accessList: "not-array" as unknown as never }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList.*array/i)
+  })
+
+  test("#473: rejects accessList entry missing address", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: [{ storageKeys: [] }] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]\.address/i)
+  })
+
+  test("#473: rejects accessList entry with bad address shape", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: [{ address: "0xtoo-short", storageKeys: [] }] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]\.address/i)
+  })
+
+  test("#473: rejects accessList entry missing storageKeys", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: [{ address: "0x" + "a".repeat(40) }] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]\.storageKeys/i)
+  })
+
+  test("#473: rejects accessList entry with non-array storageKeys", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: [{ address: "0x" + "a".repeat(40), storageKeys: "not-array" }] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]\.storageKeys/i)
+  })
+
+  test("#473: rejects accessList storage key not matching 32-byte hex", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: [{ address: "0x" + "a".repeat(40), storageKeys: ["0xZZ"] }] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]\.storageKeys\[0\]/i)
+  })
+
+  test("#473: rejects accessList over 256 entries (DoS cap)", () => {
+    const addr = "0x" + "a".repeat(40)
+    const list = Array.from({ length: 257 }, () => ({ address: addr, storageKeys: [] }))
+    const e = captureThrow(() => validateTxCallFields({ accessList: list }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList too large/i)
+  })
+
+  test("#473: rejects accessList entry with primitive value", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      accessList: ["not-an-object"] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /accessList\[0\]/i)
+  })
 })
 
 describe("validateLogFilter", () => {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -474,6 +474,45 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
       invalidParams(`maxPriorityFeePerGas (${maxTip}) > maxFeePerGas (${maxFee})`)
     }
   }
+  // #473: EIP-2930 accessList shape validation. Pre-fix eth_call /
+  // eth_estimateGas / eth_sendTransaction silently dropped ALL accessList
+  // input (callRaw only forwards from/to/data/value/gas — see rpc.ts:928).
+  // Any malformed shape — not-an-array, missing fields, bad address, bad
+  // storage key — was accepted with a 200 OK result, masking client bugs.
+  // geth/erigon both reject malformed accessList at the JSON-RPC layer.
+  // We don't yet plumb accessList through to the EVM simulator, but
+  // shape-enforcement at the boundary still surfaces caller bugs that
+  // would otherwise hit eth_sendRawTransaction with a misleading downstream
+  // error.
+  const accessList = callParams.accessList
+  if (accessList !== undefined && accessList !== null) {
+    if (!Array.isArray(accessList)) {
+      invalidParams("invalid accessList: expected array of {address, storageKeys}")
+    }
+    if (accessList.length > 256) {
+      invalidParams(`accessList too large: ${accessList.length} > 256`)
+    }
+    accessList.forEach((entry, idx) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        invalidParams(`invalid accessList[${idx}]: expected object with address+storageKeys`)
+      }
+      const e = entry as Record<string, unknown>
+      if (typeof e.address !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(e.address)) {
+        invalidParams(`invalid accessList[${idx}].address: must match /^0x[0-9a-fA-F]{40}$/`)
+      }
+      if (!Array.isArray(e.storageKeys)) {
+        invalidParams(`invalid accessList[${idx}].storageKeys: expected array`)
+      }
+      if ((e.storageKeys as unknown[]).length > 256) {
+        invalidParams(`accessList[${idx}].storageKeys too large: ${(e.storageKeys as unknown[]).length} > 256`)
+      }
+      ;(e.storageKeys as unknown[]).forEach((key, ki) => {
+        if (typeof key !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(key)) {
+          invalidParams(`invalid accessList[${idx}].storageKeys[${ki}]: must match /^0x[0-9a-fA-F]{64}$/`)
+        }
+      })
+    })
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #473.

## Summary

- Extend `validateTxCallFields` (rpc-validators.ts) to enforce EIP-2930 access-list shape: array of `{address: 20-byte hex, storageKeys: [32-byte hex]}`.
- Add per-tx (256 entries) and per-entry (256 keys) caps to bound CPU at the JSON-RPC boundary.
- 9 unit tests cover empty/absent (still accepted), non-array, missing address, bad-address, missing storageKeys, non-array storageKeys, bad-key, 257-entry overflow, primitive entry.

## Pre-fix behavior (live 88780)

Every malformed shape returned 200 OK `{result:"0x"}`. Six variants tested in the issue — all silently accepted.

## Post-fix behavior

```
$ curl ... eth_call [..., {"to": "...", "accessList": "not-array"}, ...]
{"error":{"code":-32602,"message":"invalid accessList: expected array of {address, storageKeys}"}}

$ curl ... eth_call [..., {"to": "...", "accessList": [{"storageKeys": []}]}, ...]
{"error":{"code":-32602,"message":"invalid accessList[0].address: must match /^0x[0-9a-fA-F]{40}$/"}}
```

Same boundary behavior as geth/erigon. Wallet UX no longer breaks across eth_estimateGas → eth_sendRawTransaction round-trips.

## What this PR does NOT do

This fix closes the validation gap but **does not plumb accessList through to the EVM simulator**. callRaw still ignores the field. Wallet integrations expecting EIP-2930 access-list cost to affect gas estimates will need a follow-up that wires the validated list into the simulation path. The shape-validation fix is independently valuable because it surfaces caller bugs immediately instead of after a downstream eth_sendRawTransaction round-trip.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-validators.test.ts` — 112 tests pass, 9 new
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 104 existing tests still pass (no regression)
- [x] Manual `curl` against local fixture confirms message shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)