### PR TITLE
fix(rpc): #606 coc_chainStats chainId matches eth_chainId (no '0x1' lie)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2786,17 +2786,31 @@ test("RPC Extended Methods", async (t) => {
     assert.doesNotMatch(r2.error!.message, /version=|INVALID_ARGUMENT|code=/, "must not leak ethers internals")
   })
 
-  await t.test("#184: coc_chainStats does not crash when chain.cfg.chainId is undefined", async () => {
-    // Pre-fix `chain.cfg.chainId.toString(16)` assumed chainId was
-    // always set, but ChainEngineConfig.chainId is optional in the
-    // type. Bare undefined.toString() leaked as
-    // -32603 "Cannot read properties of undefined (reading 'toString')".
+  await t.test("#184/#606: coc_chainStats does not crash + chainId matches eth_chainId (no '0x1' lie)", async () => {
+    // #184 (original): pre-fix `chain.cfg.chainId.toString(16)` assumed
+    // chainId was always set, but ChainEngineConfig.chainId is optional
+    // in the type. Bare undefined.toString() leaked as
+    //   -32603 "Cannot read properties of undefined (reading 'toString')"
+    // The fix landed `?? "1"` literal fallback.
+    //
+    // #606 (this PR): the "1" literal silently lied — same node returned
+    // chainId `0x1` from coc_chainStats and the real chainId (e.g.
+    // `0x495c` = 18780) from eth_chainId. Two endpoints disagreed about
+    // which chain you're on, breaking client connection-validation
+    // logic that compares the two. Replace the literal with the RPC
+    // handler's `chainId` parameter (canonical source for eth_chainId).
+    //
     // This fixture deliberately does NOT pass chainId to ChainEngine
-    // (see line 38-48), so chain.cfg.chainId is undefined here — making
-    // this a direct repro of the bug.
+    // (see line 38-48), so chain.cfg.chainId is undefined — direct
+    // repro for both bugs.
     const stats = await rpcCall(port, "coc_chainStats") as Record<string, unknown>
     assert.ok(typeof stats === "object" && stats !== null, "must return an object")
-    assert.equal(stats.chainId, "0x1", `chainId must fall back to "0x1" when cfg.chainId is undefined, got ${stats.chainId}`)
+    // The two endpoints must agree.
+    const ethChainId = await rpcCall(port, "eth_chainId") as string
+    assert.equal(stats.chainId, ethChainId,
+      `coc_chainStats.chainId (${stats.chainId}) must match eth_chainId (${ethChainId}) — same node, same chain`)
+    assert.notEqual(stats.chainId, "0x1",
+      `chainId must NOT fall back to the literal "0x1" — that was the #184 bug fallback that lied`)
     assert.ok(typeof stats.blockHeight === "string", "blockHeight must be hex")
     assert.ok(typeof stats.validatorCount === "number", "validatorCount must be number")
     // Defend against V8 leak in error path.

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2929,7 +2929,15 @@ async function handleRpc(
           // constructor only defaults it for the mempool, not for cfg
           // itself. Bare `undefined.toString(16)` leaked to clients
           // as -32603 "Cannot read properties of undefined".
-          chainId: `0x${chain.cfg?.chainId?.toString(16) ?? "1"}`,
+          //
+          // #606: the original fix landed `"1"` as the literal fallback,
+          // which silently lied: same node returned chainId `0x1` from
+          // coc_chainStats and `0x495c` (18780) from eth_chainId — two
+          // endpoints disagreeing about which chain you're on. Use the
+          // RPC handler's `chainId` parameter (the canonical source
+          // eth_chainId reads from, rpc.ts:813) so the two endpoints
+          // agree even when ChainEngineConfig.chainId is unset.
+          chainId: `0x${chain.cfg?.chainId?.toString(16) ?? chainId.toString(16)}`,
         }
         chainStatsCache = { result: statsResult, height, mempoolSize: poolStats.size, cachedAtMs: now }
         return statsResult


### PR DESCRIPTION
## Summary

Same node, two endpoints, two different chainIds:
- \`eth_chainId\` → \`"0x495c"\` (18780 — RPC handler's \`chainId\` param)
- \`coc_chainStats\` → \`"0x1"\` (literal \`?? "1"\` fallback when \`chain.cfg.chainId\` is unset)

Pre-#184 the latter crashed with \`Cannot read properties of undefined (reading 'toString')\`. #184's fix replaced the crash with a literal \`?? "1"\` fallback — which silently lied to clients. Connection-validation flows that fetch chainId from multiple endpoints and compare them concluded the node was misconfigured / mid-fork / hostile.

The existing #561 test explicitly called out this divergence as "its own pre-existing concern" while pinning the format-drift for \`coc_nodeInfo\`. This PR closes that concern.

## What changed

\`node/src/rpc.ts\` line 2932 fallback changed from literal \`"1"\` → \`chainId.toString(16)\` (the canonical source \`eth_chainId\` reads from at rpc.ts:813). Both endpoints now agree even when \`ChainEngineConfig.chainId\` is unset.

Test \`#184\` (now \`#184/#606\`) updated to assert:
- \`coc_chainStats.chainId === eth_chainId\` (cross-endpoint consistency)
- \`coc_chainStats.chainId !== "0x1"\` (no literal lie)

## Test plan

- [x] Probe: pre-fix \`coc_chainStats.chainId === "0x1"\` while \`eth_chainId === "0x495c"\`; post-fix both return \`"0x495c"\`
- [x] Updated \`#184/#606\` subtest + existing \`#561\` + \`#479\` all pass
- [x] TS-strip on \`rpc.ts\` green

Discovered via Ralph stress-test probe round 7 (eth_getLogs range caps, admin gating, cross-endpoint chainId consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)