### PR TITLE
fix(rpc): #617 synth-genesis stateRoot is empty-trie root (not all-zeros)

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1881,6 +1881,33 @@ test("RPC Extended Methods", async (t) => {
     assert.ok(parent !== null, "client following block1.parentHash must reach the genesis (not null)")
   })
 
+  await t.test("#617: synth-genesis stateRoot is the empty-trie root (not all-zeros)", async () => {
+    // Pre-fix: formatGenesisBlock returned stateRoot=ZERO_HASH while
+    // transactionsRoot/receiptsRoot/withdrawalsRoot were all set to
+    // EMPTY_TRIE_ROOT (keccak256(rlp([]))). ZERO_HASH is NOT a valid
+    // MPT root; the canonical empty state-trie root is 0x56e81f…b421.
+    // Live 88780 reproduction: eth_getBlockByNumber("0x0") returned
+    // a header with 3 fields at the empty-trie hash and stateRoot at
+    // all-zeros — an internally inconsistent block header that breaks
+    // any client validating roots (Hardhat fork detection, anvil
+    // compat, devp2p Status, state-trie walkers).
+    const proposed = await chain.proposeNextBlock()
+    assert.ok(proposed, "need at least one real block so height ≥ 1")
+    const EMPTY_TRIE_ROOT = "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+    const genesis = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
+    assert.equal(genesis.stateRoot, EMPTY_TRIE_ROOT,
+      `synth-genesis stateRoot must be the empty-trie root, got ${genesis.stateRoot}`)
+    // All four "empty" roots agree — the synth-genesis is internally consistent.
+    assert.equal(genesis.transactionsRoot, EMPTY_TRIE_ROOT)
+    assert.equal(genesis.receiptsRoot, EMPTY_TRIE_ROOT)
+    assert.equal(genesis.withdrawalsRoot, EMPTY_TRIE_ROOT)
+    // Symmetric: by-hash genesis lookup returns the same stateRoot.
+    const ZERO_HASH = "0x" + "0".repeat(64)
+    const byHash = await rpcCall(port, "eth_getBlockByHash", [ZERO_HASH, false]) as Record<string, unknown>
+    assert.equal(byHash.stateRoot, EMPTY_TRIE_ROOT,
+      "by-hash synth-genesis stateRoot must match by-number")
+  })
+
   await t.test("#384: state-query RPCs return defaults at synth-genesis instead of -32001 block-not-found", async () => {
     // Pre-fix: #112 carved a synth-genesis path for eth_getBlockByNumber("earliest")
     // but the state-query RPCs (eth_getBalance/Code/TxCount/StorageAt/call/...)

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -4462,7 +4462,18 @@ function formatGenesisBlock(includeTx: boolean) {
     sha3Uncles: ZERO_HASH,
     logsBloom: `0x${"0".repeat(512)}`,
     transactionsRoot: EMPTY_TRIE_ROOT,
-    stateRoot: ZERO_HASH,
+    // #617: stateRoot was ZERO_HASH, which is NOT a valid MPT root.
+    // Sibling roots (transactionsRoot, receiptsRoot, withdrawalsRoot)
+    // all use EMPTY_TRIE_ROOT for consistency with how an empty Ethereum
+    // genesis would actually serialize. Clients that cross-check header
+    // root fields (Hardhat fork detection, anvil compat, devp2p Status
+    // validation, any tool walking the state trie) saw an inconsistent
+    // synth-genesis: 3 fields with the canonical empty-trie hash but
+    // stateRoot at all-zeros. The chain has no pre-allocated accounts
+    // (genesis is synthesised because no real block 0 is persisted),
+    // so the correct stateRoot is keccak256(rlp([])) — same as the
+    // other empty-trie roots.
+    stateRoot: EMPTY_TRIE_ROOT,
     receiptsRoot: EMPTY_TRIE_ROOT,
     miner: ZERO_ADDR,
     difficulty: "0x0",


### PR DESCRIPTION
## Bug

\`formatGenesisBlock\` returned an internally inconsistent block header:

\`\`\`
transactionsRoot: 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421  ← empty-trie root
receiptsRoot:     0x56e81f...                                                        ← empty-trie root
withdrawalsRoot:  0x56e81f...                                                        ← empty-trie root
stateRoot:        0x0000000000000000000000000000000000000000000000000000000000000000 ← WRONG
\`\`\`

\`ZERO_HASH\` is NOT a valid MPT root. The canonical empty state-trie root is \`keccak256(rlp([])) = 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\` — the same value the other three \"empty\" root fields use.

## Live 88780 repro

\`\`\`bash
curl -s -X POST -H 'content-type: application/json' http://159.198.36.3:28780 \\
  -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBlockByNumber\",\"params\":[\"0x0\",false]}' \\
  | jq '.result | {transactionsRoot, stateRoot, receiptsRoot, withdrawalsRoot}'
\`\`\`

Shows the inconsistency clearly: 3 correct roots, 1 zero-hash.

## Impact

Any client that cross-checks header root fields breaks:
- Hardhat fork detection / state pinning
- Anvil compat checks
- devp2p Status validation
- State-trie walkers (e.g., snap sync verifiers, archive node consistency checks)

## What is NOT changed

COC's synth-genesis design (#112) is intentional — the chain starts producing at height 1 with no real block 0 persisted, so block 1's parentHash points at all-zeros and the synthesised block 0 mirrors that convention. The all-zeros \`hash\` and \`parentHash\` are part of that design and are **preserved**. Only \`stateRoot\` is brought into line with the other three empty-root fields.

## Test plan

- [x] New regression test \`#617: synth-genesis stateRoot is the empty-trie root (not all-zeros)\` — asserts all 4 empty roots agree on EMPTY_TRIE_ROOT for both by-number and by-hash genesis lookups
- [x] Existing #112/#422 synth-genesis tests unchanged (hash/parentHash design preserved)