### PR TITLE
fix(test): #616 rpc-extended.test.ts nested t.test deadlock — TRUE CI root cause

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -4775,6 +4775,7 @@ test("RPC Extended Methods", async (t) => {
     if (receipt.to && got.to) {
       assert.equal(receipt.to, got.to, "receipt.to must equal tx.to byte-for-byte")
     }
+  })
 
   await t.test("#454: receipt logIndex is block-global (running count across all prior txs in block)", async () => {
     // Per Ethereum spec: "logIndex: log index position in the BLOCK".
@@ -4897,7 +4898,6 @@ test("RPC Extended Methods", async (t) => {
       "eth_getLogs[0].logIndex must equal receipt.logs[0].logIndex (same log, same shape)")
     assert.equal(logsViaFilter[1].logIndex, rec2.logs[0].logIndex,
       "eth_getLogs[1].logIndex must equal receipt.logs[0].logIndex of second tx")
-  })
   })
 
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {


### PR DESCRIPTION
## True root cause

The persistent Node Tests CI timeout (16 PRs blocked) was a deadlock in rpc-extended.test.ts. PR #611's server-cleanup fix was a secondary improvement but did NOT eliminate the hang.

## The deadlock

```js
// Outer scope: test(\"RPC Extended Methods\", async (t) => {...})
await t.test(\"#456: ...\", async () => {
  // #456 callback runs, awaiting #454...
  await t.test(\"#454: ...\", async () => {
    // ...but this t.test() uses the OUTER t (captured by closure
    // because the inner callback has no t param: async () => {}).
    // #454 gets queued as a sibling subtest of \"RPC Extended Methods\".
    // The outer t is currently blocked waiting for #456 to finish.
    // #456 is blocked waiting for #454.
    // DEADLOCK.
  })
})
```

## Repro

```bash
timeout 200 node --experimental-strip-types --test --test-reporter=spec node/src/rpc-extended.test.ts
```

Before fix: hangs after \"#466: receipt.contractAddress is lowercase\" (the test just before #456). In CI: 20-minute timeout fires; two orphan Node processes are left running. After fix: 143 tests pass in 12.2s.

## Fix

Close the #456 callback before #454, making them siblings. This matches the author's intent — both are independent receipt-shape regressions (#456 = lowercase from/to, #454 = block-global logIndex).

## Why earlier diagnostic missed it

The CI log buffering plus Node's parallel test runner showed only the alphabetically-earlier finished file (rpc-debug-compatibility) as the last visible passing test. That misdirected #611 to chase a server leak in rpc-block-format.test.ts (which DID exist but wasn't the hang). Standalone reproduction of rpc-extended.test.ts in isolation pinned the actual hang point.

## Test plan

- [x] rpc-extended.test.ts standalone: 143 pass / 0 fail / 12.2s (was timing out at any length)
- [x] After this lands, 16 stacked PRs (#599-#615) should finally see green Node Tests