### PR TITLE
fix(ipfs-http): #559 files/write forwards offset to mfs (no silent data-loss merge bypass)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -881,6 +881,53 @@ describe("IpfsHttpServer", () => {
     assert.equal(huge2.status, 400, "MFS read count over MAX_SAFE_INTEGER must reject")
   })
 
+  it("#559: /api/v0/files/write?offset=N forwards offset to mfs (no silent data-loss merge bypass)", async () => {
+    // Pre-fix the HTTP write handler only forwarded create/truncate/parents
+    // and silently dropped offset. mfs.write's merge branch then never ran,
+    // so `write?offset=10` to a 5-byte file produced a 2-byte file with just
+    // the new bytes — the pre-offset content was permanently destroyed.
+    // Same silent-param-drop class as #174/#353/#460/#553 but data-destructive.
+    const { IpfsMfs: MfsCtor } = await import("./ipfs-mfs.ts")
+    const mfs = new MfsCtor(store, unixfs)
+    server.attachSubsystems({ mfs })
+
+    // Seed: AAAAA (5 bytes)
+    const seed = await fetch("/api/v0/files/write?arg=/iter27_merge&create=true&truncate=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("AAAAA"),
+    })
+    assert.equal(seed.status, 200, "seed write must succeed")
+
+    // Overlay: BB at offset=10. Expected (kubo merge): 5 A's + 5 zero bytes + 2 B's = 12 bytes total.
+    const overlay = await fetch("/api/v0/files/write?arg=/iter27_merge&offset=10", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("BB"),
+    })
+    assert.equal(overlay.status, 200, "offset write must succeed")
+
+    const read = await fetch("/api/v0/files/read?arg=/iter27_merge", { method: "POST" })
+    assert.equal(read.status, 200)
+    const data = await read.buffer()
+    assert.equal(data.length, 12, `merge result must be 12 bytes (AAAAA + 5*\\0 + BB), got ${data.length}: ${Array.from(data).map((b) => b.toString(16).padStart(2,"0")).join(",")}`)
+    assert.equal(data.slice(0, 5).toString(), "AAAAA", "first 5 bytes must still be AAAAA (no data loss)")
+    for (let i = 5; i < 10; i++) assert.equal(data[i], 0, `byte ${i} must be zero-padding`)
+    assert.equal(data.slice(10, 12).toString(), "BB", "last 2 bytes must be the new BB")
+
+    // Validation parity with read handler: negative / non-integer offset → 400 invalid offset
+    for (const qs of ["offset=-1", "offset=1.5", "offset=abc", "offset=999999999999999999999"]) {
+      const r = await fetch(`/api/v0/files/write?arg=/iter27_merge&${qs}`, {
+        method: "POST",
+        headers: { "content-type": "application/octet-stream" },
+        body: new Uint8Array(),
+      })
+      assert.equal(r.status, 400, `write ${qs} must reject with 400, got ${r.status}`)
+      const body = await r.json() as { error?: string }
+      assert.match(body.error ?? "", /invalid offset/i, qs)
+    }
+  })
+
   it("#232: /api/v0/files/* path traversal returns 400 (not 500 'internal error')", async () => {
     // Pre-fix normalizePath threw `Error("path traversal not allowed: ...")`
     // for any input with `..`. The route-level catch had regexes for

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1384,11 +1384,29 @@ export class IpfsHttpServer {
           // handles both: it extracts the file bytes from multipart, or returns
           // raw bytes when the request has no boundary in Content-Type.
           const { bytes: body } = await readMultipartFile(req)
-          await this.mfs.write(arg, body, {
+          // #559: pre-fix the HTTP handler forwarded only create/truncate/
+          // parents and silently dropped `offset`. The mfs-layer merge
+          // branch (`if (existing && !opts?.truncate && opts?.offset !== undefined)`)
+          // never ran, so `write?offset=10` to a 5-byte file produced a
+          // 2-byte file containing only the new bytes — the pre-offset
+          // content was permanently destroyed. Parse offset the same way
+          // the sibling `read` handler does (#200/#426): reject non-
+          // SafeInteger + negative with 400 invalid offset. Silent-param-
+          // drop family as #174/#353/#460/#553 but data-destructive.
+          const writeOpts: { create?: boolean; truncate?: boolean; parents?: boolean; offset?: number } = {
             create: url.query?.create === "true",
             truncate: url.query?.truncate === "true",
             parents: url.query?.parents === "true",
-          })
+          }
+          const writeOffsetRaw = firstQueryValue(url.query?.offset)
+          if (writeOffsetRaw !== undefined) {
+            const n = Number(writeOffsetRaw)
+            if (!Number.isSafeInteger(n) || n < 0) {
+              throw new HttpError(400, "invalid offset")
+            }
+            writeOpts.offset = n
+          }
+          await this.mfs.write(arg, body, writeOpts)
           res.writeHead(200, { "content-type": "application/json" })
           res.end(JSON.stringify({ ok: true }))
           break


### PR DESCRIPTION
## Summary

- HTTP `files/write` handler forwarded only `create`/`truncate`/`parents` and silently dropped `offset`.
- `mfs.write`'s merge branch (`if (existing && !opts?.truncate && opts?.offset !== undefined)`) never ran, so `write?offset=10` to a 5-byte file produced a 2-byte file with just the new bytes — pre-offset content **permanently destroyed**.
- Fix parses `offset` like the sibling `read` handler does (#200 + #426): rejects non-SafeInteger / negative with 400 `invalid offset`, forwards as `opts.offset` to mfs.write.

## Live testnet 88780 reproduction (pre-fix)

```bash
$ echo -n \"AAAAA\" | curl -X POST --data-binary @- \"http://.../files/write?arg=/p.txt&create=true&truncate=true\"
$ echo -n \"BB\"    | curl -X POST --data-binary @- \"http://.../files/write?arg=/p.txt&offset=10\"
$ curl -X POST \"http://.../files/read?arg=/p.txt\" | xxd
00000000: 4242   BB   ← AAAAA silently destroyed; 5 zero-padding bytes never written
```

## Anti-pattern

Silent-param-drop — same class as #174 (cat offset/length silently ignored), #353 (cid-version=0 silent), #460 (pin/rm silent destruct), #553 (pin=false silent ignore). This one is the most harmful: the silent drop **destroys data the client wanted to preserve**.

## Test plan

- [x] New regression test `#559` in `node/src/ipfs-http.test.ts`:
  - seeds 5-byte file, writes 2 bytes at offset=10, asserts result is 12 bytes (`AAAAA` + 5 zero bytes + `BB`)
  - validation parity: `offset=-1` / `offset=1.5` / `offset=abc` / `offset=999999999999999999999` all → 400 `invalid offset`
- [x] `node --experimental-strip-types --test node/src/ipfs-http.test.ts` → 98 pass, 0 fail
- [x] Live testnet 88780 confirmed data-destructive behavior

Closes #559