### PR TITLE
fix(rpc+erasure): coc_getFaction strict address + sanitize CID parse error (#505)

### DIFF
--- a/node/src/erasure-status-bridge.test.ts
+++ b/node/src/erasure-status-bridge.test.ts
@@ -34,6 +34,51 @@ test("#358: ErasureError must be importable from ipfs-erasure.ts for instanceof 
     "the dynamically-imported ErasureError must satisfy instanceof against itself")
 })
 
+test("#505: resolveCid sanitizes multiformats library error messages (no library-internal leak)", async () => {
+  // Pre-fix `resolveCid("not-a-cid")` threw an ErasureError whose message
+  // concatenated the multiformats library's internal text verbatim:
+  //   "unparseable CID: To parse non base32, base36 or base58btc encoded
+  //    CID multibase decoder must be provided"
+  // That message text leaked the library's internal multibase-decoder
+  // architecture to the wire — same anti-pattern family as #156
+  // (ethers BUFFER_OVERRUN leak), #176 (V8 SyntaxError leak), #182
+  // (TypedDataEncoder INVALID_ARGUMENT leak), #214 (HTTP error shape).
+  //
+  // Live testnet 88780 reproduction (this iteration):
+  //   coc_erasureStatus(["not-a-cid"])
+  //     → -32602 "unparseable CID: To parse non base32, base36 or
+  //               base58btc encoded CID multibase decoder must be provided"
+  // Fix emits a clean shape-only message.
+  const reader = await import("./ipfs-erasure-reader.ts") as {
+    resolveCid: (cid: string, store: unknown) => Promise<unknown>
+  }
+  const erasure = await import("./ipfs-erasure.ts") as Record<string, unknown>
+  const ErasureErrorKlass = erasure.ErasureError as new (...args: unknown[]) => Error & { code: string }
+
+  let caught: unknown
+  try {
+    await reader.resolveCid("not-a-cid", { get: async () => undefined } as never)
+  } catch (e) {
+    caught = e
+  }
+  assert.ok(caught instanceof ErasureErrorKlass, "must throw ErasureError")
+  const err = caught as Error & { code: string }
+  assert.equal(err.code, "invalid_cid", "error code must be invalid_cid")
+
+  // Message must NOT leak multiformats library internals.
+  assert.doesNotMatch(
+    err.message,
+    /multibase decoder must be provided|base32, base36 or base58btc|multiformats/i,
+    `error message must not leak multiformats internals, got: "${err.message}"`,
+  )
+  // Should contain a generic shape hint.
+  assert.match(
+    err.message,
+    /invalid CID|malformed/i,
+    `error message should mention "invalid CID" / "malformed", got: "${err.message}"`,
+  )
+})
+
 test("#358: simulating the pre-fix bug shape — `err instanceof undefined` throws V8 TypeError", () => {
   // Pin the V8 error message so the issue description stays accurate
   // and future maintainers see why the dynamic-import fix matters.

--- a/node/src/ipfs-erasure-reader.ts
+++ b/node/src/ipfs-erasure-reader.ts
@@ -52,8 +52,15 @@ export async function resolveCid(
   let parsed: CID
   try {
     parsed = CID.parse(cid)
-  } catch (err) {
-    throw new ErasureError("invalid_cid", `unparseable CID: ${(err as Error).message ?? err}`)
+  } catch {
+    // #505: pre-fix the multiformats library's internal error message
+    // was concatenated verbatim into the wire response, e.g.
+    //   "unparseable CID: To parse non base32, base36 or base58btc
+    //    encoded CID multibase decoder must be provided"
+    // This leaks library internals to the client (same anti-pattern
+    // family as #156 ethers leak, #176 V8 SyntaxError leak, #182
+    // TypedDataEncoder leak). Emit a clean shape-only message.
+    throw new ErasureError("invalid_cid", "invalid CID: malformed encoding")
   }
 
   if (parsed.code === CODEC_DAG_PB) {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1130,6 +1130,19 @@ test("RPC Extended Methods", async (t) => {
       assert.equal(r.error?.code, -32602,
         `coc_getFaction(${JSON.stringify(bad)}) must be -32602 (not silent null), got ${JSON.stringify(r)}`)
     }
+    // #505: malformed-but-0x-prefixed addresses must ALSO reject — pre-fix
+    // the loose `startsWith("0x")` check accepted any prefixed string and
+    // silently returned null (indistinguishable from "real address, no
+    // faction"). requireAddressParam enforces the 40-char shape.
+    for (const bad of ["0x", "0x123", "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb9226", /* 39 chars */
+                        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb922665", /* 41 chars */
+                        "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"]) {
+      const r = await probe("coc_getFaction", [bad])
+      assert.equal(r.error?.code, -32602,
+        `coc_getFaction("${bad}") must be -32602 (malformed address), got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /invalid address/i,
+        `coc_getFaction error must mention "invalid address", got "${r.error!.message}"`)
+    }
     // Sanity: valid address shape returns null (not error) without governance.
     {
       const r = await probe("coc_getFaction", ["0x0000000000000000000000000000000000000001"])

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2502,10 +2502,13 @@ async function handleRpc(
       // #436: validate shape BEFORE backend-config short-circuit (same
       // family as #432 / PR #431). Without this, garbage address shapes
       // silently get `null` instead of -32602 on read-only nodes.
-      const address = (payload.params ?? [])[0]
-      if (typeof address !== "string" || !address.startsWith("0x")) {
-        invalidParams("invalid address: expected hex string")
-      }
+      // #505: pre-fix the loose `startsWith("0x")` check accepted any
+      // 0x-prefixed string — "0x123", "0xZZZ…" and other malformed
+      // addresses all silently returned null (indistinguishable from
+      // "real address, no faction"). Use requireAddressParam (40-char
+      // enforcement) to match the rest of the coc_* address-taking
+      // endpoints (#120, #122, #124, #128, #471, family).
+      const address = requireAddressParam(payload.params ?? [], 0).toLowerCase() as Hex
       if (!hasGovernance(chain)) return null
       const factionInfo = chain.governance.getFaction?.(address)
       if (!factionInfo) return null


### PR DESCRIPTION
Closes #505.

## Summary

Two-issue bundle from probing governance + IPFS error surfaces:

**A. `coc_getFaction` strict address validation** — replaced loose `startsWith("0x")` with `requireAddressParam` (40-char shape enforcement), matching every other `coc_*` address-taking handler.

**B. `resolveCid` error sanitization** — replaced library-internal multiformats text concatenation with clean shape message.

## Pre-fix (live 88780)

```
$ curl ... coc_getFaction ["0x123"]            → {"result":null}          ← silent
$ curl ... coc_getFaction ["0xZZZZ…40 chars"]  → {"result":null}          ← silent
$ curl ... coc_erasureStatus ["not-a-cid"]     → {"error":{"code":-32602,"message":"unparseable CID: To parse non base32, base36 or base58btc encoded CID multibase decoder must be provided"}}
```

## Post-fix

```
$ curl ... coc_getFaction ["0x123"]            → {"error":{"code":-32602,"message":"invalid address: must match /^0x[0-9a-fA-F]{40}$/"}}
$ curl ... coc_erasureStatus ["not-a-cid"]     → {"error":{"code":-32602,"message":"invalid CID: malformed encoding"}}
```

## Test plan

- [x] `node --experimental-strip-types --test node/src/erasure-status-bridge.test.ts` — 3 tests pass (1 new `#505`)
- [x] `#505` test asserts error message contains "invalid CID"/"malformed" but NOT `multibase decoder`/`base32, base36 or base58btc`/`multiformats` (library-internal phrases)
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — `#436` extended (covers `coc_getFaction` strict address); pre-existing 113 tests untouched

## Related

- #122 / #124 / #128 / #471 — address-validation drift family (parent class for A)
- #156 / #176 / #182 / #214 — error-message library-internal leak family (parent class for B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)