### PR TITLE
fix(rpc): #537 coc_submitProposal validates stakeAmount before governance gate

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -3728,6 +3728,46 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#537: coc_submitProposal validates stakeAmount BEFORE the governance-module gate", async () => {
+    // The fixture chain has no governance module, so hasGovernance() is
+    // false. Pre-fix the stakeAmount shape check ran AFTER that gate, so
+    // a malformed stakeAmount surfaced -32601 "governance not enabled" —
+    // the caller could never learn their field was structurally invalid.
+    // #432 lifted the top-level object + required-field checks above the
+    // gate but missed this inner field. Fix: stakeAmount validation runs
+    // first, so the response shape is consistent across governance-on and
+    // governance-off deployments. NO monkey-patch here — exercises the
+    // real governance-disabled path.
+    const probe = async (stakeAmount: unknown) => {
+      const r = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0", id: 1, method: "coc_submitProposal",
+          params: [{ type: "add_validator", targetId: "v4", proposer: "node-1", stakeAmount }],
+        }),
+      })
+      return await r.json() as { error?: { code: number; message: string }; result?: unknown }
+    }
+    // Malformed stakeAmount → -32602 "stakeAmount", NOT -32601 "governance".
+    for (const bad of ["123abc", {}, [], -1, "0xZZ"]) {
+      const r = await probe(bad)
+      assert.equal(r.error?.code, -32602,
+        `stakeAmount=${JSON.stringify(bad)} on a governance-disabled node must be -32602, got ${JSON.stringify(r)}`)
+      assert.match(r.error!.message, /stakeAmount/i,
+        `error must name the malformed field, got "${r.error?.message}"`)
+      assert.doesNotMatch(r.error!.message, /governance/i,
+        `structural error must NOT be masked by the governance gate, got "${r.error?.message}"`)
+    }
+    // Regression sentinel: a shape-VALID stakeAmount still hits the
+    // governance gate — the module-availability check must still run.
+    const valid = await probe("0x100")
+    assert.equal(valid.error?.code, -32601,
+      `shape-valid stakeAmount must still surface -32601 on a governance-disabled node, got ${JSON.stringify(valid)}`)
+    assert.match(valid.error!.message, /governance/i,
+      `module-availability error must mention governance, got "${valid.error?.message}"`)
+  })
+
   await t.test("#220: coc_submitProposal / coc_voteProposal reject null/undefined params[0] (no V8 NPE leak)", async () => {
     // Pre-fix `(payload.params ?? [])[0] as Record<...>` was a no-op
     // cast. With params=[] / [null] the next line accessed .proposer /

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -2626,20 +2626,17 @@ async function handleRpc(
           invalidParams("invalid targetAddress: expected string")
         }
       }
-      if (!hasGovernance(chain)) {
-        methodNotFound("coc_submitProposal: governance module not enabled on this node")
-      }
-      // Only the local node can submit proposals via RPC
-      const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
-      if (localNodeId && (proposalParams.proposer as string) !== localNodeId) {
-        throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
-      }
       // #218: validate stakeAmount shape before `BigInt(...)`. Pre-fix
       // an object/array/non-digit-string flowed straight into BigInt
       // and threw a V8 SyntaxError ("Cannot convert [object Object] to
-      // a BigInt"). Same leak class as #212 (pose-http) — currently
-      // dead path because governance is disabled on prod, but fixing
-      // now avoids the leak surfacing once R3.2 (88780) enables it.
+      // a BigInt").
+      // #537: this block ran AFTER the hasGovernance() gate below, so a
+      // malformed stakeAmount on a governance-disabled node surfaced as
+      // -32601 "governance not enabled" — the caller could never learn
+      // their field was structurally invalid. #432 lifted the top-level
+      // object + required-field checks above the gate but missed this
+      // inner field. Move it up so ALL structural validation runs first
+      // and the response shape is consistent across deployments.
       const stakeRaw = proposalParams.stakeAmount as unknown
       let stakeAmount: bigint | undefined
       if (stakeRaw !== undefined && stakeRaw !== null && stakeRaw !== "") {
@@ -2650,6 +2647,14 @@ async function handleRpc(
           invalidParams("invalid stakeAmount: must be a non-negative integer or 0x-hex")
         }
         stakeAmount = BigInt(stakeRaw as string | number)
+      }
+      if (!hasGovernance(chain)) {
+        methodNotFound("coc_submitProposal: governance module not enabled on this node")
+      }
+      // Only the local node can submit proposals via RPC
+      const localNodeId = (opts as Record<string, unknown>)?.nodeId as string | undefined
+      if (localNodeId && (proposalParams.proposer as string) !== localNodeId) {
+        throw { code: -32003, message: "unauthorized: can only submit proposals as local node" }
       }
       const proposal = chain.governance.submitProposal(
         proposalParams.type as string,


### PR DESCRIPTION
## Summary

Closes #537. Completes #432's validation-order lift.

`coc_submitProposal` validated the top-level object shape and required fields (type/targetId/proposer) before the `hasGovernance()` module gate (per #432), but the `stakeAmount` shape check ran **after** it. On a governance-disabled node a malformed `stakeAmount` surfaced `-32601 "governance not enabled"` — the caller could never learn their field was structurally invalid.

## Reproduction (from #537)

```
coc_submitProposal [{description:"test", stakeAmount:"123abc"}]   # governance-disabled node
→ pre-fix:  -32601 "governance module not enabled"   ❌  (masks the real defect)
→ post-fix: -32602 "invalid stakeAmount: ..."         ✅
```

## Impact

Response shape was inconsistent across deployments: every current testnet node is governance-disabled, so a shape probe gets `-32601` regardless of input — but once 88780/R3.2 enables governance the **same** malformed inputs newly start surfacing `-32602`.

## Fix

Move the existing `stakeAmount` shape-validation block above the `hasGovernance(chain)` check. The check itself is unchanged — pure reordering so all structural validation runs before the module-availability gate.

## Test

`#537` in `rpc-extended.test.ts` exercises the real governance-disabled path (no monkey-patch): malformed `stakeAmount` shapes (`"123abc"`, `{}`, `[]`, `-1`, `"0xZZ"`) → `-32602` naming the field, never mentioning governance; a shape-valid `stakeAmount` still hits `-32601` (regression sentinel — the module gate must still run).

## Test plan

- [x] `node --experimental-strip-types --check` on both files
- [x] `RPC Extended Methods` suite — 152/152 pass (incl. new #537, siblings #218/#432 green)