### PR TITLE
fix(evm): KZG point_evaluation precompile (0x0a) reverts explicitly (#594)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -1,4 +1,5 @@
 import { VM, createVM, runTx } from "@ethereumjs/vm"
+import { EVMError } from "@ethereumjs/evm"
 import { Hardfork, createCustomCommon, getPresetChainConfig } from "@ethereumjs/common"
 import { Account, Address, bytesToHex, hexToBytes, bigIntToBytes, bigIntToHex, setLengthLeft } from "@ethereumjs/util"
 import { createTxFromRLP, createLegacyTx } from "@ethereumjs/tx"
@@ -159,7 +160,62 @@ export class EvmChain {
     const common = createCustomCommon({ chainId, networkId: chainId, name: "COC" }, base, {
       hardfork,
     })
-    const vmOpts: Record<string, unknown> = { common }
+    // #594: COC runs Cancun-fork (parentBeaconBlockRoot + Cancun opcodes are
+    // active) but does NOT initialise the EIP-4844 KZG trusted setup, so
+    // @ethereumjs/vm omits the `point_evaluation` precompile from its
+    // registry. Pre-fix, calls to 0x000…000a fell through as a regular CALL
+    // to an empty-code address, returning `"0x"` — silently masquerading
+    // as a successful no-op. Contracts that bridge KZG-protected data from
+    // other chains then read `uint256(bytes32(""))` = 0 and proceed as if
+    // verification succeeded.
+    //
+    // Mempool already rejects type-3 blob txs (`mempool.ts` "blob
+    // transactions (type 3) are not supported"), but precompile calls
+    // bypass the mempool entirely (eth_call + contract bytecode). Wire a
+    // stub at 0x0a that always REVERTS with an explicit reason so callers
+    // distinguish "precompile failed" from "precompile returned empty
+    // because chain doesn't support blobs".
+    //
+    // Charges a flat 50_000 gas (matches EIP-4844 spec POINT_EVALUATION_
+    // PRECOMPILE_GAS so gas-usage stays portable with mainnet-compiled
+    // contracts that target this precompile).
+    const KZG_PRECOMPILE_ADDRESS = Address.fromString("0x000000000000000000000000000000000000000a")
+    const KZG_GAS_COST = 50_000n  // EIP-4844 POINT_EVALUATION_PRECOMPILE_GAS
+    const kzgStub = (input: { data: Uint8Array; gasLimit: bigint }) => {
+      if (input.gasLimit < KZG_GAS_COST) {
+        // Out-of-gas: charge all available, no return value.
+        return { exceptionError: new EVMError("out of gas"), executionGasUsed: input.gasLimit, returnValue: new Uint8Array() }
+      }
+      // Always revert. The returnValue is the Solidity-ABI-encoded
+      // `Error(string)`: selector 0x08c379a0 || abi.encode(reason).
+      // Encoded reason: "KZG point_evaluation not implemented on COC"
+      const reason = "KZG point_evaluation not implemented on COC"
+      const reasonBytes = new TextEncoder().encode(reason)
+      // 0x08c379a0 (4) | offset=0x20 (32) | length (32) | data padded to 32-byte multiple
+      const padded = new Uint8Array(Math.ceil(reasonBytes.length / 32) * 32)
+      padded.set(reasonBytes)
+      const selector = hexToBytes("0x08c379a0")
+      const offset = setLengthLeft(bigIntToBytes(32n), 32)
+      const length = setLengthLeft(bigIntToBytes(BigInt(reasonBytes.length)), 32)
+      const ret = new Uint8Array(selector.length + offset.length + length.length + padded.length)
+      ret.set(selector, 0)
+      ret.set(offset, selector.length)
+      ret.set(length, selector.length + offset.length)
+      ret.set(padded, selector.length + offset.length + length.length)
+      return {
+        exceptionError: new EVMError("revert"),
+        executionGasUsed: KZG_GAS_COST,
+        returnValue: ret,
+      }
+    }
+    const vmOpts: Record<string, unknown> = {
+      common,
+      evmOpts: {
+        customPrecompiles: [
+          { address: KZG_PRECOMPILE_ADDRESS, function: kzgStub },
+        ],
+      },
+    }
     if (stateManager) {
       vmOpts.stateManager = stateManager
     }

--- a/node/src/precompiles.test.ts
+++ b/node/src/precompiles.test.ts
@@ -214,13 +214,47 @@ test("Precompiled Contracts - Edge Cases", async (t) => {
     assert.ok(result.returnValue !== undefined)
   })
 
-  await t.test("invalid precompile address (0x0a)", async () => {
-    // 不存在的预编译地址应返回空
+  await t.test("#594: KZG point_evaluation (0x0a) reverts with explicit reason on Cancun chain (was silent 0x)", async () => {
+    // Pre-fix #594: COC runs Cancun-fork blocks but doesn't initialise the
+    // EIP-4844 KZG trusted setup, so @ethereumjs/vm omits precompile0a.
+    // Calls fell through as a regular CALL to an empty-code address and
+    // returned `"0x"` — masquerading as a successful no-op. Contracts
+    // that bridge KZG-protected data from Ethereum mainnet would then
+    // read `uint256(bytes32(""))` = 0 and silently proceed as if the
+    // proof verified.
+    //
+    // Fix: register a customPrecompile at 0x0a that ALWAYS reverts with
+    // ABI-encoded Error("KZG point_evaluation not implemented on COC"),
+    // charging EIP-4844's POINT_EVALUATION_PRECOMPILE_GAS (50_000).
+    // Callers now see an explicit revert (the documented EIP-4844
+    // failure mode for invalid input) instead of silent empty bytes.
     const result = await evm.callRaw({
       to: "0x000000000000000000000000000000000000000a",
-      data: "0x1234",
+      data: "0x" + "00".repeat(192),  // canonical EIP-4844 input length
+      gas: "0xf4240",  // 1M gas (well above 50k)
     })
+    // Reverted: failed flag set, gasUsed >= KZG_GAS_COST + base call cost.
+    assert.equal(result.failed, true, "0x0a must REVERT, not return empty")
+    // returnValue should be Solidity-ABI Error(string) shape:
+    //   selector 0x08c379a0 | offset 0x20 | length | reason bytes (padded)
+    assert.match(result.returnValue, /^0x08c379a0/,
+      `returnValue must start with Error(string) selector, got ${result.returnValue?.slice(0, 20)}`)
+    // Decode the reason from the ABI-encoded revert data.
+    // Skip selector (4) + offset (32) + length (32) = 68 bytes (136 hex chars after "0x")
+    const reasonHex = result.returnValue.slice(2 + 136)
+    const reasonBytes = Buffer.from(reasonHex, "hex")
+    // Trim trailing zero padding
+    const reasonStr = reasonBytes.toString("utf8").replace(/\0+$/, "")
+    assert.match(reasonStr, /KZG point_evaluation not implemented on COC/i,
+      `revert reason must mention KZG, got: ${reasonStr}`)
+  })
 
-    assert.equal(result.returnValue, "0x")
+  await t.test("#594: KZG precompile out-of-gas charges gasLimit and reverts", async () => {
+    const result = await evm.callRaw({
+      to: "0x000000000000000000000000000000000000000a",
+      data: "0x" + "00".repeat(192),
+      gas: "0x5208",  // 21k — below the 50k POINT_EVALUATION_PRECOMPILE_GAS
+    })
+    assert.equal(result.failed, true, "OOG must surface as failed call, not empty success")
   })
 })


### PR DESCRIPTION
## Summary

Closes #594. **Medium severity** — silent precompile no-op on a Cancun-fork chain. Discovered during 2026-05-15 Ralph stress-test of testnet 88780.

## Bug

COC runs Cancun-fork (blocks include `parentBeaconBlockRoot`/`excessBlobGas`/`blobGasUsed`; Cancun opcodes active) but doesn't initialise the EIP-4844 KZG trusted setup. `@ethereumjs/vm` therefore omits `precompile0a` from its registry, and CALL to `0x000…000a` falls through as a regular CALL to an empty-code address — returning `"0x"`.

Contracts that bridge KZG-protected data from other chains read `uint256(bytes32(""))` = 0 and proceed as if verification succeeded. The existing mempool guard rejects type-3 blob txs at submission, but precompile calls bypass the mempool entirely (eth_call / contract bytecode), so the gap is reachable.

## Fix

Register a `customPrecompile` at `0x0a` that always REVERTS with ABI-encoded `Error("KZG point_evaluation not implemented on COC")`, charging EIP-4844's `POINT_EVALUATION_PRECOMPILE_GAS = 50_000` to keep gas-accounting portable with mainnet-compiled contracts.

## Why explicit revert over wiring the real precompile

- COC doesn't process blobs (type-3 txs rejected at mempool)
- Real KZG needs the 4 MB `loadTrustedSetup` ceremony parameters + adds ~50ms startup
- An explicit revert is the documented EIP-4844 failure mode for invalid input
- Callers can detect "this chain doesn't support KZG" reliably

If/when COC adds full blob support, this stub is replaced; the test below pins the current invariant.

## Test plan

- [x] `node/src/precompiles.test.ts:#594` (2 new subtests): explicit revert + OOG revert. **Pass.**
- [x] Existing `invalid precompile address (0x0a)` test updated — it asserted `returnValue === "0x"` which **masked the bug**. The comment "不存在的预编译地址应返回空" was wrong on a Cancun chain.
- [x] `precompiles.test.ts` 17/17, `cancun-compat.test.ts` 12/12, `evm.test.ts` 9/9 — no regressions
- [x] `node --experimental-strip-types -e "import('./node/src/evm.ts')"` clean

## Live testnet 88780 (after deploy):

```bash
RPC=http://159.198.36.3:28780
ZEROS=$(printf '0%.0s' $(seq 1 384))
curl -X POST $RPC -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_call\",\
  \"params\":[{\"to\":\"0x000000000000000000000000000000000000000a\",\
  \"data\":\"0x${ZEROS}\",\"gas\":\"0xf4240\"},\"latest\"]}"
# Pre-fix:  {"result":"0x"}                                          ← bug
# Post-fix: {"error":{"code":3,"message":"execution reverted",
#                     "data":"0x08c379a0…KZG point_evaluation…"}}   ← explicit
```