### PR TITLE
fix(chain-engine): #613 enforce EIP-3860 MAX_INITCODE_SIZE (49152) at mempool boundary

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -639,6 +639,22 @@ export class PersistentChainEngine {
     ) {
       throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
     }
+    // #613: enforce EIP-3860 MAX_INITCODE_SIZE = 49152 bytes (mirrors
+    // chain-engine.ts addRawTx). Pre-fix oversized contract-creation
+    // initcode was accepted, gossipped, then failed during EVM execution.
+    // Reject at the boundary so wallets see -32000 immediately, matching
+    // geth/erigon's "max initcode size exceeded" error.
+    const MAX_INITCODE_SIZE = 49152
+    if (!decoded.to) {
+      const initCodeBytes = decoded.data
+        ? (decoded.data.startsWith("0x") ? (decoded.data.length - 2) / 2 : decoded.data.length / 2)
+        : 0
+      if (initCodeBytes > MAX_INITCODE_SIZE) {
+        throw new Error(
+          `max initcode size exceeded: code size ${initCodeBytes} limit ${MAX_INITCODE_SIZE}`,
+        )
+      }
+    }
 
     // Mirror in-memory engine order: hash dedup first (more specific error
     // for same-tx replay), then stale-nonce check (catches different-tx-same-

--- a/node/src/chain-engine.test.ts
+++ b/node/src/chain-engine.test.ts
@@ -235,3 +235,73 @@ test("duplicate tx is rejected", async () => {
   // This just verifies the flow doesn't crash
   assert.equal(engine.getHeight(), 1n)
 })
