### PR TITLE
fix(ipfs-http): #553 /api/v0/add validates pin param — reject pin=false / pin=garbage

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -482,6 +482,55 @@ describe("IpfsHttpServer", () => {
     assert.ok(okBody.Hash?.startsWith("bafy"), "should still return v1 bafy CID")
   })
 
+  it("#553: /api/v0/add validates pin param — rejects pin=false (silent drop) and pin=garbage", async () => {
+    // Pre-fix `pin` was listed as a benign passed-through param but
+    // handleAdd always pinned regardless of the query value. A client
+    // explicitly opting out with `pin=false` got 200 + a Hash that was
+    // silently pinned anyway, burning disk it asked us to skip.
+    // `pin=garbage` was also accepted, drifting from kubo's
+    // strconv.ParseBool reject. Same silent-param-drop family as
+    // #174/#353/#460/#513.
+    const boundary = "----T553"
+    const mkBody = () => [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="x.txt"',
+      "Content-Type: application/octet-stream",
+      "",
+      "x",
+      `--${boundary}--`,
+      "",
+    ].join("\r\n")
+    const post = async (qs: string) => fetch(`/api/v0/add?${qs}`, {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body: mkBody(),
+    })
+
+    // pin=false is the silent-drop case — server always pins, so this
+    // must reject (not silently treat as true).
+    for (const qs of ["pin=false", "pin=0", "pin=False", "pin=FALSE"]) {
+      const r = await post(qs)
+      assert.equal(r.status, 400, `${qs}: expected 400 (got ${r.status})`)
+      const body = await r.json() as { error: string; message?: string }
+      assert.equal(body.error, "unsupported_param", qs)
+      assert.match(body.message ?? "", /always pins/i, qs)
+    }
+
+    // pin=garbage is the kubo-parser-reject case.
+    for (const qs of ["pin=maybe", "pin=yes", "pin=2", "pin="]) {
+      const r = await post(qs)
+      assert.equal(r.status, 400, `${qs}: expected 400 (got ${r.status})`)
+      const body = await r.json() as { error: string; message?: string }
+      assert.equal(body.error, "unsupported_param", qs)
+    }
+
+    // pin=true / pin=1 / unset must still succeed (no behavior change).
+    for (const qs of ["pin=true", "pin=1", "pin=True", ""]) {
+      const r = await post(qs)
+      assert.equal(r.status, 200, `${qs}: well-formed pin must succeed, got ${r.status}`)
+    }
+  })
+
   it("#180: /api/v0/add?erasure=N+M rejects N or M above MAX_DATA/PARITY_SHARDS with 400 (not 500)", async () => {
     // Pre-fix parseErasureSpec only checked the lower bound (n>=1,
     // m>=1). Values above MAX_DATA_SHARDS / MAX_PARITY_SHARDS (24

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -87,7 +87,7 @@ function isNotFoundError(err: unknown): boolean {
  * a different shape so they can fall back / retry with the right
  * settings instead of pinning a CID that doesn't match their hash.
  *
- * Benign params (pin, progress, silent, quieter, quiet, fscache,
+ * Benign params (progress, silent, quieter, quiet, fscache,
  * stdin-name, only-hash, hash-fun-code) are passed through — they
  * either don't change the CID or the response shape we already
  * emit (single newline-terminated JSON object) is a strict subset
@@ -128,6 +128,27 @@ function validateAddParams(query: Record<string, string | string[] | undefined>)
     if (norm !== "false" && norm !== "0") {
       throw new HttpError(400, "unsupported_param",
         `${key}: expected boolean (true/false/0/1), got '${raw}'`)
+    }
+  }
+
+  // #553: pin was previously listed as a "benign passed-through" param
+  // — but `handleAdd` always pins regardless of the query value, so a
+  // client passing `pin=false` got a 200 indistinguishable from "pinned
+  // anyway" and burned disk it asked us to skip. `pin=garbage` was also
+  // silently accepted, drifting from kubo's strconv.ParseBool reject.
+  // This server always pins, so the policy is: accept true/1/unset,
+  // reject false/0 as "unsupported (this server always pins)", reject
+  // everything else as the same boolean-parse 400 kubo emits.
+  const pinRaw = firstQueryValue(query.pin)
+  if (pinRaw !== undefined) {
+    const norm = pinRaw.toLowerCase()
+    if (norm === "false" || norm === "0") {
+      throw new HttpError(400, "unsupported_param",
+        `pin: this server always pins uploaded blobs (only 'true' / unset)`)
+    }
+    if (norm !== "true" && norm !== "1") {
+      throw new HttpError(400, "unsupported_param",
+        `pin: expected boolean (true/false/0/1), got '${pinRaw}'`)
     }
   }
 }


### PR DESCRIPTION
## Summary

- `pin` was listed under \"benign passed-through params\" but `handleAdd` always pinned regardless of the query value. A client opting out with `pin=false` got 200 + a Hash silently pinned anyway.
- `pin=garbage` was also silently accepted (kubo's `strconv.ParseBool` rejects with 400).
- Fix validates `pin` in `validateAddParams`: accept `true`/`1`/unset, reject `false`/`0` as `unsupported_param`, reject everything else as the boolean-parse 400 kubo emits.

## Anti-pattern

Silent-param-drop — same family as #174 (cat offset/length silently ignored), #353 (cid-version=0 silently produced v1), #460 (pin/rm silently destructive), #513 (eth_call.stateOverride silent drop).

## Test plan

- [x] New regression test `#553` in `node/src/ipfs-http.test.ts` covers: `pin=false`/`pin=0`/`pin=FALSE` → 400 with `always pins` message; `pin=maybe`/`pin=yes`/`pin=2`/`pin=` → 400 unsupported_param; `pin=true`/`pin=1`/`pin=True`/unset → 200 (unchanged)
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 98 pass, 0 fail
- [x] Verified live testnet 88780 reproduces: `pin=false` returns 200 and the CID shows up under `pin/ls?arg=<cid>` with `Type: recursive`

Closes #553