### PR TITLE
fix(rpc): #509 insufficient-funds error drops bogus data field, echoes sender

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -4925,7 +4925,7 @@ test("RPC Extended Methods", async (t) => {
             }],
           }),
         })
-        return await r.json() as { error?: { code: number; message: string; data: string }; result?: unknown }
+        return await r.json() as { error?: { code: number; message: string; data?: string }; result?: unknown }
       }
 
       const call = await probe("eth_call")
@@ -4944,6 +4944,18 @@ test("RPC Extended Methods", async (t) => {
         /execution reverted/i,
         `eth_call must NOT use "execution reverted" wording for balance issues`,
       )
+      // #509: geth's -32000 insufficient-funds error echoes the sender
+      // address and carries NO `data` field (no revert payload exists).
+      assert.match(
+        call.error!.message,
+        /address 0xc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0/i,
+        `eth_call message must echo the sender address, got: ${call.error!.message}`,
+      )
+      assert.equal(
+        call.error!.data,
+        undefined,
+        `eth_call -32000 insufficient-funds must NOT carry a data field, got: ${JSON.stringify(call.error)}`,
+      )
 
       const est = await probe("eth_estimateGas")
       assert.equal(
@@ -4952,6 +4964,11 @@ test("RPC Extended Methods", async (t) => {
         `eth_estimateGas insufficient-balance must be -32000, got ${JSON.stringify(est)}`,
       )
       assert.match(est.error!.message, /insufficient funds for gas \* price \+ value/i)
+      // #509: same address echo + no-data shape for eth_estimateGas.
+      assert.match(est.error!.message, /address 0xc0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0/i,
+        `eth_estimateGas message must echo the sender address, got: ${est.error!.message}`)
+      assert.equal(est.error!.data, undefined,
+        `eth_estimateGas -32000 insufficient-funds must NOT carry a data field`)
 
       // Sanity: a real revert still surfaces as code 3 (regression guard for #286).
       ;(evm as unknown as { callRaw: typeof origCallRaw }).callRaw = async () => ({

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -998,7 +998,8 @@ async function handleRpc(
       }, executionContext.stateRoot, executionContext)
       if (estProbe.failed) {
         // #491: distinguish insufficient-balance from real reverts.
-        throwCallFailure(estProbe)
+        // #509: echo the sender address on the insufficient-funds error.
+        throwCallFailure(estProbe, estParams.from)
       }
       const estimated = await evm.estimateGas({
         from: estParams.from,
@@ -1068,7 +1069,8 @@ async function handleRpc(
       // unknown selector before this fix.
       if (callResult.failed) {
         // #491: distinguish insufficient-balance from real reverts.
-        throwCallFailure(callResult)
+        // #509: echo the sender address on the insufficient-funds error.
+        throwCallFailure(callResult, callParams.from)
       }
       return callResult.returnValue
     }
@@ -3511,12 +3513,22 @@ function throwExecutionReverted(returnValue: string, errorReason?: string): neve
  * actual cause was a balance shortfall. geth uses -32000 "insufficient
  * funds for gas * price + value" for this case.
  */
-function throwCallFailure(result: { returnValue: string; failed: boolean; errorReason?: string }): never {
+function throwCallFailure(
+  result: { returnValue: string; failed: boolean; errorReason?: string },
+  from?: string,
+): never {
   if (result.errorReason === "insufficient balance") {
+    // #509: geth's -32000 insufficient-funds error carries NO `data` field
+    // (there's no revert payload — execution never started) and echoes the
+    // offending sender address. Pre-fix this attached `data: "0x"`, which
+    // is non-canonical noise on a -32000, and omitted the address. The
+    // exact `have N want M` amounts geth appends are not surfaced by
+    // @ethereumjs's "insufficient balance" exceptionError, so the message
+    // stops at the address.
+    const base = "insufficient funds for gas * price + value"
     throw {
       code: -32000,
-      message: "insufficient funds for gas * price + value",
-      data: result.returnValue || "0x",
+      message: from ? `${base}: address ${from.toLowerCase()}` : base,
     }
   }
   // #493: pass the errorReason through so non-revert EVM exceptions get


### PR DESCRIPTION
## Summary

Closes #509. Completes the geth error-shape parity that #491 started.

#491 already fixed the **critical** part of #509 — `eth_call` / `eth_estimateGas` INSUFFICIENT_BALANCE failures now return `code: -32000` instead of `code: 3 "execution reverted"`, so ethers/viem route them to `INSUFFICIENT_FUNDS` instead of `CALL_EXCEPTION`. That landed (with a regression test) ~5h after #509 was filed.

Two shape details still differed from geth:

| Detail | geth | pre-this-PR |
|---|---|---|
| `data` field on the -32000 | absent (no revert payload) | `data: "0x"` ❌ |
| sender address in message | `address 0x… have N want M` | omitted ❌ |

## Fix

`throwCallFailure` now takes an optional `from`. For the insufficient-balance branch it:
- drops the `data` field — an insufficient-funds failure never started execution, so there is no payload; `data: "0x"` was non-canonical noise on a -32000.
- appends `: address 0x…` to the message.

Both call sites (`eth_call`, `eth_estimateGas`) pass their call params' `from`.

The exact `have N want M` amounts geth appends are **not** surfaced by @ethereumjs's `"insufficient balance"` exceptionError (it carries only the variant name), so the message stops at the address. The geth-critical signal — `code: -32000` + the `insufficient funds for gas * price + value` prefix — is fully matched.

## Test

Extends the `#491` regression test: asserts the sender-address echo and the **absence** of a `data` field on both `eth_call` and `eth_estimateGas`; the revert-still-`code 3` sentinel (#286) is unchanged.

## Test plan

- [x] `node --experimental-strip-types --check` on both files
- [x] `RPC Extended Methods` suite — 151/151 pass (#491 updated, #286/#493 siblings green)