### PR TITLE
fix(rpc): #513 eth_call/eth_estimateGas reject non-empty stateOverride (no silent drop)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3043,6 +3043,99 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#513: eth_call / eth_estimateGas reject non-empty stateOverride (no silent drop)", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_call(callObj, "latest", {"0x…99":{"balance":"0xff…"}})
+    //   → result identical to omitting the 3rd param — override silently dropped.
+    //
+    // Geth supports EIP-3326 stateOverride. Tools that depend on it:
+    //   - foundry `cast call --state-override`
+    //   - Tenderly simulations
+    //   - ethers.js `provider.call(tx, blockTag, overrides)`
+    //   - viem `simulateContract({ stateOverride: ... })`
+    //
+    // Silently dropping the param lets clients act on natural-state results
+    // that look successful. Until COC plumbs overrides through to evm.callRaw
+    // (separate work), surface -32602 so callers know the result is unreliable.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const fromAddr = "0x0000000000000000000000000000000000000099"
+    const stateOverride = {
+      [fromAddr]: { balance: "0x100000000000000000000" },
+    }
+    for (const method of ["eth_call", "eth_estimateGas"]) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method,
+          params: [
+            { from: fromAddr, to: validAddr, value: "0x100" },
+            "latest",
+            stateOverride,
+          ],
+        }),
+      })
+      const res = await r.json() as { result?: unknown; error?: { code: number; message: string } }
+      assert.ok(res.error, `${method} with stateOverride MUST error (not silently drop), got result=${JSON.stringify(res.result)}`)
+      assert.equal(res.error!.code, -32602,
+        `${method} stateOverride must be -32602, got ${res.error!.code}`)
+      assert.match(res.error!.message, /state override/i,
+        `${method} message must mention "state override"`)
+      assert.match(res.error!.message, /not supported|not reflect/i,
+        `${method} message must signal that override won't be applied`)
+      assert.equal(res.result, undefined)
+    }
+  })
+
+  await t.test("#513: eth_call / eth_estimateGas accept undefined/null/empty stateOverride (backward-compat)", async () => {
+    // Defense: well-behaved clients pass `{}` (no overrides specified) or
+    // omit the param entirely. Both must still work — the #513 reject is
+    // scoped to non-empty overrides only.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const cases: Array<{ params: unknown[]; desc: string }> = [
+      { params: [{ to: validAddr }, "latest"], desc: "no 3rd param" },
+      { params: [{ to: validAddr }, "latest", undefined], desc: "undefined 3rd param" },
+      { params: [{ to: validAddr }, "latest", null], desc: "null 3rd param" },
+      { params: [{ to: validAddr }, "latest", {}], desc: "empty {} 3rd param" },
+    ]
+    for (const { params, desc } of cases) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_call", params }),
+      })
+      const res = await r.json() as { result?: string; error?: { code: number; message: string } }
+      if (res.error) {
+        assert.doesNotMatch(res.error.message, /state override/i,
+          `eth_call(${desc}) must not be rejected as state-override misuse, got: ${res.error.message}`)
+      } else {
+        assert.match(res.result!, /^0x[0-9a-f]*$/i, `eth_call(${desc}) result must be hex`)
+      }
+    }
+  })
+
+  await t.test("#513: eth_call rejects non-object stateOverride shape (defensive validation)", async () => {
+    // Sanity: arrays/numbers/strings as 3rd param must reject with the
+    // shape-validation branch of #513.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const bad: unknown[] = [["not", "an", "object"], 42, "not-an-object"]
+    for (const override of bad) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "eth_call",
+          params: [{ to: validAddr }, "latest", override],
+        }),
+      })
+      const res = await r.json() as { result?: unknown; error?: { code: number; message: string } }
+      assert.ok(res.error, `eth_call with non-object stateOverride=${JSON.stringify(override)} must error`)
+      assert.equal(res.error!.code, -32602)
+      assert.match(res.error!.message, /state override.*must be an object/i,
+        `must complain about the object-shape requirement, got: ${res.error!.message}`)
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -888,6 +888,10 @@ async function handleRpc(
       // treated non-hex as 0, so {value:"not-hex"} gave a clean gas
       // estimate that ignored the value transfer.
       validateTxCallFields(estParams)
+      // #513: same fix as eth_call — reject non-empty state overrides
+      // instead of returning a natural-state gas estimate that won't
+      // match the caller's intended simulation.
+      rejectUnsupportedStateOverride((payload.params ?? [])[2], "eth_estimateGas")
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
@@ -942,6 +946,18 @@ async function handleRpc(
       // where malformed input either silently becomes 0 (value) or
       // surfaces as -32603 with V8 message leak (data).
       validateTxCallFields(callParams)
+      // #513: surface unsupported 3rd-arg state override instead of
+      // silently dropping it. Pre-fix `eth_call(callObj, blockTag,
+      // stateOverride)` accepted the override param, ignored it, and
+      // returned the natural-state result — indistinguishable from a
+      // successful simulation. Tools that depend on the override (foundry
+      // `cast call --state-override`, Tenderly simulations, ethers.js
+      // provider.call(tx, tag, overrides), viem simulateContract({
+      // stateOverride })) silently got wrong answers. Geth supports
+      // EIP-3326-style overrides; until COC plumbs that through the EVM
+      // (separate work), explicitly -32602 reject non-empty overrides
+      // so callers know the result is unreliable.
+      rejectUnsupportedStateOverride((payload.params ?? [])[2], "eth_call")
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
       const callResult = await evm.callRaw({
         from: callParams.from,
@@ -2963,6 +2979,34 @@ function throwExecutionReverted(returnValue: string): never {
   const reason = decodeRevertReason(returnValue)
   const message = reason ? `execution reverted: ${reason}` : "execution reverted"
   throw { code: 3, message, data: returnValue || "0x" }
+}
+
+// #513: surface unsupported eth_call(callObj, blockTag, stateOverride)
+// 3rd parameter as -32602 instead of silently dropping the override.
+// Accept `undefined`, `null`, and the empty object `{}` (all geth-equivalent
+// to "no override") so existing well-behaved clients aren't broken. Reject
+// anything with at least one address-keyed entry — that's a real override
+// request the EVM layer can't honor today (#513 follow-up tracked separately
+// to plumb the override through to evm.callRaw).
+function rejectUnsupportedStateOverride(rawOverride: unknown, method: string): void {
+  if (rawOverride === undefined || rawOverride === null) return
+  // Disallow non-object shapes upfront — geth's contract is "object map of
+  // address → override object", anything else is a client typo.
+  if (typeof rawOverride !== "object" || Array.isArray(rawOverride)) {
+    throw {
+      code: -32602,
+      message: `${method}: state override (3rd param) must be an object map of address → override fields`,
+    }
+  }
+  const keys = Object.keys(rawOverride as Record<string, unknown>)
+  if (keys.length === 0) return
+  // Reject the moment the caller asks for any actual override. Silently
+  // dropping it would let the caller act on a natural-state result that
+  // looked like a successful simulation.
+  throw {
+    code: -32602,
+    message: `${method}: state override (3rd param) is not supported on this node (${keys.length} override${keys.length === 1 ? "" : "s"} requested); the result would not reflect your override and is therefore unsafe to act on. Drop the parameter or run against a node that supports EIP-3326-style overrides.`,
+  }
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #513.

## Summary

- `eth_call` and `eth_estimateGas` accept a 3rd `stateOverride` param per EIP-3326. COC silently dropped it before reaching `evm.callRaw`, so clients got natural-state results that looked like successful simulations.
- Until COC plumbs overrides through the EVM (non-trivial; separate work), surface `-32602` so callers can't act on misleading results.
- Accept `undefined`/`null`/`{}` for backward-compat with clients that pass empty overrides unconditionally.

## Test plan

- [x] `node/src/rpc-extended.test.ts` `#513` (3 tests):
  - Non-empty override on both methods → `-32602` + "state override" + "not supported"/"not reflect". Confirmed: `ok 109`.
  - Backward-compat: `undefined`/`null`/`{}`/no-3rd-param all still work. Confirmed: `ok 110`.
  - Shape validation: arrays/numbers/strings rejected with shape-guidance message. Confirmed: `ok 111`.
- [x] `#286` (REVERT detection) unaffected. Confirmed: `ok 108`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_call","params":[
    {"to":"0x0000000000000000000000000000000000001234"},
    "latest",
    {"0x0000000000000000000000000000000000001234":{"code":"0x6005600052602060005260206000f3"}}]}'
→ {"result":"0x"}     # Injected code NOT executed
```

## Scope

This PR is the **immediate** fix (surface -32602 to prevent silent failures). The **follow-up** that actually implements override plumbing through `evm.callRaw` is tracked separately. The two-stage approach lets clients fail loudly today and migrate to a supporting node, then transparently work when COC adds override support.

## Related

- #250 / #251 (silently-dropped optional param anti-pattern family)
- EIP-3326 (state override JSON-RPC extension)