### PR TITLE
fix(ipfs-gateway): #545 /ipfs/<cid>/<subpath> returns 404 (not misleading 400)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -871,6 +871,74 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#545: gateway /ipfs/<cid>/<subpath> returns 404 'no such file' (not misleading 400 'invalid CID')", async () => {
+    // Pre-fix `url.pathname.slice(6)` treated the ENTIRE tail (including
+    // subpaths) as the CID string. So `/ipfs/<valid-cid>/sub` had
+    // `isValidCid("<valid-cid>/sub")` reject it (slash invalid in
+    // base58/base32 alphabet) — and the wire said "invalid CID". But
+    // the CID itself was well-formed! Only the subpath traversal failed.
+    //
+    // Live testnet 88780 reproduction (pre-fix):
+    //   ipfs add "data"  # returns <cid>
+    //   curl /ipfs/<cid>/extra
+    //   → 400 {"error":"invalid CID"}    # misleading; CID is fine
+    //
+    // Kubo's gateway: returns 404 "no link named 'extra' under <cid>"
+    // for subpath misses. Same anti-pattern family as #543 (misleading
+    // error for a well-formed input).
+    //
+    // Fix: split path; treat first segment as CID. Subpath traversal
+    // within dag-pb dirs is out of scope (would need UnixFsBuilder
+    // walking integration); for now, surface a clean 404 with kubo-style
+    // "no link named ..." so callers don't blame their CID.
+    const addRes = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": "multipart/form-data; boundary=----X" },
+      body: [
+        "------X",
+        'Content-Disposition: form-data; name="file"; filename="test.txt"',
+        "Content-Type: text/plain",
+        "",
+        "subpath-test-data",
+        "------X--",
+        "",
+      ].join("\r\n"),
+    })
+    const addBody = await addRes.json() as { Hash?: string }
+    const cid = addBody.Hash!
+    assert.ok(cid, "add must return a CID")
+
+    // (a) Bare /ipfs/<cid> still works
+    const bare = await fetch(`/ipfs/${cid}`)
+    assert.equal(bare.status, 200, `bare /ipfs/<cid> must return 200, got ${bare.status}`)
+
+    // (b) /ipfs/<cid>/extra — pre-fix returned 400 "invalid CID"
+    const sub = await fetch(`/ipfs/${cid}/extra`)
+    assert.equal(sub.status, 404,
+      `/ipfs/<cid>/extra must return 404 'no such file', got ${sub.status} (the pre-fix bug was 400 'invalid CID')`)
+    const subBody = await sub.json() as { error?: string; message?: string }
+    assert.notEqual(subBody.error, "invalid CID",
+      `must NOT say 'invalid CID' (the pre-fix bug shape), got ${JSON.stringify(subBody)}`)
+    assert.match(`${subBody.error} ${subBody.message ?? ""}`, /no link|no such file/i,
+      `error must reference 'no link' or 'no such file', got ${JSON.stringify(subBody)}`)
+    assert.match(subBody.message ?? "", new RegExp(`'extra'.*${cid.slice(0, 20)}`),
+      `message must name both subpath and CID for clarity, got: ${subBody.message}`)
+
+    // (c) /ipfs/<cid>/a/b/c — multi-segment subpath
+    const deep = await fetch(`/ipfs/${cid}/a/b/c`)
+    assert.equal(deep.status, 404)
+    const deepBody = await deep.json() as { error?: string; message?: string }
+    assert.notEqual(deepBody.error, "invalid CID")
+    assert.match(deepBody.message ?? "", /'a'/, "message names the FIRST missing segment")
+
+    // (d) Truly invalid CID still returns 400 "invalid CID" (regression sentinel)
+    const invalid = await fetch("/ipfs/not-a-cid")
+    assert.equal(invalid.status, 400, "truly malformed CID still returns 400")
+    const invalidBody = await invalid.json() as { error?: string }
+    assert.equal(invalidBody.error, "invalid CID",
+      "malformed CID still surfaces as 'invalid CID' (no regression)")
+  })
+
   it("#236: /api/v0/files/cp + /files/mv read second ?arg= for destination (kubo compat)", async () => {
     // Pre-fix the handlers read `?dest=<path>` but kubo HTTP RPC sends
     // dest as a second `?arg=` value. Result: every kubo-CLI / ipfs-http-

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -328,10 +328,41 @@ export class IpfsHttpServer {
       //   #340 — MIME-type sniffing so browsers render content correctly
       const isGatewayMethod = req.method === "GET" || req.method === "HEAD"
       if (isGatewayMethod && url.pathname?.startsWith("/ipfs/")) {
-        const cid = url.pathname.slice(6) // strip "/ipfs/"
+        // #545: pre-fix `url.pathname.slice(6)` treated the ENTIRE tail
+        // (including subpaths like `/ipfs/<cid>/foo/bar`) as the CID
+        // string. `isValidCid("<cid>/foo/bar")` rejected the embedded
+        // slash and returned "invalid CID" — misleading because the CID
+        // itself is well-formed; only the subpath traversal couldn't be
+        // resolved. Kubo's gateway: returns 404 "no link named 'foo'
+        // under <CID>" (or similar) for subpath misses, NOT "invalid
+        // CID". Same anti-pattern family as #543 (regex-mismatch produces
+        // misleading error for a well-formed input).
+        //
+        // Fix: split the path; treat the first segment as the CID
+        // candidate. If a non-empty subpath follows AND we don't have a
+        // dag-pb subtree resolver wired up, surface 404 "no such file"
+        // explicitly so callers don't think their CID is malformed. This
+        // is a clean minimum — full subpath traversal within dag-pb dirs
+        // is out of scope for this PR (would need UnixFsBuilder dir-
+        // walking integration).
+        const tail = url.pathname.slice(6) // strip "/ipfs/"
+        const slashIdx = tail.indexOf("/")
+        const cid = slashIdx < 0 ? tail : tail.slice(0, slashIdx)
+        const subpath = slashIdx < 0 ? "" : tail.slice(slashIdx)
         if (!isValidCid(cid)) {
           res.writeHead(400, { "content-type": "application/json", "access-control-allow-origin": "*" })
           res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: "invalid CID" }))
+          return
+        }
+        if (subpath !== "" && subpath !== "/") {
+          // CID is valid; subpath traversal isn't supported on this
+          // gateway. Surface 404 with the kubo-style "no link named ..."
+          // message rather than a misleading 400 "invalid CID".
+          res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })
+          res.end(req.method === "HEAD" ? undefined : JSON.stringify({
+            error: "no such file",
+            message: `no link named '${subpath.replace(/^\//, "").split("/")[0]}' under ${cid}`,
+          }))
           return
         }
         // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated


