### PR TITLE
fix(rpc): #511 eth_getFilterChanges/Logs throw -32000 on unknown id

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3043,6 +3043,95 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#511: eth_getFilterChanges / eth_getFilterLogs return -32000 'filter not found' for unknown filter id (not silent [])", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_getFilterChanges("0x12345678901234567890123456789012")  // valid shape, never created
+    //   → {"jsonrpc":"2.0","id":1,"result":[]}
+    //   eth_getFilterLogs("0x12345678901234567890123456789012")
+    //   → {"jsonrpc":"2.0","id":1,"result":[]}
+    //
+    // Geth contract (eth/filters/api.go GetFilterChanges / GetFilterLogs):
+    //   {"error":{"code":-32000,"message":"filter not found"}}
+    //
+    // The pre-fix `[]` return is indistinguishable from "filter exists, no
+    // matches yet". Long-running log subscribers (ethers.js, viem) detect
+    // filter expiry via the error and recreate the filter; pre-fix they
+    // silently lost ALL log updates after the server's filter TTL elapsed.
+    // Block-explorers / indexers polling on a stale id would log empty
+    // forever, eventually missing events the contract emitted.
+    //
+    // eth_uninstallFilter is the only filter method that *should* return a
+    // bool (true/false) instead of an error — geth matches that, and #196
+    // already aligned us with it. The #511 fix is scoped to the two methods
+    // that need to carry "filter expired, please recreate" semantics.
+    const validIdShape = "0x12345678901234567890123456789012"
+    const probe = async (method: string) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [validIdShape] }),
+      })
+      return await r.json() as { result?: unknown; error?: { code: number; message: string } }
+    }
+    for (const method of ["eth_getFilterChanges", "eth_getFilterLogs"]) {
+      const res = await probe(method)
+      assert.ok(res.error, `${method}("${validIdShape}") MUST return an error for unknown filter id, got result=${JSON.stringify(res.result)}`)
+      assert.equal(res.error!.code, -32000,
+        `${method} unknown-id error code must be -32000 (geth parity), got ${res.error!.code}`)
+      assert.match(res.error!.message, /^filter not found$/i,
+        `${method} unknown-id message must be exactly "filter not found" (geth verbatim), got "${res.error!.message}"`)
+      assert.equal(res.result, undefined,
+        `${method} MUST NOT carry a result alongside the error`)
+    }
+    // Regression: eth_uninstallFilter is the OPPOSITE — unknown id returns
+    // `false`, not an error. Lock that contract so future cleanups don't
+    // over-apply the #511 change.
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_uninstallFilter", params: [validIdShape] }),
+    })
+    const rJson = await r.json() as { result?: unknown; error?: unknown }
+    assert.equal(rJson.error, undefined,
+      `eth_uninstallFilter MUST NOT error on unknown id (geth returns false), got ${JSON.stringify(rJson)}`)
+    assert.equal(rJson.result, false,
+      `eth_uninstallFilter unknown-id MUST return false, got ${JSON.stringify(rJson.result)}`)
+  })
+
+  await t.test("#511: eth_getFilterChanges DOES return [] for existing filter with no new events (not 'filter not found')", async () => {
+    // Defense: ensure the #511 fix doesn't conflate "no matches" with
+    // "filter expired". Create a fresh block filter, immediately poll —
+    // there may or may not be new blocks; the call must still succeed
+    // (return an array, not a -32000 error).
+    const newF = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_newBlockFilter", params: [] }),
+    })
+    const newJson = await newF.json() as { result?: string; error?: unknown }
+    assert.equal(newJson.error, undefined, `eth_newBlockFilter must succeed: ${JSON.stringify(newJson)}`)
+    const filterId = newJson.result!
+    assert.match(filterId, /^0x[0-9a-fA-F]{32}$/, "filter id must be 16-byte hex")
+    try {
+      const poll = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getFilterChanges", params: [filterId] }),
+      })
+      const pollJson = await poll.json() as { result?: unknown[]; error?: unknown }
+      assert.equal(pollJson.error, undefined,
+        `eth_getFilterChanges on a real existing filter MUST NOT error, got ${JSON.stringify(pollJson)}`)
+      assert.ok(Array.isArray(pollJson.result),
+        "eth_getFilterChanges on existing filter must return an array (possibly empty)")
+    } finally {
+      await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_uninstallFilter", params: [filterId] }),
+      })
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1195,7 +1195,14 @@ async function handleRpc(
       // a perpetual empty stream that mimics "no new events."
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #511: pre-fix returned [] for an unknown filter ID, indistinguishable
+      // from "filter exists but matched zero events". Long-running ethers.js
+      // / viem log subscribers detect filter expiry via the `filter not
+      // found` error and recreate; pre-fix they silently lost all log updates
+      // after the filter aged out of the server's TTL window. Geth's contract
+      // (eth/filters/api.go GetFilterChanges) returns
+      // `{"error":{"code":-32000,"message":"filter not found"}}` for this case.
+      if (!filter) throw { code: -32000, message: "filter not found" }
       // Refresh the filter's last-access timestamp so cleanupExpiredFilters
       // doesn't reap an actively polled subscriber.
       filter.lastAccessedAtMs = Date.now()
@@ -1844,7 +1851,10 @@ async function handleRpc(
       // #196: parity with eth_getFilterChanges / eth_uninstallFilter.
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #511: same `[]` → `-32000 "filter not found"` fix as
+      // eth_getFilterChanges — clients can't recover from filter expiry
+      // without an error signal.
+      if (!filter) throw { code: -32000, message: "filter not found" }
       // Refresh last-access time so active polls keep the filter alive.
       filter.lastAccessedAtMs = Date.now()
       // getFilterLogs is a log-filter-only method: block and pendingTx


### PR DESCRIPTION
Closes #511.

## Summary

- `eth_getFilterChanges` and `eth_getFilterLogs` returned `result: []` for valid-shape but unknown filter ID — indistinguishable from "filter exists, matched zero events".
- Geth's contract: `{"error":{"code":-32000,"message":"filter not found"}}`.
- Long-running log subscribers in ethers.js/viem detect filter expiry via the error and recreate the filter; pre-fix they silently lost all log updates after TTL elapsed.
- One-line change per handler: `if (!filter) return []` → `if (!filter) throw { code: -32000, message: "filter not found" }`.

## Test plan

- [x] `node/src/rpc-extended.test.ts` `#511`: probes both methods with unknown id, asserts -32000 + verbatim "filter not found" + no `result`. Also asserts `eth_uninstallFilter` still returns `false` (not error) — defending against over-correction. Confirmed: `ok 109 - #511: eth_getFilterChanges / eth_getFilterLogs return -32000 'filter not found' for unknown filter id (not silent [])`.
- [x] `node/src/rpc-extended.test.ts` `#511 existing-filter-empty regression`: creates a real block filter, polls, asserts non-error array return. Confirmed: `ok 110`.
- [x] `#286` (REVERT detection) unaffected. Confirmed: `ok 108`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_getFilterChanges",
  "params":["0x12345678901234567890123456789012"]}'
→ {"jsonrpc":"2.0","id":1,"result":[]}
```

Post-fix:
```bash
→ {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"filter not found"}}
```

## Scope

- Only `eth_getFilterChanges` + `eth_getFilterLogs`.
- `eth_uninstallFilter` intentionally still returns `false` for unknown ids — that's the geth contract and #196 already aligned us. Widening the #511 change would break clients that "delete optimistically".

## Related

- #196 (filter-id shape validation — added type validation but missed the unknown-id case)
- General anti-pattern: silent empty result that mimics "no events" — same family as the #480 chainStats fix