### PR TITLE
fix(rpc): #523 eth_getBlockReceipts accepts EIP-1898 object forms (no [object Object] leak)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -444,6 +444,83 @@ test("RPC Extended Methods", async (t) => {
     assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
   })
 
+  await t.test("#523: eth_getBlockReceipts accepts all 5 EIP-1898 BlockNumberOrHash shapes (no [object Object] leak)", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_getBlockReceipts({"blockNumber":"latest"})
+    //   → {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
+    //   eth_getBlockReceipts({"blockHash":"0xca8d..."})
+    //   → {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
+    //
+    // Same `[object Object]` leak family as #497/#499 — those PRs fixed
+    // `eth_call`-family methods via `resolveHistoricalExecutionContext`
+    // which handles all 5 EIP-1898 shapes. `eth_getBlockReceipts` was
+    // missed because it doesn't need state-root resolution, so its
+    // simpler `String(rawParam ?? "latest")` path silently coerced
+    // objects to literal `"[object Object]"`.
+    //
+    // Tooling that batches receipts via EIP-1898 forms:
+    //   - ethers.js `provider.getBlock(h).then(b => provider.send(
+    //       "eth_getBlockReceipts", [{blockHash: b.hash}]))`
+    //   - The Graph indexer's bulk-receipt fetcher
+    //   - Etherscan-clones / block explorers
+    // All silently got -32602 from this method.
+    //
+    // Fix: handle all 5 EIP-1898 shapes — bare tag, hex number, bare hash,
+    // {blockNumber: …}, {blockHash: …}. Reject hybrid {both} per spec.
+    await chain.proposeNextBlock()
+    const blockByNumber = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash: string } | null
+    assert.ok(blockByNumber, "fixture must have block 0x1 after proposeNextBlock")
+    const blockHash = blockByNumber!.hash
+    const expectedReceipts = await rpcCall(port, "eth_getBlockReceipts", ["0x1"])
+
+    // Shape (i): {blockNumber: "0x1"} — hex quantity in object
+    const sBN = await rpcCall(port, "eth_getBlockReceipts", [{ blockNumber: "0x1" }])
+    assert.deepEqual(sBN, expectedReceipts,
+      `{blockNumber:"0x1"} must yield same receipts as "0x1", got ${JSON.stringify(sBN)}`)
+
+    // Shape (ii): {blockNumber: "latest"} — named tag in object
+    const sLatest = await rpcCall(port, "eth_getBlockReceipts", [{ blockNumber: "latest" }])
+    assert.ok(Array.isArray(sLatest) || sLatest === null,
+      `{blockNumber:"latest"} must return array or null, got ${JSON.stringify(sLatest)}`)
+
+    // Shape (iii): {blockHash: "0x…"} — 32-byte hash in object
+    const sBH = await rpcCall(port, "eth_getBlockReceipts", [{ blockHash }])
+    assert.deepEqual(sBH, expectedReceipts,
+      `{blockHash:"${blockHash}"} must yield same receipts as "0x1", got ${JSON.stringify(sBH)}`)
+
+    // Reject hybrid {both} per EIP-1898 spec (geth + Erigon return -32602).
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getBlockReceipts", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    const hybrid = await probe([{ blockNumber: "latest", blockHash }])
+    assert.ok(hybrid.error, "EIP-1898 hybrid {blockNumber, blockHash} must error")
+    assert.equal(hybrid.error!.code, -32602)
+    assert.match(hybrid.error!.message, /EIP-1898 forbids.*together/,
+      `hybrid message must explain the spec violation, got: ${hybrid.error!.message}`)
+
+    // Defense against the regression: confirm pre-fix leak is gone.
+    // ANY error message MUST NOT contain "[object Object]".
+    const badObj = await probe([{ unrelated: "field" }])
+    assert.ok(badObj.error, "object missing both blockNumber/blockHash must error")
+    assert.doesNotMatch(badObj.error!.message, /\[object Object\]/,
+      `must not leak [object Object] coercion, got: ${badObj.error!.message}`)
+    assert.match(badObj.error!.message, /EIP-1898|blockNumber|blockHash/i,
+      `must explain what's wrong, got: ${badObj.error!.message}`)
+
+    // Malformed blockHash in object form must surface as -32602 with a
+    // specific blockHash-shape error (not the generic block-number message).
+    const badHash = await probe([{ blockHash: "0xshort" }])
+    assert.ok(badHash.error)
+    assert.equal(badHash.error!.code, -32602)
+    assert.match(badHash.error!.message, /invalid blockHash/i,
+      `must complain about blockHash shape, got: ${badHash.error!.message}`)
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1978,14 +1978,47 @@ async function handleRpc(
       // doesn't exist." Detect the 66-char hash shape and route to
       // `getBlockByHash` instead. Indexers that bulk-fetch receipts
       // by block hash (Etherscan-clones, The Graph, etc.) need this.
+      // #523: pre-fix this only handled bare-string forms (named tag, hex
+      // number, 32-byte hash). EIP-1898 object forms `{blockNumber: "…"}`
+      // and `{blockHash: "…"}` fell through to `String(rawParam)` which
+      // coerced the object to literal `"[object Object]"` and bubbled out
+      // as `-32602 "invalid block number: [object Object]"`. Same
+      // `[object Object]` leak family as #497/#499 — except those PRs
+      // only fixed `eth_call`-family methods via
+      // `resolveHistoricalExecutionContext`. `eth_getBlockReceipts` was
+      // missed because it doesn't need state-root resolution, so its
+      // handler kept the simpler String()-coercion path. Tooling that
+      // batches receipts via EIP-1898 forms (ethers.js
+      // `provider.getBlock(blockHash).then(b => provider.send("eth_getBlockReceipts", [{blockHash: b.hash}]))`,
+      // The Graph indexer's bulk-receipt fetcher, Etherscan-clones) all
+      // emit object forms and silently got `-32602` from this method.
       const rawParam = (payload.params ?? [])[0]
       let block: Awaited<ReturnType<typeof chain.getBlockByNumber>> | null = null
       if (typeof rawParam === "string" && /^0x[0-9a-fA-F]{64}$/.test(rawParam)) {
-        // 32-byte block hash — case-insensitive, mirroring #364 normalization.
+        // Form (a): bare 32-byte block hash.
         block = await Promise.resolve(chain.getBlockByHash(rawParam.toLowerCase() as Hex))
+      } else if (typeof rawParam === "object" && rawParam !== null) {
+        // EIP-1898 object forms. Reject hybrid {blockNumber, blockHash}
+        // upfront per spec (geth + Erigon both -32602 this case).
+        const obj = rawParam as Record<string, unknown>
+        if ("blockNumber" in obj && "blockHash" in obj) {
+          invalidParams("invalid block parameter: EIP-1898 forbids blockNumber and blockHash together")
+        }
+        if ("blockHash" in obj) {
+          const rawHash = obj.blockHash
+          if (typeof rawHash !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(rawHash)) {
+            invalidParams("invalid blockHash: must match /^0x[0-9a-fA-F]{64}$/")
+          }
+          block = await Promise.resolve(chain.getBlockByHash((rawHash as string).toLowerCase() as Hex))
+        } else if ("blockNumber" in obj) {
+          const num = await resolveBlockNumber(obj.blockNumber, chain)
+          block = await Promise.resolve(chain.getBlockByNumber(num))
+        } else {
+          invalidParams("invalid block parameter: EIP-1898 object must contain blockNumber or blockHash")
+        }
       } else {
-        const tag = String(rawParam ?? "latest")
-        const num = await resolveBlockNumber(tag, chain)
+        // Form (b): bare string tag / hex number / undefined → latest.
+        const num = await resolveBlockNumber(rawParam, chain)
         block = await Promise.resolve(chain.getBlockByNumber(num))
       }
       if (!block) return null


### PR DESCRIPTION
Closes #523.

## Summary

- `eth_getBlockReceipts` was missed in the #497/#499 cleanup of `[object Object]` leaks. Object inputs `{blockNumber: …}` / `{blockHash: …}` hit `String(rawParam)` → literal `"[object Object]"` → misleading "invalid block number" error.
- Inline EIP-1898 handler: support `{blockNumber}`, `{blockHash}`, reject hybrid per spec, surface shape-specific errors.

## Test plan

- [x] `#523` regression: 3 EIP-1898 forms yield same receipts as bare form, hybrid rejected, defense against `"[object Object]"` leak. Confirmed: `ok 23`.
- [x] `#366` (existing): unaffected, still passes. Confirmed: `ok 22`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts",
  "params":[{"blockNumber":"latest"}]}'
→ {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
```

## Related

- #497 (EIP-1898 resolver for `eth_call`-family — established the spec contract this PR completes)
- #499 (String() coercion leak family)