### PR TITLE
fix(ipfs): #543 files/mkdir on file-path collision returns 400 not 500

### DIFF
--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1307,6 +1307,48 @@ describe("IpfsHttpServer", () => {
     assert.equal(ok.status, 200, `legal mv must still 200, got ${ok.status}`)
   })
 
+  it("#543: /api/v0/files/mkdir on a file-path collision returns 400 (not 500 'internal error')", async () => {
+    // Pre-fix the route-level catch had `/is a directory/i` (the inverse
+    // phrase, for read-on-dir) but no `/^not a directory/i`. The #302
+    // file-collision guard throws `not a directory: <path>` when mkdir
+    // targets — or descends through — an existing file. Unmatched, it fell
+    // through to 500 "internal error" + an ERROR log line per probe.
+    // Same regex-mismatch family as #232/#268/#270.
+    const { IpfsMfs: MfsCtor543 } = await import("./ipfs-mfs.ts")
+    const mfs = new MfsCtor543(store, unixfs)
+    server.attachSubsystems({ mfs })
+
+    // Seed a file at /coll.txt
+    const seed = await fetch("/api/v0/files/write?arg=/coll.txt&create=true", {
+      method: "POST",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("data"),
+    })
+    assert.equal(seed.status, 200, "seed write must succeed")
+
+    // (a) mkdir directly on the file path
+    const onFile = await fetch("/api/v0/files/mkdir?arg=/coll.txt", { method: "POST" })
+    assert.equal(onFile.status, 400, `mkdir on file path must be 400, got ${onFile.status}`)
+    const onFileBody = await onFile.json() as { error?: string; message?: string }
+    assert.notEqual(onFileBody.error, "internal error",
+      `must not leak 'internal error', got ${JSON.stringify(onFileBody)}`)
+    assert.match(`${onFileBody.error} ${onFileBody.message ?? ""}`, /not a directory/i,
+      `error must reference the actual throw, got ${JSON.stringify(onFileBody)}`)
+
+    // (b) mkdir UNDER a file path with parents=true
+    const underFile = await fetch("/api/v0/files/mkdir?arg=/coll.txt/sub&parents=true", { method: "POST" })
+    assert.equal(underFile.status, 400, `mkdir under file path must be 400, got ${underFile.status}`)
+    const underFileBody = await underFile.json() as { error?: string; message?: string }
+    assert.notEqual(underFileBody.error, "internal error",
+      `must not leak 'internal error', got ${JSON.stringify(underFileBody)}`)
+    assert.match(`${underFileBody.error} ${underFileBody.message ?? ""}`, /not a directory/i,
+      `error must reference the actual throw, got ${JSON.stringify(underFileBody)}`)
+
+    // Sanity: legal mkdir on a fresh path still 200 (regression guard)
+    const okDir = await fetch("/api/v0/files/mkdir?arg=/fresh_dir", { method: "POST" })
+    assert.equal(okDir.status, 200, `legal mkdir must still 200, got ${okDir.status}`)
+  })
+
   it("#545: gateway /ipfs/<cid>/<subpath> returns 404 'no such file' (not misleading 400 'invalid CID')", async () => {
     // Pre-fix `url.pathname.slice(6)` treated the ENTIRE tail (including
     // subpaths) as the CID string. So `/ipfs/<valid-cid>/sub` had

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1736,6 +1736,12 @@ export class IpfsHttpServer {
           httpErr = new HttpError(404, "not found", msg)
         } else if (
           /is a directory/i.test(msg) ||
+          // #543: mkdir on (or under) an existing file path throws the #302
+          // file-collision guard's `not a directory: <path>`. The chain had
+          // `/is a directory/` (the inverse phrase) but no `/not a directory/`,
+          // so the collision leaked as 500 "internal error" + an ERROR log
+          // line per probe. Same regex-mismatch family as #232/#268/#270.
+          /^not a directory/i.test(msg) ||
           /directory not empty/i.test(msg) ||
           // #270: sibling of `cannot copy directory into its own subdirectory`
           // — mfs.mv throws the same shape with `move` instead of `copy`. The


### PR DESCRIPTION
## Summary

Closes #543.

`/api/v0/files/mkdir` on (or under) a path that's already a file threw the #302 file-collision guard's `Error("not a directory: <path>")`, but the ipfs-http.ts route-level catch had `/is a directory/i` (the inverse phrase) and no `/not a directory/i`. The error fell through to the 500 "internal error" default and spammed `log.error("MFS route failed")` per probe.

## Reproduction (from #543)

```
files/write  /coll.txt  "data"  (create=true)        → 200
files/mkdir  /coll.txt                                → pre-fix: 500 "internal error"  ❌
files/mkdir  /coll.txt/sub      (parents=true)        → pre-fix: 500 "internal error"  ❌
```

The underlying error message is correct and informative — only the HTTP-layer mapping was missing.

## Fix

Add `/^not a directory/i.test(msg)` to the 400-class regex chain in `ipfs-http.ts`. One-line change. Same regex-mismatch family as #232 (path traversal), #268 (max depth), #270 (cannot-move) — each fixed by extending the same chain retroactively.

## Test

`#543` in `ipfs-http.test.ts`: mkdir on a file path → 400 "not a directory"; mkdir under a file path with `parents=true` → 400 "not a directory"; defense asserts body is never "internal error"; legal mkdir on a fresh path still 200 (regression guard).

## Test plan

- [x] `node --experimental-strip-types --check` on both files
- [x] `#543` + sibling `#232/#268/#270` regex tests pass
- [x] Full `ipfs-http.test.ts` suite: 123/123 pass (was 122, +1 new)