### PR TITLE
fix(ipfs-http): #547 register /api/v0/repo/stat (kubo canonical path)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -106,6 +106,21 @@ describe("IpfsHttpServer", () => {
     assert.ok("NumObjects" in body)
   })
 
+  it("#547: /api/v0/repo/stat and /api/v0/stats/repo expose repo stats (kubo canonical paths)", async () => {
+    // Pre-fix the handler was registered under /api/v0/stat only — a
+    // path kubo-rpc-client never calls. POST /api/v0/repo/stat (canonical)
+    // and POST /api/v0/stats/repo (alias) both 404'd, blocking every
+    // ipfs-http-client / web3.storage caller from polling repo size.
+    for (const path of ["/api/v0/repo/stat", "/api/v0/stats/repo"]) {
+      const res = await fetch(path)
+      assert.equal(res.status, 200, `${path} must 200 (kubo parity), got ${res.status}`)
+      const body = await res.json() as Record<string, unknown>
+      assert.equal(body.Version, "0.1.0-coc", `${path} body must contain Version`)
+      assert.ok("NumObjects" in body, `${path} body must include NumObjects`)
+      assert.ok("RepoSize" in body, `${path} body must include RepoSize`)
+    }
+  })
+
   it("POST /api/v0/add uploads a file and returns CID", async () => {
     const boundary = "----TestBoundary"
     const content = "hello ipfs"

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -472,7 +472,17 @@ export class IpfsHttpServer {
         await this.handleId(res)
         return
       }
-      if (url.pathname === "/api/v0/stat") {
+      // #547: kubo-rpc-client / ipfs-http-client / web3.storage call
+      // POST /api/v0/repo/stat (canonical) or POST /api/v0/stats/repo
+      // (alias). The handler was only registered under the non-standard
+      // /api/v0/stat path, so every canonical client got a 404 trying
+      // to poll repo size. Keep /api/v0/stat as an internal alias for
+      // backward compatibility with anything already calling it.
+      if (
+        url.pathname === "/api/v0/repo/stat" ||
+        url.pathname === "/api/v0/stats/repo" ||
+        url.pathname === "/api/v0/stat"
+      ) {
         await this.handleStat(res)
         return
       }


### PR DESCRIPTION
## Summary

- `POST /api/v0/repo/stat` is Kubo's canonical path for repository stats; `POST /api/v0/stats/repo` is its alias. Every kubo-rpc-client / ipfs-http-client / web3.storage caller polls one of these.
- This node only registered the handler under `POST /api/v0/stat` — a fabricated path no canonical client calls. Both Kubo paths returned 404.
- Fix wires the same handler to all three paths. `/api/v0/stat` stays as an internal alias to avoid breaking anything already using it.

## Anti-pattern

Wire-path drift — same family as #460 (`pin/rm` missing auth gate) and #543 (mkdir error not regex-mapped). The Kubo HTTP API spec is the contract; clients hardcode these paths in their SDKs.

## Test plan

- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 98 pass, 0 fail
- [x] New regression test `#547` exercises both `/api/v0/repo/stat` and `/api/v0/stats/repo`, asserting 200 + Version + NumObjects + RepoSize fields
- [x] Verified live testnet 88780 (159.198.44.136:28800) currently 404s both paths

Closes #547