### PR TITLE
fix(ipfs-mfs): #418 reject whitespace-only path components (no silent namespace garbage) — rework of toxic PR #419

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1559,6 +1559,9 @@ export class IpfsHttpServer {
           /^directory nesting too deep/i.test(msg) ||
           /^path too long/i.test(msg) ||
           /^null byte in path/i.test(msg) ||
+          // #418: whitespace-only path components rejected at normalizePath
+          // — map to 400 (sibling of path-traversal / null-byte / depth caps).
+          /^path component cannot be whitespace-only/i.test(msg) ||
           // #232: pre-fix normalizePath threw `Error("path traversal not
           // allowed: ...")` for any input containing `..`, but the
           // catch had no regex for it → 500 "internal error" instead of

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -419,3 +419,30 @@ test("#302: mkdir at root depth with file collision still rejects", async () => 
     cleanup()
   }
 })
+
+test("#418: MFS whitespace-only path components rejected (no silent garbage in namespace)", async () => {
+  // Sibling of #380 (empty arg). Pre-fix `arg=%20` (single space),
+  // `arg=%09` (tab), `arg=%20%20%20` (multi-space) sailed through
+  // normalizePath and downstream mkdir/write created files/dirs named
+  // " ", "\t", "   " — silent garbage indistinguishable from a real
+  // empty-name component. Reject so client typos surface.
+  const { mfs, cleanup } = await createMfs()
+  try {
+    const whitespaceProbes = [" ", "\t", "   ", "/\t", "/ ", "/path/ /sub", "/path/\t/sub"]
+    for (const path of whitespaceProbes) {
+      await assert.rejects(
+        () => mfs.mkdir(path),
+        /path component cannot be whitespace-only/i,
+        `mkdir ${JSON.stringify(path)} must reject whitespace-only component`,
+      )
+    }
+    // Sanity: paths with non-whitespace components containing internal
+    // whitespace are still allowed (e.g. "/my dir" — space inside name).
+    await mfs.mkdir("/my dir")
+    const entries = await mfs.ls("/")
+    assert.ok(entries.some((e) => e.name === "my dir"),
+      "internal-whitespace name still allowed")
+  } finally {
+    cleanup()
+  }
+})

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -498,6 +498,16 @@ function normalizePath(path: string): string {
     if (part === ".." || part === ".") {
       throw new Error(`path traversal not allowed: ${path}`)
     }
+    // #418: sibling of #380 (which rejected empty arg). Whitespace-only
+    // path components (`%20`, `%09`, `%20%20%20`) sailed through here
+    // pre-fix and downstream mkdir/write created files/dirs named " ",
+    // "\t", "   " — silent garbage in the MFS namespace, indistinguishable
+    // from a real empty-name component. Reject so client typos surface
+    // (e.g. forgetting to fill in a template variable, accidental
+    // urlencoded space, copy-paste of leading/trailing whitespace).
+    if (part.length > 0 && /^\s+$/.test(part)) {
+      throw new Error(`path component cannot be whitespace-only: ${path}`)
+    }
   }
   return path
 }


### PR DESCRIPTION
## Summary

Rework on current \`main\` of toxic-batch PR #419.

- \`arg=%20\` / \`arg=%09\` / \`arg=%20%20%20\` sailed through \`normalizePath\` and downstream \`mkdir\`/\`write\` created files/dirs named \` \` / \`\\t\` / \`   \` — silent namespace garbage.
- Add \`/^\\s+\$/.test(part)\` check on each path component.
- Extend \`ipfs-http.ts\` route-catch regex with \`^path component cannot be whitespace-only\` → 400.

Internal whitespace in names (e.g. \`/my dir\`) is still permitted — only purely-whitespace components reject.

Sibling of #380 (empty arg rejection); same family as #232, #268, path-traversal, null-byte.

## Test plan

- [x] New \`#418\` regression test exercises \` \`, \`\\t\`, \`   \`, \`/\\t\`, \`/ \`, \`/path/ /sub\`, \`/path/\\t/sub\` → all reject with \`path component cannot be whitespace-only\`
- [x] Sanity: \`/my dir\` (internal whitespace) still allowed
- [x] TS-strip OK on \`ipfs-mfs.ts\` + \`ipfs-http.ts\`

Closes #418