### PR TITLE
test(rpc-extended): fix #390 stale missing-filter assertion

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -487,10 +487,16 @@ test("RPC Extended Methods", async (t) => {
     const r3 = await rpcCall(port, "eth_getFilterLogs", [logFid])
     assert.ok(Array.isArray(r3), "log filter still works")
 
-    // Missing filter case (sanity: #342 unchanged, returns []):
+    // Missing filter case: per the #342 fix landed in PR #573, missing
+    // filter id now returns -32000 "filter not found" (geth semantic),
+    // NOT silent []. Pre-fix this assertion expected `[]` which was the
+    // OLD (pre-#342) behavior; the test fixture was stale since PR #573.
     const missing = "0x" + "00".repeat(16)
-    const r4 = await rpcCall(port, "eth_getFilterLogs", [missing])
-    assert.deepEqual(r4, [], "missing filter returns [] (#342 contract)")
+    const r4raw = await rpcCallRaw(port, "eth_getFilterLogs", [missing])
+    assert.ok(r4raw.error, "missing filter must error (not silent [])")
+    assert.equal(r4raw.error!.code, -32000, `expected -32000, got ${r4raw.error!.code}`)
+    assert.match(r4raw.error!.message, /filter not found/i,
+      `expected "filter not found", got: ${r4raw.error!.message}`)
   })
 
   await t.test("#360: oversize RPC body returns 413 + JSON-RPC error (no ECONNRESET race after res.end)", async () => {


### PR DESCRIPTION
## Summary

Quick test-fixture fix: the `#390` test in \`node/src/rpc-extended.test.ts:493\` had a stale sanity-check from before PR #573 landed the #342 fix.

\`\`\`diff
-// Missing filter case (sanity: #342 unchanged, returns []):
-assert.deepEqual(r4, [], "missing filter returns [] (#342 contract)")
+// Missing filter case: per PR #573 (revival), returns -32000 "filter not found"
+assert.equal(r4raw.error!.code, -32000, ...)
+assert.match(r4raw.error!.message, /filter not found/i, ...)
\`\`\`

## Why

PR #573 (revived from toxic PR #343) landed `#342` which changed missing-filter behavior from silent `[]` to -32000 "filter not found" (geth semantic). The #390 test was never updated to match — it was the only failure in the rpc-extended suite (135/136 → now 136/136).

Surfaced during 2026-05-15 Ralph stress-test full-suite run.

## Test plan

- [x] `#390` subtest now PASSES (was failing on main)
- [x] **Full rpc-extended suite: 136/136 pass** (was 135/136)
- [x] No production code changed — fixture-only fix