### PR TITLE
fix(rpc): #563 eth_call/estimateGas/createAccessList honor `input` as data alias (viem/ethers v6 parity)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2032,6 +2032,68 @@ test("RPC Extended Methods", async (t) => {
     assert.match(ok as string, /^0x[0-9a-f]+$/i)
   })
 
+  await t.test("#563: eth_call/estimateGas/createAccessList honor input as data alias (viem/ethers v6 parity)", async () => {
+    // Pre-fix `input` (the canonical Ethereum JSON-RPC field since 2019)
+    // was silently dropped: every call-site read only `callParams.data`.
+    // viem/ethers v6/web3.js v5+ emit only `input`, so every modern dApp
+    // got eth_call executed against EMPTY calldata. Silent-param-drop
+    // family with #174/#353/#553/#559 but worst impact (modern default).
+    //
+    // SHA-256 precompile lives at 0x…02; result == sha256(calldata).
+    // sha256(0xdeadbeef) = 0x5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953
+    const sha256Precompile = "0x0000000000000000000000000000000000000002"
+    const from = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const sha256Deadbeef = "0x5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953"
+    const sha256Empty = "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    // (1) input alone is honored as the calldata
+    const inputOnly = await rpcCall(port, "eth_call", [{ from, to: sha256Precompile, input: "0xdeadbeef" }, "latest"])
+    assert.strictEqual(inputOnly, sha256Deadbeef,
+      `input-only must compute sha256(0xdeadbeef), got ${inputOnly} (would be ${sha256Empty} if input was silently dropped)`)
+
+    // (2) data alone still works (no regression)
+    const dataOnly = await rpcCall(port, "eth_call", [{ from, to: sha256Precompile, data: "0xdeadbeef" }, "latest"])
+    assert.strictEqual(dataOnly, sha256Deadbeef, `data-only must still compute sha256(0xdeadbeef), got ${dataOnly}`)
+
+    // (3) matching values both set → accepted (no mismatch error)
+    const both = await rpcCall(port, "eth_call", [{ from, to: sha256Precompile, input: "0xdeadbeef", data: "0xdeadbeef" }, "latest"])
+    assert.strictEqual(both, sha256Deadbeef, `matching input+data must work, got ${both}`)
+
+    // (4) mismatch → -32602 (geth parity, no silent "data wins")
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_call",
+        params: [{ from, to: sha256Precompile, input: "0xdeadbeef", data: "0x12345678" }, "latest"],
+      }),
+    })
+    const mismatchJson = await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    assert.equal(mismatchJson.error?.code, -32602,
+      `input/data mismatch must reject with -32602, got ${JSON.stringify(mismatchJson)}`)
+    assert.match(mismatchJson.error!.message, /input.*data|data.*input|different/i,
+      `error must name both fields, got ${mismatchJson.error!.message}`)
+
+    // (5) malformed input gets the same validation gate as data
+    const badInput = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_call",
+        params: [{ from, to: sha256Precompile, input: "not-hex" }, "latest"],
+      }),
+    })
+    const badInputJson = await badInput.json() as { error?: { code: number; message: string } }
+    assert.equal(badInputJson.error?.code, -32602, `malformed input must -32602, got ${JSON.stringify(badInputJson)}`)
+    assert.match(badInputJson.error!.message, /invalid input/i, "error must name input field")
+
+    // (6) parity covers eth_estimateGas + eth_createAccessList (every call-shape method)
+    const estG = await rpcCall(port, "eth_estimateGas", [{ from, to: sha256Precompile, input: "0xdeadbeef" }])
+    assert.match(estG as string, /^0x[0-9a-f]+$/i, "estimateGas with input only must succeed")
+    const acl = await rpcCall(port, "eth_createAccessList", [{ from, to: sha256Precompile, input: "0xdeadbeef" }, "latest"]) as Record<string, unknown>
+    assert.ok(Array.isArray(acl.accessList), "createAccessList with input only must succeed")
+  })
+
   await t.test("#150: eth_getTransactionByHash / eth_getTransactionReceipt reject short tx hashes with -32602", async () => {
     // Pre-fix the loose requireHexParam accepted any 0x-prefixed hex up
     // to 64 chars. `"0x123"` slipped through and the tx-lookup returned

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -458,11 +458,43 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
       invalidParams(`${field} too large: ${v.length} chars > ${maxLen} (uint${bits} max)`)
     }
   }
