### PR TITLE
fix(rpc): gate Cancun fields in formatBlock by stored presence (#596)

### DIFF
--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -4502,9 +4502,21 @@ async function formatBlock(block: Awaited<ReturnType<IChainEngine["getBlockByNum
     baseFeePerGas: `0x${headerView.baseFeePerGas.toString(16)}`,
     withdrawals: [],
     withdrawalsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-    blobGasUsed: `0x${(block.blobGasUsed ?? 0n).toString(16)}`,
-    excessBlobGas: `0x${(block.excessBlobGas ?? 0n).toString(16)}`,
-    parentBeaconBlockRoot: block.parentBeaconBlockRoot ?? ("0x" + "0".repeat(64)),
+    // #596: gate Cancun-only fields (parentBeaconBlockRoot, blobGasUsed,
+    // excessBlobGas) on whether the block actually stored them.
+    // Pre-fix used `block.X ?? defaultZero` which unconditionally emitted
+    // zero defaults — on a Shanghai chain, blocks don't store these
+    // fields at all (chain-engine.ts:497-499 only persists when the
+    // upstream EVM execution set them, which happens iff Cancun is
+    // active). The unconditional emission made eth_getBlockByNumber lie
+    // that the chain was Cancun (claiming all 3 EIP-4844/4788 fields
+    // present), while EVM execution rejected Cancun opcodes
+    // (TLOAD/TSTORE/MCOPY/BLOBHASH/BLOBBASEFEE) as "invalid opcode".
+    // Clients (ethers, viem) handle these fields as optional — emit
+    // them when present, omit when absent, matching the actual fork.
+    ...(block.blobGasUsed !== undefined ? { blobGasUsed: `0x${block.blobGasUsed.toString(16)}` } : {}),
+    ...(block.excessBlobGas !== undefined ? { excessBlobGas: `0x${block.excessBlobGas.toString(16)}` } : {}),
+    ...(block.parentBeaconBlockRoot !== undefined ? { parentBeaconBlockRoot: block.parentBeaconBlockRoot } : {}),
     // #481: default to false so the key is always serialized. Pre-fix a
     // chain block stored without a finalized flag (e.g. genesis-as-real-
     // block on older chains, or any pre-BFT-finalization block) emitted


### PR DESCRIPTION
## Summary

Closes #596. Discovered during 2026-05-15 Ralph stress-test.

## Bug

`formatBlock` in `node/src/rpc.ts:4505-4507` emitted Cancun-only fields with zero defaults:

```ts
blobGasUsed: \`0x\${(block.blobGasUsed ?? 0n).toString(16)}\`,
excessBlobGas: \`0x\${(block.excessBlobGas ?? 0n).toString(16)}\`,
parentBeaconBlockRoot: block.parentBeaconBlockRoot ?? ("0x" + "0".repeat(64)),
```

The chain-engine correctly stores nothing when these fields are undefined (Shanghai chain). But the formatter falsified zero defaults, making **every eth_getBlockByNumber response look Cancun** while the EVM rejected Cancun opcodes as `"invalid opcode"`.

Fork-gated opcode probe on testnet 88780 confirmed the actual hardfork:

| Opcode | Activated | COC Result |
|---|---|---|
| BASEFEE (0x48) | London+ | ✅ works |
| PREVRANDAO (0x44) | Paris+ | ✅ works |
| PUSH0 (0x5f) | Shanghai+ | ✅ works |
| TLOAD/TSTORE/MCOPY/BLOBHASH/BLOBBASEFEE | Cancun+ | ❌ "invalid opcode" |

So chain is **exactly Shanghai** but the formatter pretended Cancun.

## Impact

- Clients (ethers, viem) seeing Cancun fields assumed Cancun semantics
- Bridge contracts called `0x0a` KZG precompile (silently returned empty pre-PR #595)
- Block-hash verifiers re-hashing the emitted header got wrong hash (Shanghai header doesn't include these fields)
- Solidity 0.8.24+ contracts emitting MCOPY for memory copies got `"invalid opcode"` revert

## Fix

Replace `block.X ?? defaultZero` with conditional spread, matching `chain-engine.ts:497-499`'s existing storage pattern:

```diff
-blobGasUsed: \`0x\${(block.blobGasUsed ?? 0n).toString(16)}\`,
-excessBlobGas: \`0x\${(block.excessBlobGas ?? 0n).toString(16)}\`,
-parentBeaconBlockRoot: block.parentBeaconBlockRoot ?? ("0x" + "0".repeat(64)),
+...(block.blobGasUsed !== undefined ? { blobGasUsed: \`0x\${block.blobGasUsed.toString(16)}\` } : {}),
+...(block.excessBlobGas !== undefined ? { excessBlobGas: \`0x\${block.excessBlobGas.toString(16)}\` } : {}),
+...(block.parentBeaconBlockRoot !== undefined ? { parentBeaconBlockRoot: block.parentBeaconBlockRoot } : {}),
```

On Shanghai: fields omitted (correct).  
On Cancun: fields emitted (correct).

ethers / viem treat these as **optional fields**, so the change is backward-compatible.

## Test plan

- [x] `node --experimental-strip-types -e "import('./node/src/rpc.ts')"` clean
- [x] **135/136 rpc-extended tests pass** (the 1 failure is `#390 "missing filter returns []"` — pre-existing, fixture stale since PR #573 changed behavior to -32000; **unrelated to this PR**, verified failing on bare main)
- [x] `#452` synth-genesis test still passes (formatGenesisBlock unchanged — its Cancun fields are hardcoded for the synth path)
- [x] `#448` extraData test still passes
- [ ] Live testnet 88780: after merge, eth_getBlockByNumber response no longer contains parentBeaconBlockRoot/excessBlobGas/blobGasUsed

## Note for operators

This PR fixes the **formatter inconsistency**. To actually run Cancun semantics (activate TLOAD/TSTORE/MCOPY/BLOBHASH/BLOBBASEFEE + EIP-4788 beacon-roots contract + EIP-4844 KZG precompile), set `COC_HARDFORK=cancun` on validator nodes. That's an operational decision logged in #596 (Option A in the issue body). My PR #595 (KZG explicit-revert stub) provides safe behavior at 0x0a regardless of hardfork.