### PR TITLE
fix(rpc): state-query RPCs return defaults at synth-genesis (#384)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1677,6 +1677,86 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(parent !== null, "client following block1.parentHash must reach the genesis (not null)")
   })
 
+  await t.test("#384: state-query RPCs return defaults at synth-genesis instead of -32001 block-not-found", async () => {
+    // Pre-fix: #112 carved a synth-genesis path for eth_getBlockByNumber("earliest")
+    // but the state-query RPCs (eth_getBalance/Code/TxCount/StorageAt/call/...)
+    // still threw -32001 "block not found: earliest" because their helper
+    // resolveHistoricalExecutionContext had no parallel fallback. Wallet
+    // probes (ethers/viem) hitting earliest balance during the JSON-RPC
+    // handshake broke immediately. Match geth/anvil at an empty-allocs
+    // genesis: zero balance, no code, nonce 0, zero storage, "0x" return.
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block so height ≥ 1")
+
+    const TEST_ADDR = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const ZERO_HASH32 = "0x" + "0".repeat(64)
+    const ZERO_ADDR = "0x0000000000000000000000000000000000000000"
+
+    // Cover all five shapes the issue calls out: "earliest", "0x0",
+    // and the three EIP-1898 object forms ({blockNumber: "0x0"}). The
+    // bare-hash and {blockHash} forms target a real block so they
+    // legitimately fail at synth-genesis (no hash to look up) and are
+    // not part of this fix.
+    const SYNTH_GENESIS_TAGS: Array<string | { blockNumber: string }> = [
+      "earliest",
+      "0x0",
+      { blockNumber: "0x0" },
+    ]
+
+    for (const tag of SYNTH_GENESIS_TAGS) {
+      const label = typeof tag === "string" ? tag : JSON.stringify(tag)
+
+      const balance = await rpcCall(port, "eth_getBalance", [TEST_ADDR, tag])
+      assert.equal(balance, "0x0", `eth_getBalance @ ${label} must be 0x0 at synth-genesis`)
+
+      const code = await rpcCall(port, "eth_getCode", [TEST_ADDR, tag])
+      assert.equal(code, "0x", `eth_getCode @ ${label} must be "0x" at synth-genesis`)
+
+      const nonce = await rpcCall(port, "eth_getTransactionCount", [TEST_ADDR, tag])
+      assert.equal(nonce, "0x0", `eth_getTransactionCount @ ${label} must be 0x0 at synth-genesis`)
+
+      const slot = await rpcCall(port, "eth_getStorageAt", [TEST_ADDR, "0x0", tag])
+      assert.equal(slot, ZERO_HASH32, `eth_getStorageAt @ ${label} must be 32-byte zero at synth-genesis`)
+
+      // eth_call against an empty-allocs genesis: no contracts deployed,
+      // returns empty bytes (matches geth/anvil).
+      const callResult = await rpcCall(port, "eth_call", [
+        { to: ZERO_ADDR, data: "0x" },
+        tag,
+      ])
+      assert.equal(callResult, "0x", `eth_call @ ${label} must return "0x" at synth-genesis`)
+
+      // eth_estimateGas: intrinsic-gas floor (21k for value-transfer, 53k
+      // for contract creation). Anvil returns the floor rather than -32001.
+      const estimateGas = await rpcCall(port, "eth_estimateGas", [
+        { to: ZERO_ADDR, value: "0x0" },
+        tag,
+      ])
+      assert.equal(estimateGas, "0x5208", `eth_estimateGas @ ${label} must be intrinsic 21000 (0x5208)`)
+
+      const estimateGasCreate = await rpcCall(port, "eth_estimateGas", [
+        { data: "0x60006000fd" },
+        tag,
+      ])
+      assert.equal(estimateGasCreate, "0xcf08", `eth_estimateGas (creation) @ ${label} must be intrinsic 53000 (0xcf08)`)
+
+      // eth_createAccessList: empty list + intrinsic-gas at synth-genesis.
+      const accessList = await rpcCall(port, "eth_createAccessList", [
+        { to: ZERO_ADDR, data: "0x" },
+        tag,
+      ]) as { accessList: unknown[]; gasUsed: string }
+      assert.deepEqual(accessList.accessList, [], `eth_createAccessList @ ${label} must be empty at synth-genesis`)
+      assert.equal(accessList.gasUsed, "0x5208", `eth_createAccessList gasUsed @ ${label} must be 0x5208`)
+    }
+
+    // Sanity: eth_getBlockByNumber("earliest") still works (the #112 path
+    // we're mirroring). Cross-method symmetry: state queries succeed at
+    // the same tag that block lookups already do.
+    const earliestBlock = await rpcCall(port, "eth_getBlockByNumber", ["earliest", false]) as Record<string, unknown> | null
+    assert.ok(earliestBlock !== null, "eth_getBlockByNumber('earliest') still works")
+    assert.equal(earliestBlock!.number, "0x0")
+  })
+
   await t.test("#108 part-2: coc_getPeers exposes the public peer list (id + url)", async () => {
     const peers = await rpcCall(port, "coc_getPeers") as Array<{ id: string; url: string }>
     assert.ok(Array.isArray(peers), "must return an array")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -799,8 +799,13 @@ async function handleRpc(
       // #122: validate at the boundary so a typo gives -32602 instead of
       // -32603 with the raw input echoed back from the EVM.
       const address = requireAddressParam(payload.params ?? [], 0)
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[1], chain)
-      const balance = await evm.getBalance(address, stateRoot)
+      // #384: short-circuit synth-genesis ("earliest"/"0x0" with no real
+      // block 0) to the empty-allocs default (zero balance), matching
+      // geth/anvil. Without this, ethers/viem wallet probes against
+      // earliest balance break the JSON-RPC handshake.
+      const balanceCtx = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      if (balanceCtx.syntheticGenesis) return "0x0"
+      const balance = await evm.getBalance(address, balanceCtx.stateRoot)
       return `0x${balance.toString(16)}`
     }
     case "eth_getTransactionCount": {
@@ -813,8 +818,10 @@ async function handleRpc(
         const pendingNonce = chain.mempool.getPendingNonce(address as Hex, onchainNonce)
         return `0x${pendingNonce.toString(16)}`
       }
-      const stateRoot = await resolveHistoricalStateRoot(tag, chain)
-      const nonce = await evm.getNonce(address, stateRoot)
+      // #384: synth-genesis ⇒ nonce 0 (no accounts allocated at genesis).
+      const nonceCtx = await resolveHistoricalExecutionContext(tag, chain)
+      if (nonceCtx.syntheticGenesis) return "0x0"
+      const nonce = await evm.getNonce(address, nonceCtx.stateRoot)
       return `0x${nonce.toString(16)}`
     }
     case "eth_getTransactionReceipt": {
@@ -942,6 +949,14 @@ async function handleRpc(
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: synth-genesis ⇒ no contracts deployed, estimate is the bare
+      // intrinsic-gas floor (21k for value-only, 53k for creation). Match
+      // anvil's behaviour: fall back to the intrinsic floor rather than
+      // throwing -32001.
+      if (executionContext.syntheticGenesis) {
+        const isCreate = !estParams.to || estParams.to === ""
+        return `0x${(isCreate ? 53_000n : 21_000n).toString(16)}`
+      }
       // #286: pre-fix eth_estimateGas (which delegates to callRaw under the
       // hood) ignored the underlying call's `failed` flag and returned a
       // gas estimate even when execution reverted — clients would then
@@ -971,8 +986,10 @@ async function handleRpc(
     }
     case "eth_getCode": {
       const codeAddr = requireAddressParam(payload.params ?? [], 0)
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[1], chain)
-      return await evm.getCode(codeAddr, stateRoot)
+      // #384: synth-genesis ⇒ no code allocated.
+      const codeCtx = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      if (codeCtx.syntheticGenesis) return "0x"
+      return await evm.getCode(codeAddr, codeCtx.stateRoot)
     }
     case "eth_call": {
       // #172: reject non-object first param upfront — runtime type
@@ -995,6 +1012,9 @@ async function handleRpc(
       // surfaces as -32603 with V8 message leak (data).
       validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: synth-genesis ⇒ no contracts deployed → empty return.
+      // Matches geth/anvil eth_call against an empty-allocs genesis.
+      if (executionContext.syntheticGenesis) return "0x"
       const callResult = await evm.callRaw({
         from: callParams.from,
         to,
@@ -1031,8 +1051,10 @@ async function handleRpc(
       if (!/^0x[0-9a-fA-F]{1,64}$/.test(storageSlot)) {
         invalidParams(`invalid storage slot: must match /^0x[0-9a-fA-F]{1,64}$/`)
       }
-      const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[2], chain)
-      return await evm.getStorageAt(storageAddr, storageSlot, stateRoot)
+      // #384: synth-genesis ⇒ all slots are zero (no contracts allocated).
+      const storageCtx = await resolveHistoricalExecutionContext((payload.params ?? [])[2], chain)
+      if (storageCtx.syntheticGenesis) return `0x${"0".repeat(64)}`
+      return await evm.getStorageAt(storageAddr, storageSlot, storageCtx.stateRoot)
     }
     case "eth_getProof": {
       const proofAddr = requireAddressParam(payload.params ?? [], 0)
@@ -1470,6 +1492,14 @@ async function handleRpc(
       }
       validateTxCallFields(callParams)
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
+      // #384: synth-genesis ⇒ no contracts, empty access list + intrinsic gas.
+      if (executionContext.syntheticGenesis) {
+        const isCreate = !callParams.to || callParams.to === ""
+        return {
+          accessList: [],
+          gasUsed: `0x${(isCreate ? 53_000n : 21_000n).toString(16)}`,
+        }
+      }
       const result = await evm.traceCall({
         from: callParams.from,
         to: callParams.to ?? "",
@@ -3323,10 +3353,18 @@ async function resolveHistoricalStateRoot(input: unknown, chain: IChainEngine): 
   return (await resolveHistoricalExecutionContext(input, chain)).stateRoot
 }
 
+// #384: state-query RPCs (eth_getBalance, eth_getCode, eth_getTransactionCount,
+// eth_getStorageAt, eth_call/estimateGas, etc.) need to recognise the same
+// synthesised-genesis case that #112 carved out for eth_getBlockByNumber:
+// when the caller asks for block 0 ("earliest" / "0x0" / {blockNumber:"0x0"})
+// and the chain has no persisted block 0 but is past genesis (height ≥ 1),
+// return a sentinel rather than -32001 so the handler can short-circuit to
+// the empty-state default (zero balance, no code, nonce 0, "0x" call return)
+// — matching geth/anvil behaviour at an empty-allocs genesis.
 async function resolveHistoricalExecutionContext(
   input: unknown,
   chain: IChainEngine,
-): Promise<{ stateRoot?: string } & ExecutionContext> {
+): Promise<{ stateRoot?: string; syntheticGenesis?: boolean } & ExecutionContext> {
   if (
     input === undefined ||
     input === null ||
@@ -3418,6 +3456,12 @@ async function resolveHistoricalExecutionContext(
     const blockNumber = parseBlockTag(inner, heightForObj)
     const block = await Promise.resolve(chain.getBlockByNumber(blockNumber))
     if (!block) {
+      // #384: parallel to #112 — block 0 missing with chain past genesis
+      // signals "empty allocs genesis"; surface as syntheticGenesis so
+      // state-query handlers can short-circuit to defaults.
+      if (blockNumber === 0n && heightForObj >= 1n) {
+        return { syntheticGenesis: true, blockNumber: 0n }
+      }
       throw { code: -32001, message: `block not found: ${String(inner)}` }
     }
     if (!block.stateRoot) {
@@ -3434,6 +3478,10 @@ async function resolveHistoricalExecutionContext(
   const blockNumber = parseBlockTag(input, height)
   const block = await Promise.resolve(chain.getBlockByNumber(blockNumber))
   if (!block) {
+    // #384: same synthesised-genesis fallback as the {blockNumber} branch.
+    if (blockNumber === 0n && height >= 1n) {
+      return { syntheticGenesis: true, blockNumber: 0n }
+    }
     throw { code: -32001, message: `block not found: ${String(input)}` }
   }
   if (!block.stateRoot) {


### PR DESCRIPTION
## Summary

Closes #384.

`eth_getBalance/Code/TxCount/StorageAt/call/estimateGas/createAccessList` threw `-32001 block not found: earliest` because `resolveHistoricalExecutionContext` lacked the parallel to #112's synthesised-genesis path (which only `eth_getBlockByNumber` carried). ethers/viem/web3.js wallets probe `earliest` balance during their initial JSON-RPC handshake — every wallet hitting testnet 88780 broke at connect.

## Fix

Mirror #112 inside `resolveHistoricalExecutionContext`: when block 0 is requested (`"earliest"`, `"0x0"`, `{blockNumber:"0x0"}`) and the chain has no persisted block 0 but height ≥ 1, return `{syntheticGenesis:true}`. Each state-query handler short-circuits to the empty-allocs default — matching geth/anvil behaviour at an empty-allocs genesis:

| RPC | Synth-genesis default |
|---|---|
| `eth_getBalance` | `0x0` |
| `eth_getCode` | `"0x"` |
| `eth_getTransactionCount` | `0x0` |
| `eth_getStorageAt` | 32-byte zero |
| `eth_call` | `"0x"` |
| `eth_estimateGas` | `0x5208` (21k) / `0xcf08` (53k creation) |
| `eth_createAccessList` | `{accessList: [], gasUsed: 0x5208}` |

`eth_getProof` and `debug_traceCall/trace_call*` deliberately left alone — out of scope and not part of the wallet handshake path.

## Test plan
- [x] Regression test `#384` in `node/src/rpc-extended.test.ts` covers all 7 RPCs × 3 shapes (`"earliest"`, `"0x0"`, `{blockNumber:"0x0"}`) — passed locally
- [x] No regressions across 128 sibling subtests (suite runs to ~3min with rate-limit disabled; truncated by timeout, no `not ok` lines)
- [x] `node --experimental-strip-types -e "import('./node/src/rpc.ts')"` parses cleanly
- [ ] Live verification on 88780: `curl -X POST … eth_getBalance [addr, "earliest"]` returns `0x0` not `-32001`