### PR TITLE
fix(rpc): #515 coc_dht* methods validate real CID shape (no silent empty result)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3043,6 +3043,82 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#515: coc_dhtFindProviders / coc_ipfsFetchBlockFromPeer reject valid-shape-but-not-CID strings (no silent empty result)", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   coc_dhtFindProviders("bad-cid")  → {"providers":[]}
+    //   coc_ipfsFetchBlockFromPeer("bad-cid") → {"bytes":null}
+    //
+    // The pre-fix shape gate (#146) accepted any ≤512-char ascii string
+    // without path-traversal markers as a "CID". `findProviders("bad-cid")`
+    // routed garbage into the DHT layer, which correctly returned no
+    // matches — but clients couldn't distinguish "no providers advertise
+    // this CID" from "your CID string is malformed and was silently routed
+    // to a meaningless lookup". Same anti-pattern family as #511 (silent
+    // empty result that mimics no-data) and #513 (silent param drop).
+    //
+    // Fix: validate against the real Qm v0 base58 / b/B v1 base32 CID
+    // shape — same policy as IpfsHttpServer.isValidCid so the JSON-RPC
+    // surface aligns with the HTTP gateway. coc_erasureStatus already
+    // uses CID.parse() (via resolveCid) and rejects "bad-cid" with -32602;
+    // this fix brings the two DHT-only methods in line.
+    const fakeCids = [
+      "bad-cid",          // missing Qm / b prefix
+      "not-a-cid",        // ditto
+      "deadbeef",         // looks hex
+      "qmlowercaseprefix",// Qm-prefix is case-sensitive
+      "bUPPERCASE",       // base32 v1 must be lowercase
+      "Qm-has-dashes",    // base58 alphabet excludes -
+      "bafy with space",  // (would already fail the control-char gate but test the shape too)
+    ]
+    const probe = async (method: string, cid: string) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [cid] }),
+      })
+      return await r.json() as { result?: unknown; error?: { code: number; message: string } }
+    }
+    for (const method of ["coc_dhtFindProviders", "coc_ipfsFetchBlockFromPeer"]) {
+      for (const cid of fakeCids) {
+        const res = await probe(method, cid)
+        assert.ok(res.error, `${method}("${cid}") MUST error (not silently return empty), got result=${JSON.stringify(res.result)}`)
+        assert.equal(res.error!.code, -32602,
+          `${method}("${cid}") must be -32602, got ${res.error!.code}`)
+        assert.match(res.error!.message, /invalid cid/i,
+          `${method}("${cid}") message must mention "invalid cid", got "${res.error!.message}"`)
+        assert.equal(res.result, undefined,
+          `${method}("${cid}") MUST NOT carry a result alongside the error`)
+      }
+    }
+  })
+
+  await t.test("#515: coc_dhtFindProviders accepts real CID shapes (Qm v0 + b v1 base32)", async () => {
+    // Defense: lock down which shapes are ALLOWED through the gate. The
+    // -32602 reject must be scoped to real garbage; real CIDs (Qm v0
+    // base58, b/B v1 base32) should reach the DHT layer and return
+    // `{providers:[]}` if no peer has advertised them. Pre-fix this
+    // worked by accident (over-permissive gate); post-fix we lock the
+    // contract.
+    const realCids = [
+      "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",   // v0 base58 (canonical "Hello World")
+      "bafkreigh2akiscaildc3xspxqzodxwauiakiiykohrgrlqkx5kbjepltrm", // v1 base32 raw
+      "bafybeianrutwhfx2ysd6cohv2e5lrvijxihi7qgvjzuqooql6o67uta7pq", // v1 base32 dag-pb
+    ]
+    for (const cid of realCids) {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_dhtFindProviders", params: [cid] }),
+      })
+      const res = await r.json() as { result?: { providers: string[] }; error?: { code: number; message: string } }
+      assert.equal(res.error, undefined,
+        `coc_dhtFindProviders("${cid}") must accept real CID, got error: ${JSON.stringify(res.error)}`)
+      assert.ok(res.result, "must return a result")
+      assert.ok(Array.isArray(res.result!.providers),
+        "result.providers must be an array (possibly empty)")
+    }
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2043,6 +2043,19 @@ async function handleRpc(
       if (rawCid.length > 512 || /[\/\\]|\.\.|\0|\s/.test(rawCid)) {
         invalidParams("invalid cid: contains illegal characters or exceeds 512 chars")
       }
+      // #515: pre-fix the shape gate above accepted any string of ≤512
+      // chars with no path-traversal chars — "bad-cid", "not-a-cid",
+      // "deadbeef" all slipped through and `findProviders` returned
+      // `{providers:[]}` silently. The DHT layer was being asked to look
+      // up garbage and clients couldn't distinguish "no providers
+      // advertise this CID" from "your CID was malformed". Apply real
+      // CID-shape validation: must look like a Qm v0 base58 or a
+      // b/B-prefixed v1 base32, with the right alphabet for each. Same
+      // policy as IpfsHttpServer.isValidCid (ipfs-http.ts:1711) so the
+      // RPC + HTTP gateways stay in lock-step.
+      if (!isValidCidShape(rawCid)) {
+        invalidParams("invalid cid: must be a real Qm v0 (base58) or v1 (base32) CID")
+      }
       const cid = rawCid
       // #251: pre-fix `Number(... ?? 3)` silently mapped any malformed
       // maxK (true → 1, "huge" → NaN→3, {} → NaN→3, -5 → fallback 3,
@@ -2074,6 +2087,13 @@ async function handleRpc(
       }
       if (rawCid.length > 512 || /[\/\\]|\.\.|\0|\s/.test(rawCid)) {
         invalidParams("invalid cid: contains illegal characters or exceeds 512 chars")
+      }
+      // #515: same real-CID-shape check as coc_dhtFindProviders.
+      // Pre-fix this method silently returned `{bytes: null}` for any
+      // valid-shape but non-CID string, indistinguishable from "CID is
+      // real but no peer had the block".
+      if (!isValidCidShape(rawCid)) {
+        invalidParams("invalid cid: must be a real Qm v0 (base58) or v1 (base32) CID")
       }
       const cid = rawCid
       // #250: pre-fix `String((payload.params ?? [])[1] ?? "")` silently
@@ -2963,6 +2983,24 @@ function throwExecutionReverted(returnValue: string): never {
   const reason = decodeRevertReason(returnValue)
   const message = reason ? `execution reverted: ${reason}` : "execution reverted"
   throw { code: 3, message, data: returnValue || "0x" }
+}
+
+// #515: real-CID-shape gate for coc_dhtFindProviders / coc_ipfsFetchBlockFromPeer.
+// Mirrors IpfsHttpServer.isValidCid (ipfs-http.ts:1711) so the JSON-RPC and
+// HTTP gateways enforce the same CID admission policy. Accepts:
+//   - Qm v0: base58btc alphabet, 46 chars typical
+//   - b/B v1: base32 RFC4648 lowercase alphabet
+// Rejects: arbitrary printable strings, hex blobs, base64 strings, anything
+// that doesn't start with Qm or b/B with the right alphabet. Path-traversal
+// chars, control chars, and length cap (≤512) are already enforced upstream.
+function isValidCidShape(cid: string): boolean {
+  if (cid.startsWith("Qm")) {
+    return /^Qm[1-9A-HJ-NP-Za-km-z]+$/.test(cid)
+  }
+  if (cid.startsWith("b") || cid.startsWith("B")) {
+    return /^[bB][a-z2-7]+$/.test(cid)
+  }
+  return false
 }
 
 async function resolveBlockNumber(input: unknown, chain: IChainEngine): Promise<bigint> {


### PR DESCRIPTION
Closes #515.

## Summary

- `coc_dhtFindProviders` and `coc_ipfsFetchBlockFromPeer` accepted any ≤512-char ascii string as a "CID", silently returning `{providers:[]}` or `{bytes:null}` for garbage input.
- New `isValidCidShape()` helper enforces real Qm v0 base58 / b v1 base32 — same policy as the IPFS HTTP gateway's `isValidCid` so the two surfaces agree.
- `coc_erasureStatus` is unaffected (already validates via `CID.parse`).

## Test plan

- [x] `#515` regression: 7 fake-CID shapes (no Qm/b prefix, wrong alphabet, case-sensitivity) vs both methods → `-32602 "invalid cid"` + no result. Confirmed: `ok 109`.
- [x] `#515` happy-path: real Qm/bafy/bafk CIDs still reach the DHT and return a result. Confirmed: `ok 110`.
- [x] `#146` backward-compat: existing test on empty/control-char inputs unaffected. Confirmed: `ok 69`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"coc_dhtFindProviders",
  "params":["bad-cid"]}'
→ {"jsonrpc":"2.0","id":1,"result":{"providers":[]}}
```

Post-fix:
```bash
→ {"jsonrpc":"2.0","id":1,"error":{"code":-32602,
   "message":"invalid cid: must be a real Qm v0 (base58) or v1 (base32) CID"}}
```

## Related anti-pattern family

- #511 / #513 — silent empty result + silent param drop, same family
- #146 — already structured-error fix but missed the valid-shape-but-not-CID case