### PR TITLE
fix(storage): #624 index contract-creation tx under the new contract address

### DIFF
--- a/node/src/storage/block-index.test.ts
+++ b/node/src/storage/block-index.test.ts
@@ -367,6 +367,44 @@ test("BlockIndex: address index - putTransaction indexes from/to", async () => {
   assert.strictEqual(toTxs[0].receipt.transactionHash, "0x1111")
 })
 
+test("BlockIndex: #624 contract-creation tx is indexed under the new contract address", async () => {
+  // Pre-fix the address index only included receipt.from and receipt.to.
+  // Contract-creation txs have `to: null` and put the new contract's address
+  // in `receipt.contractAddress`, so querying coc_getTransactionsByAddress
+  // for that contract returned an empty list — even though the deploy tx
+  // is part of the address's history (etherscan / explorer convention).
+  const db = new MemoryDatabase()
+  const index = new BlockIndex(db)
+
+  const deployer = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Hex
+  const contractAddr = "0xb2ff9d5e60d68a52cea3cd041b32f1390a880365" as Hex
+
+  const deployHash = ("0x" + "de".repeat(32)) as Hex
+  await index.putTransaction(deployHash, {
+    rawTx: "0x00" as Hex,
+    receipt: {
+      transactionHash: deployHash,
+      blockNumber: 5n,
+      blockHash: ("0x" + "55".repeat(32)) as Hex,
+      from: deployer,
+      to: null,
+      contractAddress: contractAddr,
+      gasUsed: 54250n,
+      status: 1n,
+      logs: [],
+    },
+  })
+
+  // Deployer still sees the tx (via from index)
+  const deployerTxs = await index.getTransactionsByAddress(deployer)
+  assert.strictEqual(deployerTxs.length, 1, "deployer's history includes the deploy tx")
+
+  // NEW: contract address also surfaces the deploy tx
+  const contractTxs = await index.getTransactionsByAddress(contractAddr)
+  assert.strictEqual(contractTxs.length, 1, "contract address must surface its own deploy tx")
+  assert.strictEqual(contractTxs[0].receipt.transactionHash, deployHash)
+})
+
 test("BlockIndex: address index - multiple txs ordered by block", async () => {
   const db = new MemoryDatabase()
   const index = new BlockIndex(db)

--- a/node/src/storage/block-index.ts
+++ b/node/src/storage/block-index.ts
@@ -362,6 +362,17 @@ export class BlockIndex implements IBlockIndex {
       const toKey = ADDR_TX_PREFIX + tx.receipt.to.toLowerCase() + ":" + blockPad + ":" + hashLower
       ops.push({ type: "put", key: toKey, value: encoder.encode(txHash) })
     }
+    // #624: contract-creation txs carry `to: null` and the new contract's
+    // address is in `receipt.contractAddress` instead. Pre-fix the index
+    // only saw `from` and `to`, so querying coc_getTransactionsByAddress
+    // for the contract returned an empty list even though the creation
+    // tx IS part of the address's history (etherscan/explorer convention).
+    // Index under contractAddress too so the deploy tx surfaces when a
+    // user clicks the contract's transactions tab.
+    if (tx.receipt.contractAddress) {
+      const contractKey = ADDR_TX_PREFIX + tx.receipt.contractAddress.toLowerCase() + ":" + blockPad + ":" + hashLower
+      ops.push({ type: "put", key: contractKey, value: encoder.encode(txHash) })
+    }
 
     return ops
   }


### PR DESCRIPTION
Live 88780 probe: `coc_getTransactionsByAddress(contractAddr)` returned [] for a freshly-deployed contract even though `coc_getContractInfo` confirmed the deploy tx existed. Etherscan / explorer convention is that a contract's tx history includes its creation tx.

Pre-fix `buildTransactionOps` indexed only `receipt.from` and `receipt.to`. Contract-creation txs carry `to: null` so the index never saw the contract's address.

Fix: also push an ADDR_TX_PREFIX key under `receipt.contractAddress` when present. Deployer history unchanged.

Test: deploy tx queryable from BOTH deployer AND contract address. 14/14 pass.