### PR TITLE
ci: #618 Node Tests --test-force-exit kills orphan workers (true CI root cause)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test-node:
     name: Node Tests (859+)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -25,7 +25,13 @@ jobs:
       - name: Run node tests
         run: |
           cd node
-          node --experimental-strip-types --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=node-results.xml $(find src -name '*.test.ts' -type f | sort)
+          # #618: --test-force-exit forces the runner to exit once all tests
+          # complete even if a test file left a server / timer / socket
+          # holding the event loop open. Without it, post-test orphan node
+          # workers kept the runner alive past the 20-min timeout and the
+          # job got cancelled despite every test passing. See PR #617's CI
+          # run 25902915926 — 1230+ ✔ logged but job killed at 20m15s.
+          node --experimental-strip-types --test --test-force-exit --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=node-results.xml $(find src -name '*.test.ts' -type f | sort)
         env:
           NODE_ENV: test
       - name: Upload test results

--- a/node/src/rpc-block-format.test.ts
+++ b/node/src/rpc-block-format.test.ts
@@ -95,6 +95,21 @@ const signedTx1 = await testWallet.signTransaction({
 describe("P8: Block/receipt format standardization", () => {
   const tx1 = signedTx1
 
+  // #611: PR #596 gated Cancun fields (blobGasUsed/excessBlobGas/
+  // parentBeaconBlockRoot) in formatBlock to only emit when stored on the
+  // block. The pre-#596 test #481 mock blocks had NONE of these fields, so
+  // post-#596 formatBlock correctly omits them — but #481's assertion that
+  // genesis and regular blocks BOTH include them then fails. The assertion
+  // is throwing BEFORE the test's `server.close()` runs → the server
+  // leaks, keep-alive http sockets pin the event loop, and the WHOLE
+  // node-test suite hangs until CI timeout.
+  //
+  // Two-part fix:
+  //   (a) Set Cancun-era fields on both mock blocks so the genesis-vs-
+  //       regular field-set parity check actually exercises the
+  //       presence path the test was meant to cover.
+  //   (b) Wrap all server.close() in try/finally so a failed assertion
+  //       can never again leak a server and hang the suite.
   const blocks = [
     {
       number: 0n,
@@ -106,6 +121,9 @@ describe("P8: Block/receipt format standardization", () => {
       gasUsed: 0n,
       baseFee: 1_000_000_000n,
       finalized: true,
+      blobGasUsed: 0n,
+      excessBlobGas: 0n,
+      parentBeaconBlockRoot: "0x" + "0".repeat(64),
     },
     {
       number: 1n,
@@ -117,52 +135,52 @@ describe("P8: Block/receipt format standardization", () => {
       gasUsed: 21000n,
       baseFee: 1_000_000_000n,
       finalized: true,
+      blobGasUsed: 0n,
+      excessBlobGas: 0n,
+      parentBeaconBlockRoot: "0x" + "0".repeat(64),
     },
   ]
 
-  it("formatBlock includes mixHash field", async () => {
+  // #611: helper wraps each test body so the http server is ALWAYS closed,
+  // even when an assertion fails. Pre-fix any failing assertion (e.g. the
+  // #481 test post-PR-#596) skipped server.close() → keep-alive sockets
+  // pinned the event loop → entire node-test suite hung at CI timeout.
+  async function withTestServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
     const chain = createMockChain(blocks)
     const port = 38700 + Math.floor(Math.random() * 1000)
     const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
     await new Promise((r) => setTimeout(r, 100))
+    try {
+      return await fn(port)
+    } finally {
+      await new Promise<void>((resolve) => {
+        (server as any).close(() => resolve())
+      })
+    }
+  }
 
-    const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
-    assert.ok("mixHash" in block, "block should have mixHash")
-    assert.equal(block.mixHash, "0x" + "0".repeat(64))
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+  it("formatBlock includes mixHash field", async () => {
+    await withTestServer(async (port) => {
+      const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+      assert.ok("mixHash" in block, "block should have mixHash")
+      assert.equal(block.mixHash, "0x" + "0".repeat(64))
     })
   })
 
   it("formatBlock includes withdrawals and withdrawalsRoot", async () => {
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
-
-    const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
-    assert.ok("withdrawals" in block, "block should have withdrawals")
-    assert.ok("withdrawalsRoot" in block, "block should have withdrawalsRoot")
-    assert.deepEqual(block.withdrawals, [])
-    assert.equal(block.withdrawalsRoot, KECCAK256_RLP)
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+    await withTestServer(async (port) => {
+      const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+      assert.ok("withdrawals" in block, "block should have withdrawals")
+      assert.ok("withdrawalsRoot" in block, "block should have withdrawalsRoot")
+      assert.deepEqual(block.withdrawals, [])
+      assert.equal(block.withdrawalsRoot, KECCAK256_RLP)
     })
   })
 
   it("formatBlock gasLimit matches BLOCK_GAS_LIMIT constant", async () => {
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
-
-    const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
-    assert.equal(block.gasLimit, `0x${BLOCK_GAS_LIMIT.toString(16)}`)
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+    await withTestServer(async (port) => {
+      const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+      assert.equal(block.gasLimit, `0x${BLOCK_GAS_LIMIT.toString(16)}`)
     })
   })
 
@@ -181,98 +199,70 @@ describe("P8: Block/receipt format standardization", () => {
     //
     // Sibling Cancun fields (blobGasUsed, parentBeaconBlockRoot, etc.)
     // all use `?? <default>` fallbacks; finalized was the only one missed.
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
+    await withTestServer(async (port) => {
+      const genesis = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
+      const regular = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
 
-    const genesis = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
-    const regular = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+      const gkeys = new Set(Object.keys(genesis))
+      const rkeys = new Set(Object.keys(regular))
 
-    const gkeys = new Set(Object.keys(genesis))
-    const rkeys = new Set(Object.keys(regular))
+      // No uncles[] on either (deprecated post-merge); always finalized key.
+      assert.equal(gkeys.has("uncles"), false, "genesis must not expose uncles[]")
+      assert.equal(rkeys.has("uncles"), false, "regular block must not expose uncles[]")
+      assert.equal(gkeys.has("finalized"), true, "genesis must always include finalized as a boolean")
+      assert.equal(rkeys.has("finalized"), true, "regular block must always include finalized")
+      assert.equal(typeof genesis.finalized, "boolean", "finalized must be a boolean")
+      assert.equal(typeof regular.finalized, "boolean", "finalized must be a boolean")
 
-    // No uncles[] on either (deprecated post-merge); always finalized key.
-    assert.equal(gkeys.has("uncles"), false, "genesis must not expose uncles[]")
-    assert.equal(rkeys.has("uncles"), false, "regular block must not expose uncles[]")
-    assert.equal(gkeys.has("finalized"), true, "genesis must always include finalized as a boolean")
-    assert.equal(rkeys.has("finalized"), true, "regular block must always include finalized")
-    assert.equal(typeof genesis.finalized, "boolean", "finalized must be a boolean")
-    assert.equal(typeof regular.finalized, "boolean", "finalized must be a boolean")
+      // Cancun fields must be present on both.
+      for (const required of ["blobGasUsed", "excessBlobGas", "parentBeaconBlockRoot", "withdrawals", "withdrawalsRoot", "mixHash"]) {
+        assert.equal(gkeys.has(required), true, `genesis must include ${required}`)
+        assert.equal(rkeys.has(required), true, `regular block must include ${required}`)
+      }
 
-    // Cancun fields must be present on both.
-    for (const required of ["blobGasUsed", "excessBlobGas", "parentBeaconBlockRoot", "withdrawals", "withdrawalsRoot", "mixHash"]) {
-      assert.equal(gkeys.has(required), true, `genesis must include ${required}`)
-      assert.equal(rkeys.has(required), true, `regular block must include ${required}`)
-    }
-
-    // Symmetric diff must be empty — exact field-set parity.
-    const diff = [
-      ...[...gkeys].filter((k) => !rkeys.has(k)),
-      ...[...rkeys].filter((k) => !gkeys.has(k)),
-    ]
-    assert.deepEqual(
-      diff,
-      [],
-      `genesis and regular block field sets must match exactly (symmetric diff: ${diff.join(",")})`,
-    )
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+      // Symmetric diff must be empty — exact field-set parity.
+      const diff = [
+        ...[...gkeys].filter((k) => !rkeys.has(k)),
+        ...[...rkeys].filter((k) => !gkeys.has(k)),
+      ]
+      assert.deepEqual(
+        diff,
+        [],
+        `genesis and regular block field sets must match exactly (symmetric diff: ${diff.join(",")})`,
+      )
     })
   })
 
   it("formatBlock size varies with transaction count", async () => {
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
+    await withTestServer(async (port) => {
+      const block0 = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
+      const block1 = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
 
-    const block0 = await rpcCall(port, "eth_getBlockByNumber", ["0x0", false]) as Record<string, unknown>
-    const block1 = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as Record<string, unknown>
+      const size0 = BigInt(block0.size as string)
+      const size1 = BigInt(block1.size as string)
 
-    const size0 = BigInt(block0.size as string)
-    const size1 = BigInt(block1.size as string)
-
-    // Block with tx should be larger than empty block
-    assert.ok(size1 > size0, `block with tx (${size1}) should be larger than empty block (${size0})`)
-    // Empty block should be header overhead only (508)
-    assert.equal(size0, 508n)
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+      // Block with tx should be larger than empty block
+      assert.ok(size1 > size0, `block with tx (${size1}) should be larger than empty block (${size0})`)
+      // Empty block should be header overhead only (508)
+      assert.equal(size0, 508n)
     })
   })
 
   it("formatBlock includes type field for transactions in full-tx mode", async () => {
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
-
-    const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", true]) as Record<string, unknown>
-    const txs = block.transactions as Array<Record<string, unknown>>
-    assert.ok(txs.length > 0, "should have transactions")
-    assert.ok("type" in txs[0], "transaction should have type field")
-    assert.equal(txs[0].type, "0x2") // EIP-1559
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+    await withTestServer(async (port) => {
+      const block = await rpcCall(port, "eth_getBlockByNumber", ["0x1", true]) as Record<string, unknown>
+      const txs = block.transactions as Array<Record<string, unknown>>
+      assert.ok(txs.length > 0, "should have transactions")
+      assert.ok("type" in txs[0], "transaction should have type field")
+      assert.equal(txs[0].type, "0x2") // EIP-1559
     })
   })
 
   it("eth_blobBaseFee returns minimum blob gas price (0x1) when no excess", async () => {
-    const chain = createMockChain(blocks)
-    const port = 38700 + Math.floor(Math.random() * 1000)
-    const server = startRpcServer("127.0.0.1", port, 31337, createMockEvm() as any, chain as any, createMockP2P() as any)
-    await new Promise((r) => setTimeout(r, 100))
-
-    const result = await rpcCall(port, "eth_blobBaseFee")
-    // EIP-4844: minimum blob gas price is 1 when excessBlobGas = 0
-    assert.equal(result, "0x1")
-
-    await new Promise<void>((resolve, reject) => {
-      (server as any).close((err: Error | undefined) => err ? reject(err) : resolve())
+    await withTestServer(async (port) => {
+      const result = await rpcCall(port, "eth_blobBaseFee")
+      // EIP-4844: minimum blob gas price is 1 when excessBlobGas = 0
+      assert.equal(result, "0x1")
     })
   })
 })

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -4775,6 +4775,7 @@ test("RPC Extended Methods", async (t) => {
     if (receipt.to && got.to) {
       assert.equal(receipt.to, got.to, "receipt.to must equal tx.to byte-for-byte")
     }
+  })
 
   await t.test("#454: receipt logIndex is block-global (running count across all prior txs in block)", async () => {
     // Per Ethereum spec: "logIndex: log index position in the BLOCK".
@@ -4897,7 +4898,6 @@ test("RPC Extended Methods", async (t) => {
       "eth_getLogs[0].logIndex must equal receipt.logs[0].logIndex (same log, same shape)")
     assert.equal(logsViaFilter[1].logIndex, rec2.logs[0].logIndex,
       "eth_getLogs[1].logIndex must equal receipt.logs[0].logIndex of second tx")
-  })
   })
 
   await t.test("#332: eth_sendRawTransaction replacement-underpriced surfaces as -32000 (not -32603)", async () => {

--- a/node/src/rpc-persistent.test.ts
+++ b/node/src/rpc-persistent.test.ts
@@ -478,7 +478,10 @@ test("RPC+Persistent: historical state queries and transaction schema parity", a
     assert.ok(block2?.stateRoot)
 
     const deployTxHash = Transaction.from(deployTx).hash as Hex
-    const contractAddress = getCreateAddress({ from: wallet.address, nonce: 1 })
+    // #466: COC normalizes all address fields to lowercase for parity with
+    // geth/erigon. getCreateAddress returns EIP-55 mixed-case, so lowercase
+    // here to match the wire format.
+    const contractAddress = getCreateAddress({ from: wallet.address, nonce: 1 }).toLowerCase()
 
     const balanceAtBlock1 = await handleRpcMethod("eth_getBalance", [wallet.address, "0x1"], CHAIN_ID, evm, engine, p2p)
     const balanceAtBlock2 = await handleRpcMethod("eth_getBalance", [wallet.address, "0x2"], CHAIN_ID, evm, engine, p2p)

--- a/node/src/wallet-toolchain-compat.test.ts
+++ b/node/src/wallet-toolchain-compat.test.ts
@@ -162,7 +162,10 @@ describe("Prowl wallet/toolchain RPC compatibility", () => {
     const txHash = await rpcCall(rpcPort, "eth_sendRawTransaction", [deployTx]) as string
     await engine.proposeNextBlock()
 
-    const contractAddress = getCreateAddress({ from: wallet.address, nonce: 0 })
+    // #466: COC normalizes all address fields to lowercase (geth/erigon
+    // parity); getCreateAddress returns EIP-55 mixed-case, so lowercase
+    // here to match the wire format the receipt will carry.
+    const contractAddress = getCreateAddress({ from: wallet.address, nonce: 0 }).toLowerCase()
     const receipt = await rpcCall(rpcPort, "eth_getTransactionReceipt", [txHash]) as Record<string, unknown>
     const code = await rpcCall(rpcPort, "eth_getCode", [contractAddress, "latest"]) as string
     const estimate = await rpcCall(rpcPort, "eth_estimateGas", [{ from: FUNDED_ADDRESS, to: contractAddress, data: "0x" }, "latest"]) as string


### PR DESCRIPTION
## True root cause

PR #617's CI run (25902915926) ran for 20m15s with **1230+ ✔ test passes logged** before being killed. The cleanup section shows:

\`\`\`
Terminate orphan process: pid (2452) (node)
Terminate orphan process: pid (3106) (node)
\`\`\`

Two child node workers stayed alive AFTER every test completed, keeping the event loop open past the timeout. This is a **test process leak**, not a deadlock.

## Why earlier diagnoses missed it

- #611 (server leak in rpc-block-format.test.ts) — real bug, but not the hang root
- #616 (nested t.test deadlock in rpc-extended.test.ts) — also real bug, also fixed, also not the hang root
- After both fixes were bundled into #617, the suite ran to completion logically but still hit the timeout because the runner couldn't exit

## Fix

Node's \`--test-force-exit\` (since v18.0) forces the runner to exit once every known test finishes, even if a test file left a server / timer / socket holding the event loop open.

The proper long-term fix is to identify and clean up the leaking resources in individual test files, but force-exit unblocks the queue today while that audit happens.

Also bumps Node Tests timeout 10 → 20 min (same as #611, inlined for self-containment).

## Bundle note

This PR also includes #616's rpc-extended.test.ts nested t.test deadlock fix — that fixture's existing leak would re-introduce a hang otherwise.

## What unblocks

After this lands, the 17 stacked PRs (#599-#615, #617) should finally see green Node Tests.

## Test plan

- [x] Standalone rpc-extended.test.ts: 143 pass / 0 fail / 12.2s (#616 fix)
- [ ] Full CI run on this PR completes within 20-min timeout
- [ ] All other Node Tests assertions still pass