### PR TITLE
fix(rpc): #603 debug_traceTransaction returns -32004 for unknown tx (parity with trace_transaction)

### DIFF
--- a/node/src/rpc-debug-compatibility.test.ts
+++ b/node/src/rpc-debug-compatibility.test.ts
@@ -1419,4 +1419,39 @@ describe("RPC debug compatibility", () => {
       }
     }
   })
+
+  it("#603: debug_traceTransaction valid-shape-unknown-tx returns -32004 (parity with trace_transaction)", async () => {
+    // Pre-fix `debug_traceTransaction("0x" + 32-byte hash)` for a tx that
+    // isn't in the chain bubbled `new Error("transaction not found: ...")`
+    // from debug-trace.ts:99 → -32603 internal error.  Sibling
+    // `trace_transaction` (rpc.ts:1623) already pre-located + threw
+    // -32004 "transaction not found", so callers using either family got
+    // inconsistent codes for the same condition.  Geth returns -32000 for
+    // not-found; -32004 is COC's choice (already in use by trace_*) so
+    // both families converge on the same code.
+    const unknownHash = "0x" + "ab".repeat(32)
+    let err: { code?: number; message?: string } | undefined
+    try {
+      await rpc.handleRpcMethod("debug_traceTransaction", [unknownHash, {}],
+        CHAIN_ID, evm, engine, p2p)
+      assert.fail("debug_traceTransaction must throw for unknown tx")
+    } catch (e) {
+      err = e as { code?: number; message?: string }
+    }
+    assert.equal(err?.code, -32004,
+      `debug_traceTransaction(unknown) must be -32004, got ${JSON.stringify(err)}`)
+    assert.match(err?.message ?? "", /transaction not found/i,
+      "error message must name the not-found condition")
+    // Parity: trace_transaction returns the same code for the same input.
+    let traceErr: { code?: number; message?: string } | undefined
+    try {
+      await rpc.handleRpcMethod("trace_transaction", [unknownHash],
+        CHAIN_ID, evm, engine, p2p)
+      assert.fail("trace_transaction must throw for unknown tx")
+    } catch (e) {
+      traceErr = e as { code?: number; message?: string }
+    }
+    assert.equal(traceErr?.code, err?.code,
+      "debug_traceTransaction and trace_transaction must return same code for not-found")
+  })
 })

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1652,6 +1652,17 @@ async function handleRpc(
       // "tx not found" with the coerced garbage leaked back. Same family
       // as #260/#262.
       const txHash = requireTxHashParam(payload.params ?? [], 0)
+      // #603: pre-fix a tx-not-found error from traceTransactionResult
+      // bubbled up as a plain Error → -32603 internal error. Geth's
+      // debug_traceTransaction returns -32000 for the same condition, and
+      // our sibling trace_transaction (rpc.ts:1623) already pre-locates
+      // and surfaces -32004 "transaction not found". Match the sibling
+      // contract so callers get a consistent code for the same condition
+      // regardless of which trace family they call.
+      const debugTxContext = await locateTraceTransactionContext(chain, txHash)
+      if (!debugTxContext) {
+        throw { code: -32004, message: `transaction not found: ${txHash}` }
+      }
       const traceOpts = ((payload.params ?? [])[1] ?? {}) as Record<string, unknown>
       const traceResult = await traceTransactionResult(txHash, chain, evm, {
         disableStorage: Boolean(traceOpts.disableStorage),


### PR DESCRIPTION
## Summary

- \`debug_traceTransaction(<valid hash, not in chain>)\` returned **-32603 internal error** while the sibling \`trace_transaction\` returns **-32004 transaction not found** for the exact same condition.
- Contract divergence between two trace families that callers use interchangeably. ethers.js / viem / hardhat surface -32004 as an actionable "not found"; -32603 wraps as opaque "could not coalesce error" and breaks programmatic handling.

## What changed

\`node/src/rpc.ts\` \`debug_traceTransaction\` handler now pre-locates the tx via \`locateTraceTransactionContext\` (the same helper \`trace_transaction\` uses) and throws \`-32004 transaction not found: <hash>\` when missing. The existing \`requireTxHashParam\` -32602 validation for malformed shapes is unchanged.

## Test plan

- [x] Standalone probe: pre-fix \`-32603 transaction not found: 0xabab…\`; post-fix \`-32004 transaction not found: 0xabab…\` matching \`trace_transaction\`'s shape
- [x] New \`#603\` subtest in \`rpc-debug-compatibility.test.ts\` (25/25 pass)
- [x] Existing \`#294\` shape-validation test untouched and green
- [x] TS-strip on \`rpc.ts\` green

Discovered via Ralph stress-test probe round 5 (debug/trace methods, fee history edge cases, mempool/log queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)