### PR TITLE
fix(chain): #529 lift ALL structural tx checks before nonce in addRawTx

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -8,7 +8,7 @@
  */
 
 import type { TxReceipt, EvmChain, EvmLog } from "./evm.ts"
-import { Mempool } from "./mempool.ts"
+import { Mempool, validateTxStructure } from "./mempool.ts"
 import { hashBlockPayload, validateBlockLink, zeroHash } from "./hash.ts"
 import { keccak256Hex } from "../../services/relayer/keccak256.ts"
 import type { ChainBlock, Hex, MempoolTx } from "./blockchain-types.ts"
@@ -623,6 +623,15 @@ export class PersistentChainEngine {
     // nonce via evm.getNonce hits the live state manager, which reflects
     // the latest applied block.
     const decoded = Transaction.from(rawTx)
+    // #529: structural-only validation (chainId, gas limits, intrinsic gas,
+    // blob-type) runs BEFORE dynamic-state checks (hash dedup, nonce,
+    // balance). Pre-fix a tx with a structural defect AND a low nonce
+    // got the misleading "nonce too low" error from line ~637 because
+    // mempool.addRawTx (where these checks lived) ran AFTER the
+    // engine-level nonce check. Mirrors the same lift in chain-engine.ts
+    // addRawTx. Builds on #527 (chainId only) by extending to ALL
+    // structural properties.
+    validateTxStructure(decoded, this.cfg.chainId ?? 18780)
 
     // Mirror in-memory engine order: hash dedup first (more specific error
     // for same-tx replay), then stale-nonce check (catches different-tx-same-

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -1,5 +1,5 @@
 import type { TxReceipt, EvmChain } from "./evm.ts"
-import { Mempool } from "./mempool.ts"
+import { Mempool, validateTxStructure } from "./mempool.ts"
 import { ChainStorage } from "./storage.ts"
 import { hashBlockPayload, validateBlockLink, zeroHash } from "./hash.ts"
 import type { ChainBlock, ChainSnapshot, Hex, MempoolTx } from "./blockchain-types.ts"
@@ -174,6 +174,16 @@ export class ChainEngine {
     // Pre-check: decode tx hash and reject if already confirmed BEFORE adding to mempool
     // Fixes TOCTOU race where tx could be picked by pickForBlock between add and check
     const decoded = Transaction.from(rawTx)
+    // #529: structural-only validation (chainId, gas limits, intrinsic gas,
+    // blob-type) runs BEFORE dynamic-state checks (hash dedup, nonce,
+    // balance). Pre-fix a tx with a structural defect AND a low nonce
+    // got the misleading "nonce too low" error from line ~184 because
+    // mempool.addRawTx (where these checks lived) ran AFTER the
+    // engine-level nonce check. Geth + Erigon check structural first
+    // because a structurally-broken tx is unfixable regardless of state.
+    // Builds on #527 (chainId only) by extending to ALL structural
+    // properties.
+    validateTxStructure(decoded, this.cfg.chainId ?? 18780)
     if (this.txHashSet.has(decoded.hash as Hex)) {
       throw new Error("tx already confirmed")
     }

--- a/node/src/mempool.ts
+++ b/node/src/mempool.ts
@@ -97,6 +97,43 @@ export function computeIntrinsicGas(tx: Transaction): bigint {
   return gas
 }
 
+// #529: hoist the structural-only validation out of Mempool.addRawTx so the
+// chain engine can run these checks BEFORE its dynamic-state checks (hash
+// dedup, nonce, balance). All checks here depend only on the signed tx
+// itself — chainId is signed-in via EIP-155/EIP-2930, gas limits and
+// intrinsic gas are derivable from the tx body, blob-type is the tx type
+// field. None of them require state.
+//
+// Pre-fix the wrong validation order produced misleading errors for tx
+// that had MULTIPLE problems: a wrong-chain tx with low nonce got
+// "nonce too low" (which my #527 fix partially addressed for chainId),
+// but a tx with gasLimit > 30M and low nonce STILL got "nonce too low"
+// instead of "gasLimit exceeds maximum". Same anti-pattern, broader fix.
+//
+// Throws Error (not invalidParams) since this is shared chain-engine
+// code; rpc.ts maps these messages to -32602 via existing regex matches
+// (rpc.ts:1110-1117).
+export const MAX_TX_GAS_LIMIT = 30_000_000n
+export function validateTxStructure(tx: Transaction, chainId: number): void {
+  if (!tx.from) {
+    throw new Error("invalid tx: missing sender")
+  }
+  if (tx.chainId !== BigInt(chainId)) {
+    throw new Error(`invalid chain ID: expected ${chainId}, got ${tx.chainId}`)
+  }
+  if (tx.type === 3) {
+    throw new Error("blob transactions (type 3) are not supported")
+  }
+  const gasLimit = tx.gasLimit ?? 21000n
+  if (gasLimit > MAX_TX_GAS_LIMIT) {
+    throw new Error(`gasLimit exceeds maximum: ${gasLimit} > ${MAX_TX_GAS_LIMIT}`)
+  }
+  const intrinsicGasRequired = computeIntrinsicGas(tx)
+  if (gasLimit < intrinsicGasRequired) {
+    throw new Error(`intrinsic gas too low: have ${gasLimit}, want ${intrinsicGasRequired}`)
+  }
+}
+
 export class Mempool {
   private readonly txs = new Map<Hex, MempoolTx>()
   // Index: sender -> set of tx hashes for fast per-sender lookups
@@ -146,52 +183,25 @@ export class Mempool {
 
   addRawTx(rawTx: Hex, preDecoded?: Transaction): MempoolTx {
     const tx = preDecoded ?? Transaction.from(rawTx)
-    if (!tx.from) {
-      throw new Error("invalid tx: missing sender")
-    }
-
-    // Replay protection: validate chain ID (reject chainId=0 to prevent cross-chain replay)
-    if (tx.chainId !== BigInt(this.cfg.chainId)) {
-      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${tx.chainId}`)
-    }
+    // #529: structural-only checks (missing sender, chainId, blob type,
+    // gas limits, intrinsic gas) are hoisted to validateTxStructure so
+    // the chain engine can run them BEFORE its dynamic-state checks
+    // (hash dedup, nonce, balance). The mempool still calls them here
+    // as defense-in-depth — preDecoded txs coming from re-insertion
+    // paths (block reorg, snapshot replay) shouldn't be assumed
+    // pre-validated.
+    validateTxStructure(tx, this.cfg.chainId)
 
     if (this.poisoned.has((tx.hash as Hex).toLowerCase() as Hex)) {
       throw new Error(`tx ${tx.hash} is poisoned (hung block execution previously)`)
     }
 
-    const from = tx.from.toLowerCase() as Hex
+    const from = tx.from!.toLowerCase() as Hex
     const nonce = BigInt(tx.nonce)
     const gasPrice = tx.gasPrice ?? tx.maxFeePerGas ?? 0n
     const maxFeePerGas = tx.maxFeePerGas ?? tx.gasPrice ?? 0n
     const maxPriorityFeePerGas = tx.maxPriorityFeePerGas ?? 0n
     const gasLimit = tx.gasLimit ?? 21000n
-
-    // Reject blob transactions (type 3) — COC has no blob sidecar support
-    if (tx.type === 3) {
-      throw new Error("blob transactions (type 3) are not supported")
-    }
-
-    // Reject transactions with gasLimit exceeding block gas limit (prevents
-    // mempool pollution with txs that can never be included in a block)
-    const MAX_TX_GAS_LIMIT = 30_000_000n
-    if (gasLimit > MAX_TX_GAS_LIMIT) {
-      throw new Error(`gasLimit exceeds maximum: ${gasLimit} > ${MAX_TX_GAS_LIMIT}`)
-    }
-
-    // #334: reject gasLimit below the EIP-3 intrinsic gas cost. Pre-fix the
-    // mempool only enforced the upper bound, so a tx with `gasLimit=100`
-    // returned a success hash from eth_sendRawTransaction but could never
-    // execute — wasting a nonce slot and leaving the user with a tx they
-    // can't replace (without a 10% bump on already-zero gas price). Also
-    // a clean mempool-fill DoS surface since these txs sit forever.
-    // Geth surfaces this as -32000 "intrinsic gas too low: gas X, minimum
-    // needed Y"; mirror the message so existing clients parse it.
-    const intrinsicGasRequired = computeIntrinsicGas(tx)
-    if (gasLimit < intrinsicGasRequired) {
-      throw new Error(
-        `intrinsic gas too low: have ${gasLimit}, want ${intrinsicGasRequired}`,
-      )
-    }
 
     const item: MempoolTx = {
       hash: tx.hash as Hex,

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -388,6 +388,64 @@ test("RPC Extended Methods", async (t) => {
     assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
   })
 
+  await t.test("#529: eth_sendRawTransaction structural checks (gasLimit / intrinsic gas) fire BEFORE nonce", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   wallet.signTransaction({chainId: 88780, nonce: 0, gasLimit: 999_999_999n, ...})
+    //   eth_sendRawTransaction(raw)
+    //   → {"error":{"code":-32000,"message":"nonce too low: tx nonce 0, on-chain nonce 282"}}
+    //   The SAME tx with nonce=999 (above on-chain) got the *correct* error:
+    //   → {"error":{"code":-32000,"message":"gasLimit exceeds maximum: 999999999 > 30000000"}}
+    //
+    // #527 extracted the chainId-vs-nonce ordering bug; this PR
+    // generalizes the lift to ALL structural checks (gasLimit upper
+    // bound, intrinsic gas lower bound, blob-type rejection,
+    // missing-sender) via a shared `validateTxStructure` helper in
+    // mempool.ts. Geth + Erigon both check structural-first because
+    // a structurally broken tx is unfixable regardless of state.
+    const { Wallet } = await import("ethers")
+    const wallet = new Wallet("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+    const fixtureChainId = Number(BigInt(await rpcCall(port, "eth_chainId", []) as string))
+    const probe = async (raw: string) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) gasLimit > block max + nonce=0 → must report gasLimit error, NOT nonce.
+    const overGas = await wallet.signTransaction({
+      chainId: fixtureChainId,
+      nonce: 0,
+      gasLimit: 999_999_999n,
+      gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001",
+      value: 1n,
+    })
+    const r1 = await probe(overGas)
+    assert.ok(r1.error)
+    assert.match(r1.error!.message, /gasLimit exceeds maximum/i,
+      `over-gas tx error must mention gasLimit, got: ${r1.error!.message}`)
+    assert.doesNotMatch(r1.error!.message, /nonce too low/i,
+      `over-gas tx must NOT be misreported as nonce too low, got: ${r1.error!.message}`)
+
+    // (b) intrinsic gas too low + nonce=0 → must report intrinsic-gas, NOT nonce.
+    const underGas = await wallet.signTransaction({
+      chainId: fixtureChainId,
+      nonce: 0,
+      gasLimit: 1n,
+      gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001",
+      value: 1n,
+    })
+    const r2 = await probe(underGas)
+    assert.ok(r2.error)
+    assert.match(r2.error!.message, /intrinsic gas too low/i,
+      `under-gas tx error must mention intrinsic gas, got: ${r2.error!.message}`)
+    assert.doesNotMatch(r2.error!.message, /nonce too low/i,
+      `under-gas tx must NOT be misreported as nonce too low, got: ${r2.error!.message}`)
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back


### PR DESCRIPTION
Closes #529. Generalizes #527.

## Summary

- #527 lifted only the chainId check. The same anti-pattern applies to ALL structural checks: missing sender, blob-type rejection, gasLimit upper bound, intrinsic gas lower bound. All ran AFTER nonce check, so low-nonce + structurally-broken tx got "nonce too low" masking the real issue.
- Extract \`validateTxStructure(tx, chainId)\` helper in \`mempool.ts\`. Both engines call it at the start of \`addRawTx\`, BEFORE hash dedup / nonce check.
- \`mempool.addRawTx\` still calls \`validateTxStructure\` as defense-in-depth for re-insertion paths (block reorg, snapshot replay).

## Test plan

- [x] \`#529\` regression: \`gasLimit > 30M + nonce=0\` → "gasLimit exceeds maximum", NOT "nonce too low"; \`intrinsic gas too low + nonce=0\` → "intrinsic gas too low", NOT "nonce too low". Confirmed: \`ok 23\`.

## Stacking

This PR is independent of #528 (which also fixes part of this family for chainId only). Either can land first; once both land, the engines have a single source of truth (\`validateTxStructure\`) for all structural validation.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{
  "jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction",
  "params":["0x01f86a83015acc80...over-gas-tx..."]}'
→ {"error":{"code":-32000,"message":"nonce too low: tx nonce 0, on-chain nonce 282"}}
```

Same tx with high nonce (above on-chain) gets correct "gasLimit exceeds maximum".

## Related

- #527 (chainId-vs-nonce — same family, narrower scope)
- #521 (validation-order drift: eth_signTypedData_v4 keystore-vs-structure)