### PR TITLE
fix(rpc): #342 eth_getFilterChanges/Logs return -32000 for missing filter — revived from toxic PR #343

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -4581,6 +4581,34 @@ test("RPC Extended Methods", async (t) => {
     )
   })
 
+  await t.test("#342: eth_getFilterChanges for missing/expired filter returns -32000", async () => {
+    // Pre-fix returned `[]` for any missing filter — long-running indexers
+    // polling past FILTER_TTL_MS (5 min) silently dropped events with no
+    // error to trigger filter re-creation. Geth/erigon return -32000
+    // "filter not found"; mirror that so clients can detect the situation.
+    const r1 = await rpcCallRaw(port, "eth_getFilterChanges", ["0x" + "f".repeat(32)])
+    assert.equal(r1.error?.code, -32000,
+      `missing filter must be -32000, got ${JSON.stringify(r1)}`)
+    assert.match(r1.error!.message, /filter not found/,
+      "error message must say 'filter not found'")
+
+    const r2 = await rpcCallRaw(port, "eth_getFilterLogs", ["0x" + "e".repeat(32)])
+    assert.equal(r2.error?.code, -32000,
+      `getFilterLogs missing filter must be -32000, got ${JSON.stringify(r2)}`)
+    assert.match(r2.error!.message, /filter not found/)
+
+    // Sanity: a real filter still works without error
+    const fid = await rpcCall(port, "eth_newBlockFilter") as string
+    const ok = (await rpcCall(port, "eth_getFilterChanges", [fid])) as unknown[]
+    assert.ok(Array.isArray(ok), "valid filter must still return array")
+    await rpcCall(port, "eth_uninstallFilter", [fid])
+
+    // After uninstall, the same id now misses → -32000
+    const afterUninstall = await rpcCallRaw(port, "eth_getFilterChanges", [fid])
+    assert.equal(afterUninstall.error?.code, -32000,
+      "uninstalled filter must surface as -32000 on subsequent poll")
+  })
+
   if (prevDevAccounts === undefined) {
     delete process.env.COC_DEV_ACCOUNTS
   } else {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1197,7 +1197,11 @@ async function handleRpc(
       // a perpetual empty stream that mimics "no new events."
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #342: pre-fix returned `[]` for missing/expired filter — long-
+      // running indexers polling past the 5-minute FILTER_TTL_MS got
+      // silently dropped events with no error to trigger re-creation.
+      // Geth/erigon surface -32000 "filter not found"; mirror that.
+      if (!filter) throw { code: -32000, message: `filter not found: ${id}` }
       // Refresh the filter's last-access timestamp so cleanupExpiredFilters
       // doesn't reap an actively polled subscriber.
       filter.lastAccessedAtMs = Date.now()
@@ -1903,7 +1907,9 @@ async function handleRpc(
       // #196: parity with eth_getFilterChanges / eth_uninstallFilter.
       const id = requireFilterId(payload.params ?? [], 0)
       const filter = filters.get(id)
-      if (!filter) return []
+      // #342: -32000 for missing/expired filter — matches geth/erigon and
+      // gives indexers a clear signal to re-create the filter.
+      if (!filter) throw { code: -32000, message: `filter not found: ${id}` }
       // Refresh last-access time so active polls keep the filter alive.
       filter.lastAccessedAtMs = Date.now()
       // getFilterLogs is a log-filter-only method: block and pendingTx


### PR DESCRIPTION
Revival of toxic-batch PR #343 (force-merged 2026-05-13, rolled back via main force-push because of TS-strip break in sibling files).

Cherry-picked the merge commit onto current `main` (3-way merge resolved test-file line drift). Validated TS-strip + targeted subtest `#342` before push.

Closes #342