### PR TITLE
fix(chain-engine): #604 chain-ID error message echoes actual expected ID (not 'undefined')

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -632,12 +632,17 @@ export class PersistentChainEngine {
     // re-sign, and re-submit just to learn their chainId was fundamentally
     // wrong. Mirrors the same fix in chain-engine.ts addRawTx.
     const txChainId = (decoded as { chainId?: bigint | number | null }).chainId
+    const expectedChainId = this.cfg.chainId ?? 18780
     if (
       txChainId !== null &&
       txChainId !== undefined &&
-      BigInt(txChainId) !== BigInt(this.cfg.chainId ?? 18780)
+      BigInt(txChainId) !== BigInt(expectedChainId)
     ) {
-      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
+      // #604: mirror the chain-engine.ts fix — echo back the actual
+      // expected ID rather than `this.cfg.chainId` (which can be
+      // undefined when constructed without explicit chainId, leading
+      // to "expected undefined, got 99999" leak).
+      throw new Error(`invalid chain ID: expected ${expectedChainId}, got ${txChainId}`)
     }
 
     // Mirror in-memory engine order: hash dedup first (more specific error

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -183,12 +183,18 @@ export class ChainEngine {
     // wrong. Geth and Erigon check chainId first because it's
     // immutable for a given signed tx.
     const txChainId = (decoded as { chainId?: bigint | number | null }).chainId
+    const expectedChainId = this.cfg.chainId ?? 18780
     if (
       txChainId !== null &&
       txChainId !== undefined &&
-      BigInt(txChainId) !== BigInt(this.cfg.chainId ?? 18780)
+      BigInt(txChainId) !== BigInt(expectedChainId)
     ) {
-      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
+      // #604: pre-fix the error echoed `this.cfg.chainId` directly, which
+      // is undefined when the engine was constructed without an explicit
+      // chainId (rpc layer defaults to 18780 — see #184). Callers saw
+      // "expected undefined, got 99999" — misleading + same info-quality
+      // family as #156/#176/#182/#505/#507/#601 (cleaner is better).
+      throw new Error(`invalid chain ID: expected ${expectedChainId}, got ${txChainId}`)
     }
     if (this.txHashSet.has(decoded.hash as Hex)) {
       throw new Error("tx already confirmed")

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -835,6 +835,18 @@ test("RPC Extended Methods", async (t) => {
     // failure) per the existing #332 rpc.ts mapping at line ~1112.
     assert.equal(r1.error!.code, -32602,
       `wrong-chain tx must be -32602 (invalid params), got ${r1.error!.code}`)
+    // #604: pre-fix the message echoed `this.cfg.chainId` directly,
+    // which is undefined when the ChainEngine was constructed without
+    // an explicit chainId (rpc layer falls back to 18780 in the
+    // BigInt comparison via `?? 18780`). Callers saw "expected
+    // undefined, got 99999" — same info-quality family as #156/#176/
+    // #182/#505/#507/#601. The fixture sets chainId to fixtureChainId,
+    // so the message must echo that number rather than the literal
+    // word "undefined".
+    assert.doesNotMatch(r1.error!.message, /expected undefined/i,
+      `chainId error must echo the actual expected ID, not "undefined": ${r1.error!.message}`)
+    assert.match(r1.error!.message, new RegExp(`expected ${Number(BigInt(fixtureChainId))}`),
+      `chainId error must name the actual expected ID (${Number(BigInt(fixtureChainId))}), got: ${r1.error!.message}`)
   })
 
   await t.test("#533: eth_getLogs blockHash resolves to the correct block (non-existent → -32000 'unknown block')", async () => {


### PR DESCRIPTION
## Summary

- Pre-fix the chainId comparison used \`BigInt(this.cfg.chainId ?? 18780)\` for the check but echoed \`this.cfg.chainId\` DIRECTLY in the error message.
- When ChainEngine was constructed without an explicit chainId, callers saw \`"invalid chain ID: expected undefined, got 99999"\`.
- Same info-quality family as #156/#176/#182/#505/#507/#601 — error messages must echo back useful context.

## What changed

\`node/src/chain-engine.ts\` extracts \`const expectedChainId = this.cfg.chainId ?? 18780\` once and reuses it for BOTH the comparison and the error message, so they stay in sync.

## Test plan

- [x] Probe: pre-fix \`"expected undefined, got 99999"\`; post-fix \`"expected 18780, got 99999"\`
- [x] Existing \`#527\` test strengthened with two new assertions: message must NOT contain "expected undefined" + MUST contain the actual chainId
- [x] Mempool's \`/invalid chain ID/\` regex match unchanged (matches both pre and post-fix prefix)
- [x] TS-strip on \`chain-engine.ts\` green

Discovered via Ralph stress-test probe round 6 (EIP-1559/EIP-2930 mixed mempool stress test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)