### PR TITLE
fix(mfs): #541 files/write default (truncate=false) partial-overwrites instead of truncating

### DIFF
--- a/node/src/ipfs-mfs.test.ts
+++ b/node/src/ipfs-mfs.test.ts
@@ -100,6 +100,41 @@ test("MFS: write fails without create flag", async () => {
   }
 })
 
+test("#541: MFS write with default (truncate=false) partial-overwrites and preserves trailing bytes", async () => {
+  const { mfs, cleanup } = await createMfs()
+  try {
+    const enc = (s: string) => new TextEncoder().encode(s)
+    const dec = (u: Uint8Array) => new TextDecoder().decode(u)
+
+    // Write 17 bytes, then a short 3-byte write WITHOUT truncate flag.
+    await mfs.write("/f", enc("BIGGER_OVERWRITE"), { create: true })
+    await mfs.write("/f", enc("ZZ\n"))
+    // Pre-fix: file became "ZZ\n" (3 bytes) — trailing 13 bytes lost.
+    assert.strictEqual(
+      dec(await mfs.read("/f")),
+      "ZZ\nGER_OVERWRITE",
+      "default write must overwrite [0,len) and keep trailing bytes (kubo semantics)",
+    )
+
+    // Regression sentinel: truncate=true still replaces the whole file.
+    await mfs.write("/g", enc("BIGGER_OVERWRITE"), { create: true })
+    await mfs.write("/g", enc("ZZ\n"), { truncate: true })
+    assert.strictEqual(dec(await mfs.read("/g")), "ZZ\n", "truncate=true must replace the whole file")
+
+    // Explicit offset still partial-overwrites.
+    await mfs.write("/h", enc("AAAAAAAA"), { create: true })
+    await mfs.write("/h", enc("xy"), { offset: 3 })
+    assert.strictEqual(dec(await mfs.read("/h")), "AAAxyAAA", "explicit offset partial-overwrite")
+
+    // Default-offset write that extends past the existing length.
+    await mfs.write("/i", enc("ab"), { create: true })
+    await mfs.write("/i", enc("CDEFG"))
+    assert.strictEqual(dec(await mfs.read("/i")), "CDEFG", "default write extending file = max(existing,data)")
+  } finally {
+    cleanup()
+  }
+})
+
 test("MFS: ls lists directory entries", async () => {
   const { mfs, cleanup } = await createMfs()
   try {

--- a/node/src/ipfs-mfs.ts
+++ b/node/src/ipfs-mfs.ts
@@ -149,17 +149,26 @@ export class IpfsMfs {
     }
 
     let finalData = data
-    if (existing && !opts?.truncate && opts?.offset !== undefined) {
-      if (opts.offset < 0) throw new Error("offset must be non-negative")
+    // #541: partial-overwrite merge must run whenever truncate is off, NOT
+    // only for explicit-offset writes. Kubo's `files write` defaults to
+    // truncate=false + offset=0, meaning a short write overwrites bytes
+    // [0, data.length) and PRESERVES trailing bytes. The pre-fix
+    // `opts?.offset !== undefined` clause skipped the merge for the common
+    // default-offset case, so every short write silently truncated the
+    // file — data loss for log appenders, journal patches, JSON merges.
+    // truncate=true still bypasses the merge to replace the whole file.
+    if (existing && !opts?.truncate) {
+      const offset = opts?.offset ?? 0
+      if (offset < 0) throw new Error("offset must be non-negative")
       // Guard against memory exhaustion from large offset + data.length
       const MAX_WRITE_SIZE = 64 * 1024 * 1024 // 64 MiB
-      const mergedSize = opts.offset + data.length
+      const mergedSize = offset + data.length
       if (mergedSize > MAX_WRITE_SIZE) throw new Error(`write would exceed max size (${MAX_WRITE_SIZE} bytes)`)
-      // Append/overwrite at offset
+      // Append/overwrite at offset, preserving any trailing bytes.
       const existingData = await this.unixfs.readFile(existing.cid)
       const merged = new Uint8Array(Math.max(existingData.length, mergedSize))
       merged.set(existingData)
-      merged.set(data, opts.offset)
+      merged.set(data, offset)
       finalData = merged
     }
 


### PR DESCRIPTION
## Summary

Closes #541. Data-loss bug in the IPFS MFS layer.

`/api/v0/files/write` always replaced the entire file regardless of the `truncate` flag. Per kubo's contract, `truncate=false` (the default) overwrites only bytes `[offset, offset+data.length)` and preserves trailing bytes. COC silently truncated — losing user data on every short write.

## Reproduction (from #541)

```
files/write /f "BIGGER_OVERWRITE"  (create=true)   → 16 bytes
files/write /f "ZZ\n"              (no truncate)    → kubo: "ZZ\nGER_OVERWRITE"
files/read  /f                                      → pre-fix: "ZZ\n"  ❌ 13 bytes lost
```

## Root cause

`node/src/ipfs-mfs.ts` — the partial-overwrite merge branch was gated on `opts?.offset !== undefined`:

```ts
if (existing && !opts?.truncate && opts?.offset !== undefined) { /* merge */ }
```

With offset omitted (kubo's default 0), the merge was skipped and `finalData = data` replaced the whole file.

## Fix

Drop the `offset !== undefined` clause; treat omitted offset as `0`. The existing merge logic already sizes the buffer as `max(existingData.length, offset + data.length)`, so:
- short default write → overwrites `[0,len)`, keeps the tail
- default write extending past EOF → file grows correctly
- explicit offset → unchanged (still partial-overwrites)
- `truncate=true` → still bypasses the merge, replaces whole file

## Test

`#541` in `ipfs-mfs.test.ts` — 4 cases: default short write preserves tail, `truncate=true` replaces whole file (regression sentinel), explicit offset partial-overwrite, default write extending past EOF.

## Test plan

- [x] `node --experimental-strip-types --check` on both files
- [x] `ipfs-mfs.test.ts` — 24/24 pass (incl. new #541)
- [x] `ipfs-http.test.ts` — 122/122 pass (no regression; #559 explicit-offset test still green)