### PR TITLE
fix(rpc): #296 coc_submitProposal rejects non-string type/targetId/proposer/targetAddress — rework of toxic PR #297

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2997,6 +2997,67 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#296: coc_submitProposal rejects non-string type/targetId/proposer/targetAddress (no Record-cast no-op)", async () => {
+    // Pre-fix `rawParams as Record<string, string>` was a TypeScript
+    // runtime no-op. Any field shape (number, boolean, array, object)
+    // silently flowed through to chain.governance.submitProposal(). The
+    // resulting proposal record stored non-string values in string slots;
+    // downstream filters / serializers either rejected with -32603 V8
+    // errors or echoed the coerced garbage back. Same anti-pattern as
+    // #551 (coc_voteProposal field strict validation); same validation-
+    // order rule as #432/#538.
+    const submittedCalls: Array<{ type: string; targetId: string; proposer: string; opts: Record<string, unknown> }> = []
+    const governanceStub296 = {
+      submitProposal: (type: string, targetId: string, proposer: string, opts: Record<string, unknown>) => {
+        submittedCalls.push({ type, targetId, proposer, opts })
+        return { id: "p1", type, targetId, status: "pending" }
+      },
+    } as Record<string, unknown>
+    ;(chain as unknown as Record<string, unknown>).governance = governanceStub296
+    try {
+      const probe = async (params: unknown[]) => {
+        const r = await fetch(`http://127.0.0.1:${port}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "coc_submitProposal", params }),
+        })
+        return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+      }
+      const base = { type: "add_validator", targetId: "v4", proposer: "node-1" }
+      const badStringShapes = [undefined, null, 123, true, {}, [], ""]
+      for (const bad of badStringShapes) {
+        const rType = await probe([{ ...base, type: bad }])
+        assert.equal(rType.error?.code, -32602,
+          `type=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rType)}`)
+        assert.match(rType.error!.message, /type/i)
+        const rTarget = await probe([{ ...base, targetId: bad }])
+        assert.equal(rTarget.error?.code, -32602,
+          `targetId=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rTarget)}`)
+        const rProposer = await probe([{ ...base, proposer: bad }])
+        assert.equal(rProposer.error?.code, -32602,
+          `proposer=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(rProposer)}`)
+      }
+      // targetAddress is optional but when present must be a string
+      for (const bad of [123, true, [], {}]) {
+        const r = await probe([{ ...base, targetAddress: bad }])
+        assert.equal(r.error?.code, -32602,
+          `targetAddress=${JSON.stringify(bad)} must be -32602, got ${JSON.stringify(r)}`)
+        assert.match(r.error!.message, /targetAddress/i)
+      }
+      // Sanity: well-shaped payload still reaches the stub
+      submittedCalls.length = 0
+      const ok = await probe([{ ...base, targetAddress: "0xabc" }])
+      assert.equal(ok.error, undefined, `well-shaped submit must succeed, got ${JSON.stringify(ok)}`)
+      assert.equal(submittedCalls.length, 1, "stub must be called for well-shaped input")
+      assert.equal(submittedCalls[0].type, "add_validator")
+      assert.equal(submittedCalls[0].targetId, "v4")
+      assert.equal(submittedCalls[0].proposer, "node-1")
+      assert.equal(submittedCalls[0].opts.targetAddress, "0xabc")
+    } finally {
+      delete (chain as unknown as Record<string, unknown>).governance
+    }
+  })
+
   await t.test("#551: coc_voteProposal validates inner fields (no silent Boolean/String coercion)", async () => {
     // Pre-fix the handler validated the outer-object shape but immediately
     // ran every inner field through `String()`/`Boolean()` — a missing

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2337,13 +2337,36 @@ async function handleRpc(
       if (!rawParams || typeof rawParams !== "object" || Array.isArray(rawParams)) {
         invalidParams("invalid params: expected non-null object as first param")
       }
+      // #296: pre-fix `as Record<string, string>` was a TypeScript runtime
+      // no-op. Any field shape (number, boolean, array, object) flowed
+      // through to `chain.governance.submitProposal()` and either stored
+      // non-string values in string slots (downstream filters / serializers
+      // broke with -32603 V8 errors) or echoed the coerced garbage back to
+      // clients. Same anti-pattern as #220 (outer shape — now covered) and
+      // #551 (coc_voteProposal field strict validation). Validate each
+      // required field BEFORE the hasGovernance() gate so the same -32602
+      // fires on read-only nodes too (#432 validation-order rule).
+      const proposalParams = rawParams as Record<string, unknown>
+      for (const field of ["type", "targetId", "proposer"] as const) {
+        const v = proposalParams[field]
+        if (typeof v !== "string" || !v) {
+          invalidParams(`invalid ${field}: expected non-empty string`)
+        }
+      }
+      // Optional targetAddress: when present, must be a string (no
+      // length/hex check here — governance module decides whether it's a
+      // valid Ethereum address or a node ID).
+      if (proposalParams.targetAddress !== undefined && proposalParams.targetAddress !== null) {
+        if (typeof proposalParams.targetAddress !== "string") {
+          invalidParams("invalid targetAddress: expected string")
+        }
+      }
       if (!hasGovernance(chain)) {
         methodNotFound("coc_submitProposal: governance module not enabled on this node")
       }
-      const proposalParams = rawParams as Record<string, string>
       // Only the local node can submit proposals via RPC
       const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
-      if (localNodeId && proposalParams.proposer !== localNodeId) {
+      if (localNodeId && (proposalParams.proposer as string) !== localNodeId) {
         throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
       }
       // #218: validate stakeAmount shape before `BigInt(...)`. Pre-fix
@@ -2364,11 +2387,11 @@ async function handleRpc(
         stakeAmount = BigInt(stakeRaw as string | number)
       }
       const proposal = chain.governance.submitProposal(
-        proposalParams.type,
-        proposalParams.targetId,
-        proposalParams.proposer,
+        proposalParams.type as string,
+        proposalParams.targetId as string,
+        proposalParams.proposer as string,
         {
-          targetAddress: proposalParams.targetAddress,
+          targetAddress: proposalParams.targetAddress as string | undefined,
           stakeAmount,
         },
       )


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #297 (original cherry-pick conflicted on the handler block).

- \`rawParams as Record<string, string>\` was a TypeScript runtime no-op. Numbers, booleans, arrays, objects all silently flowed through to \`chain.governance.submitProposal()\`.
- Non-string values stored in string slots broke downstream filters/serializers with -32603 V8 errors or echoed coerced garbage back to clients.
- Fix: validate each required string field (\`type\`, \`targetId\`, \`proposer\`) and the optional \`targetAddress\` before dispatching.
- Validation runs **before** the \`hasGovernance()\` gate so the same -32602 fires on read-only nodes (validation-order rule from #432/#538/#551).

## Anti-pattern

Sibling of #551 (\`coc_voteProposal\` field strict validation). Same handler family, same TypeScript-runtime-no-op cast bug.

## Test plan

- [x] New \`#296\` regression test exercises non-string \`type\`/\`targetId\`/\`proposer\` (\`undefined\`/\`null\`/\`123\`/\`true\`/\`{}\`/\`[]\`/\`\"\"\`) → all -32602
- [x] Non-string \`targetAddress\` (\`123\`/\`true\`/\`[]\`/\`{}\`) → -32602; well-shaped \`\"0xabc\"\` reaches the stub
- [x] TS-strip OK on rpc.ts
- [x] Targeted subtest passes (ok 106)

Closes #296