### PR TITLE
fix(rpc): validate EIP-4844 + typed-tx call-shape fields (#475)

### DIFF
--- a/node/src/rpc-validators.test.ts
+++ b/node/src/rpc-validators.test.ts
@@ -645,6 +645,82 @@ describe("validateTxCallFields (#148)", () => {
     assert.equal(e.code, -32602)
     assert.match(e.message ?? "", /accessList\[0\]/i)
   })
+
+  test("#475: accepts well-shaped EIP-4844 + typed-tx fields", () => {
+    const validHash = "0x01" + "0".repeat(62)
+    validateTxCallFields({
+      type: "0x3",
+      chainId: "0x15acc",
+      maxFeePerBlobGas: "0x3b9aca00",
+      blobVersionedHashes: [validHash, validHash],
+    })
+    validateTxCallFields({ type: "0x0", chainId: "0x1" })          // legacy tx hint
+    validateTxCallFields({ blobVersionedHashes: [] })              // empty allowed
+    validateTxCallFields({ blobVersionedHashes: null })            // absent
+    validateTxCallFields({ type: "" })                             // ethers "" maps to absent
+  })
+
+  test("#475: rejects non-hex type field", () => {
+    const e = captureThrow(() => validateTxCallFields({ type: "0x not-hex" }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /invalid type/i)
+  })
+
+  test("#475: rejects oversize type (> uint8)", () => {
+    const e = captureThrow(() => validateTxCallFields({ type: "0xffff" }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /type too large.*uint8/i)
+  })
+
+  test("#475: rejects non-hex chainId", () => {
+    const e = captureThrow(() => validateTxCallFields({ chainId: "not-hex" }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /invalid chainId/i)
+  })
+
+  test("#475: rejects non-hex maxFeePerBlobGas", () => {
+    const e = captureThrow(() => validateTxCallFields({ maxFeePerBlobGas: "not-hex" }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /invalid maxFeePerBlobGas/i)
+  })
+
+  test("#475: rejects oversize maxFeePerBlobGas (> uint256)", () => {
+    const huge = "0x" + "f".repeat(65)
+    const e = captureThrow(() => validateTxCallFields({ maxFeePerBlobGas: huge }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /maxFeePerBlobGas too large.*uint256/i)
+  })
+
+  test("#475: rejects non-array blobVersionedHashes", () => {
+    const e = captureThrow(() => validateTxCallFields({ blobVersionedHashes: "not-array" as unknown as never }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /blobVersionedHashes.*array/i)
+  })
+
+  test("#475: rejects blobVersionedHashes entry with bad length", () => {
+    const e = captureThrow(() => validateTxCallFields({
+      blobVersionedHashes: ["0x1234"] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /blobVersionedHashes\[0\]/i)
+  })
+
+  test("#475: rejects blobVersionedHashes entry with non-hex", () => {
+    const validHash = "0x01" + "0".repeat(62)
+    const e = captureThrow(() => validateTxCallFields({
+      blobVersionedHashes: [validHash, "0xZZZ" + "0".repeat(60)] as unknown as never,
+    }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /blobVersionedHashes\[1\]/i)
+  })
+
+  test("#475: rejects > 16 blobVersionedHashes (DoS cap)", () => {
+    const validHash = "0x01" + "0".repeat(62)
+    const list = Array.from({ length: 17 }, () => validHash)
+    const e = captureThrow(() => validateTxCallFields({ blobVersionedHashes: list }))
+    assert.equal(e.code, -32602)
+    assert.match(e.message ?? "", /blobVersionedHashes too large/i)
+  })
 })
 
 describe("validateLogFilter", () => {

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -416,6 +416,12 @@ const TX_HEX_FIELD_CAPS: Record<string, number> = {
   maxFeePerGas: 64 + 2,
   maxPriorityFeePerGas: 64 + 2,
   nonce: 16 + 2,
+  // #475: EIP-4844 + tx-type fields. type=uint8 (2 hex), chainId=uint256
+  // for parity with sendRawTx (but the chain rejects mismatched chainId
+  // at signature recovery), maxFeePerBlobGas=uint256.
+  maxFeePerBlobGas: 64 + 2,
+  chainId: 64 + 2,
+  type: 2 + 2,
 }
 
 /**
@@ -429,7 +435,14 @@ const TX_HEX_FIELD_CAPS: Record<string, number> = {
  * so a giant hex blob can't trigger O(n²) BigInt conversion.
  */
 export function validateTxCallFields(callParams: Record<string, unknown>): void {
-  for (const field of ["value", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas", "nonce"] as const) {
+  for (const field of [
+    "value", "gas", "gasPrice", "maxFeePerGas", "maxPriorityFeePerGas", "nonce",
+    // #475: EIP-4844 + EIP-2930 typed-tx hex-quantity fields. Pre-fix
+    // eth_call/estimateGas/sendTx silently accepted any-shape garbage in
+    // these — non-hex strings, oversize blobs, etc. — and the EVM call
+    // dropped them, surfacing as 200 OK with bogus simulation results.
+    "maxFeePerBlobGas", "chainId", "type",
+  ] as const) {
     const v = callParams[field]
     if (v === undefined || v === null || v === "") continue
     if (typeof v !== "string" || !HEX_QUANTITY_RE.test(v)) {
@@ -437,7 +450,11 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
     }
     const maxLen = TX_HEX_FIELD_CAPS[field]
     if (maxLen !== undefined && v.length > maxLen) {
-      const bits = field === "gas" || field === "nonce" ? 64 : 256
+      const bits = field === "gas" || field === "nonce"
+        ? 64
+        : field === "type"
+          ? 8
+          : 256
       invalidParams(`${field} too large: ${v.length} chars > ${maxLen} (uint${bits} max)`)
     }
   }
@@ -511,6 +528,30 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
           invalidParams(`invalid accessList[${idx}].storageKeys[${ki}]: must match /^0x[0-9a-fA-F]{64}$/`)
         }
       })
+    })
+  }
+
+  // #475: EIP-4844 blobVersionedHashes shape validation. Each entry must
+  // be a 32-byte (66-char) hex string. Cap entries at 16 to bound CPU at
+  // the JSON-RPC boundary (geth/erigon enforce protocol-level MAX_BLOBS_
+  // PER_BLOCK in the mining path; we use a soft cap that exceeds current
+  // Pectra MAX_BLOB_COUNT but stays sub-DoS). We deliberately do NOT
+  // validate the version byte (first hex pair == "01" per EIP-4844 KZG
+  // versioning) at this layer: future hard forks may introduce new
+  // VERSIONED_HASH_VERSION values, and the chain-side check enforces
+  // the current version anyway.
+  const blobHashes = callParams.blobVersionedHashes
+  if (blobHashes !== undefined && blobHashes !== null) {
+    if (!Array.isArray(blobHashes)) {
+      invalidParams("invalid blobVersionedHashes: expected array of 32-byte hex strings")
+    }
+    if (blobHashes.length > 16) {
+      invalidParams(`blobVersionedHashes too large: ${blobHashes.length} > 16`)
+    }
+    blobHashes.forEach((h, idx) => {
+      if (typeof h !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(h)) {
+        invalidParams(`invalid blobVersionedHashes[${idx}]: must match /^0x[0-9a-fA-F]{64}$/`)
+      }
     })
   }
 }


### PR DESCRIPTION
Closes #475. Follow-up to #473 (accessList).

## Summary

Extend `validateTxCallFields` to enforce shape on the remaining EIP-4844 + typed-tx call-shape fields that `eth_call` / `eth_estimateGas` / `eth_sendTransaction` were silently accepting:

- `type` (EIP-2718 envelope, uint8) — hex-quantity with 4-char cap
- `chainId` (uint256)
- `maxFeePerBlobGas` (EIP-4844 uint256)
- `blobVersionedHashes` (EIP-4844 array of 32-byte hex, ≤16 entries)

## Pre-fix (live 88780)

```
$ curl ... eth_call [..., {"to": "...", "blobVersionedHashes": "not-array"}, ...]
{"result":"0x"}
$ curl ... eth_call [..., {"to": "...", "type": "garbage"}, ...]
{"result":"0x"}
```

## Post-fix

```
$ curl ... eth_call [..., {"to": "...", "blobVersionedHashes": "not-array"}, ...]
{"error":{"code":-32602,"message":"invalid blobVersionedHashes: expected array of 32-byte hex strings"}}
```

## Notes

- **Blob version byte**: deliberately not validated at this layer (KZG_VERSIONED_HASH_VERSION = 0x01 in EIP-4844, but Pectra-or-later may introduce new versions). Chain-side check enforces current version.
- **Soft 16-entry cap on blobVersionedHashes**: geth/erigon enforce protocol-level MAX_BLOB_COUNT (currently 6) in the mining path. This layer's cap just bounds CPU at the JSON-RPC boundary and stays >MAX so the boundary cap never gates before the protocol does.
- **Does NOT plumb blob fields to EVM simulator**: same scope decision as #473. The fix closes the validation gap; wiring the fields into simulation is a separate enhancement.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-validators.test.ts` — 113 tests pass (10 new)
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — 104 tests pass (no regression)
- [x] Manual `curl` against local fixture confirms message shape for all 7 reproducer variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)