+
+test("#613: rejects contract-creation tx with init code > EIP-3860 MAX_INITCODE_SIZE (49152 bytes)", async () => {
+  // Pre-fix oversized contract-creation initcode was accepted by the
+  // mempool, gossipped to peers, then failed at EVM execution time. Geth +
+  // Erigon both reject at the mempool boundary with "max initcode size
+  // exceeded" so wallets get an actionable -32000 immediately. EIP-3860
+  // is Shanghai-onwards mandate; mempool.computeIntrinsicGas already
+  // charges the per-word cost (mempool.ts:91-95) but the SIZE LIMIT
+  // check itself was missing.
+  const { Wallet } = await import("ethers")
+  const wallet = new Wallet("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+  const { engine } = await createTestEngine()
+
+  // (a) Just under the cap → accepted (gas-budget permitting).
+  const okInit = "0x" + "60ff".repeat(24_575)  // 49150 bytes
+  const okTx = await wallet.signTransaction({
+    type: 2, chainId: 18780, nonce: 0,
+    maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n,
+    gasLimit: 5_000_000n, to: null, data: okInit,
+  })
+  // Must NOT throw "max initcode size" — gas-related rejections are
+  // separate concerns and out of scope here.
+  await assert.doesNotReject(
+    () => engine.addRawTx(okTx as Hex),
+    /max initcode size/i,
+    "49150-byte initcode (just under 49152) must not trip the size cap",
+  )
+
+  // (b) Just over the cap → rejected with -32000-compatible message.
+  const badInit = "0x" + "60ff".repeat(24_577)  // 49154 bytes
+  const badTx = await wallet.signTransaction({
+    type: 2, chainId: 18780, nonce: 1,
+    maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n,
+    gasLimit: 5_000_000n, to: null, data: badInit,
+  })
+  await assert.rejects(
+    () => engine.addRawTx(badTx as Hex),
+    (err: Error) => /max initcode size exceeded: code size 49154 limit 49152/.test(err.message),
+    "49154-byte initcode (just over 49152) must be rejected with EIP-3860 message",
+  )
+
+  // (c) Way over (100KB) → also rejected.
+  const wayInit = "0x" + "60ff".repeat(50_000)  // 100000 bytes
+  const wayTx = await wallet.signTransaction({
+    type: 2, chainId: 18780, nonce: 2,
+    maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n,
+    gasLimit: 10_000_000n, to: null, data: wayInit,
+  })
+  await assert.rejects(
+    () => engine.addRawTx(wayTx as Hex),
+    /max initcode size exceeded: code size 100000 limit 49152/,
+    "100KB initcode must be rejected",
+  )
+
+  // (d) Sanity: non-creation tx (to != null) is NOT subject to the cap.
+  // Regular contract calls can have arbitrary data length (subject to
+  // intrinsic gas + block gas limit).
+  const callTx = await wallet.signTransaction({
+    type: 2, chainId: 18780, nonce: 3,
+    maxFeePerGas: 3_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n,
+    gasLimit: 5_000_000n,
+    to: "0x" + "1".repeat(40),  // non-creation
+    data: "0x" + "ab".repeat(60_000),  // 60KB data, but it's a call
+  })
+  await assert.doesNotReject(
+    () => engine.addRawTx(callTx as Hex),
+    /max initcode size/i,
+    "60KB call data on a non-creation tx must not trip the initcode cap",
+  )
+})

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -190,6 +190,28 @@ export class ChainEngine {
     ) {
       throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${txChainId}`)
     }
+    // #613: enforce EIP-3860 MAX_INITCODE_SIZE = 49152 bytes (2 * MAX_CODE_SIZE).
+    // Pre-fix a contract-creation tx with initcode > 49152 bytes was accepted
+    // by the mempool, gossipped, and only failed at EVM execution time (or
+    // silently produced an invalid receipt depending on backend). Geth +
+    // Erigon both reject at the mempool boundary with
+    //   "max initcode size exceeded: code size <N> limit <49152>"
+    // so wallets/dApps get an actionable -32000 immediately rather than
+    // waiting for a block + receipt to learn their deployment is malformed.
+    // Shanghai/Cancun mandate; mempool.computeIntrinsicGas already accounts
+    // for the per-word cost (mempool.ts:91-95) but the SIZE LIMIT itself
+    // was never wired.
+    const MAX_INITCODE_SIZE = 49152
+    if (!decoded.to) {
+      const initCodeBytes = decoded.data
+        ? (decoded.data.startsWith("0x") ? (decoded.data.length - 2) / 2 : decoded.data.length / 2)
+        : 0
+      if (initCodeBytes > MAX_INITCODE_SIZE) {
+        throw new Error(
+          `max initcode size exceeded: code size ${initCodeBytes} limit ${MAX_INITCODE_SIZE}`,
+        )
+      }
+    }
     if (this.txHashSet.has(decoded.hash as Hex)) {
       throw new Error("tx already confirmed")
     }

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1224,6 +1224,7 @@ async function handleRpc(
           /^tx already confirmed$/i.test(msg) ||
           /^intrinsic gas too low:/i.test(msg) ||
           /^gasLimit exceeds maximum:/i.test(msg) ||
+          /^max initcode size exceeded:/i.test(msg) ||
           /is poisoned \(hung block execution/i.test(msg)
         ) {
           throw { code: -32000, message: msg }


### PR DESCRIPTION
## Summary

Pre-fix a contract-creation tx with initcode > 49152 bytes was **accepted by the mempool**, gossipped to peers, then either failed at EVM execution time (backend-dependent) or silently produced an invalid receipt. Wallets/dApps had to wait for a block + receipt to learn their deployment was malformed instead of getting \`-32000\` immediately.

**Geth + Erigon** both reject at the mempool boundary with \`max initcode size exceeded: code size <N> limit <49152>\` — a Shanghai-onwards mandate. COC's mempool already charges the **per-32-byte-word gas cost** (\`mempool.ts:91-95\` \`computeIntrinsicGas\`) but the **SIZE LIMIT check** itself was never wired.

## Repro

Pre-fix:
\`\`\`
> eth_sendRawTransaction(<49154-byte init tx>)
{"result":"0x24a6cdd..."}  ← accepted!

> eth_sendRawTransaction(<100000-byte init tx>)
{"result":"0x86752ee..."}  ← accepted!
\`\`\`

Post-fix:
\`\`\`
> eth_sendRawTransaction(<49154-byte init tx>)
{"error":{"code":-32000,"message":"max initcode size exceeded: code size 49154 limit 49152"}}
\`\`\`

## What changed

- \`node/src/chain-engine.ts\` \`addRawTx\`: after the chainId check (#527), measure initcode byte length when \`tx.to\` is null and reject when >49152 with the geth-shaped error message.
- \`node/src/chain-engine-persistent.ts\` \`addRawTx\`: mirror the same check so production (PersistentChainEngine) is covered.
- \`node/src/rpc.ts\` error-code mapping: route \`"max initcode size exceeded:"\` through -32000 (sibling of \`intrinsic gas too low\` + \`gasLimit exceeds maximum\`).

## Test plan

New \`#613\` subtest in \`chain-engine.test.ts\` covers 4 cases:
- [x] (a) 49150 bytes just-under → accepted
- [x] (b) 49154 bytes just-over → rejected with geth-shape message
- [x] (c) 100KB way-over → rejected
- [x] (d) sanity: 60KB call data on non-creation tx is NOT subject to cap

TS-strip on \`chain-engine.ts\` + \`chain-engine-persistent.ts\` + \`rpc.ts\` green.

Discovered via Ralph stress-test probe round 19 (contract deploy edge cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)