+  // #563: Ethereum JSON-RPC spec defines `input` as the canonical
+  // calldata field; `data` is the legacy alias. Modern clients (viem,
+  // ethers v6, web3.js v5+, wagmi) emit only `input`. Pre-fix this
+  // node validated only `data` and every call-site (rpc.ts:949/1394/
+  // 1420/1492/3173) read only `callParams.data` — so viem/ethers-v6
+  // eth_call/estimateGas requests silently executed against EMPTY
+  // calldata. Wallets built tx with gasLimit against empty execution;
+  // real submit reverted out-of-gas. Silent-param-drop family with
+  // #174/#353/#553/#559 — but this one hits the modern client default.
+  //
+  // Resolution rules (geth parity):
+  //   data only          → use data
+  //   input only         → use input (alias)
+  //   both, same value   → use value (no error)
+  //   both, different    → -32602 mismatch
   const data = callParams.data
-  if (data !== undefined && data !== null && data !== "") {
+  const input = callParams.input
+  const dataPresent = data !== undefined && data !== null && data !== ""
+  const inputPresent = input !== undefined && input !== null && input !== ""
+  if (dataPresent) {
     if (typeof data !== "string" || !HEX_DATA_RE.test(data)) {
       invalidParams("invalid data: must match /^0x([0-9a-fA-F]{2})*$/")
     }
+  }
+  if (inputPresent) {
+    if (typeof input !== "string" || !HEX_DATA_RE.test(input)) {
+      invalidParams("invalid input: must match /^0x([0-9a-fA-F]{2})*$/")
+    }
+  }
+  if (dataPresent && inputPresent && (data as string).toLowerCase() !== (input as string).toLowerCase()) {
+    invalidParams("both data and input set with different values")
+  }
+  // Normalize: downstream call-sites read `callParams.data` only, so
+  // promote `input` to `data` when only `input` is set. Mutating here
+  // keeps the five existing read-sites unchanged.
+  if (!dataPresent && inputPresent) {
+    callParams.data = input
   }
   // #394: EIP-1559 field combinations. Pre-fix each field was shape-
   // validated in isolation but the relationship between them wasn't


### PR DESCRIPTION
## Summary

- `input` is the canonical Ethereum JSON-RPC calldata field since 2019 (EIP-1474). `data` is the legacy alias. viem, ethers v6, web3.js v5+, wagmi all emit only `input`.
- This node read only `callParams.data` and silently ignored `input`. Every modern dApp got `eth_call` / `eth_estimateGas` executed against **empty calldata** — wrong simulation results, wrong gasLimit, real txs reverted out-of-gas with no diagnostic.
- Fix validates `input` shape, rejects mismatched `input`+`data` with -32602, and normalizes `input` → `data` so the five existing read-sites stay unchanged.

## Live testnet 88780 reproduction (pre-fix, sha256 precompile @ 0x…02)

```bash
$ eth_call({input: \"0xdeadbeef\"})              → sha256(\"\")          ← input silently dropped
$ eth_call({data: \"0xdeadbeef\"})               → sha256(0xdeadbeef)   ← legacy still works
$ eth_call({input:\"0xAB\", data:\"0xCD\"})        → sha256(0xCD)         ← data wins; no mismatch error
```

## Anti-pattern

Silent-param-drop on a canonical alias — same family as #174 (cat offset/length), #353 (cid-version=0), #553 (pin=false), #559 (files/write?offset → data loss). This one has the worst real-world impact because it's the **modern-client default** (viem is the de-facto frontend lib since 2024).

## Test plan

- [x] New `#563` regression test covers:
  - `input` alone → calldata honored (sha256(0xdeadbeef))
  - `data` alone → no regression
  - matching `input`+`data` → accepted
  - mismatched `input`+`data` → -32602
  - malformed `input` → -32602 with `invalid input` message (parity with `data`)
  - parity for `eth_estimateGas` + `eth_createAccessList`
- [x] `node --experimental-strip-types --test node/src/rpc-extended.test.ts` — `#563` passes (ok 72); 113 surrounding subtests still pass through `#466` (no regression observed before stop)
- [x] Verified live testnet 88780 reproduces the silent-drop for `input`-only and the silent-data-wins for mismatched both

Closes #563