### PR TITLE
fix(ipfs): isValidCid accepts canonical short identity-hash CIDs (#489)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -278,7 +278,13 @@ describe("IpfsHttpServer", () => {
   })
 
   it("#126: POST /api/v0/block/rm returns 404 if the block is not present", async () => {
-    const res = await fetch(`/api/v0/block/rm?arg=QmNonExistent123`, { method: "POST" })
+    // #489: Qm v0 CIDs must be exactly 46 chars. Pre-fix `isValidCid`
+    // only enforced length<10/length>100, so the 15-char "QmNonExistent123"
+    // slipped through and reached the not-found code path. Post-fix the
+    // exact-46 gate rejects malformed Qm CIDs at the shape layer — provide
+    // a well-shaped 46-char Qm that's still unknown to the blockstore.
+    const fakeQm = "QmNonExistent1234567891234567891234567891234ZZ" // 46 chars
+    const res = await fetch(`/api/v0/block/rm?arg=${fakeQm}`, { method: "POST" })
     assert.equal(res.status, 404)
   })
 
@@ -951,6 +957,51 @@ describe("IpfsHttpServer", () => {
     const res = await fetch(`/api/v0/erasure/status?arg=${meta.cid}`, { method: "POST" })
     assert.notEqual(res.status, 500, "unixfs CID erasure/status must not leak 500")
     assert.equal(res.status, 415, `unixfs CID must be 415 not_a_manifest, got ${res.status}`)
+  })
+
+  it("#489: gateway accepts canonical short CIDs like bafkqaaa (empty raw block)", async () => {
+    // Pre-fix isValidCid had `cid.length < 10 → invalid`, rejecting
+    // `bafkqaaa` — the universally-accepted CIDv1 identity-hash empty
+    // raw block (codec=raw, multihash=identity, digest length 0).
+    // kubo and ipfs-http-client both treat it as valid; COC rejected
+    // it as "invalid cid", breaking interop with any tooling that
+    // emits identity-hash CIDs (inline data, dag-cbor canonical
+    // empty representations, etc.).
+    //
+    // The shape gate is what we're testing — the empty block may not
+    // exist in this fixture's blockstore, so the downstream error is
+    // "block not found" (404), NOT "invalid cid" (400). That's the
+    // post-fix correct behavior: shape validation passes, real lookup
+    // fails honestly.
+    const r = await fetch(`/api/v0/block/stat?arg=bafkqaaa`, { method: "POST" })
+    if (r.status === 200) return  // block happened to exist; still proves shape passed
+    const body = await r.json() as { error?: string }
+    assert.doesNotMatch(
+      body.error ?? "",
+      /invalid cid/i,
+      `bafkqaaa is a valid CIDv1 (identity-hash empty raw block) — must not reject as malformed. Got: ${JSON.stringify(body)}`,
+    )
+
+    // Same gate via other endpoints that funnel through isValidCid.
+    for (const path of [
+      "/api/v0/cat?arg=bafkqaaa",
+      "/api/v0/object/stat?arg=bafkqaaa",
+      "/api/v0/dag/get?arg=bafkqaaa",
+    ]) {
+      const sub = await fetch(path, { method: "POST" })
+      if (sub.status === 200) continue
+      const subBody = await sub.json() as { error?: string }
+      assert.doesNotMatch(
+        subBody.error ?? "",
+        /invalid cid/i,
+        `${path}: bafkqaaa must clear shape validator. Got: ${JSON.stringify(subBody)}`,
+      )
+    }
+
+    // Sanity: still rejects definitively-malformed CIDs (5 chars, but bad alphabet).
+    const bad = await fetch(`/api/v0/block/stat?arg=bafk!`, { method: "POST" })
+    const badBody = await bad.json() as { error?: string }
+    assert.match(badBody.error ?? "", /invalid cid|missing/i, "still rejects bad CIDs")
   })
 
   it("#216: gateway rejects valid-shape CID > 100 chars (no ENAMETOOLONG 500 leak)", async () => {

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1715,16 +1715,29 @@ function isValidCid(cid: string): boolean {
   // Pre-fix the cap of 512 let synthetic over-long CIDs reach
   // store.get(cid) which then failed `open()` with ENAMETOOLONG —
   // leaking as `500 "internal error"` instead of a clean 400.
-  if (!cid || cid.length < 10 || cid.length > 100) return false
+  //
+  // #489: lower-bound check needs to accommodate identity-hash CIDs.
+  // The canonical empty-raw-block CID `bafkqaaa` is 8 chars (CIDv1,
+  // codec=raw, multihash=identity, digest length 0). Pre-fix the
+  // length<10 guard rejected this universally-accepted CID; ipfs-
+  // http-client and kubo both parse it as valid. The minimum
+  // theoretical CIDv1 base32 length is 8 chars (1 'b' prefix +
+  // 4-byte header encoded as 8 base32 chars); v0 Qm CIDs are always
+  // 46 chars and have their own min via the regex.
+  if (!cid || cid.length > 100) return false
   const trimmed = cid.trim()
   if (trimmed !== cid) return false
   if (/[\/\\]|\.\.|\0|\s/.test(cid)) return false
   // Base58 v0: "Qm" + base58 chars. Strict alphabet (no 0/O/I/l).
+  // Qm CIDs are always exactly 46 chars (32-byte SHA-256 + 2 prefix).
   if (cid.startsWith("Qm")) {
+    if (cid.length !== 46) return false
     return /^Qm[1-9A-HJ-NP-Za-km-z]+$/.test(cid)
   }
   // Base32 v1: "b"/"B" + RFC 4648 base32 chars (no 0/1/8/9).
+  // Minimum length 8 covers identity-hash empty CIDs like `bafkqaaa`.
   if (cid.startsWith("b") || cid.startsWith("B")) {
+    if (cid.length < 8) return false
     return /^[bB][a-z2-7]+$/.test(cid)
   }
   return false


### PR DESCRIPTION
Closes #489.

## Summary

- Drop the global `length < 10` floor that rejected `bafkqaaa` (canonical empty raw block CID).
- Tighten Qm v0 to exact 46-char length (fixed-shape per IPFS spec).
- Set b/B v1 minimum to 8 chars (theoretical CIDv1 minimum, admits identity-hash forms).

## Pre-fix (live 88780)

```
$ curl POST /api/v0/object/stat?arg=bafkqaaa
{"error":"invalid cid"}                 ← rejected (8 chars, < 10)

# kubo's behavior on same CID:
{"error":"block not found"}             ← shape valid, content absent
```

## Post-fix

`bafkqaaa` clears the shape validator and gets either content (if present) or "block not found" (if absent). Behavior matches kubo / helia / ipfs-http-client across the IPFS ecosystem.

## Bonus: Qm length tightening

Pre-fix Qm CIDs of any length ≥ 10 passed validation. A 15-char `"QmNonExistent123"` reached `blockstore.get()` and either ENAMETOOLONG-leaked (pre-#216) or surfaced as "block not found" (post-#216, masked the malformed shape). Tightened to exactly 46 chars per Qm v0 spec.

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` — 98 tests pass (1 new `#489`, 1 updated `#126` to use a 46-char fake Qm)
- [x] Regression test exercises `bafkqaaa` across block/stat, cat, object/stat, dag/get
- [x] Sanity test still rejects malformed short CIDs (`bafk!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)