### PR TITLE
fix(rpc): #509 eth_call INSUFFICIENT_BALANCE -> -32000 (geth parity)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -865,7 +865,7 @@ export class EvmChain {
     params: { from?: string; to: string; data?: string; value?: string; gas?: string },
     stateRoot?: string,
     context?: bigint | ExecutionContext,
-  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean }> {
+  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }> {
     const executionContext = normalizeExecutionContext(context)
     if (stateRoot || executionContext.blockNumber !== undefined) {
       const stateManager = await this.resolveStateManager(stateRoot)
@@ -1179,7 +1179,7 @@ export class EvmChain {
     vm: VM,
     params: { from?: string; to: string; data?: string; value?: string; gas?: string },
     opts: ExecutionContext & { revertAfter?: boolean } = {},
-  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean }> {
+  ): Promise<{ returnValue: string; gasUsed: bigint; failed: boolean; errorReason?: string }> {
     const executionContext = normalizeExecutionContext(opts)
     const blockCommon = this.createExecutionCommon(executionContext.blockNumber)
     this.applyHardforkToVm(vm, executionContext.blockNumber)
@@ -1210,10 +1210,19 @@ export class EvmChain {
         ? bytesToHex(result.execResult.returnValue)
         : "0x"
 
+      // #509: surface the EvmError variant so eth_call / eth_estimateGas can
+      // distinguish REVERT (geth: code 3 "execution reverted") from
+      // pre-execution failures like INSUFFICIENT_BALANCE (geth: code -32000
+      // "insufficient funds for gas * price + value: …"). Pre-fix the rpc
+      // layer mapped every EVM failure to "execution reverted", confusing
+      // ethers.js / viem / wallets that route those error codes to
+      // different UX paths.
+      const exceptionError = result.execResult.exceptionError
       return {
         returnValue,
         gasUsed: result.execResult.executionGasUsed,
-        failed: result.execResult.exceptionError !== undefined,
+        failed: exceptionError !== undefined,
+        errorReason: exceptionError?.error,
       }
     } finally {
       if (opts.revertAfter !== false) {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3043,6 +3043,112 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#509: eth_call / eth_estimateGas surface INSUFFICIENT_BALANCE as -32000 (not code 3 'execution reverted')", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_call({from:"0x000…001", to:<addr>, value:"0xfffffffffffffffffffffffff"})
+    //   → {"error":{"code":3,"message":"execution reverted","data":"0x"}}
+    //
+    // Geth contract:
+    //   - REVERT opcode → code 3 "execution reverted" + data
+    //   - INSUFFICIENT_BALANCE (caller can't afford `value` transfer)
+    //     → code -32000 "insufficient funds for gas * price + value:
+    //         address 0x… have N want M"
+    //   - other pre-execution failures (nonce, intrinsic gas) → -32000
+    //
+    // Anti-pattern: rpc.ts mapped EVERY failed callRaw to throwExecutionReverted.
+    // Wallets (MetaMask, Frame, Rabby), ethers.js, viem all route code 3 to
+    // a different UX surface than -32000 — code 3 triggers revert-reason
+    // decoding (looking for Error(string)/Panic(uint)), while -32000 shows
+    // "Insufficient funds". Conflating them tells users their *contract
+    // logic* reverted when their *account is just broke*.
+    //
+    // Fix plumbs `errorReason` from EvmError through callRaw → rpc.ts:
+    //   - errorReason==="insufficient balance" → -32000 with geth message
+    //   - all other EVM failures → preserve existing REVERT-style mapping
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const fromAddr = "0x0000000000000000000000000000000000000001"
+    const origCallRaw = evm.callRaw.bind(evm)
+    // Stub callRaw to simulate INSUFFICIENT_BALANCE: failed:true with
+    // errorReason matching the @ethereumjs/evm EvmError.error string.
+    ;(evm as unknown as { callRaw: unknown }).callRaw = async () => ({
+      returnValue: "0x",  // no payload on INSUFFICIENT_BALANCE
+      gasUsed: 0n,
+      failed: true,
+      errorReason: "insufficient balance",
+    })
+    try {
+      const probe = async (method: string) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0", id: 1, method,
+            params: [{ from: fromAddr, to: validAddr, value: "0xffffffffffffffffffffffff" }, "latest"],
+          }),
+        })
+        return await r.json() as { result?: unknown; error?: { code: number; message: string; data?: string } }
+      }
+      // (a) eth_call must emit -32000 with geth's insufficient-funds message
+      // shape (not code 3 "execution reverted").
+      const callRes = await probe("eth_call")
+      assert.equal(callRes.error?.code, -32000,
+        `eth_call INSUFFICIENT_BALANCE must be -32000, got ${JSON.stringify(callRes)}`)
+      assert.match(callRes.error!.message, /^insufficient funds for gas \* price \+ value/,
+        "message must start with geth's canonical 'insufficient funds for gas * price + value' prefix")
+      assert.match(callRes.error!.message, new RegExp(fromAddr),
+        "message must echo the sender address so wallets can attribute the failure")
+      assert.notEqual(callRes.error!.code, 3,
+        "must NOT use code 3 — that's reserved for REVERT opcode in geth")
+      assert.equal(callRes.error!.data, undefined,
+        "must NOT carry a `data` field — INSUFFICIENT_BALANCE has no ABI-decodable payload")
+      // (b) eth_estimateGas mirrors — wallets probe estimateGas before
+      // signing, so confusing the error here breaks the entire send flow.
+      const estRes = await probe("eth_estimateGas")
+      assert.equal(estRes.error?.code, -32000,
+        `eth_estimateGas INSUFFICIENT_BALANCE must be -32000, got ${JSON.stringify(estRes)}`)
+      assert.match(estRes.error!.message, /^insufficient funds for gas \* price \+ value/)
+      assert.notEqual(estRes.error!.code, 3)
+    } finally {
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
+    }
+  })
+
+  await t.test("#509: REVERT still maps to code 3 (regression: don't over-correct INSUFFICIENT_BALANCE fix)", async () => {
+    // Defense against accidentally widening the #509 fix to swallow real
+    // REVERTs. Stub callRaw with errorReason==="revert" + a real Error(string)
+    // payload — handler MUST still emit code 3 with decoded reason, matching
+    // the #286 contract.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const origCallRaw = evm.callRaw.bind(evm)
+    const revertPayload =
+      "0x08c379a0" +
+      "0000000000000000000000000000000000000000000000000000000000000020" +
+      "0000000000000000000000000000000000000000000000000000000000000005" +
+      "4861726421000000000000000000000000000000000000000000000000000000"
+    ;(evm as unknown as { callRaw: unknown }).callRaw = async () => ({
+      returnValue: revertPayload,
+      gasUsed: 21_000n,
+      failed: true,
+      errorReason: "revert",
+    })
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_call",
+          params: [{ to: validAddr, data: "0xdeadbeef" }, "latest"],
+        }),
+      })
+      const res = await r.json() as { result?: unknown; error?: { code: number; message: string; data?: string } }
+      assert.equal(res.error?.code, 3, `REVERT must remain code 3, got ${JSON.stringify(res)}`)
+      assert.match(res.error!.message, /execution reverted: Hard!/)
+      assert.equal(res.error!.data, revertPayload, "revert payload must round-trip in `data`")
+    } finally {
+      ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = origCallRaw
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -906,7 +906,8 @@ async function handleRpc(
         gas: gasForEstimate,
       }, executionContext.stateRoot, executionContext)
       if (estProbe.failed) {
-        throwExecutionReverted(estProbe.returnValue)
+        // #509: distinguish INSUFFICIENT_BALANCE (-32000) from REVERT (code 3).
+        throwCallFailure(estProbe.errorReason, estProbe.returnValue, estParams.from)
       }
       const estimated = await evm.estimateGas({
         from: estParams.from,
@@ -959,7 +960,8 @@ async function handleRpc(
       // returned 200 OK with result:"0x" for any contract call with an
       // unknown selector before this fix.
       if (callResult.failed) {
-        throwExecutionReverted(callResult.returnValue)
+        // #509: distinguish INSUFFICIENT_BALANCE (-32000) from REVERT (code 3).
+        throwCallFailure(callResult.errorReason, callResult.returnValue, callParams.from)
       }
       return callResult.returnValue
     }
@@ -2963,6 +2965,44 @@ function throwExecutionReverted(returnValue: string): never {
   const reason = decodeRevertReason(returnValue)
   const message = reason ? `execution reverted: ${reason}` : "execution reverted"
   throw { code: 3, message, data: returnValue || "0x" }
+}
+
+// #509: route eth_call / eth_estimateGas failures to the correct geth
+// error shape. The pre-fix code mapped *every* EVM failure (including
+// pre-execution failures like INSUFFICIENT_BALANCE that the EVM raises
+// before any opcodes run) to code 3 "execution reverted", confusing
+// ethers.js / viem / MetaMask which route those codes to different UX:
+//   - code 3 → "Transaction reverted: <reason>" UI (revert decoder runs)
+//   - code -32000 → "Insufficient funds" / "Out of gas" UI (no decode)
+// Geth's behavior:
+//   - REVERT opcode (with or without revert payload) → code 3
+//   - INSUFFICIENT_BALANCE → code -32000 "insufficient funds for gas
+//     * price + value: address 0x… have N want M"
+//   - other pre-execution failures (nonce, intrinsic gas) → code -32000
+//
+// Live testnet 88780 repro (pre-fix):
+//   eth_call({from:0x000…001, value:0xffff…}) → code 3 "execution reverted"
+// Post-fix:
+//   eth_call({from:0x000…001, value:0xffff…}) → code -32000
+//     "insufficient funds for gas * price + value: address 0x000…001"
+function throwCallFailure(
+  errorReason: string | undefined,
+  returnValue: string,
+  from?: string,
+): never {
+  // EvmError.error string from @ethereumjs/evm. The "insufficient balance"
+  // case is the one observably-mishandled today; other EVMError variants
+  // (out of gas, invalid opcode, stack underflow) DO happen during code
+  // execution after value transfer succeeds, so the REVERT-style mapping
+  // is still defensible there pending separate geth-parity work.
+  if (errorReason === "insufficient balance") {
+    const addr = from ?? "0x0000000000000000000000000000000000000000"
+    throw {
+      code: -32000,
+      message: `insufficient funds for gas * price + value: address ${addr}`,
+    }
+  }
+  throwExecutionReverted(returnValue)
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #509.

## Summary

- `eth_call` and `eth_estimateGas` mapped *every* failed `callRaw` result to `code 3 "execution reverted"`. INSUFFICIENT_BALANCE is a pre-execution failure, and geth uses `-32000 "insufficient funds for gas * price + value: address ..."` for it; conflating it with REVERT breaks ethers.js / viem / MetaMask / Frame / Rabby error routing.
- Plumb `errorReason?: string` through `evm.runCall` → `evm.callRaw` carrying the `EvmError.error` string from @ethereumjs/evm.
- New `throwCallFailure()` in rpc.ts routes `"insufficient balance"` to `-32000` with geth's canonical message format. Other EVM failures stay on the REVERT path (out of scope).

## Test plan

- [x] `node/src/rpc-extended.test.ts` `#509` — INSUFFICIENT_BALANCE on `eth_call` AND `eth_estimateGas` emits -32000 with geth's canonical message + sender address echo + NO `data` field. Confirmed: `ok 109 - #509: eth_call / eth_estimateGas surface INSUFFICIENT_BALANCE as -32000`.
- [x] `node/src/rpc-extended.test.ts` `#509 REVERT-still-code-3` — defense against widening the fix to swallow real REVERTs. Confirmed: `ok 110`.
- [x] `node/src/rpc-extended.test.ts` `#286` (REVERT still code 3) — unaffected by this change. Confirmed: `ok 108`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_call","params":[
    {"from":"0x0000000000000000000000000000000000000001",
     "to":"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     "value":"0xffffffffffffffffffffffff"},"latest"]}'
→ {"error":{"code":3,"message":"execution reverted","data":"0x"}}
```

## Related anti-pattern family

- #286 (eth_call/eth_estimateGas REVERT detection — established the code 3 contract this PR refines)
- #332/#440/#444 (mempool path `-32000` shape fixes — same goal, different surface)
- ethers.js classifies code 3 as `CALL_EXCEPTION` and -32000 as `INSUFFICIENT_FUNDS`; this PR aligns the JSON-RPC layer with that classification.