### PR TITLE
fix(evm): #608 KZG precompile revert lost on createVm path — eth_call regression of #594

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -134,6 +134,51 @@ const BEACON_ROOTS_RUNTIME_CODE =
   "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
 const ZERO_BEACON_ROOT = new Uint8Array(32)
 
+// #594 / #608: KZG point_evaluation precompile stub. COC runs Cancun-fork
+// but does NOT initialise the EIP-4844 KZG trusted setup, so @ethereumjs/vm
+// omits the precompile from its registry. Pre-fix calls to 0x000…000a fell
+// through as a regular CALL to an empty-code address and returned `"0x"` —
+// silently masquerading as a successful no-op. #594 wired a stub at 0x0a
+// that ALWAYS REVERTS with an explicit ABI-encoded Error(string) reason.
+//
+// #608: #594 only wired the customPrecompile into `EvmChain.create()`'s
+// primary VM. Every callRaw / estimateGas / traceCall on a historical or
+// block-specific state goes through the private `createVm()` helper which
+// instantiates a separate VM — and that path was missing the customPrecompile
+// list, so KZG silently returned "0x" again on production code paths
+// (eth_call/eth_estimateGas always set executionContext.blockNumber via
+// resolveHistoricalExecutionContext, taking the createVm branch). Extract
+// the stub builder so both VM-construction sites share it.
+const KZG_PRECOMPILE_ADDRESS = Address.fromString("0x000000000000000000000000000000000000000a")
+const KZG_GAS_COST = 50_000n  // EIP-4844 POINT_EVALUATION_PRECOMPILE_GAS
+
+function kzgPrecompileStub(input: { data: Uint8Array; gasLimit: bigint }) {
+  if (input.gasLimit < KZG_GAS_COST) {
+    return { exceptionError: new EVMError("out of gas"), executionGasUsed: input.gasLimit, returnValue: new Uint8Array() }
+  }
+  const reason = "KZG point_evaluation not implemented on COC"
+  const reasonBytes = new TextEncoder().encode(reason)
+  const padded = new Uint8Array(Math.ceil(reasonBytes.length / 32) * 32)
+  padded.set(reasonBytes)
+  const selector = hexToBytes("0x08c379a0")
+  const offset = setLengthLeft(bigIntToBytes(32n), 32)
+  const length = setLengthLeft(bigIntToBytes(BigInt(reasonBytes.length)), 32)
+  const ret = new Uint8Array(selector.length + offset.length + length.length + padded.length)
+  ret.set(selector, 0)
+  ret.set(offset, selector.length)
+  ret.set(length, selector.length + offset.length)
+  ret.set(padded, selector.length + offset.length + length.length)
+  return {
+    exceptionError: new EVMError("revert"),
+    executionGasUsed: KZG_GAS_COST,
+    returnValue: ret,
+  }
+}
+
+const COC_CUSTOM_PRECOMPILES = [
+  { address: KZG_PRECOMPILE_ADDRESS, function: kzgPrecompileStub },
+] as const
+
 export class EvmChain {
   private vm: VM
   private readonly common: ReturnType<typeof createCustomCommon>
@@ -171,60 +216,17 @@ export class EvmChain {
     const common = createCustomCommon({ chainId, networkId: chainId, name: "COC" }, base, {
       hardfork,
     })
-    // #594: COC runs Cancun-fork (parentBeaconBlockRoot + Cancun opcodes are
-    // active) but does NOT initialise the EIP-4844 KZG trusted setup, so
-    // @ethereumjs/vm omits the `point_evaluation` precompile from its
-    // registry. Pre-fix, calls to 0x000…000a fell through as a regular CALL
-    // to an empty-code address, returning `"0x"` — silently masquerading
-    // as a successful no-op. Contracts that bridge KZG-protected data from
-    // other chains then read `uint256(bytes32(""))` = 0 and proceed as if
-    // verification succeeded.
-    //
-    // Mempool already rejects type-3 blob txs (`mempool.ts` "blob
-    // transactions (type 3) are not supported"), but precompile calls
-    // bypass the mempool entirely (eth_call + contract bytecode). Wire a
-    // stub at 0x0a that always REVERTS with an explicit reason so callers
-    // distinguish "precompile failed" from "precompile returned empty
-    // because chain doesn't support blobs".
-    //
-    // Charges a flat 50_000 gas (matches EIP-4844 spec POINT_EVALUATION_
-    // PRECOMPILE_GAS so gas-usage stays portable with mainnet-compiled
-    // contracts that target this precompile).
-    const KZG_PRECOMPILE_ADDRESS = Address.fromString("0x000000000000000000000000000000000000000a")
-    const KZG_GAS_COST = 50_000n  // EIP-4844 POINT_EVALUATION_PRECOMPILE_GAS
-    const kzgStub = (input: { data: Uint8Array; gasLimit: bigint }) => {
-      if (input.gasLimit < KZG_GAS_COST) {
-        // Out-of-gas: charge all available, no return value.
-        return { exceptionError: new EVMError("out of gas"), executionGasUsed: input.gasLimit, returnValue: new Uint8Array() }
-      }
-      // Always revert. The returnValue is the Solidity-ABI-encoded
-      // `Error(string)`: selector 0x08c379a0 || abi.encode(reason).
-      // Encoded reason: "KZG point_evaluation not implemented on COC"
-      const reason = "KZG point_evaluation not implemented on COC"
-      const reasonBytes = new TextEncoder().encode(reason)
-      // 0x08c379a0 (4) | offset=0x20 (32) | length (32) | data padded to 32-byte multiple
-      const padded = new Uint8Array(Math.ceil(reasonBytes.length / 32) * 32)
-      padded.set(reasonBytes)
-      const selector = hexToBytes("0x08c379a0")
-      const offset = setLengthLeft(bigIntToBytes(32n), 32)
-      const length = setLengthLeft(bigIntToBytes(BigInt(reasonBytes.length)), 32)
-      const ret = new Uint8Array(selector.length + offset.length + length.length + padded.length)
-      ret.set(selector, 0)
-      ret.set(offset, selector.length)
-      ret.set(length, selector.length + offset.length)
-      ret.set(padded, selector.length + offset.length + length.length)
-      return {
-        exceptionError: new EVMError("revert"),
-        executionGasUsed: KZG_GAS_COST,
-        returnValue: ret,
-      }
-    }
+    // #594 / #608: see module-level `kzgPrecompileStub` + `COC_CUSTOM_PRECOMPILES`
+    // comment for full context. Both the primary VM constructed here and every
+    // historical/per-block VM constructed by `createVm()` MUST share the same
+    // customPrecompiles list — pre-#608 only this site wired them in, so any
+    // call that took the `createVm` path (eth_call/eth_estimateGas always do,
+    // via resolveHistoricalExecutionContext setting blockNumber) silently
+    // re-introduced the #594 bug.
     const vmOpts: Record<string, unknown> = {
       common,
       evmOpts: {
-        customPrecompiles: [
-          { address: KZG_PRECOMPILE_ADDRESS, function: kzgStub },
-        ],
+        customPrecompiles: COC_CUSTOM_PRECOMPILES,
       },
     }
     if (stateManager) {
@@ -1334,7 +1336,18 @@ export class EvmChain {
   }
 
   private async createVm(stateManager: unknown, blockNumber?: bigint): Promise<VM> {
-    const opts: Record<string, unknown> = { common: this.createExecutionCommon(blockNumber), stateManager }
+    // #608: include `customPrecompiles` so historical/per-block VMs share
+    // the same precompile registry as `this.vm`. Pre-fix this helper omitted
+    // them, so every eth_call/eth_estimateGas/traceCall on a non-default
+    // execution context lost the KZG (0x0a) stub — silently returning "0x"
+    // instead of the explicit revert #594 was supposed to guarantee.
+    const opts: Record<string, unknown> = {
+      common: this.createExecutionCommon(blockNumber),
+      stateManager,
+      evmOpts: {
+        customPrecompiles: COC_CUSTOM_PRECOMPILES,
+      },
+    }
     return createVM(opts as Parameters<typeof createVM>[0])
   }
 

--- a/node/src/precompiles.test.ts
+++ b/node/src/precompiles.test.ts
@@ -257,4 +257,37 @@ test("Precompiled Contracts - Edge Cases", async (t) => {
     })
     assert.equal(result.failed, true, "OOG must surface as failed call, not empty success")
   })
+
+  await t.test("#608: KZG revert holds on the historical-state code path (createVm/eth_call regression)", async () => {
+    // #594 wired the customPrecompile only into EvmChain.create()'s primary
+    // VM. Every callRaw with a non-default execution context (which is what
+    // eth_call / eth_estimateGas / debug_traceCall ALWAYS use — they set
+    // blockNumber via resolveHistoricalExecutionContext) goes through the
+    // private createVm() helper. Pre-#608 that helper omitted the
+    // customPrecompiles list, so KZG silently returned "0x" again on the
+    // production code paths. The unit test at #594 happened to pass because
+    // it called callRaw without a context, hitting the primary-VM branch.
+    //
+    // Repro the historical-state branch by passing an explicit blockNumber
+    // (via the third positional `context` arg). With the #608 fix both code
+    // paths share the same customPrecompiles list, so KZG must revert
+    // identically.
+    const result = await evm.callRaw(
+      {
+        to: "0x000000000000000000000000000000000000000a",
+        data: "0x" + "00".repeat(192),
+        gas: "0xf4240",
+      },
+      undefined,         // stateRoot = use current
+      { blockNumber: 0n },  // forces createVm() branch (callRaw line ~929)
+    )
+    assert.equal(result.failed, true,
+      "0x0a must REVERT on the historical/per-block code path, not silently return 0x")
+    assert.match(result.returnValue, /^0x08c379a0/,
+      "returnValue must carry the same Error(string) revert payload as the primary-VM path")
+    const reasonHex = result.returnValue.slice(2 + 136)
+    const reasonStr = Buffer.from(reasonHex, "hex").toString("utf8").replace(/\0+$/, "")
+    assert.match(reasonStr, /KZG point_evaluation not implemented on COC/i,
+      `revert reason must propagate through createVm path, got: ${reasonStr}`)
+  })
 })


