### PR TITLE
fix(rpc): #602 eth_call/eth_estimateGas reject silently-dropped stateOverride param

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2734,6 +2734,62 @@ test("RPC Extended Methods", async (t) => {
     assert.equal(ok.error, undefined, `null tx must NOT error: ${JSON.stringify(ok.error)}`)
   })
 
+  await t.test("#602: eth_call/eth_estimateGas reject non-empty stateOverride + bogus shapes", async () => {
+    // Pre-fix `params[2]` (geth-style stateOverride) was silently
+    // dropped at every shape:
+    //   - non-empty object: result computed against UNMODIFIED state,
+    //     and the response shape looked normal — Tenderly/viem
+    //     `eth_call(..., overrides)` callers got authoritative-looking
+    //     wrong answers.
+    //   - string/array/garbage: same silent acceptance, same wrong-state
+    //     simulation.
+    // Same silent-success family as #172/#238/#192. anvil/erigon reject
+    // backend-unsupported features with -32601; geth honours the param.
+    // We don't (yet) honour overrides, so reject explicitly so callers
+    // fall back rather than trust a misleading result.
+    const validTx = { from: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", to: "0x" + "ab".repeat(20) }
+    const probe = async (method: string, override: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [validTx, "latest", override] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    for (const method of ["eth_call", "eth_estimateGas"]) {
+      // (a) Non-empty override → -32601 backend-not-supported.
+      const nonEmpty = await probe(method, { [validTx.to]: { code: "0xab" } })
+      assert.equal(nonEmpty.error?.code, -32601,
+        `${method} non-empty override must be -32601, got ${nonEmpty.error?.code}: ${JSON.stringify(nonEmpty.error)}`)
+      assert.match(nonEmpty.error!.message, /stateOverride|not supported/i,
+        `${method} error must name stateOverride or unavailability`)
+      // (b) String override (bogus shape) → -32602 invalid shape.
+      const stringOverride = await probe(method, "not an object")
+      assert.equal(stringOverride.error?.code, -32602,
+        `${method} string override must be -32602, got ${stringOverride.error?.code}`)
+      assert.match(stringOverride.error!.message, /expected object/i)
+      // (c) Array override (bogus shape) → -32602.
+      const arrayOverride = await probe(method, [1, 2, 3])
+      assert.equal(arrayOverride.error?.code, -32602,
+        `${method} array override must be -32602, got ${arrayOverride.error?.code}`)
+      // (d) Empty object override → still allowed (spec-permissive).
+      const emptyOverride = await probe(method, {})
+      assert.notEqual(emptyOverride.error?.code, -32601,
+        `${method} empty override must NOT reject as -32601`)
+      assert.notEqual(emptyOverride.error?.code, -32602,
+        `${method} empty override must NOT reject as -32602`)
+      // (e) Missing 3rd param entirely → no error (back-compat).
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [validTx, "latest"] }),
+      })
+      const noOverride = await r.json() as { error?: { code: number; message: string } }
+      assert.notEqual(noOverride.error?.code, -32601,
+        `${method} without override (2-arg) must NOT reject`)
+    }
+  })
+
   await t.test("#178: eth_sendTransaction validates + honors user-provided nonce", async () => {
     // Pre-fix txParams.nonce was silently dropped — every call used
     // the next sequential mempool nonce regardless of what the user

--- a/node/src/rpc-validators.ts
+++ b/node/src/rpc-validators.ts
@@ -607,6 +607,46 @@ export function validateTxCallFields(callParams: Record<string, unknown>): void 
   }
 }
 