### PR DESCRIPTION
Closes #545.

## Summary

- Gateway returned \`400 "invalid CID"\` for \`/ipfs/<valid-cid>/<subpath>\` — but the CID is fine, only the subpath traversal failed.
- Fix: split path at first slash; CID candidate is the first segment. Non-empty subpath → \`404 "no link named '<seg>' under <cid>"\` (kubo parity).
- Full subpath traversal within dag-pb dirs is out of scope (would need UnixFsBuilder integration); the clean 404 is the meaningful intermediate.

## Test plan

- [x] \`#545\` regression:
  - /ipfs/<cid>/extra → 404 with "no link" + names both subpath and CID
  - /ipfs/<cid>/a/b/c → 404 "no link named 'a'" (first segment)
  - /ipfs/not-a-cid → 400 "invalid CID" still works (sentinel)
  - Bare /ipfs/<cid> still returns 200
- Confirmed: 98/98 ipfs-http tests pass (\`ok 41\`).

## Live testnet 88780 reproduction (pre-fix)

```bash
echo "data" | curl -X POST -F "file=@-" ".../api/v0/add" → bafybei…
curl ".../ipfs/bafybei…/extra"
→ HTTP 400 {"error":"invalid CID"}    # misleading; CID is fine
```

## Related

- #543 (mkdir on file-collision returns 500 — same misleading-error family)
- #168 (gateway ENOENT → 404)