### PR TITLE
fix(rpc): drop String() coercion leaking [object Object] on block-tag params (#499)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2073,6 +2073,72 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(okNull.error, undefined, "null tag must NOT error")
   })
 
+  await t.test("#499: eth_getBlockTransactionCountByNumber / eth_feeHistory don't leak [object Object] from String() coercion", async () => {
+    // Pre-fix both endpoints used `String((payload.params)[N] ?? "latest")`
+    // which V8-stringifies any object to "[object Object]", surfacing as
+    // -32602 "invalid block number: [object Object]" — both broken shape
+    // handling AND leaks the V8 toString output (same anti-pattern as
+    // #194/#220/#226/#497). debug_getRawBlock / debug_getRawReceipts
+    // shared the same bug behind the COC_DEBUG_RPC gate.
+    //
+    // Live testnet 88780 repro:
+    //   eth_getBlockTransactionCountByNumber [{"blockNumber":"0x1"}]
+    //     → -32602 "invalid block number: [object Object]"  ← BUG
+    //   eth_feeHistory ["0x5", {"blockNumber":"0x1"}, []]
+    //     → -32602 "invalid block number: [object Object]"  ← BUG
+    //
+    // Fix routes the raw param through parseBlockTag (which already
+    // handles unknown shapes properly, per #194).
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+
+    // eth_getBlockTransactionCountByNumber: object input → structured -32602, no [object Object] leak.
+    const tcByObj = await probe("eth_getBlockTransactionCountByNumber", [{ blockNumber: "0x1" }])
+    assert.doesNotMatch(
+      JSON.stringify(tcByObj),
+      /\[object Object\]/,
+      `eth_getBlockTransactionCountByNumber must NOT leak [object Object], got ${JSON.stringify(tcByObj)}`,
+    )
+    assert.equal(tcByObj.error?.code, -32602)
+    assert.match(tcByObj.error!.message, /invalid block tag|must be hex/i)
+
+    // eth_feeHistory: object as newestBlock — must reject with structured error, no leak.
+    const fhByObj = await probe("eth_feeHistory", ["0x5", { blockNumber: "0x1" }, []])
+    assert.doesNotMatch(
+      JSON.stringify(fhByObj),
+      /\[object Object\]/,
+      `eth_feeHistory must NOT leak [object Object], got ${JSON.stringify(fhByObj)}`,
+    )
+    assert.equal(fhByObj.error?.code, -32602)
+
+    // Sanity: hex quantity still works.
+    const tcByHex = await probe("eth_getBlockTransactionCountByNumber", ["0x0"])
+    assert.equal(tcByHex.error, undefined, `eth_getBlockTransactionCountByNumber("0x0") must succeed, got ${JSON.stringify(tcByHex)}`)
+
+    // Sanity: tag still works.
+    const tcByTag = await probe("eth_getBlockTransactionCountByNumber", ["latest"])
+    assert.equal(tcByTag.error, undefined, "eth_getBlockTransactionCountByNumber(latest) must succeed")
+
+    // Sanity: omitted/null param → "latest" (preserve prior contract).
+    const tcByNull = await probe("eth_getBlockTransactionCountByNumber", [null])
+    assert.equal(tcByNull.error, undefined, "eth_getBlockTransactionCountByNumber(null) must default to latest")
+
+    // Array shape rejected with structured -32602, NO leak.
+    const tcByArr = await probe("eth_getBlockTransactionCountByNumber", [["0x1"]])
+    assert.doesNotMatch(JSON.stringify(tcByArr), /\[object Object\]/, "array input must not leak")
+    assert.equal(tcByArr.error?.code, -32602, `array input must be -32602, got ${JSON.stringify(tcByArr)}`)
+
+    // Bool shape rejected.
+    const tcByBool = await probe("eth_getBlockTransactionCountByNumber", [true])
+    assert.equal(tcByBool.error?.code, -32602)
+  })
+
   await t.test("#190: eth_getLogs rejects non-array topics field (no silent bypass)", async () => {
     // Pre-fix `validateLogFilter` only validated when Array.isArray(topics).
     // A client passing topics as a string/object got the same empty-result

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1616,9 +1616,9 @@ async function handleRpc(
     }
     case "debug_getRawReceipts": {
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
-      const rawReceiptTag = String((payload.params ?? [])[0] ?? "latest")
+      // #499: pass raw param; parseBlockTag handles unknown shapes.
       const rawReceiptHeight = await Promise.resolve(chain.getHeight())
-      const rawReceiptNum = parseBlockTag(rawReceiptTag, rawReceiptHeight)
+      const rawReceiptNum = parseBlockTag((payload.params ?? [])[0], rawReceiptHeight)
       const rawReceiptBlock = await Promise.resolve(chain.getBlockByNumber(rawReceiptNum))
       if (!rawReceiptBlock) return []
       return rawReceiptBlock.txs
@@ -1628,9 +1628,9 @@ async function handleRpc(
       if (!DEBUG_RPC_ENABLED) methodNotFound("debug methods disabled (set COC_DEBUG_RPC=1)")
       // Simplified: return JSON-encoded block data as hex (not RLP)
       // Full RLP encoding deferred to future phase
-      const rawBlockTag = String((payload.params ?? [])[0] ?? "latest")
+      // #499: pass raw param; parseBlockTag handles unknown shapes.
       const rawBlockHeight = await Promise.resolve(chain.getHeight())
-      const rawBlockNum = parseBlockTag(rawBlockTag, rawBlockHeight)
+      const rawBlockNum = parseBlockTag((payload.params ?? [])[0], rawBlockHeight)
       const rawBlock = await Promise.resolve(chain.getBlockByNumber(rawBlockNum))
       if (!rawBlock) return null
       if (payload.method === "debug_getRawHeader") {
@@ -1664,9 +1664,13 @@ async function handleRpc(
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
     case "eth_getBlockTransactionCountByNumber": {
-      const tag = String((payload.params ?? [])[0] ?? "latest")
+      // #499: pass raw param to parseBlockTag (which handles unknown
+      // shapes properly) instead of String() coercion. Pre-fix
+      // `String({blockNumber: "0x1"})` = "[object Object]" → -32602
+      // "invalid block number: [object Object]" — leaked V8 toString
+      // output (same anti-pattern as #194/#220/#226/#497).
       const height = await Promise.resolve(chain.getHeight())
-      const num = parseBlockTag(tag, height)
+      const num = parseBlockTag((payload.params ?? [])[0], height)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
@@ -1741,7 +1745,11 @@ async function handleRpc(
       } else {
         invalidParams("invalid blockCount: expected hex quantity or positive integer")
       }
-      const newestBlock = String((payload.params ?? [])[1] ?? "latest")
+      // #499: pass raw param to resolveBlockNumber (which delegates to
+      // parseBlockTag and handles unknown shapes properly). Pre-fix
+      // String({blockNumber:"0x1"}) → "[object Object]" → -32602 leak.
+      const newestBlockRaw = (payload.params ?? [])[1]
+      const newestBlock = newestBlockRaw === undefined || newestBlockRaw === null ? "latest" : newestBlockRaw
       // #224: `as number[]` was a TS runtime no-op so an object/string/
       // bool silently passed through (`{}.length === undefined`
       // bypassed the >100 check and the for-loop). Reject non-array


### PR DESCRIPTION
Closes #499.

## Summary

- 4 RPC handlers (`eth_getBlockTransactionCountByNumber`, `eth_feeHistory.newestBlock`, `debug_getRawReceipts`, `debug_getRawHeader/Block`) used `String((payload.params)[N] ?? "latest")` which V8-stringifies any object to `"[object Object]"`. This bypassed #194's parseBlockTag protection.
- Fix: pass the raw param directly through parseBlockTag (or normalize null/undefined → "latest" before passing, for eth_feeHistory).

## Pre-fix (live 88780)

```
$ curl ... eth_getBlockTransactionCountByNumber [{"blockNumber":"0x1"}]
{"error":{"code":-32602,"message":"invalid block number: [object Object]"}}

$ curl ... eth_feeHistory ["0x5",{"blockNumber":"0x1"},[]]
{"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
```

## Post-fix

Structured -32602 with `"invalid block tag: must be hex quantity or named tag"` — no V8 toString leak. Hex/tag/null inputs still succeed.

## Test plan

- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — new `#499` test passes at ok 88; pre-existing tests (`#194` parseBlockTag) untouched
- [x] Regression test exercises object / array / bool inputs across both fixable endpoints + sanity-asserts hex/tag/null still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)