### PR TITLE
fix(chain): #527 check tx chainId BEFORE nonce in addRawTx

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -624,6 +624,22 @@ export class PersistentChainEngine {
     // the latest applied block.
     const decoded = Transaction.from(rawTx)
 
+    // #527: chainId is a STRUCTURAL property of the tx — verify before any
+    // dynamic-state checks (hash dedup, nonce, balance). Pre-fix a
+    // wrong-chain tx with a low nonce got the misleading "nonce too low"
+    // error from line ~637 because mempool.addRawTx (mempool.ts:155) ran
+    // AFTER the engine-level nonce check; clients had to bump nonce,
+    // re-sign, and re-submit just to learn their chainId was fundamentally
+    // wrong. Mirrors the same fix in chain-engine.ts addRawTx.
+    const txChainId = (decoded as { chainId?: bigint | number | null }).chainId
+    if (
+      txChainId !== null &&
+      txChainId !== undefined &&
+      BigInt(txChainId) !== BigInt(this.cfg.chainId ?? 18780)
+    ) {
+      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
+    }
+
     // Mirror in-memory engine order: hash dedup first (more specific error
     // for same-tx replay), then stale-nonce check (catches different-tx-same-
     // -nonce). Both run before mempool insertion so we never accept a tx that

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -174,6 +174,22 @@ export class ChainEngine {
     // Pre-check: decode tx hash and reject if already confirmed BEFORE adding to mempool
     // Fixes TOCTOU race where tx could be picked by pickForBlock between add and check
     const decoded = Transaction.from(rawTx)
+    // #527: chainId is a STRUCTURAL property of the tx — verify it before
+    // any dynamic-state checks (hash dedup, nonce, balance). Pre-fix a
+    // wrong-chain tx with a low nonce got the misleading "nonce too low"
+    // error from line ~184 because mempool.addRawTx (mempool.ts:155)
+    // ran AFTER the engine-level nonce check; clients had to bump nonce,
+    // re-sign, and re-submit just to learn their chainId was fundamentally
+    // wrong. Geth and Erigon check chainId first because it's
+    // immutable for a given signed tx.
+    const txChainId = (decoded as { chainId?: bigint | number | null }).chainId
+    if (
+      txChainId !== null &&
+      txChainId !== undefined &&
+      BigInt(txChainId) !== BigInt(this.cfg.chainId ?? 18780)
+    ) {
+      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
+    }
     if (this.txHashSet.has(decoded.hash as Hex)) {
       throw new Error("tx already confirmed")
     }

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -521,6 +521,63 @@ test("RPC Extended Methods", async (t) => {
       `must complain about blockHash shape, got: ${badHash.error!.message}`)
   })
 
+  await t.test("#527: eth_sendRawTransaction checks chainId BEFORE nonce (no misleading 'nonce too low' for wrong-chain tx)", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   wallet.signTransaction({chainId: 99999, nonce: 0, ...})
+    //   eth_sendRawTransaction(raw)
+    //   → {"error":{"code":-32000,"message":"nonce too low: tx nonce 0, on-chain nonce 282"}}
+    //
+    // With nonce=500 (above on-chain), the SAME wrong-chain tx instead
+    // returned the correct chainId error:
+    //   → {"error":{"code":-32602,"message":"invalid chain ID: expected 88780, got 99999"}}
+    //
+    // The validation order pre-fix was: parse → tx-hash dedup → nonce →
+    // chainId (inside mempool.addRawTx). ChainId is STRUCTURAL (signed
+    // into the tx via EIP-155 / EIP-2930), nonce is DYNAMIC (state).
+    // Geth + Erigon both check structural properties first because
+    // dynamic-state errors are misleading when the tx is structurally
+    // unacceptable. A wrong-chain tx will NEVER be valid on this chain
+    // regardless of nonce; reporting "nonce too low" suggests bumping
+    // the nonce would help, which is wrong.
+    //
+    // Fix: chainId check pulled from mempool.addRawTx up to the start
+    // of chain-engine{,-persistent}.ts addRawTx. Both engines now check
+    // chainId first.
+    const { Wallet } = await import("ethers")
+    const wallet = new Wallet("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+    const probe = async (raw: string) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // The fixture's chain config exposes its chainId; pick something obviously
+    // different so the chainId check fires.
+    const fixtureChainId = await rpcCall(port, "eth_chainId", []) as string
+    const wrongChainId = Number(BigInt(fixtureChainId)) + 12345
+    const wrongChain = await wallet.signTransaction({
+      chainId: wrongChainId,
+      nonce: 0,  // intentionally low — bug case is low-nonce + wrong-chain
+      gasLimit: 21000n,
+      gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001",
+      value: 1n,
+    })
+    const r1 = await probe(wrongChain)
+    assert.ok(r1.error, `wrong-chain tx must be rejected, got result=${JSON.stringify(r1.result)}`)
+    // Must mention chainId, NOT nonce — the bug shape.
+    assert.match(r1.error!.message, /chain ID|chainId/i,
+      `wrong-chain tx error must mention chainId, got: ${r1.error!.message}`)
+    assert.doesNotMatch(r1.error!.message, /nonce too low/i,
+      `wrong-chain tx must NOT be misreported as nonce too low (the pre-fix bug), got: ${r1.error!.message}`)
+    // Geth wire convention: chainId errors are -32602 (structural shape
+    // failure) per the existing #332 rpc.ts mapping at line ~1112.
+    assert.equal(r1.error!.code, -32602,
+      `wrong-chain tx must be -32602 (invalid params), got ${r1.error!.code}`)
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back


### PR DESCRIPTION
Closes #527.

## Summary

- Wrong-chain tx with low nonce got misleading "nonce too low" instead of "invalid chain ID".
- ChainId is STRUCTURAL (signed into tx via EIP-155 / EIP-2930), nonce is DYNAMIC. Geth + Erigon check structural first.
- Lift the chainId check from \`mempool.addRawTx\` (post-nonce) to the start of \`chain-engine{,-persistent}.ts addRawTx\` (pre-everything). Mempool check stays as defense-in-depth.

## Test plan

- [x] \`#527\` regression: wrong-chain tx + nonce=0 → -32602 "invalid chain ID" (not -32000 "nonce too low"); defense asserts message does NOT contain "nonce too low". Confirmed: \`ok 23\`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction",
  "params":["0x01f868...wrong-chain-tx..."]}'
→ {"error":{"code":-32000,"message":"nonce too low: tx nonce 0, on-chain nonce 282"}}
```

Same wrong-chain tx with high nonce (above on-chain) instead returned the correct chainId error.

## Related

- #521 (validation-order drift family — same anti-pattern)
- General class: check structural properties before dynamic state