### PR TITLE
fix(rpc): #258 coc_getContracts rejects non-integer/non-bool fields inside pagination object — rework of toxic PR #259

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3580,6 +3580,56 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#258: coc_getContracts rejects non-integer/non-bool fields inside the pagination object (no Number/!== coercion)", async () => {
+    // Pre-fix the object-field variant of #254: `Number(opts.limit ?? 50)`
+    // coerced `true`→1, `"5"`→5, `[5]`→5; `opts.reverse !== false`
+    // accepted `0`/`"false"`/`null` as truthy → reverse=true (opposite
+    // of the sloppy client's intent). Same anti-pattern as #254 (the
+    // positional sibling), #252 (epochId), #224 (feeHistory blockCount).
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_getContracts", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // limit: non-integer shapes must be rejected
+    for (const bad of [true, false, "5", [3], [1, 2], {}, 1.5]) {
+      const r = await probe([{ limit: bad }])
+      assert.equal(r.error?.code, -32602,
+        `limit=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /limit/i)
+    }
+    // offset: same
+    for (const bad of [true, "0", [0], {}, 0.5]) {
+      const r = await probe([{ offset: bad }])
+      assert.equal(r.error?.code, -32602,
+        `offset=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /offset/i)
+    }
+    // reverse: non-boolean shapes must be rejected
+    for (const bad of [0, 1, "false", "true", [true], {}]) {
+      const r = await probe([{ reverse: bad }])
+      assert.equal(r.error?.code, -32602,
+        `reverse=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /reverse/i)
+    }
+    // Sanity: well-shaped values still succeed (result is array)
+    for (const opts of [
+      {},
+      { limit: 10 },
+      { offset: 0 },
+      { reverse: false },
+      { limit: 5, offset: 0, reverse: true },
+    ]) {
+      const r = await probe([opts])
+      assert.equal(r.error, undefined,
+        `well-shaped ${JSON.stringify(opts)} must succeed, got ${JSON.stringify(r)}`)
+      assert.ok(Array.isArray(r.result), `result must be array for ${JSON.stringify(opts)}`)
+    }
+  })
+
   await t.test("#485: coc_getTransactionsByAddress logs have full wire shape (parity with eth_getTransactionReceipt.logs)", async () => {
     // Pre-fix the persistent layer stripped logs to {address, topics, data}
     // when writing the receipt (chain-engine-persistent.ts:1229), and this

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2786,11 +2786,45 @@ async function handleRpc(
       // #238. Validate shape FIRST so the rejection fires regardless
       // of whether the node has blockIndex enabled.
       const opts = requireFilterObject((payload.params ?? [])[0])
+      // #258: pre-fix the inner fields used the same silent-coercion
+      // anti-pattern fixed in #254 for the positional sibling
+      // coc_getTransactionsByAddress: `Number(opts.limit ?? 50) || 50`
+      // coerced `true`→1, `"5"`→5, `[5]`→5; `opts.reverse !== false`
+      // accepted `0`/`"false"`/`null` as truthy (== reverse=true), the
+      // opposite of the client's intent. Mirror #254's strict per-field
+      // validators inline so the same -32602 message format applies.
+      let limit = 50
+      if (opts.limit !== undefined && opts.limit !== null) {
+        if (typeof opts.limit !== "number" || !Number.isInteger(opts.limit)) {
+          invalidParams(`invalid limit: expected integer, got ${Array.isArray(opts.limit) ? "array" : typeof opts.limit}`)
+        }
+        if (opts.limit < 1 || opts.limit > 10_000) {
+          invalidParams("invalid limit: must be between 1 and 10000")
+        }
+        limit = opts.limit
+      }
+      let offset = 0
+      if (opts.offset !== undefined && opts.offset !== null) {
+        if (typeof opts.offset !== "number" || !Number.isInteger(opts.offset)) {
+          invalidParams(`invalid offset: expected integer, got ${Array.isArray(opts.offset) ? "array" : typeof opts.offset}`)
+        }
+        if (opts.offset < 0 || opts.offset > 100_000) {
+          invalidParams("invalid offset: must be between 0 and 100000")
+        }
+        offset = opts.offset
+      }
+      let reverse = true
+      if (opts.reverse !== undefined && opts.reverse !== null) {
+        if (typeof opts.reverse !== "boolean") {
+          invalidParams(`invalid reverse: expected boolean, got ${Array.isArray(opts.reverse) ? "array" : typeof opts.reverse}`)
+        }
+        reverse = opts.reverse
+      }
       if (hasBlockIndex(chain)) {
         const contracts = await chain.blockIndex.getContracts({
-          limit: Math.min(Math.max(Number(opts.limit ?? 50) || 50, 1), 10_000),
-          offset: Math.min(Math.max(Number(opts.offset ?? 0) || 0, 0), 100_000),
-          reverse: opts.reverse !== false,
+          limit,
+          offset,
+          reverse,
         })
         return contracts.map((c) => ({
           address: c.address,


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #259 (cherry-pick result had broken TypeScript syntax).

- Outer \`requireFilterObject\` (#249) gates the param-0 shape, but the inner fields used silent coercion:
  - \`Number(opts.limit ?? 50) || 50\` — \`true→1, \"5\"→5, [5]→5\` silently accepted
  - \`Number(opts.offset ?? 0) || 0\` — same family
  - \`opts.reverse !== false\` — accepted \`0\`/\`\"false\"\`/\`null\`/\`\"\"\` as truthy → reverse=true (opposite of intent)
- Fix: strict per-field type-checking inline.

## Anti-pattern

Silent Number()/`!== false` coercion family — same as #254 (positional sibling), #252 (epochId), #224 (feeHistory blockCount), #226 (filter shape).

## Test plan

- [x] New \`#258\` regression test in rpc-extended.test.ts:
  - limit: \`true\`/\`false\`/\`\"5\"\`/\`[3]\`/\`[1,2]\`/\`{}\`/\`1.5\` → -32602
  - offset: \`true\`/\`\"0\"\`/\`[0]\`/\`{}\`/\`0.5\` → -32602
  - reverse: \`0\`/\`1\`/\`\"false\"\`/\`\"true\"\`/\`[true]\`/\`{}\` → -32602
  - well-shaped + null/undefined defaults still succeed; result is array
- [x] TS-strip OK on \`rpc.ts\`
- [x] Targeted subtest passes (ok 119)

Closes #258