### PR TITLE
fix(rpc): surface specific EVM error reason in eth_call message (#493)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3207,6 +3207,101 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#493: eth_call non-revert EVM exceptions surface specific reason in message", async () => {
+    // Pre-fix every EVM failure mode collapsed to bare "execution reverted":
+    //   - stack underflow, invalid opcode, out of gas, invalid jump,
+    //     refund exhausted, code size exceeds limit — all identical
+    // ethers/viem surface this as "Transaction would revert (likely
+    // require(false))" — totally wrong UX for OOG / OOPS / opcode bugs
+    // where the user should bump gas limit or fix the contract logic.
+    //
+    // Live testnet 88780 reproduction (all returned same error):
+    //   eth_call(0x50)         (POP, stack underflow)   → "execution reverted"
+    //   eth_call(0xfe)         (INVALID opcode)         → "execution reverted"
+    //   eth_call(...gas=0x10)  (out of gas)             → "execution reverted"
+    //   eth_call(0x600056)     (invalid JUMP)           → "execution reverted"
+    //
+    // geth puts the specific reason in the message so wallets can show
+    // a meaningful UI (e.g. "Out of gas — bump gas limit"). Match.
+    const origCallRaw = (evm as unknown as {
+      callRaw: (...args: unknown[]) => Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }>
+    }).callRaw
+
+    const cases: Array<{ reason: string; expectMessage: RegExp }> = [
+      { reason: "stack underflow",  expectMessage: /execution reverted: stack underflow/i },
+      { reason: "invalid opcode",   expectMessage: /execution reverted: invalid opcode/i },
+      { reason: "out of gas",        expectMessage: /execution reverted: out of gas/i },
+      { reason: "invalid JUMP",      expectMessage: /execution reverted: invalid JUMP/i },
+    ]
+
+    try {
+      for (const { reason, expectMessage } of cases) {
+        ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({
+          returnValue: "0x", gasUsed: 21000n, failed: true,
+          errorReason: reason,
+        })
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method: "eth_call",
+            params: [{ from: "0x" + "ab".repeat(20), to: "0x" + "cd".repeat(20), data: "0x" }, "latest"],
+          }),
+        })
+        const body = await r.json() as { error?: { code: number; message: string; data: string } }
+        assert.equal(body.error?.code, 3, `${reason} must still be code 3 (per geth), got ${JSON.stringify(body)}`)
+        assert.match(body.error!.message, expectMessage,
+          `${reason} must surface in message, got "${body.error!.message}"`)
+      }
+
+      // Sanity: bare revert (errorReason="revert") with no payload → bare
+      // "execution reverted" (no extra suffix). Regression guard for #286.
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({
+        returnValue: "0x", gasUsed: 21000n, failed: true,
+        errorReason: "revert",
+      })
+      const bareRevert = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_call",
+          params: [{ from: "0x" + "ab".repeat(20), to: "0x" + "cd".repeat(20), data: "0x" }, "latest"],
+        }),
+      })
+      const bareBody = await bareRevert.json() as { error?: { code: number; message: string } }
+      assert.equal(bareBody.error?.code, 3)
+      assert.equal(bareBody.error!.message, "execution reverted",
+        `bare revert with no errorReason payload must be exactly "execution reverted", got "${bareBody.error!.message}"`)
+
+      // Sanity: decoded Error(string) revert payload still works.
+      // ABI-encoded `Error("Hard!")`:
+      //   selector 08c379a0 + offset 0x20 + length 5 + "Hard!" padded to 32
+      const revertPayload = "0x08c379a0" +
+        "0000000000000000000000000000000000000000000000000000000000000020" +
+        "0000000000000000000000000000000000000000000000000000000000000005" +
+        "4861726421000000000000000000000000000000000000000000000000000000"
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({
+        returnValue: revertPayload, gasUsed: 21000n, failed: true,
+        errorReason: "revert",
+      })
+      const decoded = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_call",
+          params: [{ from: "0x" + "ab".repeat(20), to: "0x" + "cd".repeat(20), data: "0x" }, "latest"],
+        }),
+      })
+      const decodedBody = await decoded.json() as { error?: { code: number; message: string; data: string } }
+      assert.equal(decodedBody.error?.code, 3)
+      assert.match(decodedBody.error!.message, /execution reverted: Hard!/,
+        "decoded revert reason takes precedence over errorReason")
+      assert.equal(decodedBody.error!.data, revertPayload)
+    } finally {
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2977,10 +2977,32 @@ async function handleRpc(
 // payload from `error.data`. Decoded reason is appended to the message
 // when available (`Error(string)` → "execution reverted: <reason>";
 // `Panic(uint)` → "execution reverted: Panic(N)").
-function throwExecutionReverted(returnValue: string): never {
-  const reason = decodeRevertReason(returnValue)
-  const message = reason ? `execution reverted: ${reason}` : "execution reverted"
-  throw { code: 3, message, data: returnValue || "0x" }
+function throwExecutionReverted(returnValue: string, errorReason?: string): never {
+  // Try to decode an ABI-encoded revert payload first (Error(string) /
+  // Panic(uint256)). For a real REVERT opcode with payload, this gives
+  // the user-friendly Solidity reason.
+  const decoded = decodeRevertReason(returnValue)
+  if (decoded) {
+    throw { code: 3, message: `execution reverted: ${decoded}`, data: returnValue || "0x" }
+  }
+  // #493: when there's no revert payload, the failure is one of:
+  //   - explicit REVERT(0,0) with no data → "execution reverted"
+  //   - non-REVERT EVM exception (invalid opcode / out of gas / stack
+  //     underflow / invalid jump / etc) — these are NOT reverts, they're
+  //     consensus errors that consume all gas
+  // Pre-fix all of them collapsed into bare "execution reverted",
+  // misleading ethers/viem ("Transaction would revert: require(false)"
+  // is the default surface when no data is present). geth includes the
+  // specific reason in the message so wallets can show a meaningful UI
+  // ("Out of gas — increase the gas limit", "Invalid opcode" etc).
+  if (errorReason && errorReason !== "revert" && errorReason !== "insufficient balance") {
+    throw {
+      code: 3,
+      message: `execution reverted: ${errorReason}`,
+      data: returnValue || "0x",
+    }
+  }
+  throw { code: 3, message: "execution reverted", data: returnValue || "0x" }
 }
 
 /**
@@ -2999,7 +3021,10 @@ function throwCallFailure(result: { returnValue: string; failed: boolean; errorR
       data: result.returnValue || "0x",
     }
   }
-  throwExecutionReverted(result.returnValue)
+  // #493: pass the errorReason through so non-revert EVM exceptions get
+  // a specific message ("invalid opcode", "out of gas", "stack underflow",
+  // etc.) instead of bare "execution reverted".
+  throwExecutionReverted(result.returnValue, result.errorReason)
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #493. Builds on #491 / PR #492 (depends on `errorReason` plumbing in `runCall`).

## Summary

- Extend `throwExecutionReverted` to accept an optional `errorReason` and include it in the message when the call has no decoded revert payload AND the reason is distinctive (not "revert" / "insufficient balance").
- `throwCallFailure` now forwards the errorReason through.
- Code stays 3 across all non-balance EVM failures (matches geth's `vmError` surface). Only the MESSAGE distinguishes the failure type.

## Pre-fix (live 88780)

```
$ curl ... eth_call POP (0x50)        → {"code":3,"message":"execution reverted","data":"0x"}
$ curl ... eth_call INVALID (0xfe)    → {"code":3,"message":"execution reverted","data":"0x"}
$ curl ... eth_call OOG (gas=0x10)    → {"code":3,"message":"execution reverted","data":"0x"}
$ curl ... eth_call bad JUMP          → {"code":3,"message":"execution reverted","data":"0x"}
```

ethers.js surface for all 4: `"Transaction would revert (likely require(false))"`. Wrong UX hint for everything.

## Post-fix

```
POP (stack underflow)  → "execution reverted: stack underflow"
INVALID (opcode 0xfe)  → "execution reverted: invalid opcode"
OOG                    → "execution reverted: out of gas"
bad JUMP               → "execution reverted: invalid JUMP"
real REVERT            → "execution reverted"
REVERT("Hard!")        → "execution reverted: Hard!"
```

Wallets can now grep the message for OOG retry logic, opcode-bug detection, etc. matching geth/erigon behavior.

## Dependency note

Depends on #491's plumbing (`errorReason` field on `runCall` return). If #491 lands first, this rebases cleanly. If this lands without #491, the message extension still works — `errorReason` is optional and the function gracefully degrades to bare "execution reverted".

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — `#491` (ok 109) + new `#493` (ok 110) + all 113 pre-existing tests pass
- [x] Regression test exercises 4 EVM exception types (stack underflow, invalid opcode, out of gas, invalid JUMP) — each gets its specific reason in the message
- [x] Sanity assertions for bare revert + decoded Error(string) revert payload (regression guard for #286)

🤖 Generated with [Claude Code](https://claude.com/claude-code)