### PR TITLE
fix(rpc): #537 coc_submitProposal validates stakeAmount before module check

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -388,6 +388,49 @@ test("RPC Extended Methods", async (t) => {
     assert.deepEqual(byMixedHash, byLowerHash, "mixed-case hash must yield the same receipts as lowercase")
   })
 
+  await t.test("#537: coc_submitProposal validates stakeAmount BEFORE governance-enabled check", async () => {
+    // Live testnet 88780 reproduction (pre-fix):
+    //   coc_submitProposal({stakeAmount:"123abc"})  // malformed stakeAmount
+    //   → {"error":{"code":-32601,"message":"governance not enabled"}}
+    //
+    // On governance-disabled nodes, the caller learned only that the
+    // module was disabled — they couldn't tell that their `stakeAmount`
+    // field was structurally invalid until trying on a governance-enabled
+    // node. Same anti-pattern as #521 (eth_signTypedData_v4 keystore-
+    // before-structure). #432 already lifted TOP-LEVEL object validation
+    // before the governance check but missed inner-field validation.
+    //
+    // Fix: move stakeAmount shape validation upfront. Response shape is
+    // now consistent regardless of governance-module availability.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_submitProposal", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) Malformed stakeAmount must surface as -32602 (structural shape)
+    // even on governance-disabled nodes, NOT -32601 (module not available).
+    for (const bad of ["123abc", {}, [], -1, "0xZZ"]) {
+      const r = await probe([{ description: "test", stakeAmount: bad }])
+      assert.ok(r.error, `stakeAmount=${JSON.stringify(bad)} must error`)
+      assert.equal(r.error!.code, -32602,
+        `stakeAmount=${JSON.stringify(bad)} must be -32602 (shape first), got ${r.error!.code} (${r.error!.message})`)
+      assert.match(r.error!.message, /stakeAmount/i,
+        `error must mention stakeAmount, got: ${r.error!.message}`)
+    }
+    // (b) Shape-valid stakeAmount on a governance-disabled node still
+    // gets -32601 (module not available). Defends against over-rotation
+    // that would skip the module-availability check.
+    const ok = await probe([{ description: "test", stakeAmount: "0x100" }])
+    assert.ok(ok.error)
+    assert.equal(ok.error!.code, -32601,
+      `shape-valid params on disabled-governance node must be -32601 (module check), got ${ok.error!.code}`)
+    assert.match(ok.error!.message, /governance/i,
+      `error must mention governance module, got: ${ok.error!.message}`)
+  })
+
   await t.test("#122: eth_getBalance / eth_getTransactionCount / coc_getContractInfo reject malformed addresses with -32602", async () => {
     // Pre-fix bugs:
     //   - eth_getBalance returned -32603 with the raw input echoed back

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2183,21 +2183,19 @@ async function handleRpc(
       if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
         invalidParams("invalid params: expected non-null object as first param")
       }
-      if (!hasGovernance(chain)) {
-        methodNotFound("coc_submitProposal: governance module not enabled on this node")
-      }
       const proposalParams = rawParams as Record<string, string>
-      // Only the local node can submit proposals via RPC
-      const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
-      if (localNodeId && proposalParams.proposer !== localNodeId) {
-        throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
-      }
-      // #218: validate stakeAmount shape before `BigInt(...)`. Pre-fix
-      // an object/array/non-digit-string flowed straight into BigInt
-      // and threw a V8 SyntaxError ("Cannot convert [object Object] to
-      // a BigInt"). Same leak class as #212 (pose-http) — currently
-      // dead path because governance is disabled on prod, but fixing
-      // now avoids the leak surfacing once R3.2 (88780) enables it.
+      // #537: validate ALL structural fields BEFORE the governance-enabled
+      // check — top-level object validation was already lifted upstream by
+      // #432, but `stakeAmount` field validation lived AFTER the check.
+      // Same anti-pattern as #521 (eth_signTypedData_v4 keystore vs
+      // structure). On governance-disabled nodes, a caller passing a
+      // malformed `stakeAmount` got `-32601 governance not enabled` and
+      // could never learn their field was structurally invalid. Lift the
+      // shape gate upfront so the response shape is consistent regardless
+      // of whether the module is enabled.
+      //
+      // #218: original lift was for the BigInt() V8 SyntaxError leak —
+      // that fix still applies. This just moves the check earlier.
       const stakeRaw = proposalParams.stakeAmount as unknown
       let stakeAmount: bigint | undefined
       if (stakeRaw !== undefined && stakeRaw !== null && stakeRaw !== "") {
@@ -2208,6 +2206,14 @@ async function handleRpc(
           invalidParams("invalid stakeAmount: must be a non-negative integer or 0x-hex")
         }
         stakeAmount = BigInt(stakeRaw as string | number)
+      }
+      if (!hasGovernance(chain)) {
+        methodNotFound("coc_submitProposal: governance module not enabled on this node")
+      }
+      // Only the local node can submit proposals via RPC
+      const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
+      if (localNodeId && proposalParams.proposer !== localNodeId) {
+        throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
       }
       const proposal = chain.governance.submitProposal(
         proposalParams.type,


### PR DESCRIPTION
Closes #537.

## Summary

- \`coc_submitProposal\` validated top-level object shape BEFORE governance-enabled check (#432 fix), but inner-field validation (\`stakeAmount\`) ran AFTER. On governance-disabled nodes, malformed stakeAmount got -32601 "governance not enabled" instead of -32602 "invalid stakeAmount".
- Fix: lift the existing stakeAmount shape validation above the \`hasGovernance(chain)\` check. The validation logic itself is unchanged.

## Test plan

- [x] \`#537\` regression:
  - 5 malformed stakeAmount shapes ("123abc", {}, [], -1, "0xZZ") on disabled-governance fixture → -32602 + "stakeAmount" message
  - Shape-valid \`{stakeAmount:"0x100"}\` on disabled-governance fixture → still -32601 "governance" (sentinel)
- Confirmed: \`ok 23\`.

## Live testnet 88780 reproduction (pre-fix)

```bash
curl -s http://159.198.44.136:28780 -d '{"jsonrpc":"2.0","id":1,"method":"coc_submitProposal","params":[{"stakeAmount":"123abc"}]}'
→ {"error":{"code":-32601,"message":"coc_submitProposal: governance module not enabled on this node"}}
```

Same shape on a governance-enabled node would correctly return -32602 stakeAmount-shape error. Inconsistent wire contract across deployments.

## Related

- #521 (eth_signTypedData_v4 keystore-before-structure — same anti-pattern)
- #432 ("validate input BEFORE governance-module check" — established the pattern but only partially applied)