### PR TITLE
fix(rpc): #614 eth_createAccessList.gasUsed includes intrinsic gas (geth parity)

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -965,6 +965,21 @@ export class EvmChain {
     return total + total / 10n
   }
 
+  /**
+   * #614: expose intrinsic gas calculation for callers that have already
+   * run the EVM and just need to add the intrinsic floor (e.g.
+   * eth_createAccessList in rpc.ts, which returned ONLY execution gas
+   * and missed the 21000 base + per-byte data cost).
+   */
+  computeIntrinsicGasFor(data: string | undefined, isContractCreation: boolean, blockNumber?: bigint): bigint {
+    const dataBytes = data ? hexToBytes(data.startsWith("0x") ? data as `0x${string}` : (`0x${data}` as `0x${string}`)) : new Uint8Array()
+    return calculateIntrinsicGas(
+      dataBytes,
+      isContractCreation,
+      this.createExecutionCommon(blockNumber),
+    )
+  }
+
   async getCode(address: string, stateRoot?: string): Promise<string> {
     const stateManager = await this.resolveStateManager(stateRoot)
     const code = await stateManager.getCode(Address.fromString(address))

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -251,6 +251,49 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(typeof result.gasUsed === "string")
   })
 
+  await t.test("#614: eth_createAccessList.gasUsed includes intrinsic gas (parity with geth)", async () => {
+    // Pre-fix the handler returned result.gasUsed from evm.traceCall
+    // directly, which is the EVM EXECUTION gas only. For a simple value
+    // transfer (no contract code, no data) execution gas is 0, so
+    // pre-fix the response was {accessList:[], gasUsed:"0x0"} — but the
+    // tx WOULD actually cost 21000 (intrinsic). Tools wiring this number
+    // into `gas:` on a subsequent eth_sendRawTransaction sent txs
+    // guaranteed to fail with "intrinsic gas too low".
+    //
+    // Geth's eth_createAccessList returns the TOTAL tx-gas estimate
+    // including intrinsic (21000 base + per-byte data + creation extras).
+    // Sibling endpoint eth_estimateGas already did this (evm.ts:949);
+    // eth_createAccessList must match.
+    const valueTransfer = await rpcCall(port, "eth_createAccessList", [
+      {
+        from: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        to: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        value: "0x1",
+      },
+    ]) as { accessList: unknown[]; gasUsed: string }
+    // 21000 = 0x5208. Pre-fix this was "0x0".
+    assert.ok(BigInt(valueTransfer.gasUsed) >= 21_000n,
+      `value-transfer createAccessList.gasUsed must include intrinsic 21000+, got ${valueTransfer.gasUsed} = ${BigInt(valueTransfer.gasUsed)}`)
+    assert.notEqual(valueTransfer.gasUsed, "0x0",
+      "createAccessList.gasUsed must NEVER be 0x0 for a deliverable tx (the pre-fix bug)")
+    // Parity with eth_estimateGas (which already adds intrinsic; the
+    // two should be within ~10% of each other since estimateGas adds a
+    // +10% buffer on top of the intrinsic + execution sum).
+    const est = await rpcCall(port, "eth_estimateGas", [{
+      from: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      to: "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+      value: "0x1",
+    }]) as string
+    const aclGas = BigInt(valueTransfer.gasUsed)
+    const estGas = BigInt(est)
+    // estimateGas adds 10% buffer; createAccessList doesn't (it's a
+    // simulation result, not an estimate). estGas should be ~aclGas * 1.1.
+    assert.ok(estGas >= aclGas,
+      `estimateGas (${estGas}) must be >= createAccessList gasUsed (${aclGas})`)
+    assert.ok(estGas <= aclGas * 2n,
+      `estimateGas (${estGas}) and createAccessList (${aclGas}) must be in the same order of magnitude`)
+  })
+
   await t.test("eth_sendTransaction sends signed transaction", async () => {
     const accounts = await rpcCall(port, "eth_accounts")
 

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1567,9 +1567,20 @@ async function handleRpc(
         value: callParams.value,
         gas: callParams.gas,
       }, {}, executionContext.stateRoot, executionContext)
+      // #614: pre-fix returned `result.gasUsed` directly, which is the
+      // EVM execution gas only. Geth's eth_createAccessList returns the
+      // TOTAL tx-gas estimate INCLUDING intrinsic (21000 base + per-byte
+      // data cost + EIP-3860 init-code-word cost for creations). For a
+      // simple value transfer that's intrinsic 21000 vs the buggy 0x0
+      // we returned. Tools that pre-flight access-list AND set gasLimit
+      // off this number sent txs guaranteed to fail with "intrinsic gas
+      // too low" or out-of-gas. Mirror evm.estimateGas (line ~944) which
+      // already adds intrinsic.
+      const isCreate = !callParams.to || callParams.to === ""
+      const intrinsic = evm.computeIntrinsicGasFor(callParams.data, isCreate, executionContext.blockNumber)
       return {
         accessList: result.accessList,
-        gasUsed: `0x${result.gasUsed.toString(16)}`,
+        gasUsed: `0x${(intrinsic + result.gasUsed).toString(16)}`,
       }
     }
     case "debug_traceCall": {


### PR DESCRIPTION
## Summary

Pre-fix the handler returned \`result.gasUsed\` from \`evm.traceCall\` directly, which is the **EVM EXECUTION gas only** — NOT the total tx-gas estimate. For a simple value transfer (no contract code, no data) execution gas is 0, so the response was:

\`\`\`json
{"accessList":[], "gasUsed":"0x0"}
\`\`\`

even though the tx would actually cost **21000** (intrinsic).

Tools that wire this number into \`gas:\` on a subsequent \`eth_sendRawTransaction\` sent txs guaranteed to fail with "intrinsic gas too low".

Geth's \`eth_createAccessList\` returns the TOTAL tx-gas estimate including intrinsic (21000 base + per-byte data + creation extras). Sibling endpoint \`eth_estimateGas\` already did this (evm.ts:944-950); \`eth_createAccessList\` must match.

## What changed

- \`evm.ts\`: new public method \`computeIntrinsicGasFor(data, isCreate, blockNumber)\` exposing the existing internal \`calculateIntrinsicGas\` so callers that already have the execution gas can add the intrinsic floor.
- \`rpc.ts\` \`eth_createAccessList\` handler: return \`intrinsic + result.gasUsed\` rather than just \`result.gasUsed\`.

## Test plan

- [x] Probe: pre-fix \`gasUsed: "0x0"\` for value-transfer createAccessList; post-fix \`gasUsed: "0x5208"\` (21000)
- [x] New #614 subtest: value-transfer createAccessList must be ≥ 21000, NOT 0x0
- [x] Parity assertion: estimateGas ≥ createAccessList gasUsed (estimate adds 10% buffer; createAccessList is a simulation, no buffer)
- [x] Existing eth_createAccessList tests untouched
- [x] TS-strip green on rpc.ts + evm.ts

Discovered via Ralph stress-test probe round 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)