### PR TITLE
fix(ipfs-http): #557 pubsub/peers drops non-standard `count` field (kubo wire shape)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -2106,4 +2106,36 @@ describe("#312 pubsub topic rejects control characters", () => {
       pubsub.stop()
     }
   })
+
+  it("#557: pubsub/peers wire shape matches kubo — Strings only, no non-standard `count` field", async () => {
+    // Pre-fix the body was `{Strings:[], count:N}` — `count` is not in
+    // kubo's spec and strict-fields deserializers (Rust serde
+    // deny_unknown_fields, Java FAIL_ON_UNKNOWN_PROPERTIES) threw on it.
+    // Same drift family as #547 (path drift).
+    const { IpfsPubsub: PubsubCtor } = await import("./ipfs-pubsub.ts")
+    const pubsub = new PubsubCtor({ nodeId: "peers-test" })
+    server.attachSubsystems({ pubsub })
+    try {
+      // No-arg form (server-wide peer list)
+      const r1 = await fetch("/api/v0/pubsub/peers", { method: "POST" })
+      assert.equal(r1.status, 200)
+      const b1 = await r1.json() as Record<string, unknown>
+      assert.deepStrictEqual(Object.keys(b1).sort(), ["Strings"],
+        `body keys must be exactly ["Strings"] (kubo parity), got ${JSON.stringify(b1)}`)
+      assert.ok(Array.isArray(b1.Strings), "Strings must be an array")
+      assert.equal((b1 as { count?: unknown }).count, undefined,
+        "non-standard `count` field must not be present")
+
+      // Topic-arg form
+      const r2 = await fetch("/api/v0/pubsub/peers?arg=topic1", { method: "POST" })
+      assert.equal(r2.status, 200)
+      const b2 = await r2.json() as Record<string, unknown>
+      assert.deepStrictEqual(Object.keys(b2).sort(), ["Strings"],
+        `topic-arg body keys must be exactly ["Strings"], got ${JSON.stringify(b2)}`)
+      assert.equal((b2 as { count?: unknown }).count, undefined,
+        "non-standard `count` field must not be present (topic-arg form)")
+    } finally {
+      pubsub.stop()
+    }
+  })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1667,9 +1667,15 @@ export class IpfsHttpServer {
           break
         }
         case "peers": {
-          const count = this.pubsub.getSubscribers(topic)
+          // #557: pre-fix the body was `{Strings:[], count}` — a non-
+          // standard `count` field kubo never emits, plus an empty
+          // `Strings` array. Clients deserializing into kubo's shape
+          // either silently ignored count or (with strict-fields
+          // deserializers) threw. Kubo emits exactly `{Strings:[peer…]}`.
+          // We don't track per-peer IDs yet so Strings is empty, but
+          // the wire shape now matches kubo. Same drift family as #547.
           res.writeHead(200, { "content-type": "application/json" })
-          res.end(JSON.stringify({ Strings: [], count }))
+          res.end(JSON.stringify({ Strings: [] }))
           break
         }
         default:


### PR DESCRIPTION
## Summary

- `POST /api/v0/pubsub/peers` returned `{Strings:[], count:N}` — `count` is not in kubo's spec and strict-fields deserializers (Rust `serde(deny_unknown_fields)`, Java `FAIL_ON_UNKNOWN_PROPERTIES`) threw on the unknown field.
- Loose clients silently ignored the extra field but also concluded zero subscribers because `Strings` was hardcoded empty even when `count > 0`.
- Fix returns exactly `{Strings: []}` (kubo's actual wire shape). Per-peer ID tracking still isn't implemented so the array stays empty, but canonical clients deserialize cleanly.

## Anti-pattern

Wire-format drift — same family as #547 (path drift `/api/v0/repo/stat` registered as `/api/v0/stat`), #312 (control-char topic drift), #308 (pin/ls filter shape drift). The Kubo HTTP API spec is the contract; drift breaks canonical clients.

## Test plan

- [x] New regression test `#557` in `node/src/ipfs-http.test.ts` asserts:
  - response body keys are exactly `[\"Strings\"]` (no `count`)
  - `Strings` is an array
  - both no-arg and `arg=topic` forms emit the same shape
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 98 pass, 0 fail
- [x] Verified live testnet 88780 currently emits `{\"Strings\":[],\"count\":0}` (the drift)

Closes #557