### PR TITLE
fix(rpc): #549 uncle handlers validate inputs (no silent 0x0/null bypass)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -291,6 +291,37 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(count, "0x0")
   })
 
+  await t.test("#549: uncle handlers validate input shape (no silent 0x0/null for malformed args)", async () => {
+    // Pre-fix every uncle handler short-circuited the result without
+    // inspecting the input, so "0xbogus" / {} / bogus tag silently
+    // succeeded indistinguishable from the well-formed "zero uncles"
+    // case. Geth rejects each malformed shape with -32602.
+    const badHashCount = await rpcCallRaw(port, "eth_getUncleCountByBlockHash", ["0xbogus"])
+    assert.equal(badHashCount.error?.code, -32602, `bad hash for count must -32602, got ${JSON.stringify(badHashCount)}`)
+    assert.match(badHashCount.error?.message ?? "", /block hash/i)
+
+    const objHash = await rpcCallRaw(port, "eth_getUncleCountByBlockHash", [{}])
+    assert.equal(objHash.error?.code, -32602, `object hash for count must -32602, got ${JSON.stringify(objHash)}`)
+
+    const badTagCount = await rpcCallRaw(port, "eth_getUncleCountByBlockNumber", ["bogus"])
+    assert.equal(badTagCount.error?.code, -32602, `bad tag for count must -32602, got ${JSON.stringify(badTagCount)}`)
+
+    const badHashBy = await rpcCallRaw(port, "eth_getUncleByBlockHashAndIndex", ["0xbogus", "0x0"])
+    assert.equal(badHashBy.error?.code, -32602, `bad hash for by-hash-and-index must -32602, got ${JSON.stringify(badHashBy)}`)
+
+    const badIdx = await rpcCallRaw(port, "eth_getUncleByBlockNumberAndIndex", ["latest", "bogus"])
+    assert.equal(badIdx.error?.code, -32602, `bad index for by-number-and-index must -32602, got ${JSON.stringify(badIdx)}`)
+
+    // Well-formed inputs still return zero / null (no regression on the body)
+    const validHash = "0x" + "00".repeat(32)
+    const okCount = await rpcCall(port, "eth_getUncleCountByBlockHash", [validHash])
+    assert.equal(okCount, "0x0", "well-formed hash still returns 0x0")
+    const okBy = await rpcCall(port, "eth_getUncleByBlockHashAndIndex", [validHash, "0x0"])
+    assert.equal(okBy, null, "well-formed hash+index still returns null")
+    const okNumCount = await rpcCall(port, "eth_getUncleCountByBlockNumber", ["latest"])
+    assert.equal(okNumCount, "0x0", "well-formed tag still returns 0x0")
+  })
+
   await t.test("eth_protocolVersion returns version", async () => {
     const version = await rpcCall(port, "eth_protocolVersion")
     assert.ok(typeof version === "string")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1729,11 +1729,35 @@ async function handleRpc(
       })
     }
     case "eth_getUncleCountByBlockHash":
+    case "eth_getUncleByBlockHashAndIndex": {
+      // #549: pre-fix every uncle handler short-circuited to "0x0"/null
+      // without inspecting input shape, so "0xbogus" / {} / [] / numbers
+      // all silently succeeded — indistinguishable from "valid hash,
+      // zero uncles." Geth rejects malformed inputs with -32602
+      // regardless of whether the body would have been zero. Same
+      // empty-result-masking-bug family as #166/#188/#196/#242.
+      // COC uses PoSe consensus with no uncle blocks, so the body
+      // stays "0x0"/null for well-formed inputs.
+      requireBlockHashParam(payload.params ?? [], 0)
+      if (payload.method.endsWith("AndIndex")) {
+        requireIndexParam(payload.params ?? [], 1)
+        return null
+      }
+      return "0x0"
+    }
     case "eth_getUncleCountByBlockNumber":
-    case "eth_getUncleByBlockHashAndIndex":
-    case "eth_getUncleByBlockNumberAndIndex":
-      // COC uses PoSe consensus with no uncle blocks
-      return payload.method.includes("Count") ? "0x0" : null
+    case "eth_getUncleByBlockNumberAndIndex": {
+      // #549: same validation-bypass anti-pattern, block-tag variant.
+      // parseBlockTag rejects non-string/non-number shapes and bogus
+      // strings with -32602.
+      const uncleHeight = await Promise.resolve(chain.getHeight())
+      parseBlockTag((payload.params ?? [])[0], uncleHeight)
+      if (payload.method.endsWith("AndIndex")) {
+        requireIndexParam(payload.params ?? [], 1)
+        return null
+      }
+      return "0x0"
+    }
     case "eth_getWork":
       // PoW stub — COC uses PoSe consensus, no mining
       return ["0x" + "0".repeat(64), "0x" + "0".repeat(64), "0x" + "0".repeat(64)]


### PR DESCRIPTION
## Summary

- All four uncle handlers (`eth_getUncleCountByBlockHash`, `eth_getUncleCountByBlockNumber`, `eth_getUncleByBlockHashAndIndex`, `eth_getUncleByBlockNumberAndIndex`) returned `\"0x0\"`/`null` unconditionally, skipping the input-validation helpers used by every other block-tag/hash handler.
- A client passing `\"0xbogus\"` / `{}` / `[]` / a number got a success indistinguishable from \"valid hash, zero uncles\".
- Fix routes each method through `requireBlockHashParam` / `parseBlockTag` / `requireIndexParam` before short-circuiting. Body stays `\"0x0\"`/`null` for well-formed inputs (COC is post-PoW PoSe — uncles are always zero).

## Anti-pattern

Empty-result-masking bypass — same family as #166 (byHash hash validation), #188 (parseBlockTag shape), #196 (filter IDs), #242 (generic string-param validator). A unique body the caller can interpret as success silently masked malformed input across this whole method group.

## Test plan

- [x] New regression test `#549` in `node/src/rpc-extended.test.ts`: covers bogus hash, object hash, bogus tag, bogus index for all four methods; asserts -32602 with the right message; well-formed inputs still return `\"0x0\"`/`null`
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — verified `#549` subtest passes (ok 9), 113 surrounding subtests still pass through #466 (no regression observed before stop)
- [x] Verified live testnet 88780 (159.198.44.136:28780) reproduces the silent-success for `0xbogus`, `{}`, `bogus` tag

Closes #549