### PR TITLE
fix(rpc): distinguish insufficient-funds from revert in eth_call/estimateGas (#491)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -865,7 +865,7 @@ export class EvmChain {
     params: { from?: string; to: string; data?: string; value?: string; gas?: string },
     stateRoot?: string,
     context?: bigint | ExecutionContext,
-  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean }> {
+  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }> {
     const executionContext = normalizeExecutionContext(context)
     if (stateRoot || executionContext.blockNumber !== undefined) {
       const stateManager = await this.resolveStateManager(stateRoot)
@@ -1179,7 +1179,7 @@ export class EvmChain {
     vm: VM,
     params: { from?: string; to: string; data?: string; value?: string; gas?: string },
     opts: ExecutionContext & { revertAfter?: boolean } = {},
-  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean }> {
+  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }> {
     const executionContext = normalizeExecutionContext(opts)
     const blockCommon = this.createExecutionCommon(executionContext.blockNumber)
     this.applyHardforkToVm(vm, executionContext.blockNumber)
@@ -1214,6 +1214,14 @@ export class EvmChain {
         returnValue,
         gasUsed: result.execResult.executionGasUsed,
         failed: result.execResult.exceptionError !== undefined,
+        // #491: surface the underlying EVMError name so the JSON-RPC
+        // layer can distinguish "insufficient balance" (caller pre-
+        // execution check; geth returns -32000 "insufficient funds for
+        // gas * price + value") from "revert" (contract reverted with
+        // payload; geth returns code 3 "execution reverted"). Pre-fix
+        // both were lumped into code 3, hiding the actual cause from
+        // ethers/viem and the user.
+        errorReason: result.execResult.exceptionError?.error,
       }
     } finally {
       if (opts.revertAfter !== false) {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3128,6 +3128,85 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#491: eth_call / eth_estimateGas distinguish insufficient-balance from revert (-32000 vs code 3)", async () => {
+    // Pre-fix any callRaw failure (revert + insufficient-balance + out-of-
+    // gas + invalid opcode) was lumped into code 3 "execution reverted".
+    // geth distinguishes:
+    //   - Real revert (RETURN ❌ / REVERT opcode) → code 3 "execution reverted"
+    //   - Insufficient balance pre-execution check → -32000 "insufficient
+    //     funds for gas * price + value"
+    // ethers/viem surface different UIs for the two cases (contract bug vs
+    // user needs to top up). Live 88780 reproduction: a poor address
+    // calling eth_estimateGas for a value transfer got "execution
+    // reverted" code 3 — totally misleading.
+    //
+    // Hijack callRaw to deterministically return the "insufficient balance"
+    // exceptionError name (matches what EthereumJS-VM evm.js:949 throws
+    // when caller.balance < value).
+    const origCallRaw = (evm as unknown as {
+      callRaw: (...args: unknown[]) => Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }>
+    }).callRaw
+    ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({
+      returnValue: "0x",
+      gasUsed: 0n,
+      failed: true,
+      errorReason: "insufficient balance",
+    })
+    try {
+      const probe = async (method: string) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method,
+            params: [{
+              from: "0xc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0",
+              to: "0x0000000000000000000000000000000000000001",
+              value: "0xde0b6b3a7640000",
+            }],
+          }),
+        })
+        return await r.json() as { error?: { code: number; message: string; data: string }; result?: unknown }
+      }
+
+      const call = await probe("eth_call")
+      assert.equal(
+        call.error?.code,
+        -32000,
+        `eth_call insufficient-balance must be -32000 (geth convention), got ${JSON.stringify(call)}`,
+      )
+      assert.match(
+        call.error!.message,
+        /insufficient funds for gas \* price \+ value/i,
+        `eth_call message must say insufficient funds, got: ${call.error!.message}`,
+      )
+      assert.doesNotMatch(
+        call.error!.message,
+        /execution reverted/i,
+        `eth_call must NOT use "execution reverted" wording for balance issues`,
+      )
+
+      const est = await probe("eth_estimateGas")
+      assert.equal(
+        est.error?.code,
+        -32000,
+        `eth_estimateGas insufficient-balance must be -32000, got ${JSON.stringify(est)}`,
+      )
+      assert.match(est.error!.message, /insufficient funds for gas \* price \+ value/i)
+
+      // Sanity: a real revert still surfaces as code 3 (regression guard for #286).
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({
+        returnValue: "0x", gasUsed: 21000n, failed: true,
+        errorReason: "revert",
+      })
+      const revertCall = await probe("eth_call")
+      assert.equal(revertCall.error?.code, 3, "real revert still uses code 3")
+      assert.match(revertCall.error!.message, /execution reverted/i)
+    } finally {
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -906,7 +906,8 @@ async function handleRpc(
         gas: gasForEstimate,
       }, executionContext.stateRoot, executionContext)
       if (estProbe.failed) {
-        throwExecutionReverted(estProbe.returnValue)
+        // #491: distinguish insufficient-balance from real reverts.
+        throwCallFailure(estProbe)
       }
       const estimated = await evm.estimateGas({
         from: estParams.from,
@@ -959,7 +960,8 @@ async function handleRpc(
       // returned 200 OK with result:"0x" for any contract call with an
       // unknown selector before this fix.
       if (callResult.failed) {
-        throwExecutionReverted(callResult.returnValue)
+        // #491: distinguish insufficient-balance from real reverts.
+        throwCallFailure(callResult)
       }
       return callResult.returnValue
     }
@@ -2979,6 +2981,25 @@ function throwExecutionReverted(returnValue: string): never {
   const reason = decodeRevertReason(returnValue)
   const message = reason ? `execution reverted: ${reason}` : "execution reverted"
   throw { code: 3, message, data: returnValue || "0x" }
+}
+
+/**
+ * #491: distinguish "insufficient balance" (caller pre-execution check)
+ * from "execution reverted" (contract code reverted). Pre-fix both went
+ * through throwExecutionReverted with code 3 "execution reverted", which
+ * misled ethers/viem into surfacing "Transaction would revert" when the
+ * actual cause was a balance shortfall. geth uses -32000 "insufficient
+ * funds for gas * price + value" for this case.
+ */
+function throwCallFailure(result: { returnValue: string; failed: boolean; errorReason?: string }): never {
+  if (result.errorReason === "insufficient balance") {
+    throw {
+      code: -32000,
+      message: "insufficient funds for gas * price + value",
+      data: result.returnValue || "0x",
+    }
+  }
+  throwExecutionReverted(result.returnValue)
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #491.

## Summary

- Surface EthereumJS-VM's `exceptionError.error` from `runCall` as `errorReason` on the callRaw return.
- Add `throwCallFailure` helper that routes "insufficient balance" → `-32000` (geth convention) and everything else → existing code 3 "execution reverted".
- Apply at both `eth_call` and `eth_estimateGas` call sites.

## Pre-fix (live 88780)

```
$ curl ... eth_call/eth_estimateGas with from=0-balance, value=1 ETH
{"error":{"code":3,"message":"execution reverted","data":"0x"}}
```

ethers/viem surface this as "Transaction would revert" — totally misleading. The actual failure is a balance shortfall.

## Post-fix

```
{"error":{"code":-32000,"message":"insufficient funds for gas * price + value","data":"0x"}}
```

ethers/viem now show "Insufficient balance" / prompt to top up. Real reverts continue to surface as code 3 (regression guard in test).

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — new `#491` test (visible at `ok 109`) + all 113 pre-existing tests pass
- [x] `node --experimental-strip-types --test node/src/evm.test.ts` — 9 tests pass (no regression from runCall return-type extension)
- [x] Regression test asserts:
  - `eth_call` insufficient-balance → -32000 + message contains "insufficient funds for gas \* price + value"
  - `eth_estimateGas` insufficient-balance → same -32000
  - Real revert (errorReason="revert") still surfaces as code 3 (regression guard for #286)

## Backwards compatibility

`runCall` return-type now includes optional `errorReason?: string`. Existing callers that destructure only `{returnValue, gasUsed, failed}` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)