### PR TITLE
fix(ipfs): #507 sanitize ENOENT filesystem path leak in resolveCid

### DIFF
--- a/node/src/erasure-status-bridge.test.ts
+++ b/node/src/erasure-status-bridge.test.ts
@@ -98,3 +98,93 @@ test("#358: simulating the pre-fix bug shape — `err instanceof undefined` thro
     "V8 message must match the one leaked through the RPC -32603 reply pre-fix"
   )
 })
+
+/**
+ * #507 regression: `resolveCid()` in `ipfs-erasure-reader.ts` used to
+ * interpolate `(err as Error).message` from the blockstore's ENOENT
+ * exception into the wire error message. Node.js's `fs.readFile` error
+ * shape is:
+ *   "ENOENT: no such file or directory, open
+ *    '/var/lib/coc/node-1/storage/blocks/bafyrei…'"
+ * Anyone calling the public RPC could enumerate the server's data dir
+ * layout + node identifier. Live testnet 88780 reproduction (pre-fix):
+ *   curl -d '{"jsonrpc":"2.0","id":1,"method":"coc_erasureStatus",
+ *            "params":["bafyreidskjqd4on73tlrhh2ovrgz3ihrekrojvg6yqxgldubsvgivqo2gq"]}'
+ *   → {"error":{"code":-32604,
+ *      "message":"manifest block missing: ENOENT: no such file or directory,
+ *                 open '/var/lib/coc/node-1/storage/blocks/bafyrei…'"}}
+ * Fix: emit a clean shape-only message echoing only the CID.
+ *
+ * Two code paths leaked (dag-cbor manifest block + raw block); regression
+ * test covers both.
+ */
+test("#507: resolveCid manifest-missing message must not leak filesystem path", async () => {
+  const { resolveCid } = await import("./ipfs-erasure-reader.ts")
+  const { ErasureError } = await import("./ipfs-erasure.ts")
+
+  // Real Node.js ENOENT error shape (matches `fs.readFile` on the
+  // live testnet — both message *and* code, since some upstream catch
+  // sites branch on `err.code === 'ENOENT'`).
+  const fakeEnoent = Object.assign(
+    new Error("ENOENT: no such file or directory, open '/var/lib/coc/node-1/storage/blocks/bafyreidskjqd4on73tlrhh2ovrgz3ihrekrojvg6yqxgldubsvgivqo2gq'"),
+    { code: "ENOENT", syscall: "open", path: "/var/lib/coc/node-1/storage/blocks/bafyrei…" },
+  )
+  const throwingStore = {
+    get: async () => { throw fakeEnoent },
+    has: async () => false,
+  } as never
+
+  // Use a valid dag-cbor (0x71) CID — `bafyrei…` v1 base32, code 0x71.
+  // Picked from the live testnet repro; the manifest block doesn't exist
+  // (that's the whole point of the test).
+  const manifestCid = "bafyreidskjqd4on73tlrhh2ovrgz3ihrekrojvg6yqxgldubsvgivqo2gq"
+  await assert.rejects(
+    () => resolveCid(manifestCid, throwingStore),
+    (err: unknown) => {
+      assert.ok(err instanceof ErasureError, "must wrap into ErasureError")
+      assert.equal((err as Error & { code: string }).code, "not_found",
+        "expected code='not_found' (HTTP layer maps to -32604)")
+      const msg = (err as Error).message
+      assert.doesNotMatch(msg, /ENOENT/, "must not leak Node.js error code")
+      assert.doesNotMatch(msg, /no such file or directory/, "must not leak ENOENT phrase")
+      assert.doesNotMatch(msg, /\/var\/lib\/coc/, "must not leak filesystem layout")
+      assert.doesNotMatch(msg, /node-\d/, "must not leak node identifier from path")
+      assert.doesNotMatch(msg, /storage\/blocks/, "must not leak data directory structure")
+      // Sanity: the CID itself is fine to echo (caller already sent it).
+      assert.match(msg, new RegExp(manifestCid),
+        "CID may be echoed since the caller already knows it")
+      return true
+    },
+  )
+})
+
+test("#507: resolveCid raw-block-missing message must not leak filesystem path", async () => {
+  const { resolveCid } = await import("./ipfs-erasure-reader.ts")
+  const { ErasureError } = await import("./ipfs-erasure.ts")
+
+  const fakeEnoent = Object.assign(
+    new Error("ENOENT: no such file or directory, open '/var/lib/coc/node-1/storage/blocks/bafkrei…'"),
+    { code: "ENOENT", syscall: "open" },
+  )
+  const throwingStore = {
+    get: async () => { throw fakeEnoent },
+    has: async () => false,
+  } as never
+
+  // Valid raw codec (0x55) CID — `bafkrei…` v1 base32 raw.
+  const rawCid = "bafkreigh2akiscaildc3xspxqzodxwauiakiiykohrgrlqkx5kbjepltrm"
+  await assert.rejects(
+    () => resolveCid(rawCid, throwingStore),
+    (err: unknown) => {
+      assert.ok(err instanceof ErasureError)
+      assert.equal((err as Error & { code: string }).code, "not_found")
+      const msg = (err as Error).message
+      assert.doesNotMatch(msg, /ENOENT/)
+      assert.doesNotMatch(msg, /no such file or directory/)
+      assert.doesNotMatch(msg, /\/var\/lib\/coc/)
+      assert.doesNotMatch(msg, /storage\/blocks/)
+      assert.match(msg, new RegExp(rawCid))
+      return true
+    },
+  )
+})

