### PR TITLE
fix(rpc): #551 coc_voteProposal validates inner fields (no Boolean/String coercion)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2913,6 +2913,54 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#551: coc_voteProposal validates inner fields (no silent Boolean/String coercion)", async () => {
+    // Pre-fix the handler validated the outer-object shape but immediately
+    // ran every inner field through `String()`/`Boolean()` — a missing
+    // `approve` field silently coerced to `false` (a flipped NO vote),
+    // a numeric `proposalId` to "123" (coerced ID), a string "yes" to
+    // `true`. Same coercion-leak family as #260/#525, same validation-
+    // order rule as #432/#538.
+    const governanceStub551 = {
+      vote: () => {},
+      getProposal: () => ({ id: "p1", status: "pending", votes: new Map() }),
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub551
+    try {
+      const probe = async (params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_voteProposal", params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      // Missing approve — pre-fix silently coerced to false (flipped NO vote)
+      const noApprove = await probe([{ proposalId: "p1", voterId: "node-1" }])
+      assert.equal(noApprove.error?.code, -32602, `missing approve must be -32602, got ${JSON.stringify(noApprove)}`)
+      assert.match(noApprove.error!.message, /approve/i)
+      // String approve — pre-fix Boolean("yes") = true
+      const stringApprove = await probe([{ proposalId: "p1", voterId: "node-1", approve: "yes" }])
+      assert.equal(stringApprove.error?.code, -32602, `string approve must be -32602, got ${JSON.stringify(stringApprove)}`)
+      assert.match(stringApprove.error!.message, /approve/i)
+      // Numeric proposalId — pre-fix String(123) = "123"
+      const numId = await probe([{ proposalId: 123, voterId: "node-1", approve: true }])
+      assert.equal(numId.error?.code, -32602, `numeric proposalId must be -32602, got ${JSON.stringify(numId)}`)
+      assert.match(numId.error!.message, /proposalId/)
+      // Null proposalId — pre-fix String(null) = "null"
+      const nullId = await probe([{ proposalId: null, voterId: "node-1", approve: true }])
+      assert.equal(nullId.error?.code, -32602, `null proposalId must be -32602, got ${JSON.stringify(nullId)}`)
+      // Empty voterId
+      const emptyVoter = await probe([{ proposalId: "p1", voterId: "", approve: true }])
+      assert.equal(emptyVoter.error?.code, -32602, `empty voterId must be -32602, got ${JSON.stringify(emptyVoter)}`)
+      assert.match(emptyVoter.error!.message, /voterId/)
+      // Sanity: well-formed payload still reaches the stub
+      const ok = await probe([{ proposalId: "p1", voterId: "node-1", approve: true }])
+      assert.equal(ok.error, undefined, "well-formed vote must NOT error")
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
+    }
+  })
+
   await t.test("#226: coc_getProposals + coc_getDaoProposals + coc_getEquivocations reject malformed filter params", async () => {
     // Pre-fix:
     // - coc_getProposals(true) → `as string | undefined` runtime no-op → silent no-filter → return all

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2382,21 +2382,36 @@ async function handleRpc(
       if (!voteRaw || typeof voteRaw !== "object" || Array.isArray(voteRaw)) {
         invalidParams("invalid params: expected non-null object as first param")
       }
+      // #551: pre-fix inner fields were String()/Boolean()-coerced
+      // unconditionally — a missing `approve` silently became `false`
+      // (a flipped NO vote), a numeric `proposalId` became "123", a
+      // string `approve:"yes"` became `true`. Same coercion-leak family
+      // as #260/#525, same validation-order rule as #432/#538: every
+      // inner field has to clear its type before the governance dispatch.
+      const voteParams = voteRaw as Record<string, unknown>
+      if (typeof voteParams.proposalId !== "string" || !voteParams.proposalId) {
+        invalidParams("invalid proposalId: expected non-empty string")
+      }
+      if (typeof voteParams.voterId !== "string" || !voteParams.voterId) {
+        invalidParams("invalid voterId: expected non-empty string")
+      }
+      if (typeof voteParams.approve !== "boolean") {
+        invalidParams("invalid approve: expected boolean")
+      }
       if (!hasGovernance(chain)) {
         methodNotFound("coc_voteProposal: governance module not enabled on this node")
       }
-      const voteParams = voteRaw as Record<string, unknown>
       // Only the local node can vote via RPC
       const localVoterId = (opts as Record<string, unknown>)?.nodeId as string | undefined
-      if (localVoterId && String(voteParams.voterId) !== localVoterId) {
+      if (localVoterId && (voteParams.voterId as string) !== localVoterId) {
         throw { code: -32003, message: "unauthorized: can only vote as local node" }
       }
       chain.governance.vote(
-        String(voteParams.proposalId),
-        String(voteParams.voterId),
-        Boolean(voteParams.approve),
+        voteParams.proposalId as string,
+        voteParams.voterId as string,
+        voteParams.approve as boolean,
       )
-      const updated = chain.governance.getProposal(String(voteParams.proposalId))
+      const updated = chain.governance.getProposal(voteParams.proposalId as string)
       return {
         id: updated?.id,
         status: updated?.status,


### PR DESCRIPTION
## Summary

- `coc_voteProposal` validated the outer object shape but ran every inner field through `String()`/`Boolean()` unconditionally before passing them to `governance.vote()`.
- Missing `approve` silently coerced to `false` — **a flipped NO vote**. `\"yes\"` / `\"no\"` strings became `true`/`false`. Numeric or `null` IDs became literal `\"123\"`/`\"null\"`.
- Fix adds per-field type checks (`proposalId`/`voterId` non-empty string, `approve` strict boolean) and runs them **before** the `hasGovernance()` gate (same validation-order rule as #432/#538).

## Anti-pattern family

Same as already-fixed:
- **#260/#262/#500/#525** — `String()` coercion leak (block tag → wrong string)
- **#226** — runtime no-op `as` cast letting array/boolean filters slip through
- **#432/#538** — validate inputs BEFORE module/governance check
- **#538** — `coc_submitProposal.stakeAmount` field validation gap (same handler family)

## Test plan

- [x] New regression test `#551` covers: missing `approve` (silent NO vote), `\"yes\"` string approve, numeric proposalId, `null` proposalId, empty voterId; asserts -32602 each
- [x] Sanity: well-formed payload still reaches the governance stub
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — `#551` subtest passes (ok 95); no regression in surrounding subtests
- [x] Verified live testnet 88780 produces the silent-success path (every shape currently passes outer-object check and would silently coerce on a governance-enabled node)

Closes #551