### PR TITLE
fix(ipfs): #609 gateway 200 GET emits Content-Length (parity with HEAD/206)

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -2567,6 +2567,27 @@ describe("#324 IPFS gateway honors HTTP Range header", () => {
     assert.equal(res.status, 200)
     assert.equal(res.headers["accept-ranges"], "bytes")
   })
+
+  it("#609: full-body 200 GET includes Content-Length (parity with HEAD/206 paths)", async () => {
+    // Pre-fix the full-body GET branch omitted `content-length`, while
+    // the sibling HEAD path and 206 Partial Content path both set it
+    // (line ~487 + ~500). Result: clients couldn't pre-allocate buffers,
+    // range-aware downloaders skipped resume capability, and proxies
+    // fell back to chunked transfer-encoding for known-length payloads.
+    // Same header-emission family as #382 (HEAD on 404/405 missing
+    // Content-Length, causing chunked-framing hangs).
+    const data = Buffer.alloc(2048, 0x41)
+    const meta = await unixfs.addFile("clen-test.bin", data)
+    const res = await fetch(`/ipfs/${meta.cid}`)
+    assert.equal(res.status, 200)
+    assert.equal(res.headers["content-length"], String(data.length),
+      `200 GET must set Content-Length=${data.length}, got ${JSON.stringify(res.headers["content-length"])}`)
+    // Parity with HEAD on the same CID.
+    const head = await fetch(`/ipfs/${meta.cid}`, { method: "HEAD" })
+    assert.equal(head.status, 200)
+    assert.equal(head.headers["content-length"], res.headers["content-length"],
+      "HEAD and GET must agree on Content-Length")
+  })
 })
 
 // #312/#313 restoration: PR #429's IPFS rewrite accidentally dropped the

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -494,20 +494,24 @@ export class IpfsHttpServer {
           }
           // No Range header (or unsupported multi-range): full body
           // with #328 CORS + #340 MIME sniff + #326 HEAD body suppression.
+          // #609: pre-fix the full-body GET branch omitted `content-length`
+          // (the HEAD branch correctly emits it). Clients can't pre-
+          // allocate, range-aware downloaders skip resume capability, and
+          // HTTP caches fall back to chunked transfer for what is in fact
+          // a known-length buffer. Sibling 206 path already sets it
+          // (line ~487). Emit it on the 200 path too so all three responses
+          // agree on the wire shape.
+          const fullBodyHeaders: http.OutgoingHttpHeaders = {
+            "content-type": sniffMimeType(data),
+            "content-length": String(data.length),
+            "accept-ranges": "bytes",
+            "access-control-allow-origin": "*",
+          }
           if (req.method === "HEAD") {
-            res.writeHead(200, {
-              "content-type": sniffMimeType(data),
-              "content-length": String(data.length),
-              "accept-ranges": "bytes",
-              "access-control-allow-origin": "*",
-            })
+            res.writeHead(200, fullBodyHeaders)
             res.end()
           } else {
-            res.writeHead(200, {
-              "content-type": sniffMimeType(data),
-              "accept-ranges": "bytes",
-              "access-control-allow-origin": "*",
-            })
+            res.writeHead(200, fullBodyHeaders)
             res.end(data)
           }
         } catch (err) {


### PR DESCRIPTION
## Summary

Pre-fix the full-body 200 GET on \`/ipfs/<cid>\` omitted \`Content-Length\` while the sibling HEAD and 206 Partial Content paths both set it.

Consequences:
- HTTP clients couldn't pre-allocate buffers — every full download fell back to dynamic growth.
- Range-aware downloaders skipped resume capability (no upfront size to validate against).
- HTTP caches and proxies fell back to chunked transfer-encoding for known-length payloads.
- \`ipfs-http-client.cat\` / \`kubo-rpc-client\` / fetch wrappers using \`Content-Length\` for progress meters saw nothing.

Same header-emission family as **#382** (HEAD on 404/405 paths missing Content-Length → chunked-framing hangs).

## What changed

\`node/src/ipfs-http.ts\` — hoist headers into one \`fullBodyHeaders\` object that includes \`content-length\`, write the same object on both HEAD and GET branches. All three response shapes (GET 200, HEAD 200, GET 206) now agree.

## Test plan

- [x] Probe: pre-fix \`content-len header= undefined\` on GET; post-fix \`content-len header= 360\`
- [x] New \`#609\` subtest in \`#324\` group covers GET sets it + HEAD parity
- [x] **122/122 ipfs-http tests green**
- [x] TS-strip on \`ipfs-http.ts\` green

Discovered via Ralph stress-test probe round 12 (IPFS gateway Range/ETag/conditional GET/tar archive walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)