### PR TITLE
test(ipfs-http): #168 fix one-char CID typo (#592)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -592,7 +592,16 @@ describe("IpfsHttpServer", () => {
     // non-traversal string through isValidCid, then the blockstore
     // ENOENT propagated as a generic 500 with a stacktrace logged.
     // Now: malformed CID → 400, valid-shape-missing CID → 404.
-    const missingButValid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhz"
+    //
+    // #592: pre-fix the CID below ended in 'z' (one-char typo from the
+    // sibling test at line 583's `...alhy`). `bafy...alhz` looks like
+    // a valid CIDv1 (base32 alphabet OK, regex pass) but the decoded
+    // multihash bytes are truncated — `CID.parse` throws "Unexpected
+    // end of data", so `resolveCid` raises `ErasureError("invalid_cid")`
+    // and the gateway returns 400, not the expected 404. Use the
+    // properly-parseable sibling so the test exercises what its name
+    // claims: a valid-shape CID that just isn't stored.
+    const missingButValid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy"
     // (a) gateway: malformed → 400
     const gw1 = await fetch(`/ipfs/bogus`)
     assert.equal(gw1.status, 400, "gateway must reject 'bogus' with 400 (not 500)")


### PR DESCRIPTION
## Summary

Closes #592.

The `#168` test at `node/src/ipfs-http.test.ts:595` was failing on `main` (pre-existing — surfaced during the 2026-05-15 Ralph loop's full-suite regression run).

## Root cause: 1-character CID typo

```diff
-const missingButValid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhz"
+const missingButValid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy"
```

The trailing `z` (vs `y` at line 583's sibling test) makes the base32-decoded multihash bytes **truncated**. `CID.parse()` throws `"Unexpected end of data"`, so `resolveCid` raises `ErasureError("invalid_cid")` → 400, not the 404 the test name promises.

## Verified

```
node --experimental-strip-types -e "import * as m from 'multiformats'; ..."
bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhz → THROW: Unexpected end of data
bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy → OK codec=0x70   ← dag-pb
```

With the `y` form (which the sibling test on line 583 already uses correctly), the gateway returns clean 404 "block not found" for the unstored CID.

## Test plan

- [x] `#168` subtest now PASSES (was failing on main)
- [x] Full ipfs-http suite: **121/121 PASS** (was 120/121)
- [x] Sibling `#370` (which uses the `y` form on line 583) still green
- [x] `node --experimental-strip-types -e "import('./node/src/ipfs-http.test.ts')"` clean

Only changes a test fixture string + adds the explanatory comment — no production code changes.