### PR TITLE
fix(evm): #610 in-memory TxInfo cache restores accessList for mined EIP-2930/EIP-1559 txs

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -91,6 +91,17 @@ export interface TxInfo {
   v: string
   r: string
   s: string
+  // #610: EIP-2930 (type-1) + EIP-1559 (type-2) accessList — the in-memory
+  // tx cache path used by non-persistent ChainEngine (test fixtures, single-
+  // node devnet without state-trie persistence) was missing this field, so
+  // eth_getTransactionByHash returned every type-1/2 tx WITHOUT accessList
+  // even though it was signed into the RLP. PersistentChainEngine routes
+  // through formatRawTransaction (rpc.ts:4109) which always re-parses, so
+  // production 88780 was unaffected — but the divergence between the two
+  // engines means tests + devnet returned tx shapes that prod didn't.
+  // Same family as #442 (accessList missing from formatRawTransaction's
+  // type-1/2 output).
+  accessList?: Array<{ address: string; storageKeys: string[] }>
 }
 
 export interface ExecutionContext {
@@ -526,6 +537,7 @@ export class EvmChain {
       if (first !== undefined) this.txs.delete(first)
     }
 
+    const accessList1 = extractAccessListFromTypedTx(tx as { type?: number | bigint; accessList?: unknown })
     this.txs.set(txHash, {
       hash: txHash,
       from,
@@ -545,6 +557,7 @@ export class EvmChain {
       v: tx.v !== undefined ? bigIntToHex(tx.v) : "0x0",
       r: tx.r !== undefined ? bigIntToHex(tx.r) : "0x0",
       s: tx.s !== undefined ? bigIntToHex(tx.s) : "0x0",
+      ...(accessList1 !== undefined ? { accessList: accessList1 } : {}),
     })
 
     const storedReceipt = this.receipts.get(txHash)
@@ -751,6 +764,7 @@ export class EvmChain {
     // Skip per-tx cache eviction in block path — call evictCaches() after block completes
     this.receipts.set(txHash, receiptObj)
 
+    const accessList2 = extractAccessListFromTypedTx(tx as { type?: number | bigint; accessList?: unknown })
     this.txs.set(txHash, {
       hash: txHash,
       from,
@@ -770,6 +784,7 @@ export class EvmChain {
       v: tx.v !== undefined ? bigIntToHex(tx.v) : "0x0",
       r: tx.r !== undefined ? bigIntToHex(tx.r) : "0x0",
       s: tx.s !== undefined ? bigIntToHex(tx.s) : "0x0",
+      ...(accessList2 !== undefined ? { accessList: accessList2 } : {}),
     })
 
     return { txHash, gasUsed: result.totalGasSpent, success: result.execResult.exceptionError === undefined, receipt: receiptObj, from, to, contractAddress }
@@ -1412,6 +1427,44 @@ export class EvmChain {
       vm.common.setHardfork(hardfork)
     }
   }
+}
+
+/**
+ * #610: extract the JSON-RPC-shape accessList from an ethereumjs typed tx.
+ * Returns undefined for legacy (type-0) txs so the caller can omit the field;
+ * returns [] for empty accessList on type-1/2 txs (matches formatRawTransaction
+ * in rpc.ts:4114 — "always include the field on type-1/2, even when empty,
+ * because callers spec-decode the presence/absence as a structural signal").
+ */
+function extractAccessListFromTypedTx(tx: {
+  type?: number | bigint
+  accessList?: unknown
+}): Array<{ address: string; storageKeys: string[] }> | undefined {
+  const type = typeof tx.type === "bigint" ? Number(tx.type) : tx.type
+  if (type !== 1 && type !== 2) return undefined
+  const raw = tx.accessList
+  if (!Array.isArray(raw) || raw.length === 0) return []
+  // ethereumjs typed tx exposes accessList as a tuple shape:
+  // [address: Uint8Array, storageKeys: Uint8Array[]] OR
+  // { address: Address, storageKeys: Uint8Array[] } depending on version.
+  // Normalize both shapes to the JSON-RPC wire form.
+  return raw.map((entry) => {
+    if (Array.isArray(entry) && entry.length === 2) {
+      const [addr, keys] = entry as [Uint8Array | string, Array<Uint8Array | string>]
+      const addrHex = typeof addr === "string" ? addr : `0x${Buffer.from(addr).toString("hex")}`
+      const keysHex = (Array.isArray(keys) ? keys : []).map((k) =>
+        typeof k === "string" ? k : `0x${Buffer.from(k).toString("hex")}`,
+      )
+      return { address: addrHex.toLowerCase(), storageKeys: keysHex }
+    }
+    const obj = entry as { address?: { toString(): string } | string; storageKeys?: Array<Uint8Array | string> }
+    const addrRaw = obj.address
+    const addrStr = typeof addrRaw === "string" ? addrRaw : (addrRaw?.toString?.() ?? "")
+    const keysHex = (Array.isArray(obj.storageKeys) ? obj.storageKeys : []).map((k) =>
+      typeof k === "string" ? k : `0x${Buffer.from(k).toString("hex")}`,
+    )
+    return { address: addrStr.toLowerCase(), storageKeys: keysHex }
+  })
 }
 
 function normalizeExecutionContext(context?: bigint | ExecutionContext): ExecutionContext {

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -5277,6 +5277,82 @@ test("RPC Extended Methods", async (t) => {
     )
   })
 
+  await t.test("#610: eth_getTransactionByHash includes accessList for MINED EIP-2930/EIP-1559 txs (in-memory engine path)", async () => {
+    // #442 fixed the mempool path (formatRawTransaction is called when the
+    // tx is still pending). But the post-mining fallback in rpc.ts (~873)
+    // — `evm.getTransaction(hash)` — returns a TxInfo struct that doesn't
+    // include accessList, so non-persistent ChainEngine setups (test
+    // fixtures + single-node devnet) silently dropped the field once the
+    // tx was mined. PersistentChainEngine routes through formatRawTransaction
+    // via its blockIndex so production 88780 wasn't affected — but the
+    // divergence meant in-memory engine returned a shape prod didn't.
+    //
+    // Repro: submit type-1, force a block proposal so the tx leaves mempool,
+    // then GET via eth_getTransactionByHash. Pre-#610 accessList is undefined.
+    const { Wallet } = await import("ethers")
+    const wallet = new Wallet(`0x${"42".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+    const targetAddr = `0x${"19".repeat(20)}`
+    const slot3 = `0x${"00".repeat(31)}03`
+
+    // EIP-2930 (type 1) — sign, submit, mine.
+    const tx2930 = await wallet.signTransaction({
+      type: 1,
+      to: targetAddr, value: 1n,
+      nonce: Number(startN),
+      gasPrice: 1_000_000_000n, gasLimit: 50_000n, chainId,
+      accessList: [{ address: targetAddr, storageKeys: [slot3] }],
+    })
+    const rRes = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [tx2930] }),
+    })
+    const submitted = await rRes.json() as { result?: string }
+    assert.ok(submitted.result, "tx must accept")
+    // Force-mine so the tx leaves the mempool and lands in evm.txs.
+    // chain.proposeNextBlock applies a block from currently pending txs.
+    await chain.proposeNextBlock()
+
+    const getRes = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionByHash", params: [submitted.result] }),
+    })
+    const got = await getRes.json() as { result?: Record<string, unknown> }
+    assert.ok(got.result, `mined tx must be findable: ${JSON.stringify(got)}`)
+    assert.equal(got.result!.type, "0x1", "type field must be 0x1 for mined EIP-2930")
+    // The bug: accessList missing after mining on the in-memory engine.
+    const acl = got.result!.accessList as Array<{ address: string; storageKeys: string[] }> | undefined
+    assert.ok(Array.isArray(acl),
+      `accessList must be present on MINED EIP-2930 tx (got ${typeof acl}: ${JSON.stringify(got.result)})`)
+    assert.equal(acl!.length, 1, "accessList must have 1 entry")
+    assert.equal(acl![0].address.toLowerCase(), targetAddr.toLowerCase(),
+      "accessList[0].address must match what was signed")
+    assert.deepEqual(acl![0].storageKeys.map(k => k.toLowerCase()), [slot3],
+      "accessList[0].storageKeys must round-trip the signed slot")
+
+    // Sanity: legacy mined tx still has NO accessList (closing parity loop with #442's legacy assertion).
+    const txLegacy = await wallet.signTransaction({
+      type: 0, to: targetAddr, value: 1n,
+      nonce: Number(startN) + 1, gasPrice: 1_000_000_000n, gasLimit: 21_000n, chainId,
+    })
+    const submitLegacy = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [txLegacy] }),
+    }).then(r => r.json()) as { result?: string }
+    await chain.proposeNextBlock()
+    const getLegacy = await fetch(`http://127.0.0.1:${port}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionByHash", params: [submitLegacy.result] }),
+    }).then(r => r.json()) as { result?: Record<string, unknown> }
+    assert.equal(getLegacy.result!.accessList, undefined,
+      "MINED legacy tx must NOT carry accessList field")
+  })
+
   await t.test("#342: eth_getFilterChanges for missing/expired filter returns -32000", async () => {
     // Pre-fix returned `[]` for any missing filter — long-running indexers
     // polling past FILTER_TTL_MS (5 min) silently dropped events with no


### PR DESCRIPTION
## Summary — silent post-mining regression of #442

**#442** fixed the mempool path so \`eth_getTransactionByHash\` returns \`accessList\` for unmined type-1/2 txs (\`formatRawTransaction\` re-parses the raw RLP).

But the post-mining fallback in \`rpc.ts:873\` — \`evm.getTransaction(hash)\` — returns a \`TxInfo\` struct from the in-memory \`evm.txs\` Map, and that struct never had an \`accessList\` field. So once a type-1 or type-2 tx was mined on a non-persistent \`ChainEngine\` (test fixtures, single-node devnet, anywhere \`PersistentChainEngine\` isn't wired), the field silently disappeared.

\`PersistentChainEngine\` routes through \`formatRawTransaction\` via its blockIndex, so production 88780 was not affected — but the **engine-divergence** meant in-memory engine returned a shape prod didn't. Indexers / MEV tooling / gas-cost analysis running against devnet silently saw \`undefined\` for every mined type-1/2 tx.

## Repro (pre-fix)

\`\`\`
[type-1 tx fields]: {"type":"0x1","gasPrice":"0x77359400"}  ← accessList missing!
\`\`\`

post-fix:

\`\`\`
[type-1 tx fields]: {"type":"0x1","accessList":[{"address":"0x7099…","storageKeys":["0x00…00"]}],"gasPrice":"0x77359400"}
\`\`\`

## What changed

\`node/src/evm.ts\`:
- Added \`accessList?\` to the \`TxInfo\` interface.
- New module-level \`extractAccessListFromTypedTx\` handles both tuple-shape and object-shape ethereumjs typed tx accessList (varies by @ethereumjs/tx version).
- Populated the field at both \`this.txs.set\` insertion sites (runTx + executeRawTx). Emit \`[]\` for type-1/2 with empty accessList (matches \`formatRawTransaction\` contract); omit entirely for legacy txs.

## Test plan

- [x] **New \`#610\` subtest** in \`rpc-extended.test.ts\` exercises the **post-mining path** explicitly (sign type-1, submit, FORCE-MINE via \`chain.proposeNextBlock()\`, then GET). Pre-fix returns no accessList, post-fix it round-trips.
- [x] Sanity branch: legacy MINED tx still has NO accessList field.
- [x] Existing \`#442\` (mempool path) untouched.
- [x] Standalone probe verified.
- [x] TS-strip on \`evm.ts\` green.

Discovered via Ralph stress-test probe round 14 (block proposing + typed-tx receipt walk + contract deploy/call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)