### PR TITLE
fix(mfs): #600 mkdir on existing path errors when parents=false (kubo parity)

### DIFF
--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1769,7 +1769,11 @@ export class IpfsHttpServer {
           // #539: `mv` / `cp` reject existing destination (data-loss
           // prevention, kubo parity). Map to 400 same as the other
           // client-input-error siblings.
-          /^destination already exists/i.test(msg)
+          /^destination already exists/i.test(msg) ||
+          // #600: `mkdir` without parents=true on existing path now errors
+          // with kubo parity ("file already exists: <path>"). Same shape
+          // as the #539 destination guard — client-input error.
+          /^file already exists/i.test(msg)
         ) {
           httpErr = new HttpError(400, "bad request", msg)
         }

--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -472,6 +472,39 @@ test("#302: mkdir at root depth with file collision still rejects", async () => 
   }
 })
 
+test("#600: mkdir without parents=true on existing path errors (kubo parity)", async () => {
+  // Pre-fix `if (this.dirs.has(normalized)) return` was unconditional, so
+  //   files/mkdir?arg=/data         → 200 ok (creates)
+  //   files/mkdir?arg=/data         → 200 ok (silent no-op)
+  // kubo's CLI errors the second call with "Error: file already exists",
+  // which is the contract operators rely on to detect race-condition
+  // wins between two concurrent mkdir callers. -p/--parents stays
+  // idempotent (the documented kubo escape hatch).
+  const { mfs, cleanup } = await createMfs()
+  try {
+    await mfs.mkdir("/data")
+    // (a) Second mkdir without parents must REJECT.
+    await assert.rejects(
+      () => mfs.mkdir("/data"),
+      /file already exists: \/data$/,
+      "mkdir on existing dir without parents=true must error",
+    )
+    // (b) mkdir -p on existing dir stays idempotent.
+    await mfs.mkdir("/data", { parents: true })
+    const stat = await mfs.stat("/data")
+    assert.strictEqual(stat.type, "directory", "parents=true must remain idempotent")
+    // (c) Sanity: write() internally calls mkdir(..., parents:true) so
+    //     create-with-parents on an existing path still works.
+    await mfs.write("/data/file.txt", new TextEncoder().encode("ok"),
+      { create: true, parents: true })
+    const data = await mfs.read("/data/file.txt")
+    assert.strictEqual(new TextDecoder().decode(data), "ok",
+      "write+parents on existing dir must not regress")
+  } finally {
+    cleanup()
+  }
+})
+
 test("#418: MFS whitespace-only path components rejected (no silent garbage in namespace)", async () => {
   // Sibling of #380 (empty arg). Pre-fix `arg=%20` (single space),
   // `arg=%09` (tab), `arg=%20%20%20` (multi-space) sailed through

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -53,7 +53,17 @@ export class IpfsMfs {
    */
   async mkdir(path: string, opts?: { parents?: boolean }): Promise<void> {
     const normalized = normalizePath(path)
-    if (this.dirs.has(normalized)) return
+    // #600: kubo CLI errors `mkdir /existing` with "file already exists"
+    // when called without -p; only `mkdir -p` is idempotent. Pre-fix this
+    // returned silently for both shapes, so a caller running
+    //   files/mkdir?arg=/data&parents=false
+    // twice got back 200 ok both times, never learning their first call
+    // had won the race. Sibling write() still relies on idempotence via
+    // its own parents=true call (line 124), which is still honoured.
+    if (this.dirs.has(normalized)) {
+      if (opts?.parents) return
+      throw new Error(`file already exists: ${normalized}`)
+    }
 
     const parts = normalized.split("/").filter(Boolean)
     let current = "/"


### PR DESCRIPTION
## Summary

- `files/mkdir?arg=/data&parents=false` returned 200 ok even when the directory already existed. kubo's CLI errors "file already exists" in that case — clients & operators rely on it to detect race-condition wins between concurrent mkdir callers.
- Two HTTP callers racing the same create both got 200, neither learning which one actually created the dir.
- Same silent-success family as #380 (empty arg), #539 (cp/mv dest exists).

## What changed

- `node/src/ipfs-mfs.ts` — `mkdir()` now throws \`file already exists: <path>\` when the path already exists AND `parents` is not true. `parents=true` stays idempotent (the documented kubo escape hatch), so `write()`'s internal `mkdir(dir, { parents: true })` call is unaffected.
- `node/src/ipfs-http.ts` — MFS route-level error catch maps the new message to 400 (sibling of #539's \`destination already exists\` mapping).

## Test plan

- [x] New `#600` test in `ipfs-mfs.test.ts` covering (a) reject, (b) idempotent with -p, (c) write+parents on existing dir still works
- [x] Full `node/src/ipfs-mfs.test.ts` — 23/23 pass
- [x] Full `node/src/ipfs-http.test.ts` — 121/121 pass (no regression in MFS HTTP layer)
- [x] TS-strip on `ipfs-mfs.ts` + `ipfs-http.ts` green

Discovered via Ralph stress-test probe round 2 (random combination of contract deploy, RPC probes, IPFS upload/MFS edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)