### PR TITLE
fix(rpc): #612 eth_signTypedData_v4 rejects non-object types/domain/message with -32602 (no V8 leak)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2696,6 +2696,42 @@ test("RPC Extended Methods", async (t) => {
       `error must mention keystore, not typedData: ${goodTd.error!.message}`)
   })
 
+  await t.test("#612: eth_signTypedData_v4 rejects non-object types/domain/message with -32602 (no V8 leak)", async () => {
+    // Pre-fix `(td.types ?? {}) as Record<...>` was a TS-only cast. A
+    // string / array / number / boolean in `td.types` (or `td.domain`,
+    // `td.message`) flowed straight into TypedDataEncoder.hash, which
+    // then threw a TypeError like
+    //   "_types[type].map is not a function"
+    // The TypeError didn't carry an ethers `.code` string so the
+    // existing #182 catch missed it → bubble surfaced as -32603 with the
+    // V8 / ethers internals leaked verbatim. Same info-leak family as
+    // #156/#176/#182. Tighten the shape check at the boundary.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_signTypedData_v4", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string } }
+    }
+    const owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    // (a) types is a string → -32602
+    const badTypes = await probe([owner, { types: "not-an-object", domain: {}, message: {} }])
+    assert.equal(badTypes.error?.code, -32602,
+      `string types must be -32602, got ${badTypes.error?.code}: ${badTypes.error?.message}`)
+    assert.match(badTypes.error!.message, /typedData\.types/i, "must name the field")
+    assert.doesNotMatch(badTypes.error!.message, /\.map is not a function|Cannot read prop/i,
+      "must not leak V8 TypeError verbatim")
+    // (b) domain is an array → -32602
+    const badDomain = await probe([owner, { types: {}, domain: [1, 2, 3], message: {} }])
+    assert.equal(badDomain.error?.code, -32602)
+    assert.match(badDomain.error!.message, /typedData\.domain/i)
+    // (c) message is a number → -32602
+    const badMsg = await probe([owner, { types: {}, domain: {}, message: 42 }])
+    assert.equal(badMsg.error?.code, -32602)
+    assert.match(badMsg.error!.message, /typedData\.message/i)
+  })
+
   await t.test("#156: eth_sendRawTransaction rejects malformed input with -32602 and clean message (no ethers leak)", async () => {
     // Pre-fix bogus input (e.g. "0xff") flowed into ethers.Transaction.from()
     // and surfaced as -32603 "data short segment too short (buffer=0xff,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1512,9 +1512,35 @@ async function handleRpc(
       // eth_sign's order: shape-validate everything that doesn't need
       // keystore, THEN authorize.
       const td = typedData as Record<string, unknown>
-      const types = (td.types ?? {}) as Record<string, Array<{ name: string; type: string }>>
-      const domain = (td.domain ?? {}) as Record<string, unknown>
-      const message = (td.message ?? {}) as Record<string, unknown>
+      // #612: pre-fix `(td.types ?? {}) as Record<...>` was a TS-only cast;
+      // a string / array / number / boolean in `types` flowed straight to
+      // TypedDataEncoder.hash, which then threw a TypeError like
+      //   "_types[type].map is not a function"
+      // or
+      //   "Cannot read properties of undefined (reading 'map')"
+      // — neither has the ethers `.code` string the catch at #182 looks
+      // for, so the message bubbled out as -32603 internal error with
+      // the V8 / ethers internals leaked verbatim. Same family as
+      // #156/#176/#182 — wrap-and-sanitize at the boundary instead of
+      // hoping the downstream catch fires.
+      const rawTypes = td.types
+      if (rawTypes !== undefined && rawTypes !== null &&
+          (typeof rawTypes !== "object" || Array.isArray(rawTypes))) {
+        invalidParams(`invalid typedData.types: expected object, got ${Array.isArray(rawTypes) ? "array" : typeof rawTypes}`)
+      }
+      const types = (rawTypes ?? {}) as Record<string, Array<{ name: string; type: string }>>
+      const rawDomain = td.domain
+      if (rawDomain !== undefined && rawDomain !== null &&
+          (typeof rawDomain !== "object" || Array.isArray(rawDomain))) {
+        invalidParams(`invalid typedData.domain: expected object, got ${Array.isArray(rawDomain) ? "array" : typeof rawDomain}`)
+      }
+      const domain = (rawDomain ?? {}) as Record<string, unknown>
+      const rawMessage = td.message
+      if (rawMessage !== undefined && rawMessage !== null &&
+          (typeof rawMessage !== "object" || Array.isArray(rawMessage))) {
+        invalidParams(`invalid typedData.message: expected object, got ${Array.isArray(rawMessage) ? "array" : typeof rawMessage}`)
+      }
+      const message = (rawMessage ?? {}) as Record<string, unknown>
       // Remove EIP712Domain from types (TypedDataEncoder handles it internally)
       const filteredTypes = { ...types }
       delete filteredTypes.EIP712Domain
@@ -1531,6 +1557,13 @@ async function handleRpc(
           encErr && typeof encErr === "object" && typeof (encErr as { code?: unknown }).code === "string"
         if (isEthersShapeError) {
           invalidParams("invalid typedData: failed to encode")
+        }
+        // #612: TypeError (V8 leak) for malformed type-shape values that
+        // sneak past the shape pre-check — same "clean message" treatment
+        // as #176 instead of letting the V8/ethers internals reach the
+        // wire.
+        if (encErr instanceof TypeError) {
+          invalidParams("invalid typedData: malformed type definition")
         }
         throw encErr
       }


### PR DESCRIPTION
## Summary

Pre-fix \`(td.types ?? {}) as Record<...>\` was a TS-only cast. A string / array / number / boolean in any of \`td.types\`, \`td.domain\`, \`td.message\` flowed straight into \`TypedDataEncoder.hash\`, which threw a TypeError like:

    "_types[type].map is not a function"

The TypeError didn't carry an ethers \`.code\` string so the existing #182 catch missed it → bubble surfaced as **-32603 internal error** with the V8 / ethers internals **leaked verbatim** (the message reveals the internal variable name \`_types[type]\`).

Same info-leak family as #156 (BUFFER_OVERRUN), #176 (V8 SyntaxError), #182 (TypedDataEncoder INVALID_ARGUMENT), #505/#507 (filesystem path / multiformats internals), #601 (state-manager class name), #604 (chainId fallback gap).

## What changed

- Pre-check each of \`td.types\`, \`td.domain\`, \`td.message\` at the boundary: must be undefined / null / plain object (NOT array, NOT primitive). Reject with -32602 naming which field is malformed.
- Defensive belt-and-suspenders catch: if a TypeError escapes the pre-check (e.g. a deeply-nested malformed type entry), the existing catch now also handles \`encErr instanceof TypeError\` → clean -32602 "malformed type definition" message.

## Test plan

- [x] Probe: pre-fix \`-32603 _types[type].map is not a function\`; post-fix \`-32602 invalid typedData.types: expected object, got string\`
- [x] New \`#612\` subtest covers types=string, domain=array, message=number paths
- [x] Asserts -32602 + that V8/ethers verbatim ("_types[type].map", "Cannot read prop") is NOT in the response
- [x] Existing \`#503\` (string-form typedData) + \`#521\` (validate-before-keystore) + \`#154\` (address shape) untouched
- [x] TS-strip on \`rpc.ts\` green

Discovered via Ralph stress-test probe round 17 (EIP-712 typed data signing edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)