### PR TITLE
fix(ipfs): readMultipartFile rejects empty/multi-part/boundaryless bodies (#356)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -177,6 +177,99 @@ describe("IpfsHttpServer", () => {
     assert.deepEqual(new Uint8Array(buf), data)
   })
 
+  it("#356: /api/v0/add rejects empty multipart body (no parts) with 400 invalid_multipart", async () => {
+    // Pre-fix: `--BOUNDARY--\r\n` (no parts at all) returned 200 with the
+    // empty-file CID `bafybeihjs...` — clients believed their (non-empty)
+    // file was uploaded but the server received zero bytes. Silent data
+    // loss. Reject explicitly.
+    const boundary = "----EmptyMpBoundary356"
+    const body = `--${boundary}--\r\n`
+    const res = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    assert.equal(res.status, 400,
+      `empty multipart must be 400, got ${res.status}`)
+    const errBody = await res.json() as Record<string, string>
+    assert.equal(errBody.error, "invalid_multipart",
+      `error code must be invalid_multipart, got ${JSON.stringify(errBody)}`)
+    assert.match(errBody.message ?? "", /no part found/i,
+      `error message must mention "no part found", got: ${errBody.message}`)
+  })
+
+  it("#356: /api/v0/add rejects multi-part body (2+ parts) with 400 unsupported_multipart (no silent drop)", async () => {
+    // Pre-fix: the readMultipartFile loop returned on the FIRST part. A
+    // 2-file multipart upload returned the CID for file #1 and silently
+    // dropped file #2 — the client saw 200 OK and believed BOTH files
+    // were stored. /api/v0/add is single-file; reject multi-part.
+    const boundary = "----MultiMpBoundary356"
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="a"',
+      "",
+      "alpha",
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="b"',
+      "",
+      "beta",
+      `--${boundary}--`,
+      "",
+    ].join("\r\n")
+    const res = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+    assert.equal(res.status, 400,
+      `multi-part body must be 400, got ${res.status}`)
+    const errBody = await res.json() as Record<string, string>
+    assert.equal(errBody.error, "unsupported_multipart",
+      `error code must be unsupported_multipart, got ${JSON.stringify(errBody)}`)
+    assert.match(errBody.message ?? "", /has 2 parts/i,
+      `error must surface part count, got: ${errBody.message}`)
+  })
+
+  it("#356: /api/v0/add rejects multipart/* Content-Type without boundary param", async () => {
+    // Pre-fix: `Content-Type: multipart/form-data` (no boundary param)
+    // fell through to the raw-body fallback — the literal envelope bytes
+    // `--XYZ\r\nContent-Disposition...\r\n\r\nfile-bytes\r\n--XYZ--` got
+    // content-addressed and stored verbatim, masquerading as the inner
+    // file. Multipart Content-Type without boundary is malformed per
+    // RFC 2046 §5.1.1; reject at the boundary.
+    const body = '--XYZ\r\nContent-Disposition: form-data; name="file"; filename="x"\r\n\r\nfile-bytes\r\n--XYZ--\r\n'
+    const res = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": "multipart/form-data" }, // no boundary!
+      body,
+    })
+    assert.equal(res.status, 400,
+      `boundaryless multipart must be 400, got ${res.status}`)
+    const errBody = await res.json() as Record<string, string>
+    assert.equal(errBody.error, "invalid_multipart",
+      `error code must be invalid_multipart, got ${JSON.stringify(errBody)}`)
+    assert.match(errBody.message ?? "", /boundary/i,
+      `error must mention boundary, got: ${errBody.message}`)
+  })
+
+  it("#356: /api/v0/add raw-body fallback still works (octet-stream / no Content-Type)", async () => {
+    // Regression guard: kubo CLI uses multipart, but raw-body uploads via
+    // `curl --data-binary` (no Content-Type, or application/octet-stream)
+    // remain a supported path. Pre-fix and post-fix both accept these.
+    const content = new TextEncoder().encode("raw upload bytes 356")
+    const r1 = await fetch("/api/v0/add", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: content,
+    })
+    assert.equal(r1.status, 200,
+      "octet-stream raw upload must still succeed")
+    const b1 = await r1.json() as Record<string, string>
+    assert.ok(b1.Hash, "raw upload must return a CID")
+    assert.equal(b1.Size, String(content.length),
+      "raw upload Size must match input length")
+  })
+
   it("#92: POST /api/v0/block/put extracts file bytes from kubo-style multipart", async () => {
     // Pre-fix bug: the entire multipart envelope (boundary, headers,
     // closing boundary) was stored as block bytes — incompatible with the

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -2004,6 +2004,19 @@ async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?
   // Limit boundary length to prevent split amplification DoS
   const boundaryMatch = /boundary=([^;\s]{1,256})/.exec(contentType)
   if (!boundaryMatch) {
+    // #356: pre-fix `Content-Type: multipart/form-data` (no boundary param)
+    // fell through to the raw-body fallback and the multipart envelope
+    // bytes were stored verbatim as a "file" — the literal
+    // `--XYZ\r\nContent-Disposition...\r\n\r\nfile-bytes\r\n--XYZ--`
+    // got content-addressed and returned as the CID. Reject multipart/*
+    // without boundary so clients can't accidentally upload envelope
+    // bytes thinking they uploaded the inner file. Non-multipart
+    // Content-Types (octet-stream, empty, etc.) still pass through —
+    // kubo CLI + curl --data-binary depend on the raw-body fallback.
+    if (/^multipart\//i.test(contentType.trim())) {
+      throw new HttpError(400, "invalid_multipart",
+        "multipart/* Content-Type requires boundary param")
+    }
     const raw = await readBody(req)
     return { bytes: raw }
   }
@@ -2011,6 +2024,11 @@ async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?
   const boundary = boundaryMatch[1]
   const raw = Buffer.from(await readBody(req))
   const parts = findMultipartParts(raw, boundary)
+  // #356: pre-fix the loop returned on the FIRST part and silently
+  // dropped any additional parts. A 2-file multipart upload returned
+  // a CID for file #1 and the client believed both files were stored.
+  // Accumulate validParts and reject !=1 — this endpoint is single-file.
+  const validParts: Array<{ filename?: string; bytes: Uint8Array }> = []
   for (const { start, end } of parts) {
     const part = raw.subarray(start, end)
     // Headers/body separator is the FIRST \r\n\r\n inside the part.
@@ -2022,8 +2040,20 @@ async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?
     const rawFilename = filenameMatch ? filenameMatch[1] : undefined
     // Strip path components to prevent directory traversal in metadata
     const filename = rawFilename ? rawFilename.replace(/.*[/\\]/, "").slice(0, 255) || undefined : undefined
-    return { filename, bytes: new Uint8Array(body) }
+    validParts.push({ filename, bytes: new Uint8Array(body) })
   }
 
-  return { bytes: new Uint8Array() }
+  // #356: pre-fix returned `{bytes: new Uint8Array()}` (empty file's CID)
+  // when no parts matched — clients uploading their (non-empty) file got
+  // a success response carrying the empty-file CID and silently lost
+  // their data. Reject empty multipart bodies with 400.
+  if (validParts.length === 0) {
+    throw new HttpError(400, "invalid_multipart",
+      "no part found in multipart body")
+  }
+  if (validParts.length > 1) {
+    throw new HttpError(400, "unsupported_multipart",
+      `multipart body has ${validParts.length} parts, but this endpoint accepts at most 1`)
+  }
+  return validParts[0]
 }


### PR DESCRIPTION
## Summary

Closes #356. **High severity** — silent data loss + content-address mismatches.

`readMultipartFile` in `node/src/ipfs-http.ts` (called by `/api/v0/{add,block/put,pubsub/pub,files/write}`) had three silent-accept paths:

| # | Input | Pre-fix | What client saw | Reality |
|---|---|---|---|---|
| A | Empty multipart `--BOUNDARY--` | 200 + empty-file CID | "uploaded my file" | Zero bytes received |
| B | 2 file parts | 200 + first-file CID | "uploaded both files" | Second part **silently dropped** |
| C | `multipart/form-data` no `boundary=` | 200 + envelope CID | "parsed multipart" | **Literal envelope bytes stored as file** |

## Fix (`node/src/ipfs-http.ts:2002-2059`)

Replace the early-return loop with a `validParts` accumulator:

- 0 parts → `400 invalid_multipart "no part found in multipart body"`
- >1 parts → `400 unsupported_multipart "multipart body has N parts, but this endpoint accepts at most 1"`
- `multipart/*` Content-Type without boundary → `400 invalid_multipart "multipart/* Content-Type requires boundary param"`

Non-multipart Content-Types (`application/octet-stream`, no header) still pass through the raw-body fallback — kubo CLI + `curl --data-binary` flows preserved.

## Test plan

4 new subtests in `node/src/ipfs-http.test.ts` (passing locally):

- `#356: /api/v0/add rejects empty multipart body (no parts) with 400 invalid_multipart`
- `#356: /api/v0/add rejects multi-part body (2+ parts) with 400 unsupported_multipart (no silent drop)`
- `#356: /api/v0/add rejects multipart/* Content-Type without boundary param`
- `#356: /api/v0/add raw-body fallback still works (octet-stream / no Content-Type)` — regression guard

- [x] `node --experimental-strip-types -e "import('./node/src/ipfs-http.ts')"` clean
- [x] All 4 #356 subtests PASS
- [x] **107/107 ipfs-http.test.ts subtests PASS** (0 regressions, including existing /add and /block/put multipart tests)

## Live testnet 88780 verification (after merge)

```bash
IPFS=http://159.198.36.25:28800
B='----X'

# A: empty multipart — now 400 (was 200 with empty CID)
printf -- '--%s--\r\n' "$B" | curl -sS -X POST "$IPFS/api/v0/add" \
  -H "Content-Type: multipart/form-data; boundary=$B" --data-binary @-
# {"error":"invalid_multipart","message":"no part found in multipart body"}

# B: 2-file multipart — now 400 (was 200 with one CID, second file silently dropped)
# {"error":"unsupported_multipart","message":"multipart body has 2 parts, but this endpoint accepts at most 1"}

# C: missing boundary — now 400 (was 200 with envelope CID)
# {"error":"invalid_multipart","message":"multipart/* Content-Type requires boundary param"}
```