### PR TITLE
fix(ipfs-mfs): #420 cp/mv reject src===dst (POSIX/kubo parity, no silent no-op) — rework of toxic PR #421

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1634,6 +1634,9 @@ export class IpfsHttpServer {
           // with the generic "internal error" body (and an ERROR log line per
           // probe). Same regex-mismatch family as #232/#268/#543.
           /^cannot (remove|operate on|copy|move)/i.test(msg) ||
+          // #420: cp/mv reject src===dst with "source and destination are
+          // the same: <path>" — map to 400 client-input error.
+          /^source and destination are the same/i.test(msg) ||
           /must be/i.test(msg) ||
           /^missing /i.test(msg) ||
           /^write would exceed/i.test(msg) ||

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -198,12 +198,64 @@ test("#477: cp/mv same source-and-dest must reject when source is missing", asyn
       "mv must reject missing source even when src == dst",
     )
 
-    // Sanity: same-path on an existing file is still a no-op (not an error).
+    // #420: same-path on an existing file ALSO rejects now (POSIX/kubo
+    // parity). Update from the #477-era no-op sanity check to the strict
+    // reject. Source file is left intact (no destructive side-effect).
     await mfs.write("/keep.txt", new TextEncoder().encode("data"), { create: true })
-    await mfs.cp("/keep.txt", "/keep.txt")    // no-op, no throw
-    await mfs.mv("/keep.txt", "/keep.txt")    // no-op, no throw
+    await assert.rejects(
+      () => mfs.cp("/keep.txt", "/keep.txt"),
+      /source and destination are the same/i,
+      "cp must reject src===dst even when source exists (POSIX/kubo parity, #420)",
+    )
+    await assert.rejects(
+      () => mfs.mv("/keep.txt", "/keep.txt"),
+      /source and destination are the same/i,
+      "mv must reject src===dst even when source exists (POSIX/kubo parity, #420)",
+    )
     const after = await mfs.read("/keep.txt")
-    assert.strictEqual(new TextDecoder().decode(after), "data", "same-path op on existing file preserves contents")
+    assert.strictEqual(new TextDecoder().decode(after), "data", "src untouched after rejected same-path op")
+  } finally {
+    cleanup()
+  }
+})
+
+test("#420: MFS cp/mv with src===dest rejects (POSIX/kubo parity, no silent no-op)", async () => {
+  // Pre-fix `if (srcNorm === destNorm) return` silently succeeded for
+  // `mv /a /a` and `cp /a /a`, masking client typos. POSIX and kubo both
+  // reject. Real renames/copies must still work (regression guard).
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.write("/src.txt", new TextEncoder().encode("hello"), { create: true })
+    // src===dest with existing source: reject
+    await assert.rejects(
+      () => mfs.cp("/src.txt", "/src.txt"),
+      /source and destination are the same: \/src\.txt/i,
+      "cp same-path on existing file must reject",
+    )
+    await assert.rejects(
+      () => mfs.mv("/src.txt", "/src.txt"),
+      /source and destination are the same: \/src\.txt/i,
+      "mv same-path on existing file must reject",
+    )
+    // Source is intact
+    assert.strictEqual(
+      new TextDecoder().decode(await mfs.read("/src.txt")),
+      "hello",
+      "src must be intact after rejected same-path op",
+    )
+    // Real rename + real copy still work (regression sentinel)
+    await mfs.cp("/src.txt", "/cp-dest.txt")
+    assert.strictEqual(
+      new TextDecoder().decode(await mfs.read("/cp-dest.txt")),
+      "hello",
+      "real cp must still succeed",
+    )
+    await mfs.mv("/src.txt", "/mv-dest.txt")
+    assert.strictEqual(
+      new TextDecoder().decode(await mfs.read("/mv-dest.txt")),
+      "hello",
+      "real mv must still succeed",
+    )
   } finally {
     cleanup()
   }

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -267,9 +267,15 @@ export class IpfsMfs {
     const entry = srcParent.entries.get(srcBase)
     if (!entry) throw new Error(`source not found: ${srcNorm}`)
 
-    // No-op when source and destination are identical (now that the
-    // source existence check has passed).
-    if (srcNorm === destNorm) return
+    // #420: pre-fix `if (srcNorm === destNorm) return` silently succeeded
+    // for `mv /a /a`, masking client typos (variable confusion, accidental
+    // copy-paste). POSIX `mv /a /a` rejects with "are the same file"; kubo's
+    // MFS does the same. Reject so a buggy client learns about misuse
+    // instead of getting a silent 200 ok. Same class as #380 (empty mkdir
+    // arg silent ok) and #418 (whitespace-only path components).
+    if (srcNorm === destNorm) {
+      throw new Error(`source and destination are the same: ${srcNorm}`)
+    }
 
     // Prevent moving a directory into its own subtree
     if (destNorm.startsWith(srcNorm + "/")) {
@@ -333,9 +339,11 @@ export class IpfsMfs {
     const entry = srcParent.entries.get(srcBase)
     if (!entry) throw new Error(`source not found: ${srcNorm}`)
 
-    // No-op when source and destination are identical (after source-
-    // existence check).
-    if (srcNorm === destNorm) return
+    // #420: same POSIX/kubo alignment as mv above — `cp /a /a` rejects
+    // instead of silent no-op so client typos surface.
+    if (srcNorm === destNorm) {
+      throw new Error(`source and destination are the same: ${srcNorm}`)
+    }
 
     // Prevent copying a directory into its own subtree (infinite recursion)
     if (destNorm.startsWith(srcNorm + "/")) {


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #421 (original cherry-pick conflicted on the mv/cp blocks which have grown with #477 + #539).

- \`if (srcNorm === destNorm) return\` silently succeeded for \`mv /a /a\` / \`cp /a /a\`, masking client typos.
- POSIX and kubo both reject; align by throwing \`source and destination are the same: <path>\`.
- Extend ipfs-http.ts route-level catch regex to map the new error → 400.
- Update the \`#477\` test's \"sanity no-op on existing file\" assertion to the strict reject (the no-op was the underlying bug; #477 only addressed the missing-source flavor).

## Anti-pattern

Silent-success on operational mistake — same class as #380 (empty mkdir arg silent ok), #418 (whitespace-only path components).

## Test plan

- [x] New \`#420\` regression test: cp/mv src===dst rejects with \`source and destination are the same\`; source intact; real cp/mv to different dest still works
- [x] Updated \`#477\` test: same-path on existing source now also rejects (consistent with #420)
- [x] TS-strip OK on \`ipfs-mfs.ts\` + \`ipfs-http.ts\`
- [x] \`node --test node/src/ipfs-mfs.test.ts\` → 21 pass, 0 fail

Closes #420