### PR TITLE
fix(filters): #535 eth_newFilter resolves blockHash + eth_subscribe rejects (geth parity)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -388,6 +388,48 @@ test("RPC Extended Methods", async (t) => {
     assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
   })
 
+  await t.test("#535: eth_newFilter resolves blockHash (snapshot semantics, geth parity)", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   eth_newFilter({"blockHash":"0xdeadbeef..."})  // valid shape, doesn't exist
+    //   → {"result":"0x99456e8befc455cf79f9dc16b1d1b5c5"}    // SUCCESSFUL FILTER ID
+    //   eth_getFilterLogs("0x99456e8b...")
+    //   → {"result":[]}    // SILENT EMPTY — caller never learns the hash didn't exist
+    //
+    // Same anti-pattern as #533 (eth_getLogs blockHash silently ignored).
+    // eth_newFilter shared the bug — `parseBlockTag(undefined, height)
+    // = latest` so a blockHash filter silently became a "latest block"
+    // filter. The blockHash field was completely dropped before the
+    // filter was stored.
+    //
+    // Fix: eth_newFilter resolves blockHash → fromBlock=toBlock=
+    // block.number (snapshot semantics matching geth's behavior).
+    // Throws -32000 "unknown block" if the hash doesn't resolve.
+    const probe = async (filter: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_newFilter", params: [filter] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: string }
+    }
+    const nonexistent = await probe({ blockHash: "0xdeadbeef000000000000000000000000000000000000000000000000deadbeef" })
+    assert.ok(nonexistent.error,
+      `non-existent blockHash must error (not silent filter ID), got result=${JSON.stringify(nonexistent.result)}`)
+    assert.equal(nonexistent.error!.code, -32000)
+    assert.match(nonexistent.error!.message, /unknown block/i)
+
+    if (typeof chain.proposeNextBlock === "function") {
+      await chain.proposeNextBlock()
+    }
+    const blockByNum = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash: string } | null
+    if (blockByNum) {
+      const existing = await probe({ blockHash: blockByNum.hash })
+      assert.equal(existing.error, undefined,
+        `existing blockHash must succeed, got: ${JSON.stringify(existing.error)}`)
+      assert.match(existing.result!, /^0x[0-9a-fA-F]{32}$/, "must return a 16-byte hex filter id")
+    }
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1169,8 +1169,27 @@ async function handleRpc(
       const query = requireFilterObject((payload.params ?? [])[0])
       const id = `0x${randomBytes(16).toString("hex")}`
       const newFilterHeight = await Promise.resolve(chain.getHeight())
-      const fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
-      const toBlock = query.toBlock !== undefined ? parseBlockTag(query.toBlock, newFilterHeight) : undefined
+      // #535: pre-fix eth_newFilter accepted `{blockHash: "..."}` and
+      // silently created a filter at fromBlock=toBlock=latest (because
+      // parseBlockTag(undefined, height) returns height and the
+      // blockHash field was never read). The companion #533 fix landed
+      // for eth_getLogs but this method shared the same gap. Resolve
+      // blockHash → block.number first; reject hashes that don't
+      // resolve with -32000 "unknown block" (geth parity).
+      let fromBlock: bigint
+      let toBlock: bigint | undefined
+      if (query.blockHash !== undefined && query.blockHash !== null) {
+        const hash = (query.blockHash as string).toLowerCase() as Hex
+        const block = await Promise.resolve(chain.getBlockByHash(hash))
+        if (!block) {
+          throw { code: -32000, message: "unknown block" }
+        }
+        fromBlock = block.number
+        toBlock = block.number
+      } else {
+        fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
+        toBlock = query.toBlock !== undefined ? parseBlockTag(query.toBlock, newFilterHeight) : undefined
+      }
       // #142 / #162: validate address + topic shape so malformed inputs
       // reject at the boundary. Shared with eth_getLogs (#162) — both
       // consume the same filter shape, both should reject the same way.

--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -404,13 +404,32 @@ describe("WebSocket RPC", () => {
         ["logs", { topics: [inner33] }])
       assert.equal(innerCapErr.code, -32602,
         `inner OR-array of 33 must be -32602, got ${innerCapErr.code} (${innerCapErr.message})`)
-      // Sanity: well-shaped filters still create subscriptions
-      const okHash = `0x${"ab".repeat(32)}`
+      // Sanity: well-shaped filters still create subscriptions.
+      // #535: blockHash removed from this happy-path filter — it's now
+      // rejected for subscriptions (geth parity, see test below). Other
+      // shape validations (address, topics, fromBlock/toBlock) unchanged.
       const okAddr = `0x${"cd".repeat(20)}`
       const okTopic = `0x${"ef".repeat(32)}`
       const sub1 = await sendRpc(ws, "eth_subscribe",
-        ["logs", { fromBlock: "0x1", toBlock: "0x100", blockHash: okHash, address: okAddr, topics: [okTopic] }])
+        ["logs", { fromBlock: "0x1", toBlock: "0x100", address: okAddr, topics: [okTopic] }])
       assert.match(sub1, /^0x[0-9a-f]+$/, `well-shaped filter must create subscription, got ${sub1}`)
+
+      // #535: blockHash is incompatible with streaming subscriptions.
+      // Pre-fix, `eth_subscribe("logs", {blockHash: <hash>})` silently
+      // created a subscription that could never match any event (the
+      // requested block is in the past; subscriptions only fire on
+      // future events). Geth's `eth/filters/api.go` rejects this with
+      // "invalid filter: blockHash is not supported for subscription".
+      // Match that contract so callers learn immediately rather than
+      // waiting forever for events that never come. Companion to
+      // eth_newFilter (rpc.ts) which DOES support blockHash via
+      // snapshot semantics — different surface, different policy.
+      const blockHashErr = await sendRpcExpectError(ws, "eth_subscribe",
+        ["logs", { blockHash: `0x${"ab".repeat(32)}` }])
+      assert.equal(blockHashErr.code, -32602,
+        `blockHash subscription must be -32602, got ${blockHashErr.code} (${blockHashErr.message})`)
+      assert.match(blockHashErr.message, /blockHash.*not supported/i,
+        `error must explain incompatibility, got: ${blockHashErr.message}`)
     } finally {
       ws.close()
     }

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -586,6 +586,23 @@ export class WsRpcServer {
           }
           filterParam = rawFilter as Record<string, unknown>
         }
