### PR TITLE
fix(rpc): #533 eth_getLogs resolves blockHash to the correct block (-32000 'unknown block' on miss)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -578,6 +578,65 @@ test("RPC Extended Methods", async (t) => {
       `wrong-chain tx must be -32602 (invalid params), got ${r1.error!.code}`)
   })
 
+  await t.test("#533: eth_getLogs blockHash resolves to the correct block (non-existent → -32000 'unknown block')", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_getLogs({"blockHash":"0xdeadbeef...deadbeef"})  // valid shape, doesn't exist
+    //   → {"result":[]}
+    //   eth_getLogs({"blockHash":"0x2a020dbc...latest"})    // valid AND exists
+    //   → {"result":[]}    // INDISTINGUISHABLE from above
+    //
+    // Upstream validation (#186 shape, #464 fromBlock/toBlock mutex)
+    // existed, but `queryLogs` (rpc.ts:4093) NEVER read `query.blockHash`.
+    // It always fell through to `parseBlockTag(query.fromBlock, height)`
+    // which returned `height` for undefined → fromBlock=toBlock=latest.
+    // A `{blockHash: "<hash>"}` filter silently queried the LATEST block
+    // instead of the block at that hash.
+    //
+    // EIP-234 batched fetchers (ethers.js provider.getLogs({blockHash:...}),
+    // viem getLogs({blockHash:...}), The Graph indexer, every block-explorer
+    // implementing reorg-aware retrieval) need:
+    //   1. Resolution to the SPECIFIC block (not latest)
+    //   2. A `-32000 "unknown block"` signal so a hash that's been reorged
+    //      out is detectable. Pre-fix `[]` masks reorgs.
+    //
+    // Fix: queryLogs reads query.blockHash, resolves to block.number for
+    // fromBlock=toBlock, throws -32000 "unknown block" if the hash doesn't
+    // match a known block.
+    const probe = async (filter: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getLogs", params: [filter] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) Non-existent blockHash → -32000 "unknown block" (geth parity)
+    const nonexistent = await probe({ blockHash: "0xdeadbeef000000000000000000000000000000000000000000000000deadbeef" })
+    assert.ok(nonexistent.error,
+      `non-existent blockHash must error (not silent []), got result=${JSON.stringify(nonexistent.result)}`)
+    assert.equal(nonexistent.error!.code, -32000,
+      `non-existent blockHash must be -32000, got ${nonexistent.error!.code}`)
+    assert.match(nonexistent.error!.message, /unknown block/i,
+      `error must mention "unknown block", got: ${nonexistent.error!.message}`)
+    assert.equal(nonexistent.result, undefined,
+      "must NOT carry a result alongside the error")
+
+    // (b) Existing blockHash (the fixture's genesis stub or block 0x1 if any
+    // were proposed) → must succeed (no -32000), regardless of log count.
+    // First, propose a block to ensure block 0x1 exists.
+    if (typeof chain.proposeNextBlock === "function") {
+      await chain.proposeNextBlock()
+    }
+    const blockByNum = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash: string } | null
+    if (blockByNum) {
+      const existing = await probe({ blockHash: blockByNum.hash })
+      assert.equal(existing.error, undefined,
+        `existing blockHash must succeed, got error: ${JSON.stringify(existing.error)}`)
+      assert.ok(Array.isArray(existing.result),
+        `existing blockHash must return array, got ${typeof existing.result}`)
+    }
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -4269,8 +4269,32 @@ const MAX_TRACE_RESULTS = 1_000
 async function queryLogs(chain: IChainEngine, query: Record<string, unknown>, resolvedHeight?: bigint): Promise<unknown[]> {
   const height = resolvedHeight ?? await Promise.resolve(chain.getHeight())
   const finalizedHeight = await Promise.resolve(chain.getHighestFinalizedBlock())
-  const fromBlock = parseBlockTag(query.fromBlock, height, finalizedHeight)
-  const toBlock = parseBlockTag(query.toBlock, height, finalizedHeight)
+  // #533: pre-fix `query.blockHash` was validated upstream (#186 shape +
+  // #464 mutex with fromBlock/toBlock) but NEVER resolved to a block
+  // number here. queryLogs always fell through to parseBlockTag(undefined,
+  // height) = latest, so a `{blockHash: "<hash>"}` filter silently queried
+  // the LATEST block instead of the block at that hash. Worse, a
+  // non-existent hash returned `result: []` indistinguishable from "block
+  // exists, no logs" — same anti-pattern family as #511 (silent empty
+  // result that mimics no-data). Geth's contract: `-32000 "unknown block"`
+  // for an unknown blockHash. EIP-234 batched fetchers (ethers.js
+  // provider.getLogs({blockHash}), viem getLogs({blockHash})) need this
+  // signal to distinguish "block was reorged out" from "block exists,
+  // matched zero logs".
+  let fromBlock: bigint
+  let toBlock: bigint
+  if (query.blockHash !== undefined && query.blockHash !== null) {
+    const hash = (query.blockHash as string).toLowerCase() as Hex
+    const block = await Promise.resolve(chain.getBlockByHash(hash))
+    if (!block) {
+      throw { code: -32000, message: "unknown block" }
+    }
+    fromBlock = block.number
+    toBlock = block.number
+  } else {
+    fromBlock = parseBlockTag(query.fromBlock, height, finalizedHeight)
+    toBlock = parseBlockTag(query.toBlock, height, finalizedHeight)
+  }
 
   // Reject invalid range where fromBlock > toBlock
   if (fromBlock > toBlock) {


### PR DESCRIPTION
Closes #533.

## Summary

- \`queryLogs\` never read \`query.blockHash\` — \`{blockHash: ...}\` filters silently queried the LATEST block instead of the block at that hash, and non-existent hashes returned \`[]\` indistinguishable from "no logs in that block".
- Fix: resolve blockHash via \`chain.getBlockByHash\`, throw -32000 "unknown block" on miss, set fromBlock=toBlock=block.number on hit.

## Test plan

- [x] \`#533\` regression:
  - Non-existent blockHash → -32000 "unknown block" (not silent [])
  - Existing blockHash → succeeds with array
- Confirmed: \`ok 23\`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"blockHash":"0xdead...beef"}]}'
→ {"result":[]}
```

Same response for an existing hash — both indistinguishable.

## Impact

EIP-234 batched fetchers (ethers.js, viem, The Graph indexer, block-explorers) silently fail when they batch by blockHash — getting logs from the LATEST block instead of the requested one.

## Related

- #511 (silent empty result mimicking no-data — same family)
- #186 + #464 (blockHash shape validation + mutex — established the field but didn't wire resolution)