### PR TITLE
fix(ws): eth_subscribe newPendingTransactions honor full-tx flag (#495)

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -684,6 +684,7 @@ export class PersistentChainEngine {
       from: tx.from,
       nonce: tx.nonce,
       gasPrice: tx.gasPrice,
+      rawTx: tx.rawTx,
     })
 
     return tx

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -207,6 +207,7 @@ export class ChainEngine {
       from: tx.from,
       nonce: tx.nonce,
       gasPrice: tx.gasPrice,
+      rawTx: tx.rawTx,
     })
 
     return tx

--- a/node/src/chain-events.ts
+++ b/node/src/chain-events.ts
@@ -21,6 +21,13 @@ export interface PendingTxEvent {
   from: Hex
   nonce: bigint
   gasPrice: bigint
+  // #495: include the raw signed RLP so a WS subscriber that opted into
+  // full-tx mode (eth_subscribe("newPendingTransactions", true)) can
+  // re-parse and surface the same shape as eth_getTransactionByHash.
+  // Pre-fix the WS path emitted only `event.hash` regardless of the
+  // boolean flag, so the geth-style full-tx subscription was silently
+  // downgraded to hash-only.
+  rawTx: Hex
 }
 
 export interface LogEvent {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3876,7 +3876,7 @@ function normalizePersistedTo(value: string | null | undefined): string | null {
   return value
 }
 
-function formatRawTransaction(
+export function formatRawTransaction(
   rawTx: Hex,
   context?: { blockHash?: Hex; blockNumber?: bigint; transactionIndex?: number | null },
 ): Record<string, unknown> | null {

--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -254,6 +254,69 @@ describe("WebSocket RPC", () => {
     }
   })
 
+  it("#495: newPendingTransactions with 2nd-arg `true` returns full tx objects (geth compat)", async () => {
+    // Pre-fix the 2nd param of eth_subscribe("newPendingTransactions",
+    // true) was silently dropped — both with-flag and without-flag
+    // subscriptions emitted only the tx hash string. Per geth API:
+    //   subscribe("newPendingTransactions")        → string hashes
+    //   subscribe("newPendingTransactions", true)  → full tx objects
+    // MEV/front-running monitors, mempool indexers, ethers/viem
+    // mempool watchers rely on the full-object mode.
+    //
+    // Live testnet 88780 reproduction showed both subscriptions
+    // returning the same hash string for the same tx.
+    const ws = await connectWs(WS_PORT)
+    try {
+      const subId = await sendRpc(ws, "eth_subscribe", ["newPendingTransactions", true])
+      assert.ok(typeof subId === "string")
+
+      const msgPromise = waitForMessage(ws)
+      const rawTx = createSignedTx(1, "0x0000000000000000000000000000000000000001", 1000n)
+      await chain.addRawTx(rawTx)
+
+      const msg = await msgPromise
+      const msgParams = msg.params as Record<string, unknown>
+      const result = msgParams.result as Record<string, unknown>
+
+      // Result must be a full tx object, not a hash string.
+      assert.equal(typeof result, "object", `expected object, got ${typeof result}: ${JSON.stringify(result)}`)
+      assert.ok(result !== null, "result must not be null")
+
+      // Required shape (matches eth_getTransactionByHash output).
+      const requiredKeys = ["hash", "from", "to", "nonce", "value", "gas", "input", "type"]
+      for (const k of requiredKeys) {
+        assert.ok(k in result, `full-tx mode must include "${k}", got keys: ${Object.keys(result).join(",")}`)
+      }
+      assert.match(result.hash as string, /^0x[0-9a-f]{64}$/, "hash must be 32-byte hex")
+      assert.match(result.from as string, /^0x[0-9a-f]{40}$/, "from must be 20-byte hex")
+      assert.match(result.nonce as string, /^0x[0-9a-f]+$/, "nonce must be hex quantity")
+    } finally {
+      ws.close()
+    }
+  })
+
+  it("#495: newPendingTransactions rejects non-boolean 2nd arg with -32602", async () => {
+    // Same shape-validation pattern as #244 for logs filter param.
+    // Pre-fix `String("not-a-bool")` would silently fall through to
+    // hash-mode, hiding the caller's bug.
+    const ws = await connectWs(WS_PORT)
+    try {
+      const reply = await new Promise<Record<string, unknown>>((resolve) => {
+        ws.once("message", (data) => resolve(JSON.parse(data.toString())))
+        ws.send(JSON.stringify({
+          jsonrpc: "2.0", id: 999, method: "eth_subscribe",
+          params: ["newPendingTransactions", "not-a-bool"],
+        }))
+      })
+      const err = reply.error as Record<string, unknown> | undefined
+      assert.ok(err, `expected error envelope, got ${JSON.stringify(reply)}`)
+      assert.equal(err.code, -32602, `bad shape must be -32602, got ${err.code}`)
+      assert.match(err.message as string, /boolean or omitted/i)
+    } finally {
+      ws.close()
+    }
+  })
+
   it("unsubscribe stops notifications", async () => {
     const ws = await connectWs(WS_PORT)
     try {

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -20,6 +20,7 @@ import type { EvmChain } from "./evm.ts"
 import type { P2PNode } from "./p2p.ts"
 import type { ChainEventEmitter, BlockEvent, PendingTxEvent, LogEvent } from "./chain-events.ts"
 import { formatNewHeadsNotification, formatLogNotification } from "./chain-events.ts"
+import { formatRawTransaction } from "./rpc.ts"
 import type { Hex } from "./blockchain-types.ts"
 import type { IndexedLog } from "./storage/block-index.ts"
 import { createLogger } from "./logger.ts"
@@ -562,8 +563,31 @@ export class WsRpcServer {
         break
       }
       case "newPendingTransactions": {
+        // #495: geth-compat 2nd param `true` ⇒ emit full tx objects
+        // (eth_getTransactionByHash shape). Pre-fix this boolean was
+        // silently dropped — both ["newPendingTransactions"] and
+        // ["newPendingTransactions", true] returned hash strings.
+        // Reject non-boolean / non-omitted shapes upfront so a buggy
+        // client gets -32602 instead of silent fallback (same anti-
+        // pattern family as #244 for logs).
+        const fullObjects = params[1]
+        if (fullObjects !== undefined && fullObjects !== null && typeof fullObjects !== "boolean") {
+          invalidParams("invalid newPendingTransactions param: 2nd argument must be boolean or omitted")
+        }
+        const emitFull = fullObjects === true
         const handler = (event: PendingTxEvent) => {
           if (!this.clients.has(ws)) return
+          if (emitFull) {
+            // Parse the raw RLP into the standard tx object shape used by
+            // eth_getTransactionByHash. The tx isn't in a block yet, so
+            // blockHash/blockNumber/transactionIndex stay null per spec.
+            const formatted = formatRawTransaction(event.rawTx)
+            if (formatted) {
+              this.sendSubscription(ws, subId, formatted)
+              return
+            }
+            // Fallback to hash if parsing fails — better than dropping the event.
+          }
           this.sendSubscription(ws, subId, event.hash)
         }
         this.events.onPendingTx(handler as (event: PendingTxEvent) => void)


### PR DESCRIPTION
Closes #495.

## Summary

Per geth API, the 2nd boolean param to `eth_subscribe("newPendingTransactions", true)` opts into full-tx-object mode (same shape as `eth_getTransactionByHash`). COC silently dropped the flag and always emitted hash strings. This PR:

- Adds `rawTx: Hex` to `PendingTxEvent` so the WS handler can re-parse the signed RLP.
- Updates both `emitPendingTx` call sites to pass `tx.rawTx`.
- Exports `formatRawTransaction` from rpc.ts.
- Reads `params[1]` in the WS subscribe handler. When `true`, formats via `formatRawTransaction`. Non-boolean shapes reject with -32602.

## Pre-fix (live 88780)

```
$ ws.send(eth_subscribe, ["newPendingTransactions"])           → push: "0x043d0e..."  (hash)
$ ws.send(eth_subscribe, ["newPendingTransactions", true])     → push: "0x043d0e..."  (BUG: should be obj)
```

## Post-fix

```
$ ws.send(eth_subscribe, ["newPendingTransactions"])           → push: "0x043d0e..."        (unchanged)
$ ws.send(eth_subscribe, ["newPendingTransactions", true])     → push: {hash, from, to,
                                                                       nonce, value, gas,
                                                                       input, type, ...}
$ ws.send(eth_subscribe, ["newPendingTransactions", "bad"])    → -32602 invalid params
```

Pending txs have `blockHash` / `blockNumber` / `transactionIndex` = null per spec — `formatRawTransaction`'s default context already produces this.

## Test plan

- [x] `node --experimental-strip-types --test node/src/websocket-rpc.test.ts` — 16 tests pass (2 new `#495`)
- [x] Full-tx mode test asserts result is an object with all 8 required keys + hex-shape validation
- [x] Bad-shape test asserts -32602 with mention of "boolean or omitted"
- [x] Pre-existing hashes-only test still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)