### PR TITLE
fix(ipfs-mfs): #541 write without truncate preserves trailing bytes (kubo parity)

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -177,6 +177,68 @@ test("#477: cp/mv same source-and-dest must reject when source is missing", asyn
   }
 })
 
+test("#541: write without truncate preserves trailing bytes (kubo parity)", async () => {
+  // Live testnet 88780 reproduction (pre-fix):
+  //   write /f "BIGGER_OVERWRITE\n"  // 17 bytes written
+  //   write /f "ZZ\n"                 // 3 bytes, no truncate flag
+  //   read /f                         // → "ZZ\n" (3 bytes)
+  //
+  // Kubo's behavior with truncate=false (the default):
+  //   read /f → "ZZ\nGER_OVERWRITE\n"  // bytes 0..2 overwritten,
+  //                                     // bytes 3..16 preserved
+  //
+  // Pre-fix the merge logic at ipfs-mfs.ts:135 had
+  // `opts?.offset !== undefined` in its condition, so partial-overwrite
+  // semantics ONLY fired when offset was explicitly passed. The default
+  // offset=0 case fell through and the file was completely replaced.
+  // This is a data-loss bug — clients porting from kubo expect partial-
+  // overwrite semantics, COC silently dropped the trailing content.
+  // Same family as #539 (cp/mv silent overwrite).
+  //
+  // Fix: treat omitted `offset` as 0, apply merge logic in both
+  // implicit and explicit offset cases. `truncate=true` still bypasses
+  // the merge and replaces the whole file.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    // (a) Default (no truncate): partial overwrite preserves trailing bytes
+    await mfs.write("/f", new TextEncoder().encode("BIGGER_OVERWRITE\n"), { create: true })
+    const before = await mfs.read("/f")
+    assert.strictEqual(new TextDecoder().decode(before), "BIGGER_OVERWRITE\n")
+
+    await mfs.write("/f", new TextEncoder().encode("ZZ\n"))  // 3 bytes, no opts
+    const after = await mfs.read("/f")
+    assert.strictEqual(new TextDecoder().decode(after), "ZZ\nGER_OVERWRITE\n",
+      `default write must preserve trailing bytes (kubo non-truncate semantics), got ${JSON.stringify(new TextDecoder().decode(after))}`)
+    assert.strictEqual(after.length, 17,
+      "merged file size must equal max(existing.length, offset+data.length)")
+
+    // (b) truncate=true: whole file replaced
+    await mfs.write("/f", new TextEncoder().encode("TINY\n"), { truncate: true })
+    const truncated = await mfs.read("/f")
+    assert.strictEqual(new TextDecoder().decode(truncated), "TINY\n",
+      "truncate=true must replace whole file")
+    assert.strictEqual(truncated.length, 5, "truncated file size matches new data length only")
+
+    // (c) Explicit offset (existing #477-era behavior, still works)
+    await mfs.write("/f2", new TextEncoder().encode("0123456789"), { create: true })
+    await mfs.write("/f2", new TextEncoder().encode("AB"), { offset: 4 })
+    const offsetResult = await mfs.read("/f2")
+    assert.strictEqual(new TextDecoder().decode(offsetResult), "0123AB6789",
+      "explicit offset still partial-overwrites correctly")
+
+    // (d) Default-offset write that EXTENDS the file (new data longer
+    // than existing): final size = max(existing, data) — same as kubo.
+    await mfs.write("/f3", new TextEncoder().encode("short"), { create: true })   // 5 bytes
+    await mfs.write("/f3", new TextEncoder().encode("longer_text"))                 // 11 bytes
+    const extended = await mfs.read("/f3")
+    assert.strictEqual(new TextDecoder().decode(extended), "longer_text",
+      "writing longer data extends the file (no trailing preservation needed)")
+    assert.strictEqual(extended.length, 11)
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: stat returns file info", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -132,17 +132,36 @@ export class IpfsMfs {
     }
 
     let finalData = data
-    if (existing && !opts?.truncate && opts?.offset !== undefined) {
-      if (opts.offset < 0) throw new Error("offset must be non-negative")
+    // #541: kubo's `files write` preserves trailing bytes unless
+    // `truncate=true` is explicitly passed. Pre-fix the merge logic
+    // ONLY fired when `offset` was explicitly defined — when offset
+    // was omitted (the default behavior, equivalent to offset=0), the
+    // file was completely replaced regardless of truncate. So writing
+    // 2 bytes "ZZ" over an existing 17-byte file silently truncated
+    // the file to 2 bytes instead of producing "ZZ" + 15 bytes of
+    // preserved trailing content. Same data-loss family as #539.
+    //
+    // Live testnet 88780 repro (pre-fix):
+    //   write /f "BIGGER_OVERWRITE\n"  → 17 bytes
+    //   write /f "ZZ\n"                 → file becomes 3 bytes (wrong)
+    //   kubo: file becomes "ZZ\nGER_OVERWRITE\n" (17 bytes, partial overwrite)
+    //
+    // Fix: treat omitted `offset` as 0 and apply the same merge logic
+    // for the implicit-offset case. `truncate=true` still bypasses
+    // the merge and replaces the whole file.
+    if (existing && !opts?.truncate) {
+      const offset = opts?.offset ?? 0
+      if (offset < 0) throw new Error("offset must be non-negative")
       // Guard against memory exhaustion from large offset + data.length
       const MAX_WRITE_SIZE = 64 * 1024 * 1024 // 64 MiB
-      const mergedSize = opts.offset + data.length
+      const mergedSize = offset + data.length
       if (mergedSize > MAX_WRITE_SIZE) throw new Error(`write would exceed max size (${MAX_WRITE_SIZE} bytes)`)
-      // Append/overwrite at offset
+      // Append/overwrite at offset; preserve trailing bytes beyond
+      // offset+data.length (kubo non-truncate semantics).
       const existingData = await this.unixfs.readFile(existing.cid)
       const merged = new Uint8Array(Math.max(existingData.length, mergedSize))
       merged.set(existingData)
-      merged.set(data, opts.offset)
+      merged.set(data, offset)
       finalData = merged
     }
 


### PR DESCRIPTION
Closes #541. Companion to #540 (cp/mv overwrite — same data-loss family).

## Summary

- \`mfs.write\` always replaced the entire file regardless of \`truncate\` flag. Kubo's \`files write\` with \`truncate=false\` (default) preserves trailing bytes — only \`[offset, offset+data.length)\` should be overwritten.
- Pre-fix the merge logic was gated on \`opts?.offset !== undefined\`, so it only fired for explicit-offset writes. Default-offset (kubo's normal case) silently truncated.
- Fix: drop the \`opts?.offset !== undefined\` clause; treat omitted offset as 0; unified merge logic for both cases. \`truncate=true\` still bypasses.

## Test plan

- [x] \`#541\` regression: 4 cases (default preserves trailing, truncate=true replaces, explicit offset preserves, default-offset extending). Confirmed: 19/19 MFS tests pass (\`ok 11\`).

## Live testnet 88780 reproduction (pre-fix)

```bash
echo "BIGGER_OVERWRITE" | curl -X POST -F "data=@-" ".../files/write?arg=/f&create=true"
echo "ZZ" | curl -X POST -F "data=@-" ".../files/write?arg=/f"
curl -X POST ".../files/read?arg=/f"
→ "ZZ\n"   # 3 bytes — trailing 14 bytes silently lost
```

Kubo: \`"ZZ\\nGER_OVERWRITE\\n"\` (17 bytes preserved).

## Related

- #540 (#539: cp/mv overwrite — same data-loss family)
- General: MFS write semantics must match kubo to support ipfs-http-client