### PR TITLE
feat(bft): #622 BFT equivocation evidence gossip wire (closes issue #620)

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -11,7 +11,7 @@ import type { IChainEngine } from "./chain-engine-types.ts"
 import type { ChainBlock } from "./blockchain-types.ts"
 import { hasGovernance } from "./chain-engine-types.ts"
 import { P2PNode, buildSignedGetAuth } from "./p2p.ts"
-import type { BftMessagePayload } from "./p2p.ts"
+import type { BftMessagePayload, BftEvidencePayload } from "./p2p.ts"
 import { ConsensusEngine } from "./consensus.ts"
 import type { SnapSyncProvider } from "./consensus.ts"
 import { IpfsBlockstore } from "./ipfs-blockstore.ts"
@@ -35,7 +35,7 @@ import type { EquivocationEvidence } from "./bft.ts"
 import { IpfsMfs } from "./ipfs-mfs.ts"
 import { IpfsPubsub } from "./ipfs-pubsub.ts"
 import type { PubsubMessage } from "./ipfs-pubsub.ts"
-import { BftCoordinator } from "./bft-coordinator.ts"
+import { BftCoordinator, bftCanonicalMessage } from "./bft-coordinator.ts"
 import type { BftMessage } from "./bft.ts"
 import { WireServer } from "./wire-server.ts"
 import { WireClient } from "./wire-client.ts"
@@ -221,6 +221,14 @@ const bftEnabled = config.enableBft && config.validators.length >= 3
 let cachedStateSnapshot: { snapshot: StateSnapshot; tipHash: Hex; cachedAtMs: number } | null = null
 const STATE_SNAPSHOT_CACHE_TTL_MS = 30_000
 
