### PR TITLE
fix(ipfs-mfs): cp/mv reject missing source even when src == dst (#477)

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -143,6 +143,40 @@ test("MFS: cp copies file", async () => {
   }
 })
 
+test("#477: cp/mv same source-and-dest must reject when source is missing", async () => {
+  // Pre-fix the same-path no-op short-circuit fired before source-
+  // existence validation, so `cp /missing /missing` and `mv /missing
+  // /missing` silently returned ok:true even though no file existed.
+  // Live testnet 88780 reproduction:
+  //   curl POST /api/v0/files/cp?arg=/nonexistent&arg=/nonexistent
+  //   pre-fix: {"ok":true}    (no file created, no error)
+  //   post-fix: {"error":"...","message":"source not found: /nonexistent"}
+  // POSIX cp/mv + kubo go-ipfs-mfs both error here. The silent success
+  // masked client bugs where dest computation collapsed to src.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await assert.rejects(
+      () => mfs.cp("/missing-cp-target", "/missing-cp-target"),
+      /source not found/i,
+      "cp must reject missing source even when src == dst",
+    )
+    await assert.rejects(
+      () => mfs.mv("/missing-mv-target", "/missing-mv-target"),
+      /source not found/i,
+      "mv must reject missing source even when src == dst",
+    )
+
+    // Sanity: same-path on an existing file is still a no-op (not an error).
+    await mfs.write("/keep.txt", new TextEncoder().encode("data"), { create: true })
+    await mfs.cp("/keep.txt", "/keep.txt")    // no-op, no throw
+    await mfs.mv("/keep.txt", "/keep.txt")    // no-op, no throw
+    const after = await mfs.read("/keep.txt")
+    assert.strictEqual(new TextDecoder().decode(after), "data", "same-path op on existing file preserves contents")
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: stat returns file info", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -246,22 +246,28 @@ export class IpfsMfs {
     const srcNorm = normalizePath(source)
     const destNorm = normalizePath(dest)
 
-    // No-op when source and destination are identical
+    const { dir: srcDir, base: srcBase } = splitPath(srcNorm)
+    const { dir: destDir, base: destBase } = splitPath(destNorm)
+
+    // #477: validate source exists BEFORE applying the same-path no-op
+    // short-circuit. Pre-fix `mv /missing /missing` silently returned
+    // ok:true even though no file existed — POSIX mv and kubo go-ipfs-
+    // mfs both error in this case. The early return masked client bugs
+    // where dest computation yielded the same path as src.
+    const srcParent = this.dirs.get(srcDir)
+    if (!srcParent) throw new Error(`source not found: ${srcNorm}`)
+
+    const entry = srcParent.entries.get(srcBase)
+    if (!entry) throw new Error(`source not found: ${srcNorm}`)
+
+    // No-op when source and destination are identical (now that the
+    // source existence check has passed).
     if (srcNorm === destNorm) return
 
     // Prevent moving a directory into its own subtree
     if (destNorm.startsWith(srcNorm + "/")) {
       throw new Error(`cannot move directory into its own subdirectory: ${srcNorm} -> ${destNorm}`)
     }
-
-    const { dir: srcDir, base: srcBase } = splitPath(srcNorm)
-    const { dir: destDir, base: destBase } = splitPath(destNorm)
-
-    const srcParent = this.dirs.get(srcDir)
-    if (!srcParent) throw new Error(`source not found: ${srcNorm}`)
-
-    const entry = srcParent.entries.get(srcBase)
-    if (!entry) throw new Error(`source not found: ${srcNorm}`)
 
     const destParent = this.dirs.get(destDir)
     if (!destParent) throw new Error(`destination directory not found: ${destDir}`)
@@ -295,22 +301,27 @@ export class IpfsMfs {
     const srcNorm = normalizePath(source)
     const destNorm = normalizePath(dest)
 
-    // No-op when source and destination are identical
+    const { dir: srcDir, base: srcBase } = splitPath(srcNorm)
+    const { dir: destDir, base: destBase } = splitPath(destNorm)
+
+    // #477: validate source exists BEFORE the same-path no-op short-
+    // circuit. Pre-fix `cp /missing /missing` silently returned ok:true.
+    // POSIX cp + kubo go-ipfs-mfs both error on missing source even
+    // when src == dst.
+    const srcParent = this.dirs.get(srcDir)
+    if (!srcParent) throw new Error(`source not found: ${srcNorm}`)
+
+    const entry = srcParent.entries.get(srcBase)
+    if (!entry) throw new Error(`source not found: ${srcNorm}`)
+
+    // No-op when source and destination are identical (after source-
+    // existence check).
     if (srcNorm === destNorm) return
 
     // Prevent copying a directory into its own subtree (infinite recursion)
     if (destNorm.startsWith(srcNorm + "/")) {
       throw new Error(`cannot copy directory into its own subdirectory: ${srcNorm} -> ${destNorm}`)
     }
-
-    const { dir: srcDir, base: srcBase } = splitPath(srcNorm)
-    const { dir: destDir, base: destBase } = splitPath(destNorm)
-
-    const srcParent = this.dirs.get(srcDir)
-    if (!srcParent) throw new Error(`source not found: ${srcNorm}`)
-
-    const entry = srcParent.entries.get(srcBase)
-    if (!entry) throw new Error(`source not found: ${srcNorm}`)
 
     const destParent = this.dirs.get(destDir)
     if (!destParent) throw new Error(`destination directory not found: ${destDir}`)


### PR DESCRIPTION
Closes #477.

## Summary

- Move source-existence validation **before** the same-path no-op short-circuit in `cp()` and `mv()` so missing-source errors fire consistently regardless of whether src equals dst.
- Reorder fields without changing the destination-resolution path or any successful-copy semantics.
- Regression test exercises both methods + sanity case (same-path on existing file is still a no-op).

## Pre-fix (live 88780)

```
$ curl POST /api/v0/files/cp?arg=/nonexistent&arg=/nonexistent
{"ok":true}                                      ← silently succeeds

$ curl POST /api/v0/files/mv?arg=/nonexistent&arg=/nonexistent
{"ok":true}                                      ← silently succeeds
```

## Post-fix

```
$ curl POST /api/v0/files/cp?arg=/nonexistent&arg=/nonexistent
{"error":"not found","message":"source not found: /nonexistent"}

$ curl POST /api/v0/files/mv?arg=/nonexistent&arg=/nonexistent
{"error":"not found","message":"source not found: /nonexistent"}
```

Same-path on existing file is still a silent no-op (preserves the prior contract for `cp /existing /existing` and `mv /existing /existing`).

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-mfs.test.ts` — 16 tests pass (1 new)
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 94 tests pass (no regression)
- [x] Manual `curl` against local fixture confirms both methods now error on missing same-path source

🤖 Generated with [Claude Code](https://claude.com/claude-code)