### PR TITLE
fix(rpc): #561 coc_nodeInfo.chainId is 0x-hex (parity with eth_chainId)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1203,12 +1203,34 @@ test("RPC Extended Methods", async (t) => {
     const info = await rpcCall(port, "coc_nodeInfo")
     assert.ok(typeof info === "object")
     assert.strictEqual(info.clientVersion, "COC/0.2")
-    assert.strictEqual(info.chainId, chainId)
+    // #561: chainId returned as 0x-prefixed hex quantity (parity with
+    // eth_chainId + coc_chainStats.chainId; Ethereum JSON-RPC contract).
+    assert.strictEqual(info.chainId, `0x${chainId.toString(16)}`)
     assert.ok(typeof info.blockHeight === "number" || typeof info.blockHeight === "string")
     assert.ok(typeof info.mempool === "object")
     assert.ok(typeof info.mempool.size === "number")
     assert.ok(typeof info.uptime === "number")
     // nodeVersion, platform, arch removed from public endpoint (info disclosure)
+  })
+
+  await t.test("#561: coc_nodeInfo.chainId is 0x-prefixed hex (parity with eth_chainId)", async () => {
+    // Pre-fix coc_nodeInfo emitted chainId as a raw JS number (e.g. 88780)
+    // while sibling methods returned hex ("0x15acc"). Clients aggregating
+    // chainId from multiple endpoints saw `88780 !== "0x15acc"` and
+    // concluded the node was misconfigured. Same format-drift family as
+    // #517 (nextProposalBlock decimal vs hex on same response).
+    //
+    // Both coc_nodeInfo and eth_chainId derive from the same `chainId`
+    // argument passed to handleRpc, so they must match exactly. The test
+    // fixture's coc_chainStats reads from chain.cfg.chainId (a separate
+    // source that may be unset in the fixture) — that cross-method
+    // divergence is its own pre-existing concern; this regression pins
+    // only the format and the eth_chainId<->coc_nodeInfo parity.
+    const info = await rpcCall(port, "coc_nodeInfo")
+    const ethId = await rpcCall(port, "eth_chainId")
+    assert.equal(typeof info.chainId, "string", `coc_nodeInfo.chainId must be a string, got ${typeof info.chainId}`)
+    assert.match(info.chainId, /^0x[0-9a-f]+$/i, `coc_nodeInfo.chainId must be 0x-prefixed hex, got ${JSON.stringify(info.chainId)}`)
+    assert.strictEqual(info.chainId, ethId, `coc_nodeInfo.chainId (${info.chainId}) must match eth_chainId (${ethId})`)
   })
 
   await t.test("web3_clientVersion returns version string", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2246,7 +2246,14 @@ async function handleRpc(
       const mempoolStats = chain.mempool.stats()
       return {
         clientVersion: "COC/0.2",
-        chainId,
+        // #561: pre-fix chainId leaked as a raw JS number (88780) here
+        // while eth_chainId + coc_chainStats.chainId both emit hex
+        // ("0x15acc"). Clients comparing across endpoints saw
+        // `88780 !== "0x15acc"` and concluded the node was misconfigured.
+        // Format-drift family with #517 (nextProposalBlock decimal vs hex
+        // on same response). Hex-quantity is the Ethereum JSON-RPC
+        // contract — viem/ethers/wagmi all hard-code that parse.
+        chainId: `0x${chainId.toString(16)}`,
         blockHeight: height,
         mempool: mempoolStats,
         uptime: Math.floor(process.uptime()),


### PR DESCRIPTION
## Summary

- `coc_nodeInfo.chainId` emitted as a raw JS number (e.g. `88780`) while `eth_chainId` + `coc_chainStats.chainId` both emit hex (`\"0x15acc\"`).
- Clients aggregating chainId across endpoints saw `88780 !== \"0x15acc\"` and concluded the node was misconfigured.
- Fix formats with `\`0x${chainId.toString(16)}\`` (one-line) — matching `eth_chainId`.

## Anti-pattern

Cross-method format drift on a canonical field — same family as #517/PR #518 (nextProposalBlock decimal vs hex on same response). The Ethereum JSON-RPC spec is the contract; chainId is hex everywhere downstream tooling parses (viem, ethers, wagmi, web3.py).

## Test plan

- [x] Updated existing `coc_nodeInfo returns node metadata` test to assert `info.chainId === \`0x${chainId.toString(16)}\`` (was numeric equality)
- [x] New regression test `#561` asserts `coc_nodeInfo.chainId` is 0x-prefixed hex and matches `eth_chainId` exactly (same source of truth — both derive from the `chainId` arg to `handleRpc`)
- [x] `#561` subtest passes (ok 35) on the new branch
- [x] Live testnet 88780 reproduction confirmed: `coc_nodeInfo.chainId` = `88780` (raw number) vs `eth_chainId` = `\"0x15acc\"` (hex)

## Out of scope

Separate concern: `coc_chainStats.chainId` reads from `chain.cfg.chainId` (a different source from the `chainId` arg `handleRpc` receives), so the two can also diverge if `cfg.chainId` isn't set. That second drift is pre-existing and out of scope for this minimal PR.

Closes #561