### PR TITLE
fix(rpc): #525 drop String() coercion leaks in get-block-tx-count + feeHistory

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -388,6 +388,57 @@ test("RPC Extended Methods", async (t) => {
     assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
   })
 
+  await t.test("#525: eth_getBlockTransactionCountByNumber + eth_feeHistory.newestBlock reject objects without [object Object] leak", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_getBlockTransactionCountByNumber({"blockNumber":"latest"})
+    //   → {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
+    //   eth_feeHistory("0x4", {"blockNumber":"latest"}, [])
+    //   → {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
+    //
+    // Same `[object Object]` leak family as #497/#499/#523:
+    // `String(rawParam ?? "latest")` coerces any object to the literal
+    // string `"[object Object]"`. These two methods (per geth spec)
+    // take BlockNumber, NOT BlockNumberOrHash, so EIP-1898 object
+    // support is out of scope — but the rejection must be a clean
+    // shape error rather than a coerced-string leak.
+    const probe = async (method: string, params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) eth_getBlockTransactionCountByNumber with object input MUST
+    // error with a clean shape message — NOT "[object Object]".
+    for (const obj of [{ blockNumber: "latest" }, { blockHash: "0x" + "a".repeat(64) }, { random: "field" }]) {
+      const r = await probe("eth_getBlockTransactionCountByNumber", [obj])
+      assert.ok(r.error, `eth_getBlockTransactionCountByNumber(${JSON.stringify(obj)}) must error`)
+      assert.equal(r.error!.code, -32602)
+      assert.doesNotMatch(r.error!.message, /\[object Object\]/,
+        `must not leak [object Object] coercion, got: ${r.error!.message}`)
+      assert.match(r.error!.message, /block (number|tag)/i,
+        `must mention "block number" or "block tag", got: ${r.error!.message}`)
+    }
+    // (b) eth_feeHistory with object newestBlock MUST error cleanly.
+    for (const obj of [{ blockNumber: "latest" }, { blockHash: "0x" + "a".repeat(64) }]) {
+      const r = await probe("eth_feeHistory", ["0x4", obj, []])
+      assert.ok(r.error, `eth_feeHistory(_, ${JSON.stringify(obj)}, _) must error`)
+      assert.equal(r.error!.code, -32602)
+      assert.doesNotMatch(r.error!.message, /\[object Object\]/,
+        `must not leak [object Object] coercion, got: ${r.error!.message}`)
+      assert.match(r.error!.message, /newestBlock|block (number|tag)/i,
+        `must mention newestBlock or block-number shape, got: ${r.error!.message}`)
+    }
+    // (c) Sanity: the happy paths still work.
+    const okCount = await probe("eth_getBlockTransactionCountByNumber", ["latest"])
+    assert.equal(okCount.error, undefined,
+      `eth_getBlockTransactionCountByNumber("latest") must succeed, got error: ${JSON.stringify(okCount.error)}`)
+    const okFee = await probe("eth_feeHistory", ["0x2", "latest", []])
+    assert.equal(okFee.error, undefined,
+      `eth_feeHistory("0x2", "latest", []) must succeed, got error: ${JSON.stringify(okFee.error)}`)
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1662,9 +1662,18 @@ async function handleRpc(
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
     case "eth_getBlockTransactionCountByNumber": {
-      const tag = String((payload.params ?? [])[0] ?? "latest")
+      // #525: pre-fix `String(rawParam ?? "latest")` coerced any object
+      // input to literal `"[object Object]"`, then parseBlockTag rejected
+      // it with the misleading "invalid block number: [object Object]"
+      // — same `[object Object]` leak family as #497/#499/#523. This
+      // method takes BlockNumber (NOT BlockNumberOrHash per geth/spec),
+      // so EIP-1898 object forms aren't required, but the rejection
+      // must still be a clean shape error rather than a coerced leak.
+      // Hand the raw input to parseBlockTag directly — it rejects
+      // unknown shapes with a clean message.
+      const rawTag = (payload.params ?? [])[0]
       const height = await Promise.resolve(chain.getHeight())
-      const num = parseBlockTag(tag, height)
+      const num = parseBlockTag(rawTag, height)
       const block = await Promise.resolve(chain.getBlockByNumber(num))
       return block ? `0x${block.txs.length.toString(16)}` : null
     }
@@ -1739,7 +1748,25 @@ async function handleRpc(
       } else {
         invalidParams("invalid blockCount: expected hex quantity or positive integer")
       }
-      const newestBlock = String((payload.params ?? [])[1] ?? "latest")
+      // #525: same `[object Object]` leak fix as
+      // eth_getBlockTransactionCountByNumber. Pre-fix
+      // `String(rawParam ?? "latest")` coerced object inputs to
+      // `"[object Object]"` and surfaced as misleading
+      // "invalid block number: [object Object]". newestBlock is a
+      // BlockNumber (not BlockNumberOrHash) per the EIP-1559 / geth
+      // spec, so EIP-1898 object support is out of scope; the fix is
+      // to surface the shape error cleanly rather than via String()
+      // coercion.
+      const rawNewestBlock = (payload.params ?? [])[1]
+      if (
+        rawNewestBlock !== undefined &&
+        rawNewestBlock !== null &&
+        typeof rawNewestBlock !== "string" &&
+        typeof rawNewestBlock !== "number"
+      ) {
+        invalidParams("invalid newestBlock: expected hex quantity or named tag")
+      }
+      const newestBlock = rawNewestBlock ?? "latest"
       // #224: `as number[]` was a TS runtime no-op so an object/string/
       // bool silently passed through (`{}.length === undefined`
       // bypassed the >100 check and the for-loop). Reject non-array


### PR DESCRIPTION
Closes #525.

## Summary

- `eth_getBlockTransactionCountByNumber` and `eth_feeHistory.newestBlock` were two `String()`-coercion sites missed by the #499 cleanup. Object input → literal `"[object Object]"` → misleading "invalid block number" error.
- Both methods take `BlockNumber` (NOT `BlockNumberOrHash`), so EIP-1898 object support is out of scope (separate from #523's `eth_getBlockReceipts` work).
- Fix: replace `String(rawParam ?? "latest")` with proper type-guards.

## Test plan

- [x] `#525` regression: both methods × 3+2 object shapes → -32602 clean message, no `"[object Object]"` leak. Happy-path "latest" still works. Confirmed: `ok 23`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_getBlockTransactionCountByNumber",
  "params":[{"blockNumber":"latest"}]}'
→ {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}

curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_feeHistory",
  "params":["0x4",{"blockNumber":"latest"},[]]}'
→ {"error":{"code":-32602,"message":"invalid block number: [object Object]"}}
```

## Related

- #497/#499 (String() coercion cleanup — earlier rounds)
- #523 (EIP-1898 object support for eth_getBlockReceipts — separate scope)