### PR TITLE
fix(rpc): #601 eth_getProof on unsupported backend → -32601 (was -32603 + class-name leak)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -977,7 +977,14 @@ export class EvmChain {
   }> {
     const stateManager = await this.resolveStateManager(stateRoot)
     if (!(stateManager instanceof PersistentStateManager) || typeof stateManager.getProof !== "function") {
-      throw new Error("eth_getProof requires proof-capable persistent state manager support")
+      // #601: surface as a tagged error so the RPC layer maps to -32601
+      // ("method not available") matching anvil/erigon. Pre-fix this fell
+      // through to the default -32603 internal-error path and the message
+      // ("requires proof-capable persistent state manager") leaked internal
+      // implementation details (state-manager class name) to every caller.
+      const err = new Error("eth_getProof is not available: backend does not support state proofs") as Error & { rpcMethodUnavailable?: boolean }
+      err.rpcMethodUnavailable = true
+      throw err
     }
     return stateManager.getProof(
       Address.fromString(address),

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2046,13 +2046,44 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(nonHex.error?.code, -32602, "non-hex slot must be -32602")
 
     // Sanity: well-shaped short hex passes the slot validator. The fixture's
-    // in-memory EVM doesn't expose proofs (returns -32603 "requires proof-
-    // capable persistent state manager"), so we only assert the result is
-    // NOT -32602 — the validator gate let the request through.
+    // in-memory EVM doesn't expose proofs — pre-#601 returned -32603
+    // "requires proof-capable persistent state manager", post-#601 returns
+    // -32601 "eth_getProof is not available" (anvil/erigon parity, no
+    // internal class names leaked). Either way, NOT -32602 — the validator
+    // gate let the request through.
     const shortValid = await probe("0x1")
     assert.notEqual(shortValid.error?.code, -32602, `shortValid must clear validator (got ${JSON.stringify(shortValid)})`)
     const mixedCase = await probe("0xAb")
     assert.notEqual(mixedCase.error?.code, -32602, "mixed-case hex must clear validator")
+  })
+
+  await t.test("#601: eth_getProof unsupported backend returns -32601 (was -32603 + class-name leak)", async () => {
+    // Pre-fix: in-memory EVM (or any backend without proof-capable state
+    // manager) threw a plain Error → -32603 internal error with message
+    //   "eth_getProof requires proof-capable persistent state manager support"
+    // which (a) misled clients into thinking the request itself broke
+    // something internal, and (b) leaked the state-manager class name
+    // (same info-disclosure family as #156/#176/#182/#505/#507).
+    // anvil + erigon return -32601 ("method not available") when their
+    // backend doesn't support a method; match that contract.
+    const validAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    const r = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_getProof",
+        params: [validAddr, ["0x0"], "latest"],
+      }),
+    })
+    const json = await r.json() as { error?: { code: number; message: string } }
+    assert.equal(json.error?.code, -32601,
+      `unsupported backend must be -32601 method-not-available, got ${json.error?.code}: ${json.error?.message}`)
+    // Clean message — no class names, no implementation details.
+    assert.doesNotMatch(json.error!.message,
+      /persistent state manager|PersistentStateManager|StateManager/i,
+      "must not leak internal class/type names")
+    assert.match(json.error!.message, /eth_getProof|not available|not supported/i,
+      "must name the method or the unavailability")
   })
 
   await t.test("#128: eth_estimateGas rejects malformed to/from addresses with -32602", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1105,7 +1105,17 @@ async function handleRpc(
         return `0x${normalized.padStart(64, "0")}`
       })
       const stateRoot = await resolveHistoricalStateRoot((payload.params ?? [])[2], chain)
-      return await evm.getProof(proofAddr, proofSlots, stateRoot)
+      try {
+        return await evm.getProof(proofAddr, proofSlots, stateRoot)
+      } catch (err) {
+        // #601: backend without proof-capable state manager returns
+        // a tagged error; translate to -32601 so callers can fall back
+        // (anvil/erigon use this code for backend-unsupported methods).
+        if ((err as { rpcMethodUnavailable?: boolean })?.rpcMethodUnavailable) {
+          methodNotFound((err as Error).message)
+        }
+        throw err
+      }
     }
     case "eth_syncing": {
       const syncProgressGetter = (opts as Record<string, unknown> | undefined)?.getSyncProgress as RpcRuntimeOptions["getSyncProgress"] | undefined


### PR DESCRIPTION
## Summary

- `eth_getProof` on any backend without proof-capable state manager (in-memory EVM, light-mode nodes) returned **-32603 internal-error** with message \`eth_getProof requires proof-capable persistent state manager support\`.
- Wrong code (it's a backend-unsupported method, not an internal failure) **and** info leak (mentions \`PersistentStateManager\` class name — same family as #156/#176/#182/#505/#507).
- anvil + erigon return **-32601** for backend-unsupported methods. Match that contract.

## What changed

- `node/src/evm.ts` `getProof()`: tag the thrown error with `rpcMethodUnavailable=true` and a clean message that names the method, not the implementation class.
- `node/src/rpc.ts` `eth_getProof` handler: catch the tagged error and re-throw via `methodNotFound(...)` so the wire response carries -32601.

## Test plan

- [x] Standalone probe: `eth_getProof` now returns `{"code":-32601,"message":"eth_getProof is not available: backend does not support state proofs"}` (no class-name leak)
- [x] New `#601` subtest in `rpc-extended.test.ts` asserts -32601 + cleanness
- [x] Updated `#471`'s stale comment about the old -32603 behaviour (the assertion is still NOT -32602 so it stays green either way)
- [x] TS-strip on `evm.ts` + `rpc.ts` green

Discovered via Ralph stress-test probe round 3 (contract execution + debug_trace + getProof edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)