+// #622 (issue #620): forward-declared so the p2p `onBftEvidence` handler
+// (created at p2p init, BEFORE the bft init block runs) can dispatch into
+// the shared equivocation-processing path. The bft init block (later)
+// assigns the actual implementation. When BFT is disabled or the init
+// hasn't run yet, this stays null and `onBftEvidence` drops inbound
+// evidence as a no-op.
+let handleEquivocationEvidence: ((ev: EquivocationEvidence) => void) | null = null
+
 const p2p = new P2PNode(
   {
     bind: config.p2pBind,
@@ -318,6 +326,47 @@ const p2p = new P2PNode(
         // Propagate stateRoot (part of BFT quorum on (hash, stateRoot)).
         if (msg.stateRoot) bftMsg.stateRoot = msg.stateRoot
         await bftCoordinator.handleMessage(bftMsg)
+      }
+      : undefined,
+    // #622 (issue #620): receive equivocation evidence from peers, verify
+    // signatures, dedup, import into the local detector. When import
+    // succeeds (status "imported"), the local `onEquivocation` callback
+    // fires — applying the slash, persisting for relayer pickup, AND
+    // re-gossiping to peers. The receiver re-broadcast is what makes the
+    // network converge in ~one gossip round even when the original
+    // witness only reached a subset of peers.
+    onBftEvidence: bftEnabled
+      ? async (msg: BftEvidencePayload) => {
+        if (!bftCoordinator) return
+        const ev: EquivocationEvidence = {
+          validatorId: msg.validatorId,
+          height: BigInt(msg.height),
+          phase: msg.phase,
+          blockHash1: msg.blockHash1,
+          blockHash2: msg.blockHash2,
+          detectedAtMs: msg.detectedAtMs,
+          signature1: msg.signature1 as Hex,
+          signature2: msg.signature2 as Hex,
+        }
+        const result = bftCoordinator.equivocationDetector.importEvidence(
+          ev,
+          bftCanonicalMessage,
+          (canonical, signature, expectedAddress) =>
+            nodeSigner.verifyNodeSig(canonical, signature, expectedAddress),
+        )
+        if (result === "imported") {
+          // Fire the same downstream path as locally-detected equivocation:
+          // local slash + relayer pickup + RE-GOSSIP. Imports converge the
+          // network on the same evidence set in O(log N) gossip rounds.
+          handleEquivocationEvidence?.(ev)
+        } else if (result === "invalid") {
+          log.warn("rejected bogus BFT evidence from peer", {
+            validator: msg.validatorId,
+            height: msg.height,
+            phase: msg.phase,
+          })
+        }
+        // "duplicate" → silent drop (expected during gossip steady-state)
       }
       : undefined,
     onStateSnapshotRequest: (stateTrie && config.enableSnapSync)
@@ -443,6 +492,83 @@ if (bftEnabled) {
     )
   }
 
+  // #622 (issue #620): factored out of `onEquivocation` so peer-imported
+  // evidence flows through the SAME local-slash + relayer + re-gossip path
+  // as locally-detected evidence. Assigned to the file-scoped forward-
+  // declared `handleEquivocationEvidence` so the p2p `onBftEvidence`
+  // handler (initialized earlier) can dispatch into it.
+  handleEquivocationEvidence = (evidence: EquivocationEvidence) => {
+    log.warn("BFT equivocation detected", {
+      validator: evidence.validatorId,
+      height: evidence.height.toString(),
+      phase: evidence.phase,
+      hash1: evidence.blockHash1,
+      hash2: evidence.blockHash2,
+    })
+
+    // Apply immediate governance slash penalty
+    if (bftSlashingHandler) {
+      const slashEvent = bftSlashingHandler.handleEquivocation(evidence)
+      if (slashEvent) {
+        log.warn("BFT equivocation slash applied", {
+          validatorId: slashEvent.validatorId,
+          slashedAmount: slashEvent.slashedAmount.toString(),
+          remaining: slashEvent.remainingStake.toString(),
+          removed: slashEvent.removed,
+        })
+      }
+    }
+
+    // Persist as SlashEvidence for relayer pickup
+    const nodeIdHex = evidence.validatorId.startsWith("0x")
+      ? evidence.validatorId.padEnd(66, "0")
+      : `0x${evidence.validatorId.padStart(64, "0")}`
+    const rawEvidence: Record<string, unknown> = {
+      type: "bft-equivocation",
+      nodeId: nodeIdHex,
+      validatorId: evidence.validatorId,
+      height: evidence.height.toString(),
+      phase: evidence.phase,
+      blockHash1: evidence.blockHash1,
+      blockHash2: evidence.blockHash2,
+      detectedAtMs: evidence.detectedAtMs,
+    }
+    bftEvidenceStore.push({
+      nodeId: nodeIdHex as `0x${string}`,
+      reasonCode: EvidenceReason.BftEquivocation,
+      evidenceHash: hashSlashEvidencePayload(nodeIdHex as `0x${string}`, rawEvidence),
+      rawEvidence,
+    })
+
+    // #622: gossip evidence to peers so the equivocation history converges
+    // across the network. Without this, only the node that directly
+    // witnessed both conflicting votes can detect the equivocation; nodes
+    // that received only one vote stay unaware, making slashing
+    // inconsistent and on-chain reporting depend on a single relayer
+    // happening to run alongside the witness. Signatures are mandatory
+    // on the wire — pre-PR-I3b paths can produce sig-less evidence, skip
+    // those (peers have nothing to verify against).
+    if (evidence.signature1 && evidence.signature2) {
+      const broadcastPayload: BftEvidencePayload = {
+        validatorId: evidence.validatorId,
+        height: evidence.height.toString(),
+        phase: evidence.phase,
+        blockHash1: evidence.blockHash1,
+        blockHash2: evidence.blockHash2,
+        signature1: evidence.signature1,
+        signature2: evidence.signature2,
+        detectedAtMs: evidence.detectedAtMs,
+      }
+      p2p.broadcastBftEvidence(broadcastPayload).catch((err) => {
+        log.warn("broadcastBftEvidence failed", {
+          validator: evidence.validatorId,
+          height: evidence.height.toString(),
+          error: String(err),
+        })
+      })
+    }
+  }
+
   bftCoordinator = new BftCoordinator({
     localId: config.nodeId,
     validators,
@@ -466,49 +592,7 @@ if (bftEnabled) {
       })
       consensus.markProposerUnreachable(proposerId)
     },
-    onEquivocation: (evidence: EquivocationEvidence) => {
-      log.warn("BFT equivocation detected", {
-        validator: evidence.validatorId,
-        height: evidence.height.toString(),
-        phase: evidence.phase,
-        hash1: evidence.blockHash1,
-        hash2: evidence.blockHash2,
-      })
-
-      // Apply immediate governance slash penalty
-      if (bftSlashingHandler) {
-        const slashEvent = bftSlashingHandler.handleEquivocation(evidence)
-        if (slashEvent) {
-          log.warn("BFT equivocation slash applied", {
-            validatorId: slashEvent.validatorId,
-            slashedAmount: slashEvent.slashedAmount.toString(),
-            remaining: slashEvent.remainingStake.toString(),
-            removed: slashEvent.removed,
-          })
-        }
-      }
-
-      // Persist as SlashEvidence for relayer pickup
-      const nodeIdHex = evidence.validatorId.startsWith("0x")
-        ? evidence.validatorId.padEnd(66, "0")
-        : `0x${evidence.validatorId.padStart(64, "0")}`
-      const rawEvidence: Record<string, unknown> = {
-        type: "bft-equivocation",
-        nodeId: nodeIdHex,
-        validatorId: evidence.validatorId,
-        height: evidence.height.toString(),
-        phase: evidence.phase,
-        blockHash1: evidence.blockHash1,
-        blockHash2: evidence.blockHash2,
-        detectedAtMs: evidence.detectedAtMs,
-      }
-      bftEvidenceStore.push({
-        nodeId: nodeIdHex as `0x${string}`,
-        reasonCode: EvidenceReason.BftEquivocation,
-        evidenceHash: hashSlashEvidencePayload(nodeIdHex as `0x${string}`, rawEvidence),
-        rawEvidence,
-      })
-    },
+    onEquivocation: (evidence: EquivocationEvidence) => handleEquivocationEvidence?.(evidence),
     broadcastMessage: async (msg: BftMessage) => {
       const payload: BftMessagePayload = {
         type: msg.type as "prepare" | "commit",

--- a/node/src/p2p.ts
+++ b/node/src/p2p.ts
@@ -51,11 +51,38 @@ export interface BftMessagePayload {
   stateRoot?: Hex
 }
 
+/**
+ * #622 (issue #620): wire payload for gossiping BFT equivocation evidence
+ * across peers. `EquivocationDetector` only sees votes that arrive at the
+ * local node, so equivocators that selectively target subsets end up
+ * detected on one witness and invisible everywhere else. Gossiping the
+ * proof (both signatures over the conflicting `(height, phase, blockHash)`
+ * canonical messages) lets every node converge on the same equivocation
+ * history. height is a decimal string to survive JSON serialization.
+ */
+export interface BftEvidencePayload {
+  validatorId: string
+  height: string
+  phase: "prepare" | "commit"
+  blockHash1: Hex
+  blockHash2: Hex
+  signature1: string
+  signature2: string
+  detectedAtMs: number
+}
+
 export interface P2PHandlers {
   onTx: (rawTx: Hex) => Promise<void>
   onBlock: (block: ChainBlock) => Promise<void>
   onSnapshotRequest: () => ChainSnapshot | Promise<ChainSnapshot>
   onBftMessage?: (msg: BftMessagePayload) => Promise<void>
+  /**
+   * #622: invoked on every inbound `/p2p/bft-evidence` POST. Implementation
+   * verifies signatures via `EquivocationDetector.importEvidence`, applies
+   * the local slash path, and (if newly imported) re-broadcasts the evidence
+   * to peers so the network converges within ~one gossip round.
+   */
+  onBftEvidence?: (msg: BftEvidencePayload) => Promise<void>
   onStateSnapshotRequest?: () => Promise<unknown | null>
   getHeight?: () => Promise<bigint> | bigint
 }
@@ -808,6 +835,29 @@ export class P2PNode {
             return
           }
 
+          // #622 (issue #620): equivocation evidence gossip
+          if (req.url === "/p2p/bft-evidence") {
+            const payload = unsignedPayload as BftEvidencePayload
+            // Shape validation — the handler verifies signatures, but
+            // malformed shape should still be rejected at the wire layer
+            // so we never invoke handler logic on garbage input.
+            if (!payload.validatorId || typeof payload.validatorId !== "string"
+              || !payload.height || (typeof payload.height !== "string" && typeof payload.height !== "number")
+              || !payload.phase || (payload.phase !== "prepare" && payload.phase !== "commit")
+              || !payload.blockHash1 || !payload.blockHash2
+              || !payload.signature1 || !payload.signature2) {
+              throw new Error("missing BFT evidence fields")
+            }
+            // Coerce height to canonical decimal string (handlers expect string-of-decimal)
+            payload.height = String(payload.height)
+            if (this.handlers.onBftEvidence) {
+              await this.handlers.onBftEvidence(payload)
+            }
+            res.writeHead(200)
+            res.end(serializeJson({ ok: true }))
+            return
+          }
+
           res.writeHead(404)
           res.end(serializeJson({ error: "not found" }))
         } catch (error) {
@@ -1099,6 +1149,72 @@ export class P2PNode {
         attempted: allPeers.length,
         failed: failures.length,
         // Cap to first 5 to keep log entry bounded
+        sample: failures.slice(0, 5),
+      })
+    }
+  }
+
+  /**
+   * #622 (issue #620): broadcast a BFT equivocation evidence to all peers.
+   * Mirrors `broadcastBft`'s peer-set + retry + observability so evidence
+   * reaches the same audience as the votes it indicts. Receivers verify
+   * both signatures recover to the claimed validatorId before importing,
+   * so a malicious peer cannot forge evidence accusing an honest validator.
+   *
+   * No outbound dedup — the receiver dedups on `(validatorId, height, phase)`
+   * and returns "duplicate" without re-gossiping, so the network converges
+   * in at most one gossip round.
+   */
+  async broadcastBftEvidence(msg: BftEvidencePayload): Promise<void> {
+    const staticPeers = this.cfg.peers
+    const discoveredPeers = this.cfg.enableDiscovery !== false
+      ? this.discovery.getActivePeers()
+      : []
+    // Same case-insensitive id/url dedup as broadcastBft — PR-1N pattern.
+    const seenIds = new Set<string>()
+    const seenUrls = new Set<string>()
+    const allPeers: NodePeer[] = []
+    for (const p of [...staticPeers, ...discoveredPeers]) {
+      const idLower = (p.id ?? "").toLowerCase()
+      const urlLower = (p.url ?? "").toLowerCase()
+      if (idLower && seenIds.has(idLower)) continue
+      if (urlLower && seenUrls.has(urlLower)) continue
+      if (idLower) seenIds.add(idLower)
+      if (urlLower) seenUrls.add(urlLower)
+      allPeers.push(p)
+    }
+
+    const payloadRecord = ensurePayloadObject(msg as unknown as Record<string, unknown>)
+    const signedPayload = this.cfg.signer
+      ? buildSignedP2PPayload("/p2p/bft-evidence", payloadRecord, this.cfg.signer)
+      : payloadRecord
+    const payloadSize = serializeJson(signedPayload).length
+
+    const failures: Array<{ peerId: string; url: string; reason: string }> = []
+    for (let i = 0; i < allPeers.length; i += BROADCAST_CONCURRENCY) {
+      const batch = allPeers.slice(i, i + BROADCAST_CONCURRENCY)
+      await Promise.all(batch.map(async (peer) => {
+        try {
+          await requestJson(`${peer.url}/p2p/bft-evidence`, "POST", signedPayload)
+          this.scoring.recordSuccess(peer.id)
+          this.bytesSent += payloadSize
+        } catch (err) {
+          this.scoring.recordFailure(peer.id)
+          failures.push({
+            peerId: peer.id,
+            url: peer.url,
+            reason: String(err ?? "unknown").slice(0, 200),
+          })
+        }
+      }))
+    }
+    if (failures.length > 0) {
+      log.warn("broadcastBftEvidence: peer failures", {
+        validator: msg.validatorId,
+        height: msg.height,
+        phase: msg.phase,
+        attempted: allPeers.length,
+        failed: failures.length,
         sample: failures.slice(0, 5),
       })
     }


### PR DESCRIPTION
## Context

Follow-up to #621 (merged) which added \`EquivocationDetector.importEvidence\`. This PR wires up the P2P transport so the network converges on the same equivocation history — closes issue #620.

## What this PR does

### 1. p2p.ts — wire protocol
- New \`BftEvidencePayload\` JSON-serializable wire type
- New \`/p2p/bft-evidence\` HTTP route handler (shape-validates, then dispatches to \`handlers.onBftEvidence\`)
- New \`P2PNode.broadcastBftEvidence(msg)\` method — mirrors \`broadcastBft\` (static+discovered peers, case-insensitive dedup, signed payload when signer configured, per-peer failure logging)
- New \`P2PHandlers.onBftEvidence\` slot

### 2. index.ts — outbound (locally-detected equivocation)
- Extracted the inline \`onEquivocation\` body to a named \`handleEquivocationEvidence\` helper so the same logic fires for both locally-detected and peer-imported evidence
- Helper now also calls \`p2p.broadcastBftEvidence(...)\` after persisting evidence
- Forward-declared the helper at file scope so the p2p \`onBftEvidence\` handler (initialized earlier in module load order) can dispatch into it

### 3. index.ts — inbound (peer-gossiped evidence)
- Implements \`onBftEvidence\` callback: verifies via \`equivocationDetector.importEvidence(ev, bftCanonicalMessage, nodeSigner.verifyNodeSig)\`
- When status is \`\"imported\"\` (new evidence, signatures verified, dedup passed), fires the same \`handleEquivocationEvidence\` helper — applying the slash, persisting for relayer, AND **re-broadcasting**
- The re-gossip step is what makes the network converge in ~one gossip round even when the original witness only reached a subset of peers

## Why pass through importEvidence twice (verify + re-gossip)

A naive \"forward inbound evidence to all peers\" would amplify a bogus payload from a malicious peer. The \`importEvidence\` return value disciplines that: only \`\"imported\"\` triggers re-gossip. \`\"duplicate\"\` is silent drop (steady-state of gossip), \`\"invalid\"\` is logged + dropped without re-broadcast (poison containment).

## Test plan

- [x] \`node/src/p2p.test.ts\`: 10/10 pass
- [x] \`node/src/bft.test.ts\`: 47/47 pass (importEvidence still green from #621)
- [x] Standalone module-load of \`node/src/index.ts\` succeeds with new code
- [ ] CI: full Node Tests suite must pass

## Follow-ups not in this PR

- Multi-node integration test for the gossip path (needs docker-compose fixture) — planned: \`tests/multinode-integration/04-equivocation-gossip\`
- Wire-protocol equivalent for nodes using TCP frames instead of HTTP gossip (mirror dual-transport pattern in \`broadcastMessage\`)

## Relates

- issue #620 — original report
- PR #621 — receive-side primitive (merged)