### PR TITLE
fix(mempool): #615 same-sender contiguous nonces all picked in single pass

### DIFF
--- a/node/src/mempool.test.ts
+++ b/node/src/mempool.test.ts
@@ -225,6 +225,58 @@ describe("Mempool", () => {
     }
   })
 
+  it("#615: same-sender contiguous nonces all picked when prices increase (no single-pass throttle)", async () => {
+    // Pre-fix: global sort by gas price desc puts [n2@10gw, n1@5gw, n0@1gw].
+    // Loop visits n2 → expected=0, gap → skip; n1 → expected=0, gap → skip;
+    // n0 → expected=0, picked. n1/n2 already past — only 1 of 3 picked.
+    // High-volume senders (faucets, MEV bots, agents) were throttled to
+    // 1 tx/block whenever per-nonce gas prices differed.
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    signAndAdd(pool, PK1, 0, "0x3b9aca00") // 1 gwei
+    signAndAdd(pool, PK1, 1, "0x12a05f200") // 5 gwei
+    signAndAdd(pool, PK1, 2, "0x2540be400") // 10 gwei
+
+    const picked = await pool.pickForBlock(10, async () => 0n, 0n)
+    assert.equal(picked.length, 3, "all three contiguous-nonce txs must be picked")
+    assert.equal(picked[0].nonce, 0n)
+    assert.equal(picked[1].nonce, 1n)
+    assert.equal(picked[2].nonce, 2n)
+  })
+
+  it("#615: mixed-sender ordering preserves gas-price priority across senders", async () => {
+    // PK1: nonce 0/1 @ 1gw/10gw. PK2: nonce 0 @ 5gw.
+    // Highest single-tx price is PK1.n1 @ 10gw but it's gapped behind PK1.n0.
+    // Expected order: PK1.n0 (the predecessor that unlocks the higher-priced
+    // n1), then PK2.n0 vs PK1.n1 by price. Total = all 3 picked.
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    signAndAdd(pool, PK1, 0, "0x3b9aca00") // 1 gwei
+    signAndAdd(pool, PK1, 1, "0x2540be400") // 10 gwei
+    signAndAdd(pool, PK2, 0, "0x12a05f200") // 5 gwei
+
+    const picked = await pool.pickForBlock(10, async () => 0n, 0n)
+    assert.equal(picked.length, 3, "all 3 txs must be included")
+    // PK1's two nonces must be in correct order
+    const pk1Picks = picked.filter((p) => p.from === new Wallet(PK1).address.toLowerCase())
+    assert.equal(pk1Picks.length, 2)
+    assert.equal(pk1Picks[0].nonce, 0n)
+    assert.equal(pk1Picks[1].nonce, 1n)
+  })
+
+  it("#615: deferred drain stops at gas-budget exhaustion (no over-fill)", async () => {
+    // PK1 has 3 contiguous nonces; only 2 fit in the gas budget.
+    // The deferred drain must not exceed gas budget when picking the 3rd.
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    signAndAdd(pool, PK1, 0, "0x3b9aca00")
+    signAndAdd(pool, PK1, 1, "0x12a05f200")
+    signAndAdd(pool, PK1, 2, "0x2540be400")
+
+    // 21000 * 2 + 1 — fits exactly 2 txs, third would exceed
+    const picked = await pool.pickForBlock(10, async () => 0n, 0n, 0n, 42_001n)
+    assert.equal(picked.length, 2)
+    assert.equal(picked[0].nonce, 0n)
+    assert.equal(picked[1].nonce, 1n)
+  })
+
   it("does not pick transactions that cannot pay base fee", async () => {
     const pool = new Mempool({ chainId: CHAIN_ID })
     signAndAdd(pool, PK1, 0, "0x3b9aca00") // 1 gwei

--- a/node/src/mempool.ts
+++ b/node/src/mempool.ts
@@ -395,18 +395,38 @@ export class Mempool {
      * picked if the 1st already drained the wallet.
      */
     const cumulativeSpend = new Map<Hex, bigint>()
+    /**
+     * #615: per-sender deferred queue for txs whose nonce is ahead of
+     * the sender's current expected nonce at visit time. Without this,
+     * the single-pass loop wastes contiguous-nonce txs from the same
+     * sender whenever the global gas-price sort visits them before
+     * their predecessor.
+     *
+     * Repro before fix: PK1 submits nonce 0 @ 1 gwei + nonce 1 @ 5 gwei
+     * + nonce 2 @ 10 gwei. Sort puts [n2, n1, n0]. Loop visits n2 → gap
+     * (skip), n1 → gap (skip), n0 → pick. n1/n2 already passed → only
+     * 1 of 3 picked. High-volume senders (agents, MEV bots, faucets) were
+     * effectively throttled to 1 tx/block whenever their per-nonce gas
+     * prices differed.
+     *
+     * Fix: when a tx is skipped due to gap, queue it sorted by nonce
+     * under its sender. After each successful pick, drain the sender's
+     * deferred queue while the head's nonce matches the freshly-advanced
+     * expected nonce. Each tx is visited at most twice → O(N log N).
+     */
+    const deferred = new Map<Hex, MempoolTx[]>()
 
-    for (const tx of sorted) {
-      if (picked.length >= maxTx) break
-      if (cumulativeGas + tx.gasLimit > blockGasLimit) continue
+    const tryPickOne = (tx: MempoolTx): "picked" | "deferred" | "rejected" => {
+      if (picked.length >= maxTx) return "rejected"
+      if (cumulativeGas + tx.gasLimit > blockGasLimit) return "rejected"
       const next = expected.get(tx.from)
-      if (next === undefined || next === -1n) continue
+      if (next === undefined || next === -1n) return "rejected"
       // Evict transactions whose nonce is already confirmed on-chain
       if (tx.nonce < next) {
         this.removeTx(tx.hash)
-        continue
+        return "rejected"
       }
-      if (tx.nonce !== next) continue
+      if (tx.nonce !== next) return "deferred"
 
       // Phase H3: affordability check
       if (getBalance !== undefined) {
@@ -426,7 +446,7 @@ export class Mempool {
             // sender's nonce queue indefinitely.
             this.removeTx(tx.hash)
           }
-          continue
+          return "rejected"
         }
         cumulativeSpend.set(tx.from, alreadySpent + upfrontCost)
       }
@@ -434,6 +454,42 @@ export class Mempool {
       picked.push(tx)
       cumulativeGas += tx.gasLimit
       expected.set(tx.from, next + 1n)
+      return "picked"
+    }
+
+    const enqueueDeferred = (tx: MempoolTx): void => {
+      let q = deferred.get(tx.from)
+      if (!q) {
+        q = []
+        deferred.set(tx.from, q)
+      }
+      // Insert sorted by nonce ascending. Small per-sender queues in
+      // practice (a few txs); linear insertion is fine.
+      let i = 0
+      while (i < q.length && q[i].nonce < tx.nonce) i++
+      q.splice(i, 0, tx)
+    }
+
+    const drainDeferred = (sender: Hex): void => {
+      const q = deferred.get(sender)
+      if (!q) return
+      while (q.length > 0) {
+        const exp = expected.get(sender)
+        if (exp === undefined || q[0].nonce !== exp) break
+        const head = q.shift()!
+        const r = tryPickOne(head)
+        // If the eligible head was rejected (gas budget exhausted,
+        // affordability), stop draining — subsequent (higher-nonce)
+        // txs from this sender are now stuck behind a non-pickable
+        // head and won't become eligible this block.
+        if (r !== "picked") break
+      }
+    }
+
+    for (const tx of sorted) {
+      const result = tryPickOne(tx)
+      if (result === "deferred") enqueueDeferred(tx)
+      else if (result === "picked") drainDeferred(tx.from)
     }
 
     return picked


### PR DESCRIPTION
## Summary

`Mempool.pickForBlock` had a single-pass bug where the global gas-price sort would visit a sender's higher-nonce tx before its predecessor, causing the higher-nonce tx to be permanently skipped within that block — even after the predecessor was picked.

## Repro

```
PK1 submits:
  nonce 0 @ 1 gwei
  nonce 1 @ 5 gwei
  nonce 2 @ 10 gwei

Global sort by gas price desc → [n2, n1, n0]
Loop:
  visit n2 → expected[PK1]=0, gap → skip
  visit n1 → expected[PK1]=0, gap → skip
  visit n0 → picked, expected[PK1]→1, but n1/n2 already past loop cursor
```

Result: 1 of 3 picked. High-volume senders (faucets, MEV bots, PoSe agents, batch submitters) effectively throttled to 1 tx/block whenever per-nonce gas prices differed.

The existing test `picks txs in gas price order with nonce continuity` only asserted `length >= 2` + consecutive nonces, so it silently passed despite the throttle.

## Fix

Per-sender deferred queue (sorted by nonce ASC). When `tryPickOne` returns `\"deferred\"` (gap), the tx is enqueued under its sender. After each successful pick, `drainDeferred(sender)` peels off head txs while `head.nonce === expected[sender]`. Drain stops on gas-budget exhaustion or affordability failure. Each tx is touched at most twice → O(N log N).

## Test plan

- [x] New test `#615: same-sender contiguous nonces all picked when prices increase` — 3 of 3 picked, nonce-ordered
- [x] New test `#615: mixed-sender ordering preserves gas-price priority across senders` — predecessor unlocks higher-priced successor, cross-sender priority preserved
- [x] New test `#615: deferred drain stops at gas-budget exhaustion (no over-fill)` — 2 of 3 fit within 42_001 gas budget
- [x] All 25 mempool tests pass
- [x] All 42 chain-engine-persistent + cancun-compat tests pass (mempool-touching callers)