### PR TITLE
fix(ipfs-mfs): #539 cp/mv reject existing destination (data-loss prevention, kubo parity)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1485,7 +1485,11 @@ export class IpfsHttpServer {
           // the 400 that path-too-long / null-byte / max-depth siblings
           // already emit. Treat as client-input error.
           /^path traversal/i.test(msg) ||
-          /^invalid /i.test(msg)
+          /^invalid /i.test(msg) ||
+          // #539: `mv` / `cp` reject existing destination (data-loss
+          // prevention, kubo parity). Map to 400 same as the other
+          // client-input-error siblings.
+          /^destination already exists/i.test(msg)
         ) {
           httpErr = new HttpError(400, "bad request", msg)
         }

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -177,6 +177,63 @@ test("#477: cp/mv same source-and-dest must reject when source is missing", asyn
   }
 })
 
+test("#539: cp / mv reject when destination already exists (kubo parity, data-loss prevention)", async () => {
+  // Live testnet 88780 reproduction (pre-fix):
+  //   echo "AAA" > /src.txt; echo "BBB" > /dst.txt; mv /src.txt /dst.txt
+  //   curl /files/read?arg=/dst.txt → "AAA"   // BBB silently lost
+  //
+  // Pre-fix `mfs.mv` and `mfs.cp` did `destParent.entries.set(destBase, ...)`
+  // without checking whether the destination already existed. Any pre-
+  // existing file at that path was silently clobbered. This is a
+  // data-loss bug — a user moving a file to what they think is a new
+  // location can accidentally overwrite something at that path with no
+  // warning.
+  //
+  // Kubo: `files cp` and `files mv` both error when destination exists.
+  // Per kubo docs: "If the destination already exists, then the command
+  // fails." Match that contract so existing-destination clobbering is
+  // surfaced as an actionable error instead of silent data loss.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/src.txt", new TextEncoder().encode("AAA"), { create: true })
+    await mfs.write("/dst.txt", new TextEncoder().encode("BBB"), { create: true })
+
+    // (a) cp into existing dest must reject; dest content preserved.
+    await assert.rejects(
+      () => mfs.cp("/src.txt", "/dst.txt"),
+      /destination already exists/i,
+      "cp must reject existing destination (data-loss prevention)",
+    )
+    const afterCp = await mfs.read("/dst.txt")
+    assert.strictEqual(new TextDecoder().decode(afterCp), "BBB",
+      "dst.txt content preserved after rejected cp")
+
+    // (b) mv into existing dest must reject; both src and dest preserved.
+    await assert.rejects(
+      () => mfs.mv("/src.txt", "/dst.txt"),
+      /destination already exists/i,
+      "mv must reject existing destination",
+    )
+    const srcAfter = await mfs.read("/src.txt")
+    const dstAfter = await mfs.read("/dst.txt")
+    assert.strictEqual(new TextDecoder().decode(srcAfter), "AAA",
+      "src.txt preserved after rejected mv (NOT atomically removed despite the failed move)")
+    assert.strictEqual(new TextDecoder().decode(dstAfter), "BBB",
+      "dst.txt content preserved after rejected mv")
+
+    // (c) Sanity: cp / mv to a fresh path still work.
+    await mfs.cp("/src.txt", "/copy.txt")    // works
+    const copy = await mfs.read("/copy.txt")
+    assert.strictEqual(new TextDecoder().decode(copy), "AAA", "fresh-dest cp still works")
+    await mfs.mv("/copy.txt", "/moved.txt")   // works
+    const moved = await mfs.read("/moved.txt")
+    assert.strictEqual(new TextDecoder().decode(moved), "AAA", "fresh-dest mv still works")
+    await assert.rejects(() => mfs.read("/copy.txt"), /not found/i, "moved-from path is gone")
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: stat returns file info", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -272,6 +272,18 @@ export class IpfsMfs {
     const destParent = this.dirs.get(destDir)
     if (!destParent) throw new Error(`destination directory not found: ${destDir}`)
 
+    // #539: kubo's `files/mv` MUST error if destination already exists —
+    // pre-fix the `destParent.entries.set(destBase, ...)` call silently
+    // overwrote any existing entry at the destination path, clobbering the
+    // file the caller didn't intend to replace. Live testnet 88780 repro
+    // (pre-fix): mv /src.txt(AAA) → /dst.txt(BBB) succeeded with no
+    // warning, then dst.txt's content was AAA — BBB lost. This is a
+    // data-loss bug for any client that uses MFS as a versioned filesystem
+    // (web3.storage clones, distributed wikis, archive systems).
+    if (destParent.entries.has(destBase)) {
+      throw new Error(`destination already exists: ${destNorm}`)
+    }
+
     // Move entry
     destParent.entries.set(destBase, { ...entry, name: destBase, modifiedMs: Date.now() })
     srcParent.entries.delete(srcBase)
@@ -325,6 +337,17 @@ export class IpfsMfs {
 
     const destParent = this.dirs.get(destDir)
     if (!destParent) throw new Error(`destination directory not found: ${destDir}`)
+
+    // #539: kubo's `files/cp` MUST error if destination already exists —
+    // same fix as `mv` above. Pre-fix the `destParent.entries.set` call
+    // silently overwrote any existing entry, losing the original file
+    // content. Even though IPFS data is content-addressed (the original
+    // CID is still recoverable in theory), the MFS namespace mapping is
+    // lost, breaking any tooling that uses MFS paths as a stable
+    // reference.
+    if (destParent.entries.has(destBase)) {
+      throw new Error(`destination already exists: ${destNorm}`)
+    }
 
     // Copy entry (content-addressed, so CID reuse is safe)
     const now = Date.now()


### PR DESCRIPTION
Closes #539.

## Summary

- \`mfs.cp\` and \`mfs.mv\` silently overwrote pre-existing destinations. Data-loss bug.
- Per kubo: "If the destination already exists, then the command fails."
- Fix: add \`destParent.entries.has(destBase)\` check before set; throw \`destination already exists\`. Add ipfs-http.ts regex to map error → 400.

## Test plan

- [x] \`#539\` regression: cp/mv into existing dest reject; src AND dst preserved. Fresh-dest cp/mv still works. Confirmed: 19/19 MFS tests pass (\`ok 11\`).

## Live testnet 88780 reproduction (pre-fix)

```bash
echo "AAA" | curl -X POST -F "data=@-" "http://159.198.44.136:28800/api/v0/files/write?arg=/src.txt&create=true"
echo "BBB" | curl -X POST -F "data=@-" "http://159.198.44.136:28800/api/v0/files/write?arg=/dst.txt&create=true"
curl -X POST "http://159.198.44.136:28800/api/v0/files/mv?arg=/src.txt&arg=/dst.txt"
→ {"ok":true}
curl -X POST "http://159.198.44.136:28800/api/v0/files/read?arg=/dst.txt"
→ AAA   # BBB silently lost!
```

## Related

- #477 (cp/mv same-path no-op fix — established the pre-existing-entry check pattern, but only for source-vs-dest equality, not dest-existence)