### PR TITLE
fix(rpc): #260 eth_getBlockByNumber/Hash reject non-boolean includeTx — rework of toxic PR #261

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -286,6 +286,36 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(count === null || count.startsWith("0x"))
   })
 
+  await t.test("#260: eth_getBlockByNumber/Hash reject non-boolean includeTx (no Boolean() coercion)", async () => {
+    // Pre-fix `Boolean((payload.params ?? [])[1])` accepted every shape:
+    //   Boolean("false") === true  → client thinking "false" gets full txs
+    //   Boolean([]) === true       → array silently treated as truthy
+    //   Boolean({}) === true       → object silently treated as truthy
+    //   Boolean(1) === true        → numeric truthy
+    // Clients sending the wrong shape got the OPPOSITE of what they meant
+    // (full tx objects ~5-6× bandwidth instead of hashes). Spec requires
+    // strict boolean; geth rejects everything else with -32602.
+    await chain.proposeNextBlock()
+    const validHash = "0x" + "00".repeat(32)
+    for (const method of ["eth_getBlockByNumber", "eth_getBlockByHash"]) {
+      const arg0 = method === "eth_getBlockByNumber" ? "0x0" : validHash
+      for (const bad of ["false", "true", [], {}, 0, 1, "yes", "no"]) {
+        const r = await rpcCallRaw(port, method, [arg0, bad])
+        assert.equal(r.error?.code, -32602,
+          `${method}([${arg0}, ${JSON.stringify(bad)}]) must -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /includeTransactions/i,
+          `${method} error must name the param, got ${r.error!.message}`)
+      }
+      // Sanity: strict booleans still work
+      for (const good of [true, false, undefined, null]) {
+        const params = good === undefined ? [arg0] : [arg0, good]
+        const r = await rpcCallRaw(port, method, params)
+        assert.equal(r.error, undefined,
+          `${method}([${arg0}, ${JSON.stringify(good)}]) must succeed, got ${JSON.stringify(r.error)}`)
+      }
+    }
+  })
+
   await t.test("eth_getUncleCountByBlockNumber returns zero", async () => {
     const count = await rpcCall(port, "eth_getUncleCountByBlockNumber", ["0x0"])
     assert.strictEqual(count, "0x0")

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -241,6 +241,25 @@ export function requireIndexParam(params: unknown[], index: number, name = "inde
 }
 
 /**
+ * #260: Strict boolean validator for params like eth_getBlockByNumber's
+ * `includeTransactions`. Pre-fix `Boolean(params[i])` accepted every
+ * shape — `Boolean("false") === true`, `Boolean({}) === true`,
+ * `Boolean([]) === true` — and clients sending those got the OPPOSITE
+ * of what they meant (full tx objects ~5-6× bandwidth instead of hashes).
+ * Spec requires strict boolean; geth rejects everything else with -32602.
+ * Defaults to `false` when the param is missing/undefined to match the
+ * Ethereum JSON-RPC spec default.
+ */
+export function requireStrictBooleanParam(params: unknown[], index: number, name: string): boolean {
+  const value = (params ?? [])[index]
+  if (value === undefined || value === null) return false
+  if (value !== true && value !== false) {
+    invalidParams(`invalid ${name} at param ${index}: expected boolean, got ${Array.isArray(value) ? "array" : typeof value}`)
+  }
+  return value
+}
+
+/**
  * Validate a 16-byte filter ID (#196). Filter IDs are minted as
  * `0x` + `randomBytes(16).toString("hex")` (32 hex chars). Pre-fix
  * `String((payload.params ?? [])[0] ?? "")` silently coerced any

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -35,6 +35,7 @@ import {
   requireBlockHashParam,
   requireIndexParam,
   requireFilterId,
+  requireStrictBooleanParam,
   requireCallObject,
   requireFilterObject,
   requireStringParam,
@@ -835,7 +836,12 @@ async function handleRpc(
       // → 0n → silently returned the genesis block. Sibling of #188 / #194.
       // resolveBlockNumber accepts unknown and dispatches through parseBlockTag,
       // which rejects non-string / non-number shapes at -32602.
-      const includeTx = Boolean((payload.params ?? [])[1])
+      // #260: pre-fix `Boolean((payload.params ?? [])[1])` accepted every
+      // shape — `Boolean("false") === true`, `Boolean([]) === true`,
+      // `Boolean({}) === true` — and clients sending those got the OPPOSITE
+      // of what they meant (full tx objects ~5-6× bandwidth). Spec requires
+      // strict boolean; geth rejects everything else with -32602.
+      const includeTx = requireStrictBooleanParam(payload.params ?? [], 1, "includeTransactions")
       const number = await resolveBlockNumber((payload.params ?? [])[0], chain)
       const block = await Promise.resolve(chain.getBlockByNumber(number))
       // #112: synthesise a genesis block when block 0 is missing. The
@@ -856,8 +862,9 @@ async function handleRpc(
       // undefined, null, short hex, non-hex — and returned null,
       // indistinguishable from "valid hash, no such block". Symmetric
       // with #150's eth_getTransactionByHash fix.
+      // #260: same Boolean()-coercion fix as eth_getBlockByNumber above.
       const hash = requireBlockHashParam(payload.params ?? [], 0)
-      const includeTx = Boolean((payload.params ?? [])[1])
+      const includeTx = requireStrictBooleanParam(payload.params ?? [], 1, "includeTransactions")
       const block = await Promise.resolve(chain.getBlockByHash(hash))
       return formatBlock(block, includeTx, chain, evm)
     }


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #261 (original cherry-pick conflicts on the handler region which has grown).

- Both \`eth_getBlockByNumber\` and \`eth_getBlockByHash\` parsed \`includeTransactions\` via \`Boolean((payload.params ?? [])[1])\`. JS \`Boolean()\` is asymmetric:
  - \`Boolean(\"false\") === true\` — client thinking \"false\" gets full tx objects (5-6× bandwidth)
  - \`Boolean([]) === Boolean({}) === true\` — array/object treated as truthy
  - \`Boolean(1) === Boolean(\"yes\") === true\`
- Spec requires a strict boolean; geth rejects everything else with \`-32602\`.

## Anti-pattern

Silent coercion family — same class as #260's cousin sites (#250 String coercion, #525, #561). The fix introduces a reusable \`requireStrictBooleanParam(params, index, name)\` validator that defaults to \`false\` for missing param (matching the spec default).

## Test plan

- [x] New \`#260\` regression test covers: \`\"false\"\`, \`\"true\"\`, \`[]\`, \`{}\`, \`0\`, \`1\`, \`\"yes\"\`, \`\"no\"\` → all -32602; \`true\`/\`false\`/missing → succeed
- [x] TS-strip OK on \`rpc.ts\` and \`rpc-validators.ts\`
- [x] Targeted subtest passes (ok 9 in rpc-extended test suite)
- [x] Branched fresh off \`origin/main\`

Closes #260