### PR TITLE
fix(ws): #519 eth_subscribe('logs') topic-error wording matches HTTP

### DIFF
--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -398,6 +398,22 @@ describe("WebSocket RPC", () => {
         ["logs", { topics: [null, null, null, null, null] }])
       assert.equal(tooManyTopicsErr.code, -32602,
         `5 outer topics must be -32602, got ${tooManyTopicsErr.code} (${tooManyTopicsErr.message})`)
+      // #519: wording parity with HTTP `eth_getLogs` (rpc-validators.ts
+      // line 638). Pre-fix WS emitted "topics array must have at most 4
+      // elements" while HTTP emitted "topics array too large: 5 > 4 (max
+      // indexed log topics)". Clients pattern-matching the error string had
+      // to handle both forms. Lock the wording to the HTTP variant since
+      // its message is geth-canonical and rpc-validators.test.ts:779 already
+      // asserts against it.
+      assert.match(tooManyTopicsErr.message, /^topics array too large: 5 > 4/,
+        `WS topic-too-many wording must match HTTP eth_getLogs (rpc-validators.ts:638), got "${tooManyTopicsErr.message}"`)
+      // Symmetric: non-array topics must also match HTTP wording.
+      const nonArrayTopicsErr = await sendRpcExpectError(ws, "eth_subscribe",
+        ["logs", { topics: "not-an-array" }])
+      assert.equal(nonArrayTopicsErr.code, -32602,
+        `non-array topics must be -32602, got ${nonArrayTopicsErr.code}`)
+      assert.match(nonArrayTopicsErr.message, /^invalid filter topics:/,
+        `WS non-array topics wording must match HTTP wording, got "${nonArrayTopicsErr.message}"`)
       // Inner topic OR-array: 33+ → -32602 (matches HTTP cap from #266)
       const inner33 = Array.from({ length: 33 }, (_, i) => `0x${i.toString(16).padStart(64, "0")}`)
       const innerCapErr = await sendRpcExpectError(ws, "eth_subscribe",

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -789,11 +789,18 @@ function validateLogFilter(params: Record<string, unknown>): LogSubscriptionFilt
   }
 
   if (params.topics !== undefined && params.topics !== null) {
+    // #519: align wording with HTTP `validateLogFilter` (rpc-validators.ts:584)
+    // so clients pattern-matching the error string don't have to handle two
+    // variants per surface. Pre-fix this WS validator used distinct wording
+    // ("topics must be an array" / "topics array must have at most 4 elements")
+    // that pre-dated #274's HTTP-validator extraction; the HTTP side wins
+    // since its wording matches geth's `eth/filters` package + the existing
+    // rpc-validators.test.ts assertions.
     if (!Array.isArray(params.topics)) {
-      invalidParams("topics must be an array")
+      invalidParams("invalid filter topics: must be array or omitted")
     }
     if ((params.topics as unknown[]).length > 4) {
-      invalidParams("topics array must have at most 4 elements")
+      invalidParams(`topics array too large: ${(params.topics as unknown[]).length} > 4 (max indexed log topics)`)
     }
     const topics: Array<string | string[] | null> = []
     for (const t of params.topics as unknown[]) {


### PR DESCRIPTION
Closes #519.

## Summary

- WS `eth_subscribe("logs")` and HTTP `eth_getLogs` produced two different wire messages for the same topic-validation failures.
- Align the two WS error strings to the HTTP/geth-canonical wording.

## Test plan

- [x] `websocket-rpc.test.ts`: existing 5-outer-topics test now also asserts `/^topics array too large: 5 > 4/` matching HTTP wording. New non-array-topics assertion: `/^invalid filter topics:/`. All 14 ws-rpc tests pass: `# pass 14`.
- [x] HTTP `rpc-validators.test.ts:779` already asserts the canonical wording — unchanged.

## Scope

Just the two `topics` error wordings. The local WS validator has wider drift from HTTP (e.g. `address`-error wording); a full unification via `validateLogFilter()` is out of scope for this PR (larger refactor).

## Live testnet 88780 reproduction (pre-fix)

```bash
# HTTP eth_getLogs with 5 topics
→ {"error":{"code":-32602,"message":"topics array too large: 5 > 4 (max indexed log topics)"}}

# WS eth_subscribe("logs", {topics:[null,null,null,null,null]})
→ {"error":{"code":-32602,"message":"topics array must have at most 4 elements"}}
```

## Related

- #274 (WS log filter validator gap; this completes the work)
- Wire-format parity family: #448 / #454 / #456 / #466 / #480