+/**
+ * #602: eth_call / eth_estimateGas accept an optional 3rd parameter for
+ * geth-style state overrides:
+ *
+ *   {[address]: {balance?, nonce?, code?, state?, stateDiff?}, …}
+ *
+ * COC's EVM doesn't wire this through to callRaw, but pre-fix the param
+ * was silently ignored — including bogus shapes (string, array, non-empty
+ * object). Tenderly-style simulators and viem's
+ * `eth_call(..., overrides)` got back results computed WITHOUT their
+ * override and treated them as authoritative. Same silent-success family
+ * as #172/#238 but worse because the response shape looks correct.
+ *
+ * Until the EVM supports overrides, reject:
+ *   - non-object shape (string/array/number/bool) → -32602 invalid shape
+ *   - non-empty object → -32601 method-doesn't-support-this-yet
+ *
+ * Accept (no-op): undefined / null / {} — these are spec-allowed.
+ */
+export function validateStateOverrideUnsupported(raw: unknown, methodName: string): void {
+  if (raw === undefined || raw === null) return
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    invalidParams(
+      `invalid stateOverride for ${methodName}: expected object, got ${
+        Array.isArray(raw) ? "array" : typeof raw
+      }`,
+    )
+  }
+  const obj = raw as Record<string, unknown>
+  // Empty object is fine — many wallets always send the param even when
+  // they have no overrides.
+  if (Object.keys(obj).length === 0) return
+  // Non-empty: this backend doesn't apply overrides. Surface via -32601
+  // ("method not available") so callers know to fall back rather than
+  // trusting an unmodified-state result.
+  methodNotFound(
+    `${methodName} stateOverride parameter is not supported on this backend`,
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Log filter (eth_getLogs / eth_newFilter) shape + normalization
 // ---------------------------------------------------------------------------

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -43,6 +43,7 @@ import {
   optionalIntegerParam,
   optionalBooleanParam,
   validateTxCallFields,
+  validateStateOverrideUnsupported,
   validateLogFilter,
   sanitizeEthersError,
   sanitizeJsonParseError,
@@ -966,6 +967,10 @@ async function handleRpc(
       // treated non-hex as 0, so {value:"not-hex"} gave a clean gas
       // estimate that ignored the value transfer.
       validateTxCallFields(estParams)
+      // #602: sibling of eth_call — geth honours stateOverride on
+      // eth_estimateGas too. We don't; reject non-empty overrides
+      // rather than silently estimating against unmodified state.
+      validateStateOverrideUnsupported((payload.params ?? [])[2], "eth_estimateGas")
       // Default gas cap to block gas limit (30M) to prevent DoS via unbounded execution
       const gasForEstimate = estParams.gas ?? "0x1c9c380"
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
@@ -1031,6 +1036,17 @@ async function handleRpc(
       // where malformed input either silently becomes 0 (value) or
       // surfaces as -32603 with V8 message leak (data).
       validateTxCallFields(callParams)
+      // #602: geth/anvil/erigon all honour a 3rd param `stateOverride`
+      // (per-call balance/nonce/code/state overrides). COC's EVM doesn't
+      // wire those into callRaw, but pre-fix params[2] was silently
+      // ignored — including string/array/garbage shapes. A caller using
+      // Tenderly-style simulation (or viem's `eth_call(..., overrides)`)
+      // got back a result computed WITHOUT their override and treated it
+      // as authoritative. Same silent-success family as #172/#238/#192
+      // but worse because the wire shape looks valid. Reject non-empty
+      // overrides with -32601 so callers fall back; allow undefined/null/{}
+      // through as no-ops.
+      validateStateOverrideUnsupported((payload.params ?? [])[2], "eth_call")
       const executionContext = await resolveHistoricalExecutionContext((payload.params ?? [])[1], chain)
       // #384: synth-genesis ⇒ no contracts deployed → empty return.
       // Matches geth/anvil eth_call against an empty-allocs genesis.


### PR DESCRIPTION
## Summary

- The 3rd parameter to `eth_call` / `eth_estimateGas` (geth-style **stateOverride**) was silently dropped at every shape.
- Non-empty overrides: Tenderly simulators + viem `eth_call(..., overrides)` callers got results computed against UNMODIFIED state — the response looked normal and was treated as authoritative.
- Bogus shapes (string, array, number, bool): same silent acceptance, same wrong-state simulation.
- Same silent-success family as #172/#238/#192.

## What changed

New validator `validateStateOverrideUnsupported(raw, methodName)` in `rpc-validators.ts`:
- non-object shape → **-32602** `expected object, got <type>`
- non-empty object → **-32601** `<method> stateOverride parameter is not supported on this backend` (anvil/erigon contract for backend-unsupported features)
- undefined / null / `{}` → pass through (spec-permissive for wallets that always send the field)

Wired into both `eth_call` (rpc.ts:1048) and `eth_estimateGas` (rpc.ts:973) — geth honours overrides on both, so we must reject in both.

## Test plan

- [x] Standalone probe (`BALANCE` opcode runtime + code override): pre-fix `result: "0x"`; post-fix `-32601 stateOverride not supported`. Bogus shapes now `-32602`. Empty `{}` still accepted.
- [x] New `#602` subtest in `rpc-extended.test.ts` covers 5 cases × 2 methods = 10 assertions
- [x] TS-strip on `rpc.ts` + `rpc-validators.ts` green

Discovered via Ralph stress-test probe round 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)