### PR TITLE
fix(chain): #529 lift all structural tx checks before nonce in addRawTx

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -661,6 +661,13 @@ export class PersistentChainEngine {
       }
     }
 
+    // #529: lift ALL remaining structural checks (missing sender, blob
+    // type 3, gasLimit bounds, intrinsic gas) ahead of the nonce check —
+    // mirrors chain-engine.ts addRawTx. Pre-fix these ran inside
+    // mempool.addRawTx, AFTER the engine nonce check, so a structurally-
+    // broken tx with a stale nonce surfaced the misleading "nonce too low".
+    this.mempool.validateTxStructure(decoded)
+
     // Mirror in-memory engine order: hash dedup first (more specific error
     // for same-tx replay), then stale-nonce check (catches different-tx-same-
     // -nonce). Both run before mempool insertion so we never accept a tx that

--- a/node/src/chain-engine.ts
+++ b/node/src/chain-engine.ts
@@ -218,6 +218,13 @@ export class ChainEngine {
         )
       }
     }
+    // #529: lift ALL remaining structural checks (missing sender, blob
+    // type 3, gasLimit bounds, intrinsic gas) ahead of the nonce check.
+    // Pre-fix these ran inside mempool.addRawTx — AFTER the engine nonce
+    // check below — so a structurally-broken tx with a stale nonce got the
+    // misleading "nonce too low" error. Generalizes #527 (chainId) and
+    // #613 (initcode size), which already moved their checks up.
+    this.mempool.validateTxStructure(decoded)
     if (this.txHashSet.has(decoded.hash as Hex)) {
       throw new Error("tx already confirmed")
     }

--- a/node/src/mempool.ts
+++ b/node/src/mempool.ts
@@ -144,40 +144,31 @@ export class Mempool {
     return this.poisoned.has(hash.toLowerCase() as Hex)
   }
 
