### PR TITLE
docs(rpc): #108 part-4 — replace unimplemented coc_poseStatus + coc_validatorActivity refs

### DIFF
--- a/docs/openclaw-skills-v0.2-spec.md
+++ b/docs/openclaw-skills-v0.2-spec.md
@@ -91,8 +91,9 @@ openclaw coc pose-status [--node <id>] [--epoch <n>] [--json] [--watch]
 - Pretty-printed banner identifies the failing leg in human mode; JSON
   mode encodes via the `health.issues` array.
 
-**Backing RPC calls**: `coc_nodeInfo`, `coc_chainStats`, `coc_poseStatus`
-(adminRpc-gated), `coc_getEquivocations`. All read-only.
+**Backing RPC calls**: `coc_nodeInfo`, `coc_chainStats`, `coc_getBftStatus`
+(BFT-progress signals, partial substitute for the `coc_poseStatus` originally
+sketched here), `coc_getEquivocations`. All read-only.
 
 ## 2. `openclaw coc chain-stats`
 
@@ -133,7 +134,10 @@ openclaw coc chain-stats [--node <id>] [--window <duration>] [--validators] [--j
 ```
 
 **Backing**: `coc_chainStats`, `eth_getBlockByNumber` for sampled blocks,
-`coc_validatorActivity`.
+`coc_validators` (per-validator stake + voting power; the
+`coc_validatorActivity` previously referenced here is not implemented —
+the `blocksProposed` / `missedRotations` fields above are computed
+skill-side by walking sampled blocks).
 
 ## 3. `openclaw coc health`
 


### PR DESCRIPTION
## Summary

Closes #108. Part 4 of the audit started in parts 1-3.

#108 listed 5 \`coc_*\` RPCs referenced in docs but not implemented:

| RPC | Resolution |
|---|---|
| \`coc_erasureStatus\` | Implemented in part-1 (\`d166a1c\`) |
| \`coc_getPeers\` | Implemented in part-2 (\`55af462\`) |
| \`coc_getContractsByPage\` | Renamed in docs to \`coc_getContracts\` in part-3 (\`6d1e870\`) |
| \`coc_poseStatus\` | **This PR**: replaced with \`coc_getBftStatus\` + \`coc_getEquivocations\` |
| \`coc_validatorActivity\` | **This PR**: replaced with \`coc_validators\` + skill-side block walking |

The v0.2 spec sketched both methods but no implementation ever landed. Replacing the spec refs with existing siblings closes the audit without adding speculative APIs.

## Test plan

- [x] \`grep -rE \"coc_poseStatus|coc_validatorActivity\" docs/ node/\` returns only the explanatory mentions in the updated spec, no live API refs
- [x] All replacement RPCs (\`coc_getBftStatus\`, \`coc_getEquivocations\`, \`coc_validators\`) have working handlers in \`node/src/rpc.ts\`