--- a/node/src/ipfs-erasure-reader.ts
+++ b/node/src/ipfs-erasure-reader.ts
@@ -71,8 +71,15 @@ export async function resolveCid(
     let block
     try {
       block = await store.get(cid)
-    } catch (err) {
-      throw new ErasureError("not_found", `manifest block missing: ${(err as Error).message ?? err}`)
+    } catch {
+      // #507: pre-fix the catch interpolated `(err as Error).message`,
+      // leaking the full filesystem path from the Node.js ENOENT message:
+      //   "manifest block missing: ENOENT: no such file or directory,
+      //    open '/var/lib/coc/node-1/storage/blocks/bafyrei…'"
+      // This is information disclosure — anyone calling public RPC can
+      // enumerate the server's data directory layout and node identifier.
+      // Emit a clean shape-only message with the CID as the only echo.
+      throw new ErasureError("not_found", `manifest block missing: ${cid}`)
     }
     let manifest: ErasureManifest
     try {
@@ -91,8 +98,11 @@ export async function resolveCid(
     let block
     try {
       block = await store.get(cid)
-    } catch (err) {
-      throw new ErasureError("not_found", `raw block missing: ${(err as Error).message ?? err}`)
+    } catch {
+      // #507: same fix as the dag-cbor branch above. ENOENT messages
+      // leak the server's filesystem layout — emit a clean shape-only
+      // message with the CID as the only echo.
+      throw new ErasureError("not_found", `raw block missing: ${cid}`)
     }
     return { kind: "raw", bytes: block.bytes }
   }


### PR DESCRIPTION
Closes #507.

## Summary

- `resolveCid()` in `ipfs-erasure-reader.ts` had two catch blocks that interpolated the raw Node.js `fs.readFile` ENOENT error message into the wire error, leaking the server's full filesystem path + node identifier to any public RPC caller.
- Pre-fix wire message: `"manifest block missing: ENOENT: no such file or directory, open '/var/lib/coc/node-1/storage/blocks/bafyrei…'"`
- Strip `err.message` interpolation; emit shape-only message that echoes only the CID (the caller already sent it).

## Test plan

- [x] `node/src/erasure-status-bridge.test.ts` — 2 new regression tests, one per branch (dag-cbor manifest + raw block), asserting wire message contains no `ENOENT`, `/var/lib/coc`, `node-N`, or `storage/blocks` markers
- [x] Tests fail on `main` (3ff9596) and pass on this branch — confirmed by `git stash` toggle
- [x] All 4 tests in `erasure-status-bridge.test.ts` pass: `# pass 4, # fail 0`

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"coc_erasureStatus",
  "params":["bafyreidskjqd4on73tlrhh2ovrgz3ihrekrojvg6yqxgldubsvgivqo2gq"]
}'
→ {"error":{"code":-32604,"message":"manifest block missing: ENOENT: no such file or directory, open '/var/lib/coc/node-1/storage/blocks/bafyrei…'"}}
```

## Related anti-pattern family

This is the same anti-pattern surfaced in #497 (`[object Object]` leak), #499 (`String(unknown)` family), #156 (library-internal err.message leak), and #505 (`multiformats` library internals leak). The general rule: never interpolate `err.message` from internal library exceptions into wire error messages without sanitization.