-  addRawTx(rawTx: Hex, preDecoded?: Transaction): MempoolTx {
-    const tx = preDecoded ?? Transaction.from(rawTx)
+  /**
+   * #529: structural-only validation — checks that depend solely on the
+   * signed tx body, NOT on dynamic chain state (nonce, balance, hash dedup).
+   * Lifted out of addRawTx so the engine layer can run it BEFORE its own
+   * nonce check. Pre-fix a structurally-broken tx with a stale nonce got
+   * the misleading "nonce too low" error: the caller bumped the nonce,
+   * re-signed, and re-submitted only to THEN learn the tx was malformed
+   * from the start. Generalizes #527 (chainId) / #613 (initcode size) to
+   * the remaining structural properties. Idempotent — safe to call twice.
+   */
+  validateTxStructure(tx: Transaction): void {
     if (!tx.from) {
       throw new Error("invalid tx: missing sender")
     }
-
-    // Replay protection: validate chain ID (reject chainId=0 to prevent cross-chain replay)
-    if (tx.chainId !== BigInt(this.cfg.chainId)) {
-      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${tx.chainId}`)
-    }
-
-    if (this.poisoned.has((tx.hash as Hex).toLowerCase() as Hex)) {
-      throw new Error(`tx ${tx.hash} is poisoned (hung block execution previously)`)
-    }
-
-    const from = tx.from.toLowerCase() as Hex
-    const nonce = BigInt(tx.nonce)
-    const gasPrice = tx.gasPrice ?? tx.maxFeePerGas ?? 0n
-    const maxFeePerGas = tx.maxFeePerGas ?? tx.gasPrice ?? 0n
-    const maxPriorityFeePerGas = tx.maxPriorityFeePerGas ?? 0n
-    const gasLimit = tx.gasLimit ?? 21000n
-
-    // Reject blob transactions (type 3) — COC has no blob sidecar support
+    // Reject blob transactions (type 3) — COC has no blob sidecar support.
     if (tx.type === 3) {
       throw new Error("blob transactions (type 3) are not supported")
     }
-
-    // Reject transactions with gasLimit exceeding block gas limit (prevents
-    // mempool pollution with txs that can never be included in a block)
+    const gasLimit = tx.gasLimit ?? 21000n
+    // Reject gasLimit exceeding the block gas limit (prevents mempool
+    // pollution with txs that can never be included in a block).
     const MAX_TX_GAS_LIMIT = 30_000_000n
     if (gasLimit > MAX_TX_GAS_LIMIT) {
       throw new Error(`gasLimit exceeds maximum: ${gasLimit} > ${MAX_TX_GAS_LIMIT}`)
     }
-
     // #334: reject gasLimit below the EIP-3 intrinsic gas cost. Pre-fix the
     // mempool only enforced the upper bound, so a tx with `gasLimit=100`
     // returned a success hash from eth_sendRawTransaction but could never
@@ -192,6 +183,31 @@ export class Mempool {
         `intrinsic gas too low: have ${gasLimit}, want ${intrinsicGasRequired}`,
       )
     }
+  }
+
+  addRawTx(rawTx: Hex, preDecoded?: Transaction): MempoolTx {
+    const tx = preDecoded ?? Transaction.from(rawTx)
+    // #529: structural validation runs first. Defense-in-depth — the engine
+    // layer (chain-engine{,-persistent}.ts addRawTx) also calls
+    // validateTxStructure before its nonce check, but re-insertion paths
+    // (block reorg, snapshot replay) reach this method directly.
+    this.validateTxStructure(tx)
+
+    // Replay protection: validate chain ID (reject chainId=0 to prevent cross-chain replay)
+    if (tx.chainId !== BigInt(this.cfg.chainId)) {
+      throw new Error(`invalid chain ID: expected ${this.cfg.chainId}, got ${tx.chainId}`)
+    }
+
+    if (this.poisoned.has((tx.hash as Hex).toLowerCase() as Hex)) {
+      throw new Error(`tx ${tx.hash} is poisoned (hung block execution previously)`)
+    }
+
+    const from = (tx.from as string).toLowerCase() as Hex
+    const nonce = BigInt(tx.nonce)
+    const gasPrice = tx.gasPrice ?? tx.maxFeePerGas ?? 0n
+    const maxFeePerGas = tx.maxFeePerGas ?? tx.gasPrice ?? 0n
+    const maxPriorityFeePerGas = tx.maxPriorityFeePerGas ?? 0n
+    const gasLimit = tx.gasLimit ?? 21000n
 
     const item: MempoolTx = {
       hash: tx.hash as Hex,

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -892,6 +892,65 @@ test("RPC Extended Methods", async (t) => {
       `chainId error must name the actual expected ID (${Number(BigInt(fixtureChainId))}), got: ${r1.error!.message}`)
   })
 
+  await t.test("#529: eth_sendRawTransaction lifts structural checks BEFORE nonce (no misleading 'nonce too low' for broken tx)", async () => {
+    // Extends #527 (chainId) to ALL structural checks. Pre-fix the
+    // missing-sender / blob-type / gasLimit-upper-bound / intrinsic-gas-
+    // lower-bound checks all ran inside mempool.addRawTx — AFTER the engine
+    // nonce check. A tx that was BOTH structurally broken AND carried a
+    // stale nonce surfaced "nonce too low", so the caller bumped the nonce,
+    // re-signed, and re-submitted only to THEN learn the tx was malformed
+    // from the start. Fix: validateTxStructure() in mempool.ts, called by
+    // chain-engine{,-persistent}.ts addRawTx before the nonce check.
+    const { Wallet } = await import("ethers")
+    const wallet = new Wallet(`0x${"29".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const fixtureChainId = Number(BigInt(await rpcCall(port, "eth_chainId", []) as string))
+
+    const probe = async (raw: string) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: string }
+    }
+
+    // Bump the wallet's on-chain nonce to 1 so a later nonce=0 is genuinely
+    // stale — the bug only manifests when BOTH defects are present.
+    const valid = await wallet.signTransaction({
+      chainId: fixtureChainId, nonce: 0, gasLimit: 21000n, gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001", value: 1n,
+    })
+    const validRes = await probe(valid)
+    if (!validRes.result) return // fixture skips this submission path
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+    const onchainNonce = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+    if (onchainNonce < 1n) return // nonce didn't advance — can't exercise masking
+
+    // (a) gasLimit far above the 30M block max, with stale nonce=0.
+    const tooBigGas = await wallet.signTransaction({
+      chainId: fixtureChainId, nonce: 0, gasLimit: 999_999_999n, gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001", value: 1n,
+    })
+    const rGas = await probe(tooBigGas)
+    assert.ok(rGas.error, "oversized-gasLimit tx must be rejected")
+    assert.match(rGas.error!.message, /gasLimit exceeds maximum/i,
+      `must report the structural defect, got: ${rGas.error!.message}`)
+    assert.doesNotMatch(rGas.error!.message, /nonce too low/i,
+      `structural defect must NOT be masked by 'nonce too low' (the #529 bug), got: ${rGas.error!.message}`)
+
+    // (b) gasLimit below the 21000 intrinsic base cost, with stale nonce=0.
+    const tooLowGas = await wallet.signTransaction({
+      chainId: fixtureChainId, nonce: 0, gasLimit: 1000n, gasPrice: 1_000_000_000n,
+      to: "0x0000000000000000000000000000000000000001", value: 1n,
+    })
+    const rLow = await probe(tooLowGas)
+    assert.ok(rLow.error, "intrinsic-gas-too-low tx must be rejected")
+    assert.match(rLow.error!.message, /intrinsic gas too low/i,
+      `must report the structural defect, got: ${rLow.error!.message}`)
+    assert.doesNotMatch(rLow.error!.message, /nonce too low/i,
+      `structural defect must NOT be masked by 'nonce too low' (the #529 bug), got: ${rLow.error!.message}`)
+  })
+
   await t.test("#533: eth_getLogs blockHash resolves to the correct block (non-existent → -32000 'unknown block')", async () => {
     // Live testnet 88780 reproduction (pre-fix):
     //   eth_getLogs({"blockHash":"0xdeadbeef...deadbeef"})  // valid shape, doesn't exist


### PR DESCRIPTION
## Summary

Closes #529. Generalizes #527 (chainId-before-nonce) to all structural tx checks.

Pre-fix the missing-sender / blob-type-3 / gasLimit-upper-bound / intrinsic-gas-lower-bound checks all ran inside `mempool.addRawTx`, which both engines call **after** their own nonce check. A tx that was *both* structurally broken *and* carried a stale nonce surfaced the misleading `nonce too low` — the caller bumped the nonce, re-signed, and re-submitted only to *then* learn the tx was malformed from the start.

## Reproduction (from #529)

```
gasLimit: 999_999_999 (> 30M block max), nonce: 0 (stale)
eth_sendRawTransaction → pre-fix: "nonce too low: tx nonce 0, on-chain nonce 282"  ❌
                       → post-fix: "gasLimit exceeds maximum: 999999999 > 30000000"  ✅
```

## Fix

- **`mempool.ts`**: extract `validateTxStructure(tx)` — the four structural-only checks (depend solely on the signed tx body, not on chain state). `addRawTx` now calls it first; the chainId + poison checks stay (chainId is structural but already lifted by #527, poison is mempool state).
- **`chain-engine.ts` / `chain-engine-persistent.ts`** `addRawTx`: call `mempool.validateTxStructure(decoded)` before the hash-dedup + nonce check, alongside the already-lifted #527 (chainId) and #613 (initcode size) checks.
- `mempool.addRawTx` keeps calling `validateTxStructure` as defense-in-depth for re-insertion paths (block reorg, snapshot replay).

## Test

`#529` in `rpc-extended.test.ts`: bumps a wallet's on-chain nonce to 1, then submits a gasLimit-over-30M tx and an intrinsic-gas-too-low tx both at the now-stale `nonce=0`; asserts each surfaces its structural defect and never `nonce too low`.

## Test plan

- [x] `node --experimental-strip-types --check` on all 4 files
- [x] `mempool.test.ts` + `chain-engine.test.ts` + `chain-engine-persistent.test.ts` — 73/73 pass
- [x] `RPC Extended Methods` suite — 152/152 pass (incl. new #529, sibling #527 still green)