### PR DESCRIPTION
## Summary — silent regression of #594

#594 wired a \`customPrecompile\` at 0x0a that always REVERTS so calls to the EIP-4844 \`point_evaluation\` precompile (which COC can't honour without a KZG trusted setup) get an explicit error instead of silent \`"0x"\`.

The test at \`precompiles.test.ts:217\` happened to call \`evm.callRaw\` without an execution context, hitting \`EvmChain.create()\`'s primary VM where the customPrecompiles list lives. **But every production RPC path** (eth_call, eth_estimateGas, debug_traceCall, debug_traceTransaction, trace_*) ALWAYS sets \`executionContext.blockNumber\` via \`resolveHistoricalExecutionContext\` (rpc.ts:3409). That forces \`callRaw\` (evm.ts:925-930) to instantiate a fresh per-block VM via the private \`createVm()\` helper — **which pre-fix omitted \`evmOpts.customPrecompiles\`.**

Result: KZG silently returned \`"0x"\` again on every real-world \`eth_call\`, fully re-introducing the #594 vulnerability. A contract bridging KZG-protected data would re-read \`uint256(bytes32(""))\` = 0 and proceed as if the proof verified.

## Repro (pre-fix)

\`\`\`bash
curl http://node -d '{
  "method":"eth_call",
  "params":[{
    "to":"0x000000000000000000000000000000000000000a",
    "data":"0x'$(yes 0 | head -384 | tr -d '\n')'",
    "gas":"0xf4240"
  }, "latest"]
}'
# pre-fix: {"result":"0x"}  ← silent! #594's revert message gone.
# post-fix: {"error":{"code":3,"message":"execution reverted: KZG point_evaluation not implemented on COC","data":"0x08c379a0..."}}
\`\`\`

## What changed

\`node/src/evm.ts\`:
- Extracted \`kzgPrecompileStub\` + \`COC_CUSTOM_PRECOMPILES\` to module-level constants so both VM-construction sites can share the same registry.
- \`EvmChain.create()\` now uses \`COC_CUSTOM_PRECOMPILES\` (unchanged behaviour).
- \`createVm()\` now also passes \`evmOpts.customPrecompiles: COC_CUSTOM_PRECOMPILES\` so historical/per-block VMs match.

## Test plan

- [x] **New \`#608\` subtest in \`precompiles.test.ts\`** explicitly exercises the historical-state code path (passes \`{blockNumber: 0n}\` context → forces createVm branch) and asserts the revert + reason match.
- [x] All pre-existing \`#594\` tests (primary-VM path) still pass.
- [x] **18/18 precompile tests green.**
- [x] TS-strip on \`evm.ts\` green.

Discovered via Ralph stress-test probe round 11 (precompile execution via eth_call HTTP boundary, which reproduced the bug shape #594 was supposed to close but the createVm path silently reopened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)