### PR TITLE
fix(rpc): #607 coc_validators.nextProposalBlock returns 0x-hex (close #517 format drift)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1473,6 +1473,37 @@ test("RPC Extended Methods", async (t) => {
     assert.strictEqual(info.chainId, ethId, `coc_nodeInfo.chainId (${info.chainId}) must match eth_chainId (${ethId})`)
   })
 
+  await t.test("#607: coc_validators.nextProposalBlock is 0x-prefixed hex (closing #517 format drift)", async () => {
+    // Pre-fix `nextProposalBlock: Number(h)` emitted a decimal JS number
+    // (e.g. 88751) while every sibling block-height field on the same
+    // response shape returned 0x-prefixed hex per Ethereum JSON-RPC
+    // convention (`currentHeight: "0x15a8e"`, `coc_chainStats.blockHeight:
+    // "0x15a8e"`, `eth_blockNumber: "0x15a8e"`).  Clients aggregating
+    // block numbers from multiple fields saw the same height twice in
+    // two different formats and concluded the response was corrupted.
+    // Same format-drift family as #561 (chainId) and the historical
+    // #517 (next-proposer decimal vs hex) — closes the remaining
+    // instance the comment at #561 explicitly identified.
+    const result = await rpcCall(port, "coc_validators") as {
+      validators: Array<{ id: string; isCurrentProposer: boolean; nextProposalBlock: unknown }>
+      currentHeight: string
+      nextProposer: string
+    }
+    assert.ok(Array.isArray(result.validators), "validators must be array")
+    assert.ok(result.validators.length > 0, "fixture has at least node-1")
+    for (const v of result.validators) {
+      assert.equal(typeof v.nextProposalBlock, "string",
+        `nextProposalBlock must be a string (hex), got ${typeof v.nextProposalBlock}: ${JSON.stringify(v.nextProposalBlock)}`)
+      assert.match(v.nextProposalBlock as string, /^0x[0-9a-f]+$/i,
+        `nextProposalBlock must be 0x-prefixed hex, got ${JSON.stringify(v.nextProposalBlock)}`)
+    }
+    // Sanity: currentHeight (sibling field) is also hex — pre-fix it
+    // already serialized correctly via the bigint→hex JSON replacer,
+    // pin so a future change can't regress it.
+    assert.match(result.currentHeight, /^0x[0-9a-f]+$/i,
+      `currentHeight must be 0x-prefixed hex, got ${JSON.stringify(result.currentHeight)}`)
+  })
+
   await t.test("web3_clientVersion returns version string", async () => {
     const version = await rpcCall(port, "web3_clientVersion")
     assert.strictEqual(version, "COC/0.2")

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2440,7 +2440,15 @@ async function handleRpc(
         validators.push({
           id: v,
           isCurrentProposer: v === currentProposer,
-          nextProposalBlock: Number(h),
+          // #607: pre-fix this emitted a raw JS number (decimal) while
+          // sibling endpoints (eth_blockNumber, coc_chainStats.blockHeight,
+          // coc_validators.currentHeight, coc_nodeInfo.blockHeight) all
+          // return 0x-prefixed hex per Ethereum JSON-RPC convention.
+          // Clients aggregating block numbers from multiple endpoints saw
+          // `nextProposalBlock=88751` ≠ `blockHeight="0x15a8f"` and concluded
+          // the response shape was corrupted. Same format-drift family as
+          // #517 (next-proposer decimal vs hex), #561 (chainId).
+          nextProposalBlock: `0x${h.toString(16)}`,
         })
       }
       return { validators, currentHeight: height, nextProposer: currentProposer }


### PR DESCRIPTION
## Summary

Pre-fix \`coc_validators.validators[i].nextProposalBlock\` emitted decimal JS numbers (e.g. \`88751\`) while every sibling block-height field on the SAME response returned 0x-prefixed hex per Ethereum JSON-RPC convention:

- \`coc_validators.currentHeight\` → \`"0x15a8e"\`
- \`coc_chainStats.blockHeight\` → \`"0x15a8e"\`
- \`eth_blockNumber\` → \`"0x15a8e"\`
- \`coc_validators.nextProposalBlock\` → \`88751\` ← only outlier

Clients aggregating block numbers from multiple fields on the same response saw the same height twice in two different formats and concluded the response was corrupted. Same format-drift family as #561 (chainId) — the #561 comment at rpc-extended.test.ts:1449 explicitly named \`"#517 (nextProposalBlock decimal vs hex on same response)"\` as the historical sibling. This PR closes that remaining instance.

## What changed

One-line change in \`node/src/rpc.ts\` coc_validators handler: \`Number(h)\` → \`\\\`0x\${h.toString(16)}\\\`\`.

## Test plan

- [x] Probe: pre-fix \`nextProposalBlock: 1\`; post-fix \`nextProposalBlock: "0x1"\`
- [x] New \`#607\` subtest in \`rpc-extended.test.ts\` pins the format
- [x] Existing \`#561\` test untouched (covered chainId already)
- [x] TS-strip on \`rpc.ts\` green

Discovered via Ralph stress-test probe round 8 (governance, reward, equivocation, validator endpoint walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)