### PR TITLE
fix(ws): newHeads payload field parity with eth_getBlockByNumber (#487)

### DIFF
--- a/node/src/chain-events.test.ts
+++ b/node/src/chain-events.test.ts
@@ -227,6 +227,90 @@ describe("formatNewHeadsNotification", () => {
     assert.match(result.receiptsRoot as string, /^0x[0-9a-f]{64}$/)
     assert.match(result.logsBloom as string, /^0x[0-9a-f]{512}$/)
   })
+
+  it("#487: includes all Cancun + finalized + size + totalDifficulty + mixHash fields (parity with eth_getBlockByNumber)", async () => {
+    // Pre-fix WebSocket newHeads subscription returned 16 fields while
+    // eth_getBlockByNumber returned 26 (minus `transactions` which is
+    // correctly omitted for headers-only). Missing: mixHash, size,
+    // totalDifficulty, withdrawals, withdrawalsRoot, blobGasUsed,
+    // excessBlobGas, parentBeaconBlockRoot, finalized.
+    //
+    // Live testnet 88780 reproduction:
+    //   WS newHeads payload keys: 16
+    //   RPC eth_getBlockByNumber keys: 26 (incl. transactions)
+    //   Diff (in RPC, not in WS): 10 fields
+    //
+    // ethers/viem feature-detect Cancun by inspecting the head — pre-fix
+    // a subscription client saw a "pre-Cancun" chain while a query client
+    // saw the correct Cancun fields. Same class as #481 (genesis vs
+    // regular block shape drift), but on the WS notification path.
+    const block = makeBlock(100n)
+    block.timestampMs = 1700000000000
+    block.stateRoot = `0x${"11".repeat(32)}` as Hex
+    block.baseFee = 1_000_000_000n
+    block.finalized = true
+    block.blobGasUsed = 0x20000n
+    block.excessBlobGas = 0x40000n
+    block.parentBeaconBlockRoot = `0x${"55".repeat(32)}` as Hex
+
+    const result = await formatNewHeadsNotification({
+      block,
+      receipts: [],
+    })
+
+    // All 25 header fields must be present (transactions is the only
+    // omission vs eth_getBlockByNumber).
+    const expectedKeys = [
+      "baseFeePerGas", "blobGasUsed", "difficulty", "excessBlobGas", "extraData",
+      "finalized", "gasLimit", "gasUsed", "hash", "logsBloom", "miner", "mixHash",
+      "nonce", "number", "parentBeaconBlockRoot", "parentHash", "receiptsRoot",
+      "sha3Uncles", "size", "stateRoot", "timestamp", "totalDifficulty",
+      "transactionsRoot", "withdrawals", "withdrawalsRoot",
+    ]
+    const actualKeys = new Set(Object.keys(result))
+    for (const key of expectedKeys) {
+      assert.equal(
+        actualKeys.has(key),
+        true,
+        `newHeads must include ${key} (pre-fix it was missing). Current keys: ${[...actualKeys].sort().join(",")}`,
+      )
+    }
+
+    // Type/value checks for the previously-missing fields.
+    assert.equal(typeof result.size, "string", "size must be hex string")
+    assert.match(result.size as string, /^0x[0-9a-f]+$/, "size must be valid hex")
+    assert.equal(typeof result.finalized, "boolean", "finalized must be boolean")
+    assert.equal(result.finalized, true, "fixture set finalized=true → must be propagated")
+    assert.equal(result.mixHash, `0x${"00".repeat(32)}`, "mixHash must be zero hash (PoS)")
+    assert.equal(result.totalDifficulty, "0x0", "totalDifficulty must be 0x0 (PoS)")
+    assert.deepEqual(result.withdrawals, [], "withdrawals must be empty array")
+    assert.equal(
+      result.withdrawalsRoot,
+      "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+      "withdrawalsRoot must be EMPTY_TRIE_ROOT",
+    )
+    assert.equal(result.blobGasUsed, "0x20000", "blobGasUsed must propagate from block")
+    assert.equal(result.excessBlobGas, "0x40000", "excessBlobGas must propagate from block")
+    assert.equal(result.parentBeaconBlockRoot, `0x${"55".repeat(32)}`, "parentBeaconBlockRoot must propagate from block")
+
+    // newHeads correctly excludes `transactions` (header-only stream).
+    assert.equal(actualKeys.has("transactions"), false, "newHeads must NOT include transactions[]")
+  })
+
+  it("#487: defaults blob fields to 0x0 + finalized to false when block omits them", async () => {
+    const block = makeBlock(101n)
+    block.timestampMs = 1700000000000
+    block.baseFee = 1_000_000_000n
+    // Intentionally NOT setting finalized / blobGasUsed / excessBlobGas /
+    // parentBeaconBlockRoot to test the default fallbacks.
+
+    const result = await formatNewHeadsNotification({ block, receipts: [] })
+
+    assert.equal(result.finalized, false, "finalized defaults to false when block.finalized is undefined")
+    assert.equal(result.blobGasUsed, "0x0", "blobGasUsed defaults to 0x0")
+    assert.equal(result.excessBlobGas, "0x0", "excessBlobGas defaults to 0x0")
+    assert.equal(result.parentBeaconBlockRoot, `0x${"00".repeat(32)}`, "parentBeaconBlockRoot defaults to zero hash")
+  })
 })
 
 describe("formatLogNotification", () => {

--- a/node/src/chain-events.ts
+++ b/node/src/chain-events.ts
@@ -88,28 +88,54 @@ export class ChainEventEmitter {
 export async function formatNewHeadsNotification(event: BlockEvent): Promise<Record<string, unknown>> {
   const { block, receipts } = event
   const headerView = await buildBlockHeaderView(block, receipts)
+  // #487: same-block-shape parity with rpc.ts:formatBlock. Pre-fix this
+  // function returned 16 fields while eth_getBlockByNumber returned 26
+  // (minus `transactions` which is correctly omitted from newHeads, per
+  // spec). Missing: mixHash, size, totalDifficulty, withdrawals,
+  // withdrawalsRoot, blobGasUsed, excessBlobGas, parentBeaconBlockRoot,
+  // finalized. ethers/viem feature-detect Cancun support by inspecting
+  // the head, so missing Cancun fields made the chain appear pre-Cancun
+  // to subscription clients while query clients saw the correct fields.
+  // EMPTY_TRIE_ROOT is geth/erigon's withdrawalsRoot for empty withdrawals.
+  const EMPTY_TRIE_ROOT = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+  const ZERO_HASH = "0x" + "0".repeat(64)
+  const HEADER_OVERHEAD = 508
+  let txBytesSize = 0
+  for (const rawTx of block.txs) {
+    txBytesSize += Math.max(0, (rawTx.length - 2)) / 2
+  }
+  const blockSize = HEADER_OVERHEAD + Math.floor(txBytesSize)
   return {
     number: `0x${block.number.toString(16)}`,
     hash: block.hash,
     parentHash: block.parentHash,
     nonce: "0x0000000000000000",
-    sha3Uncles: "0x" + "0".repeat(64),
+    sha3Uncles: ZERO_HASH,
     logsBloom: headerView.logsBloom,
     transactionsRoot: headerView.transactionsRoot,
     stateRoot: headerView.stateRoot,
     receiptsRoot: headerView.receiptsRoot,
     miner: block.proposer.startsWith("0x") ? block.proposer : "0x0000000000000000000000000000000000000000",
     difficulty: "0x0",
+    totalDifficulty: "0x0",
     // #448: encode proposer as address bytes (20 bytes), not ASCII string.
     // See rpc.ts:formatBlockResponse for context. Falls back to UTF-8
     // (truncated to 32 bytes) when proposer isn't a hex address.
     extraData: /^0x[0-9a-fA-F]{40}$/.test(block.proposer)
       ? block.proposer.toLowerCase()
       : `0x${Buffer.from(block.proposer, "utf-8").toString("hex").slice(0, 64)}`,
+    mixHash: ZERO_HASH,
+    size: `0x${blockSize.toString(16)}`,
     gasLimit: "0x1c9c380",
     gasUsed: `0x${headerView.gasUsed.toString(16)}`,
     timestamp: `0x${Math.floor(block.timestampMs / 1000).toString(16)}`,
     baseFeePerGas: `0x${headerView.baseFeePerGas.toString(16)}`,
+    withdrawals: [],
+    withdrawalsRoot: EMPTY_TRIE_ROOT,
+    blobGasUsed: `0x${(block.blobGasUsed ?? 0n).toString(16)}`,
+    excessBlobGas: `0x${(block.excessBlobGas ?? 0n).toString(16)}`,
+    parentBeaconBlockRoot: block.parentBeaconBlockRoot ?? ZERO_HASH,
+    finalized: block.finalized ?? false,
   }
 }
 


### PR DESCRIPTION
Closes #487.

## Summary

- `formatNewHeadsNotification` now mirrors `eth_getBlockByNumber`'s field set field-for-field, minus `transactions` (header-only stream contract).
- Adds the 9 missing fields: `mixHash`, `size`, `totalDifficulty`, `withdrawals`, `withdrawalsRoot`, `blobGasUsed`, `excessBlobGas`, `parentBeaconBlockRoot`, `finalized`.
- Defaults fall back to `0x0` / zero hash / `false` when the chain block omits the field, matching `formatBlock`'s pattern.

## Pre-fix (live 88780)

```
WS newHeads keys (16):  baseFeePerGas, difficulty, extraData, gasLimit,
  gasUsed, hash, logsBloom, miner, nonce, number, parentHash,
  receiptsRoot, sha3Uncles, stateRoot, timestamp, transactionsRoot

RPC getBlockByNumber keys (26): above 16 + blobGasUsed, excessBlobGas,
  finalized, mixHash, parentBeaconBlockRoot, size, totalDifficulty,
  transactions, withdrawals, withdrawalsRoot

Diff: 10 fields missing from WS (9 wrong + transactions correctly omitted)
```

## Post-fix

WS newHeads now exposes all 25 header fields (everything except `transactions`). Cancun feature-detect in ethers/viem succeeds for WS subscribers, matching HTTP-RPC behavior.

## Test plan

- [x] `node --experimental-strip-types --test node/src/chain-events.test.ts` — 13 tests pass (2 new `#487`)
- [x] Live `ws://159.198.44.136:28790` repro from this iteration confirmed the gap before the fix
- [x] Regression tests cover: all 25 header fields present, type/value correctness for previously-missing fields, default fallbacks when block.finalized/blobGasUsed/excessBlobGas/parentBeaconBlockRoot are undefined, exclusion of `transactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)