### PR TITLE
fix(ipfs-http): #382 HEAD on 404/405 paths sets Content-Length (no 6s keep-alive hang) — rework of toxic PR #383

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -785,6 +785,33 @@ describe("IpfsHttpServer", () => {
     assert.equal(post.status, 200, "POST /api/v0/version must still work")
   })
 
+  it("#382: HEAD on 404/405 paths gets Content-Length (doesn't hang waiting for chunked framing)", async () => {
+    // Pre-fix `res.writeHead(X, headers); res.end([body])` with no
+    // Content-Length defaulted to chunked Transfer-Encoding. HEAD
+    // requests on these paths waited 5s+ for the keep-alive timeout
+    // because the response framing was ambiguous.
+    // Affected sites: dispatch-prefix 404 (non-/api/v0/ + non-/ipfs/),
+    // /api/v0/* method-not-allowed 405, dispatch-end 404 catch-all.
+    // Family: same systemic bug class as #376 (rpc.ts root 405).
+    // (a) prefix 404: bare 404 from non-routable path
+    const r1 = await fetch("/nonexistent", { method: "HEAD" })
+    assert.equal(r1.status, 404)
+    assert.ok(r1.headers["content-length"] !== undefined,
+      `prefix 404 HEAD must set Content-Length, got ${JSON.stringify(r1.headers)}`)
+    // (b) 405 method-not-allowed on /api/v0/*
+    const r2 = await fetch("/api/v0/version", { method: "GET" })
+    assert.equal(r2.status, 405)
+    assert.ok(r2.headers["content-length"] !== undefined,
+      `405 must set Content-Length, got ${JSON.stringify(r2.headers)}`)
+    assert.equal(r2.headers.allow, "POST")
+    // (c) dispatch-end 404 (unknown /api/v0/ endpoint via POST — HEAD
+    // would short-circuit at the 405 method-check first).
+    const r3 = await fetch("/api/v0/unknown-route-xyz", { method: "POST" })
+    assert.equal(r3.status, 404)
+    assert.ok(r3.headers["content-length"] !== undefined,
+      `dispatch-end 404 must set Content-Length, got ${JSON.stringify(r3.headers)}`)
+  })
+
   it("#136: /ipfs/<cid> gateway accepts GET (read-only content addressing)", async () => {
     // The /ipfs/ gateway is intentionally GET-able — it's read-only
     // content addressing, no state mutation possible. Only /api/v0/*

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -455,7 +455,11 @@ export class IpfsHttpServer {
       }
 
       if (!url.pathname?.startsWith("/api/v0/")) {
-        res.writeHead(404)
+        // #382: pre-fix bare `writeHead(404); end()` had no Content-Length
+        // and no Transfer-Encoding. HEAD clients waited 5s+ for the
+        // keep-alive timeout because the response framing was ambiguous.
+        // Set explicit Content-Length: 0 so HEAD short-circuits cleanly.
+        res.writeHead(404, { "content-length": "0" })
         res.end()
         return
       }
@@ -466,8 +470,17 @@ export class IpfsHttpServer {
       // visited webpage trigger state-changing operations (pin/add,
       // block/rm, repo/gc) against a victim's local IPFS daemon.
       if (req.method !== "POST") {
-        res.writeHead(405, { "allow": "POST", "content-type": "application/json" })
-        res.end(JSON.stringify({ error: "method not allowed: /api/v0/* requires POST" }))
+        // #382: same Content-Length fix as the 404 above. For HEAD on
+        // /api/v0/* the body is suppressed by Node but the framing must
+        // still be unambiguous. JSON body length is computed here so HEAD
+        // gets the exact byte count the server would have written.
+        const body = JSON.stringify({ error: "method not allowed: /api/v0/* requires POST" })
+        res.writeHead(405, {
+          "allow": "POST",
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body)),
+        })
+        res.end(req.method === "HEAD" ? undefined : body)
         return
       }
 
@@ -613,8 +626,14 @@ export class IpfsHttpServer {
         return
       }
 
-      res.writeHead(404)
-      res.end(JSON.stringify({ error: "not found" }))
+      // #382: dispatch-end 404 catch-all — set Content-Length so HEAD
+      // doesn't hang waiting for chunked framing.
+      const notFoundBody = JSON.stringify({ error: "not found" })
+      res.writeHead(404, {
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(notFoundBody)),
+      })
+      res.end(req.method === "HEAD" ? undefined : notFoundBody)
       } catch (err) {
         // #180: defensively map ErasureError to 4xx — the inline
         // handleCat path already does this for read-side ErasureError,


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #383.

- Three response sites used \`writeHead(X, headers); end([body])\` with no Content-Length. Node defaulted to chunked Transfer-Encoding; HEAD clients hung 5s+ waiting for the terminating chunk.
- Fixed prefix 404 (non-routable paths), 405 method-not-allowed, and dispatch-end 404 catch-all.
- Body is now suppressed for HEAD via the existing \`req.method === \"HEAD\" ? undefined : body\` idiom.

Same systemic class as #376 (rpc.ts root 405).

## Test plan

- [x] New \`#382\` regression test exercises HEAD on \`/nonexistent\` (prefix 404), GET on \`/api/v0/version\` (405), POST on \`/api/v0/unknown-xyz\` (dispatch-end 404); asserts \`content-length\` header present on all
- [x] TS-strip OK on \`ipfs-http.ts\`
- [x] Targeted subtest passes (ok 1)

Closes #382