### PR TITLE
fix(ipfs-http): #270 map 'cannot move directory into own subtree' to 400 (not 500) — rework of toxic PR #271

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -982,6 +982,33 @@ describe("IpfsHttpServer", () => {
     }
   })
 
+  it("#270: /api/v0/files/mv into own subtree returns 400 (not 500 'internal error')", async () => {
+    // Pre-fix the route-level catch alternation `/^cannot (remove|operate
+    // on|copy)/i` was missing `move`. mfs.mv throws `cannot move directory
+    // into its own subdirectory: ...` which fell through to the outer 500
+    // with the generic "internal error" body (and an ERROR log line per
+    // probe). Sibling /files/cp WAS matched via `copy` in the alternation.
+    // Same regex-mismatch family as #232/#268/#543.
+    const { IpfsMfs: MfsCtor270 } = await import("./ipfs-mfs.ts")
+    const mfs = new MfsCtor270(store, unixfs)
+    server.attachSubsystems({ mfs })
+    await mfs.mkdir("/parent/child", { parents: true })
+    const res = await fetch(
+      "/api/v0/files/mv?arg=/parent&arg=/parent/child/grandchild",
+      { method: "POST" },
+    )
+    assert.equal(res.status, 400, `mv-into-own-subtree must be 400, got ${res.status}`)
+    const body = await res.json() as { error?: string; message?: string }
+    assert.notEqual(body.error, "internal error",
+      `must not leak 'internal error', got ${JSON.stringify(body)}`)
+    assert.match(`${body.error} ${body.message ?? ""}`, /cannot move/i,
+      `error must reference the actual throw, got ${JSON.stringify(body)}`)
+    // Sanity: legal mv still works (regression guard)
+    await mfs.mkdir("/ok-src")
+    const ok = await fetch("/api/v0/files/mv?arg=/ok-src&arg=/ok-dst", { method: "POST" })
+    assert.equal(ok.status, 200, `legal mv must still 200, got ${ok.status}`)
+  })
+
   it("#545: gateway /ipfs/<cid>/<subpath> returns 404 'no such file' (not misleading 400 'invalid CID')", async () => {
     // Pre-fix `url.pathname.slice(6)` treated the ENTIRE tail (including
     // subpaths) as the CID string. So `/ipfs/<valid-cid>/sub` had

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1544,7 +1544,12 @@ export class IpfsHttpServer {
         } else if (
           /is a directory/i.test(msg) ||
           /directory not empty/i.test(msg) ||
-          /^cannot (remove|operate on|copy)/i.test(msg) ||
+          // #270: sibling of `cannot copy directory into its own subdirectory`
+          // — mfs.mv throws the same shape with `move` instead of `copy`. The
+          // alternation was missing `move` so /files/mv falls through to 500
+          // with the generic "internal error" body (and an ERROR log line per
+          // probe). Same regex-mismatch family as #232/#268/#543.
+          /^cannot (remove|operate on|copy|move)/i.test(msg) ||
           /must be/i.test(msg) ||
           /^missing /i.test(msg) ||
           /^write would exceed/i.test(msg) ||


### PR DESCRIPTION
## Summary

Rework on current `main` of toxic-batch PR #271 (the original cherry-pick conflicts on the route-catch block which has grown since).

- Route-level catch alternation \`/^cannot (remove|operate on|copy)/i\` was missing \`move\`.
- \`mfs.mv\` throws \`cannot move directory into its own subdirectory: ...\` which fell through to the outer 500 \`internal error\` (with an ERROR log line per probe).
- Sibling \`/files/cp\` was already matched via \`copy\` in the same alternation.

## Anti-pattern

Regex-mismatch family — same class as #232 (path traversal → 500), #268 (path-too-deep → 500), #543 (mkdir on file-collision → 500). Generic 500 leak for a well-defined client-input case.

## Test plan

- [x] New \`#270\` regression test in \`node/src/ipfs-http.test.ts\` covers: mv into own subtree → 400 + \`cannot move\` body; legal mv still 200
- [x] TS-strip OK (\`node --experimental-strip-types -e "import('./node/src/ipfs-http.ts')\")
- [x] Targeted test passes: \`node --test --test-name-pattern="#270" node/src/ipfs-http.test.ts\` → 1 pass, 0 fail
- [x] Branched fresh off \`origin/main\`

Closes #270