+        // #535: blockHash is incompatible with streaming subscriptions
+        // — a subscription only matches FUTURE events but a blockHash
+        // refers to a SPECIFIC past block. Pre-fix the WS handler
+        // silently accepted `{blockHash: "..."}` filters, created a
+        // subscription, and that subscription could never match any
+        // event (the requested block is already in the past). Geth's
+        // `eth/filters/api.go` rejects this case explicitly
+        // ("invalid filter: blockHash is not supported for
+        // subscription"). Match that contract so callers learn
+        // immediately rather than waiting forever for events that
+        // never come. Companion fix: eth_newFilter (rpc.ts) DOES
+        // support blockHash by resolving to fromBlock=toBlock=
+        // block.number (one-shot snapshot semantics) — different
+        // surface, different policy.
+        if (filterParam.blockHash !== undefined && filterParam.blockHash !== null) {
+          invalidParams("invalid filter: blockHash is not supported for subscription (use eth_getLogs instead)")
+        }
         const filter = validateLogFilter(filterParam)
 
         const handler = (event: LogEvent) => {


### PR DESCRIPTION
Closes #535. Companion to #534 (eth_getLogs blockHash fix).

## Summary

- \`eth_newFilter\` silently ignored \`blockHash\` (stored as \`fromBlock=toBlock=latest\`). Fix: resolve to \`block.number\`, throw -32000 on miss. Geth snapshot semantics.
- \`eth_subscribe("logs", {blockHash})\` silently created a subscription that could never fire. Fix: reject -32602 upfront. Geth: "blockHash is not supported for subscription".

## Test plan

- [x] \`rpc-extended.test.ts #535\`: non-existent blockHash → -32000 "unknown block"; existing blockHash → valid filter ID. Confirmed: \`ok 23\`.
- [x] \`websocket-rpc.test.ts #274 extension\`: blockHash on eth_subscribe("logs") → -32602 + "not supported"; existing happy-path test's bogus blockHash field removed (was silently ignored pre-fix). Confirmed: 14/14 ws tests pass.

## Live testnet 88780 reproduction (pre-fix)

```bash
# eth_newFilter with non-existent hash succeeds (wrong!)
curl -s http://159.198.44.136:28780 -d '{"jsonrpc":"2.0","id":1,"method":"eth_newFilter","params":[{"blockHash":"0xdead...beef"}]}'
→ {"result":"0x99456e8b..."}

# WS subscribe with blockHash succeeds (wrong!) — subscription never fires
ws://...:28790 — eth_subscribe("logs", {blockHash: "0x..."})
→ {"result":"0xf533ffa1..."}
```

## Surface policy table

| Surface | Geth | COC pre-fix | COC post-fix |
|---|---|---|---|
| eth_getLogs(blockHash) | works | silent ignore | works (#534) |
| eth_newFilter(blockHash) | works (snapshot) | silent ignore | works |
| eth_subscribe("logs", blockHash) | reject | silent accept | reject |

Different surface, different policy, both mirroring geth.

## Related

- #534 (eth_getLogs blockHash — same family, different surface)
- #511 (silent empty result mimicking no-data — broader family)