### PR TITLE
fix(ipfs-mfs): #555 mkdir error names missing intermediate, not existing parent

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -43,6 +43,38 @@ test("MFS: mkdir with parents", async () => {
   }
 })
 
+test("#555: mkdir error names the missing intermediate, not the existing parent", async () => {
+  // Pre-fix the throw interpolated `parent` (the existing ancestor we
+  // just walked into) instead of `current` (the missing path the walker
+  // just discovered). `mkdir /no_such_parent_a/sub_b` reported "parent
+  // directory not found: /" — but / exists. Operators read that as "root
+  // is gone." Same wording-drift family as #543/#545.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    // Top-level missing parent — error must name /no_such_a, not /
+    await assert.rejects(
+      () => mfs.mkdir("/no_such_a/sub_b"),
+      /parent directory not found: \/no_such_a$/,
+      "missing top-level parent must be named, not /",
+    )
+    // Deep missing parent — must name /existing/no_such_b (the
+    // missing intermediate), not /existing.
+    await mfs.mkdir("/existing")
+    await assert.rejects(
+      () => mfs.mkdir("/existing/no_such_b/sub_c"),
+      /parent directory not found: \/existing\/no_such_b$/,
+      "deep missing parent must be named, not its existing ancestor",
+    )
+    // Sanity: mkdir --parents still works (no regression on the path
+    // that bypasses the throw).
+    await mfs.mkdir("/par_ok/sub", { parents: true })
+    const stat = await mfs.stat("/par_ok/sub")
+    assert.strictEqual(stat.type, "directory")
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: write and read file", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -79,7 +79,14 @@ export class IpfsMfs {
 
       if (!opts?.parents && i < parts.length - 1) {
         if (!parentDir?.entries.has(parts[i])) {
-          throw new Error(`parent directory not found: ${parent}`)
+          // #555: pre-fix the message interpolated `parent` (the dir we
+          // just successfully walked into) instead of `current` (the
+          // path we just found is missing). A user running
+          // `mkdir /no_such_a/sub_b` got "parent directory not found: /"
+          // and concluded the root was gone. Same wording-drift family
+          // as #543/#545 — error built from visited-so-far instead of
+          // failed-now state.
+          throw new Error(`parent directory not found: ${current}`)
         }
       }
 


### PR DESCRIPTION
## Summary

- `mkdir /no_such_a/sub_b` reported `parent directory not found: /` — but `/` exists. The missing path was `/no_such_a`.
- The throw interpolated `parent` (the existing dir just walked into) instead of `current` (the missing path just discovered).
- Operators reading the message concluded the root was gone.

## Anti-pattern

Wording-drift — same family as #543 (MFS mkdir on file-collision used the wrong wording) and #545 (gateway path-split misidentified which segment was missing). Error string assembled from *visited-so-far* state instead of *failed-now* state.

## Test plan

- [x] New regression test `#555` in `node/src/ipfs-mfs.test.ts` covers: top-level missing parent (must name `/no_such_a`, not `/`), deep missing parent (must name `/existing/no_such_b`, not `/existing`); sanity that `--parents` still works
- [x] `node --experimental-strip-types --test node/src/ipfs-mfs.test.ts` → 19 pass, 0 fail
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 97 pass, 0 fail (no cross-file regression)
- [x] Verified live testnet 88780 reproduces the misleading message for both top-level and deeper missing parents

Closes #555