### PR TITLE
fix(rpc): #535 eth_newFilter resolves blockHash; eth_subscribe rejects it

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -1135,12 +1135,61 @@ test("RPC Extended Methods", async (t) => {
     const r3 = await probe([{ blockHash: "0x" + "00".repeat(32), fromBlock: "0x0", toBlock: "latest" }])
     assert.equal(r3.error?.code, -32602, "blockHash+fromBlock+toBlock must reject")
 
-    // Sanity: blockHash alone is OK.
-    const ok = await probe([{ blockHash: "0x" + "00".repeat(32) }])
-    assert.ok(ok.result, `blockHash alone must succeed: ${JSON.stringify(ok)}`)
+    // Sanity: blockHash alone (no range) passes the EIP-234 mutex. #535
+    // additionally resolves the hash to a real block, so propose a block
+    // and use its genuine hash — an all-zeros hash would now -32000.
+    if (typeof chain.proposeNextBlock === "function") {
+      await chain.proposeNextBlock()
+    }
+    const realBlock = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash?: string } | null
+    if (realBlock?.hash) {
+      const ok = await probe([{ blockHash: realBlock.hash }])
+      assert.ok(ok.result, `blockHash alone (real hash) must succeed: ${JSON.stringify(ok)}`)
+    }
     // Sanity: fromBlock alone is OK.
     const ok2 = await probe([{ fromBlock: "0x0", toBlock: "latest" }])
     assert.ok(ok2.result, `fromBlock+toBlock alone must succeed: ${JSON.stringify(ok2)}`)
+  })
+
+  await t.test("#535: eth_newFilter resolves blockHash to a real block (non-existent → -32000 'unknown block')", async () => {
+    // Pre-fix eth_newFilter ignored query.blockHash entirely. The filter
+    // was stored with fromBlock=toBlock=latest because
+    // parseBlockTag(undefined, height) returns height — so a
+    // {blockHash}-only filter silently became a "latest block" filter.
+    // Worse, a non-existent hash still returned a usable filter id that
+    // polled [] forever (indistinguishable from "block exists, no logs").
+    // Same family as #533 (eth_getLogs blockHash silent ignore). Geth's
+    // contract: -32000 "unknown block" for an unknown blockHash.
+    const probe = async (params: unknown[]) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_newFilter", params }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: string }
+    }
+
+    // Non-existent (but well-formed) blockHash → -32000 "unknown block",
+    // NOT a usable filter id.
+    const bogus = await probe([{ blockHash: `0x${"de".repeat(32)}` }])
+    assert.equal(bogus.error?.code, -32000,
+      `non-existent blockHash must be -32000, got ${JSON.stringify(bogus)}`)
+    assert.match(bogus.error!.message, /unknown block/i,
+      `error must say "unknown block", got "${bogus.error?.message}"`)
+    assert.equal(bogus.result, undefined, "must NOT return a filter id for an unknown block")
+
+    // A real block hash → valid filter id. Propose a block first so 0x1
+    // exists and is indexed by getBlockByHash (the fixture genesis stub is
+    // not hash-indexed — same approach as the #533 sibling test).
+    if (typeof chain.proposeNextBlock === "function") {
+      await chain.proposeNextBlock()
+    }
+    const blockByNum = await rpcCall(port, "eth_getBlockByNumber", ["0x1", false]) as { hash: string } | null
+    if (blockByNum?.hash) {
+      const ok = await probe([{ blockHash: blockByNum.hash }])
+      assert.ok(ok.result, `real blockHash must create a filter, got ${JSON.stringify(ok)}`)
+      assert.match(ok.result!, /^0x[0-9a-f]+$/, "filter id must be a hex string")
+    }
   })
 
   await t.test("#114: eth_getBlockReceipts shape matches eth_getTransactionReceipt", async () => {

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -1291,12 +1291,33 @@ async function handleRpc(
       const query = requireFilterObject((payload.params ?? [])[0])
       const id = `0x${randomBytes(16).toString("hex")}`
       const newFilterHeight = await Promise.resolve(chain.getHeight())
-      const fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
-      const toBlock = query.toBlock !== undefined ? parseBlockTag(query.toBlock, newFilterHeight) : undefined
-      // #142 / #162: validate address + topic shape so malformed inputs
-      // reject at the boundary. Shared with eth_getLogs (#162) — both
-      // consume the same filter shape, both should reject the same way.
+      // #142 / #162 / #186 / #464: validate address + topic + blockHash
+      // shape and the EIP-234 blockHash/range mutex. Shared with
+      // eth_getLogs — both consume the same filter shape, both reject the
+      // same way. Runs before blockHash resolution so the hash is
+      // shape-checked + lowercased by the time we look it up.
       const { address: filterAddress, addresses: filterAddresses, topics: normalizedTopics } = validateLogFilter(query)
+      // #535: resolve a blockHash filter to a concrete single-block range.
+      // Pre-fix eth_newFilter ignored query.blockHash entirely —
+      // parseBlockTag(undefined, height) returned `height`, so a
+      // {blockHash} filter silently became a "latest block" filter, and a
+      // non-existent hash still returned a usable filter id that polled
+      // [] forever (indistinguishable from "block exists, no logs").
+      // Mirror eth_getLogs / queryLogs (#533): resolve to the block,
+      // -32000 "unknown block" on miss.
+      let fromBlock: bigint
+      let toBlock: bigint | undefined
+      if (query.blockHash !== undefined && query.blockHash !== null) {
+        const hashBlock = await Promise.resolve(chain.getBlockByHash(query.blockHash as Hex))
+        if (!hashBlock) {
+          throw { code: -32000, message: "unknown block" }
+        }
+        fromBlock = hashBlock.number
+        toBlock = hashBlock.number
+      } else {
+        fromBlock = parseBlockTag(query.fromBlock, newFilterHeight)
+        toBlock = query.toBlock !== undefined ? parseBlockTag(query.toBlock, newFilterHeight) : undefined
+      }
       const filter: PendingFilter = {
         id,
         kind: "log",

--- a/node/src/websocket-rpc.test.ts
+++ b/node/src/websocket-rpc.test.ts
@@ -452,6 +452,16 @@ describe("WebSocket RPC", () => {
         assert.equal(err.code, -32602,
           `blockHash=${JSON.stringify(bad)} must be -32602, got ${err.code} (${err.message})`)
       }
+      // #535: a WELL-FORMED blockHash is also rejected — a subscription
+      // only matches FUTURE events but blockHash pins a PAST block, so the
+      // subscription could never fire. Pre-fix it was silently accepted
+      // and hung forever. Geth rejects it; mirror that.
+      const validHash = `0x${"ab".repeat(32)}`
+      const blockHashErr = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { blockHash: validHash }])
+      assert.equal(blockHashErr.code, -32602,
+        `valid blockHash on eth_subscribe must be -32602, got ${blockHashErr.code} (${blockHashErr.message})`)
+      assert.match(blockHashErr.message, /blockHash is not supported for subscription/i,
+        `must explain blockHash is unsupported for subscriptions, got "${blockHashErr.message}"`)
       // address: shape-rejected → -32602 (was -32603 pre-fix)
       const addrErr = await sendRpcExpectError(ws, "eth_subscribe", ["logs", { address: "not-an-address" }])
       assert.equal(addrErr.code, -32602,
@@ -483,12 +493,14 @@ describe("WebSocket RPC", () => {
         ["logs", { topics: [inner33] }])
       assert.equal(innerCapErr.code, -32602,
         `inner OR-array of 33 must be -32602, got ${innerCapErr.code} (${innerCapErr.message})`)
-      // Sanity: well-shaped filters still create subscriptions
-      const okHash = `0x${"ab".repeat(32)}`
+      // Sanity: well-shaped filters still create subscriptions. #535:
+      // blockHash is no longer part of the happy path — it's rejected for
+      // subscriptions (asserted above), so a valid filter uses the block
+      // range form instead.
       const okAddr = `0x${"cd".repeat(20)}`
       const okTopic = `0x${"ef".repeat(32)}`
       const sub1 = await sendRpc(ws, "eth_subscribe",
-        ["logs", { fromBlock: "0x1", toBlock: "0x100", blockHash: okHash, address: okAddr, topics: [okTopic] }])
+        ["logs", { fromBlock: "0x1", toBlock: "0x100", address: okAddr, topics: [okTopic] }])
       assert.match(sub1, /^0x[0-9a-f]+$/, `well-shaped filter must create subscription, got ${sub1}`)
     } finally {
       ws.close()

--- a/node/src/websocket-rpc.ts
+++ b/node/src/websocket-rpc.ts
@@ -617,6 +617,15 @@ export class WsRpcServer {
           }
           filterParam = rawFilter as Record<string, unknown>
         }
+        // #535: a blockHash filter is fundamentally incompatible with a
+        // subscription — subscriptions only match FUTURE events, but
+        // blockHash pins a specific PAST block, so the subscription can
+        // never fire. Pre-fix this was silently accepted: clients got a
+        // subscription id that hung forever, never matching any log.
+        // Geth rejects it upfront; mirror that with -32602.
+        if (filterParam.blockHash !== undefined && filterParam.blockHash !== null) {
+          invalidParams("blockHash is not supported for subscription")
+        }
         const filter = validateLogFilter(filterParam)
 
         const handler = (event: LogEvent) => {


### PR DESCRIPTION
## Summary

Closes #535. Two related filter/subscription bugs, same family as #533 (eth_getLogs blockHash silently ignored).

### 1. `eth_newFilter` silently ignored `blockHash`

The filter was stored with `fromBlock=toBlock=latest` because `parseBlockTag(undefined, height)` returns `height`. A `{blockHash}`-only filter quietly became a "latest block" filter, and a non-existent hash still returned a usable filter id that polled `[]` forever.

**Fix**: resolve `query.blockHash` via `chain.getBlockByHash`, set `fromBlock=toBlock=block.number`, throw `-32000 "unknown block"` on miss — mirrors `eth_getLogs` / `queryLogs` (#533). `validateLogFilter` now runs *before* resolution so the hash is shape-checked + lowercased and the EIP-234 mutex still applies.

### 2. `eth_subscribe("logs")` accepted an unfireable `blockHash`

Subscriptions only match **future** events, but `blockHash` pins a **past** block — the subscription could never fire. Clients got a subscription id that hung forever.

**Fix**: reject `blockHash` upfront with `-32602 "blockHash is not supported for subscription"`, matching geth.

## Tests

- `#535` in `rpc-extended.test.ts`: non-existent hash → `-32000 "unknown block"` + no filter id; real proposed-block hash → valid filter id.
- `#274` in `websocket-rpc.test.ts`: extended to assert a well-formed `blockHash` → `-32602`; the happy-path filter no longer carries the (previously silently-ignored) `blockHash` field.
- `#464`'s blockHash-alone sanity updated to use a real proposed-block hash (an all-zeros hash now correctly `-32000`).

## Test plan

- [x] `node --experimental-strip-types --check` on all 4 files
- [x] `rpc-extended.test.ts` + `websocket-rpc.test.ts` — 169/169 pass (incl. new #535, updated #274/#464, sibling #533 green)