### PR TITLE
fix(ipfs-http): #272 gateway /ipfs/<raw-cid> returns 200 (not 500 internal error) — rework of toxic PR #273

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -372,6 +372,31 @@ describe("IpfsHttpServer", () => {
     assert.equal(bgBody.error, "block not found")
   })
 
+  it("#272: gateway /ipfs/<raw-cid> returns 200 (not 500 'internal error')", async () => {
+    // Pre-fix the gateway called `this.unixfs.readFile(cid)` directly,
+    // which throws `Error("not a unixfs file")` for any non-UnixFS CID.
+    // The inline catch only mapped "not found"; the unixfs-shape mismatch
+    // fell through to the outer 500. Sibling `/api/v0/cat` already
+    // dispatched raw/erasure via `resolveCid`.
+    // Same family as #168 (ENOENT → 500), #232 (path traversal → 500),
+    // #268 (path-too-deep → 500), #270 (cannot-move → 500), #543 (mkdir
+    // on file-collision → 500): each spammed log.error per probe.
+    const payload = new TextEncoder().encode("raw-block payload-272")
+    const putRes = await fetch("/api/v0/block/put", { method: "POST", body: payload })
+    assert.equal(putRes.status, 200, "block/put must accept raw bytes")
+    const putBody = await putRes.json() as { Key: string }
+    const cid = putBody.Key
+    // gateway should now succeed for raw block CIDs
+    const gw = await fetch(`/ipfs/${cid}`)
+    assert.equal(gw.status, 200, `gateway must 200 for raw-block CID, got ${gw.status}`)
+    const body = new Uint8Array(await gw.buffer())
+    assert.deepEqual(body, payload, "gateway body must match raw block bytes")
+    // Sibling /api/v0/cat must still work the same
+    const cat = await fetch(`/api/v0/cat?arg=${cid}`, { method: "POST" })
+    assert.equal(cat.status, 200, "cat must still 200 for raw-block CID")
+    assert.deepEqual(new Uint8Array(await cat.buffer()), payload)
+  })
+
   it("#174: /api/v0/cat honors offset + length query params", async () => {
     // Pre-fix the handler accepted offset/length/count via query but
     // ignored them, returning the full file. Malformed values

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -389,8 +389,17 @@ export class IpfsHttpServer {
         // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated
         // to the outer 500 handler, logging a stacktrace for every probe.
         // Map to 404 explicitly so missing-block looks like missing-block.
+        //
+        // #272: pre-fix the gateway called `unixfs.readFile()` directly,
+        // which throws `Error("not a unixfs file")` for raw blocks — falling
+        // through to the outer 500. The sibling `/api/v0/cat` already
+        // dispatches raw / erasure via `resolveCid`. Reuse `readByCid`
+        // here so the gateway behaves identically; its HttpError throws
+        // (404 for missing, 400 for invalid CID, etc.) flow through the
+        // outer catch's structured handler. Same family as #168/#232/
+        // #268/#270/#543 — generic 500 leak for a well-defined case.
         try {
-          const data = await this.unixfs.readFile(cid)
+          const data = await this.readByCid(cid)
           // #324: HTTP Range support per RFC 7233. Pre-fix the gateway
           // returned the full body for every request, even when the
           // client sent `Range: bytes=N-M` — making resumable downloads,
@@ -444,7 +453,10 @@ export class IpfsHttpServer {
             res.end(data)
           }
         } catch (err) {
-          if (isNotFoundError(err)) {
+          // #272: readByCid throws HttpError instead of raw "not found"
+          // strings, so map back here to preserve the existing CORS-on-404
+          // contract that browser callers rely on.
+          if (isNotFoundError(err) || (err instanceof HttpError && err.status === 404)) {
             res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })
             res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: "not found" }))
           } else {


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #273 (original cherry-pick had broken TypeScript syntax — the toxic commit itself was corrupted, hence rewriting from scratch).

- Gateway called \`this.unixfs.readFile(cid)\` directly, which throws \`Error(\"not a unixfs file\")\` for non-UnixFS CIDs.
- The inline catch only mapped \"not found\" — the unixfs-shape mismatch fell through to the outer 500 with stacktrace logged per probe.
- Sibling \`/api/v0/cat\` already dispatched raw/erasure via \`resolveCid\` + \`readByCid\` and worked correctly.
- Fix: reuse \`readByCid\` from the gateway path so both read endpoints behave identically. Add an HttpError(404) guard to the local catch to preserve the existing CORS-on-404 contract.

## Anti-pattern

Regex-mismatch / log-spam family — same class as #168, #232, #268, #270, #543. Generic 500 leak for a well-defined error case (with ERROR log line per probe).

## Test plan

- [x] New \`#272\` regression test in \`ipfs-http.test.ts\`: \`/api/v0/block/put\` raw bytes, then \`GET /ipfs/<rawcid>\` must 200 with matching body; sibling \`/api/v0/cat?arg=<rawcid>\` must also still 200
- [x] TS-strip OK on \`ipfs-http.ts\`
- [x] Targeted test passes (ok 1)
- [x] Branched fresh off \`origin/main\`

Closes #272