### PR TITLE
fix(rpc): #599 eth_feeHistory rejects newestBlock beyond chain head

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2601,6 +2601,33 @@ test("RPC Extended Methods", async (t) => {
     assert.match(r2.error!.message, /monotonic|ascending|non-decreasing/i, "error must mention ordering")
   })
 
+  await t.test("#599: eth_feeHistory rejects newestBlock beyond chain head (was fabricating future-block data)", async () => {
+    // Pre-fix: requesting newestBlock = 0xffffffffff (future) silently
+    // produced `blockCount` entries labelled with the requested future
+    // numbers, all carrying baseFeePerGas=baseline / gasUsedRatio=0 /
+    // reward=[]. A client wiring this into a fee-prediction heuristic
+    // would think mainnet had crashed into a deflation spiral. Geth
+    // rejects unknown blocks; we reject with -32602 because the
+    // request itself names a block that doesn't exist yet.
+    const probe = async (newest: unknown, count: unknown = "0x4") => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_feeHistory", params: [count, newest, []] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // (a) Future block — reject.
+    const future = await probe("0xffffffffff")
+    assert.equal(future.error?.code, -32602, `future newestBlock must be -32602, got ${future.error?.code}: ${JSON.stringify(future.result)}`)
+    assert.match(future.error!.message, /beyond chain head|newestBlock/i, "error must name newestBlock")
+    // (b) "latest" / "pending" tags MUST still work (they're not "beyond" head).
+    const ok1 = await probe("latest")
+    assert.equal(ok1.error, undefined, `'latest' must not error: ${JSON.stringify(ok1.error)}`)
+    const ok2 = await probe("pending")
+    assert.equal(ok2.error, undefined, `'pending' must not error: ${JSON.stringify(ok2.error)}`)
+  })
+
   await t.test("#162: eth_getLogs validates address + topic shape (parity with eth_newFilter #142)", async () => {
     // Pre-fix `eth_getLogs({address:"0x123"})` silently returned [] —
     // clients couldn't distinguish "no matching logs" from "your filter

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1950,6 +1950,18 @@ async function handleRpc(
         prevPercentile = p
       }
       const newest = await resolveBlockNumber(newestBlock, chain)
+      // #599: pre-fix a numeric newestBlock beyond chain tip silently
+      // produced 1024 fabricated entries (baseFee=baseline, gasUsedRatio=0,
+      // reward=[]) labelled with the requested future block numbers.
+      // Callers building fee strategies off those zeros would think
+      // mainnet had crashed into a deflation spiral. Geth rejects with
+      // -32000 "header not found" for unknown blocks; we match the
+      // shape but use -32602 because the requested range is invalid
+      // input (block doesn't exist yet), not a missing header.
+      const chainHeightForFeeHistory = await Promise.resolve(chain.getHeight())
+      if (newest > chainHeightForFeeHistory) {
+        invalidParams(`newestBlock ${newest} is beyond chain head ${chainHeightForFeeHistory}`)
+      }
       const count = Math.min(blockCount, Number(newest), 1024)
       const baseFees: string[] = []
       const gasUsedRatios: number[] = []


### PR DESCRIPTION
## Summary

- `eth_feeHistory` accepted a numeric `newestBlock` past the chain tip and silently fabricated `blockCount` entries (baseFeePerGas=baseline, gasUsedRatio=0, reward=[]) labelled with the future block numbers.
- Discovered via Ralph stress-test probing: `eth_feeHistory("0x4", "0xffffffffff", [])` on a fresh chain returned 4 blocks of fake data instead of an error.
- Geth rejects unknown blocks with -32000 "header not found"; we reject with -32602 because the request itself names a block that doesn't exist yet (parity with #224/#160 input-shape validation).

## What changed

`node/src/rpc.ts` `eth_feeHistory` handler — after `resolveBlockNumber(newestBlock, chain)`, compare the resolved height against `chain.getHeight()` and `invalidParams("newestBlock <n> is beyond chain head <h>")` when the caller asks for a future block. `"latest"` / `"pending"` tags continue to work because `parseBlockTag` resolves them to current head before the new check (test asserts this).

## Test plan

- [x] `node --experimental-strip-types -e \"import('./node/src/rpc.ts')\"` — TS strip green
- [x] Standalone probe (`/tmp/probe-fee-history-599.mjs`): chain head=0, future newestBlock returns `-32602` with explanatory message; "latest"/"pending" still return 1 entry each
- [x] New `#599` subtest in `node/src/rpc-extended.test.ts` covers all three branches
- [x] Adjacent `#160` rewardPercentile validation test untouched and still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)