### PR TITLE
fix(rpc): #636 eth_estimateGas returns exact gas instead of a flat +10%

### DIFF
--- a/node/src/evm.ts
+++ b/node/src/evm.ts
@@ -956,14 +956,44 @@ export class EvmChain {
     const executionContext = normalizeExecutionContext(context)
     // Use caller-supplied gas cap or default to 30M (block gas limit)
     const gasCap = params.gas ?? "0x1c9c380"
-    const { gasUsed } = await this.callRaw({ ...params, gas: gasCap }, stateRoot, executionContext)
+    const { gasUsed, failed } = await this.callRaw({ ...params, gas: gasCap }, stateRoot, executionContext)
     const executionCommon = this.createExecutionCommon(executionContext.blockNumber)
     const intrinsicGas = calculateIntrinsicGas(
       params.data ? hexToBytes(params.data) : new Uint8Array(),
       !params.to,
       executionCommon,
     )
+    // #636: no EVM execution (plain value transfer / call to an EOA) → the
+    // cost is deterministically the intrinsic gas. Pre-fix a flat +10%
+    // buffer made eth_estimateGas return 23100 for a 21000 transfer; geth
+    // returns the exact 21000. Return it exactly.
+    if (gasUsed === 0n) {
+      return intrinsicGas
+    }
     const total = intrinsicGas + gasUsed
+    // The call failed even at the full cap — not a gas shortfall (revert /
+    // OOG-regardless). Preserve the historical buffered shape; the rpc
+    // layer probes for reverts separately before reaching here.
+    if (failed) {
+      return total + total / 10n
+    }
+    // #636: a single run reports the gas consumed under a *generous* cap,
+    // which is the exact minimum for gas-independent code (the vast
+    // majority) but can under-state gas-limit-dependent code (the 63/64
+    // call rule, gasleft()-branching). Probe by re-running with the gas
+    // limit set to exactly the observed gasUsed: if it still succeeds the
+    // code is gas-independent and gasUsed IS the exact minimum — return it
+    // with no buffer (geth parity). If the tight re-run fails, the code is
+    // gas-limit-dependent; keep the 10% safety buffer so the estimate
+    // can't under-shoot.
+    const tight = await this.callRaw(
+      { ...params, gas: `0x${gasUsed.toString(16)}` },
+      stateRoot,
+      executionContext,
+    )
+    if (!tight.failed) {
+      return total
+    }
     return total + total / 10n
   }
 

--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -5078,6 +5078,66 @@ test("RPC Extended Methods", async (t) => {
     }
   })
 
+  await t.test("#636: eth_estimateGas returns the exact gas, not a flat +10% buffer", async () => {
+    // Pre-fix evm.estimateGas returned `total + total/10n` — a flat 10%
+    // buffer on every estimate. A plain value transfer (deterministically
+    // 21000 gas) estimated 23100; geth returns exactly 21000. The buffer
+    // also compounds with ethers/viem's own client-side margin (double-
+    // buffering → inflated gasLimit on every tx). Fix: gas-independent
+    // calls return the exact minimum; only gas-limit-dependent code keeps
+    // a safety buffer.
+    const { Wallet: EW636 } = await import("ethers")
+    const wallet = new EW636(`0x${"63".repeat(32)}`)
+    await evm.prefund([{ address: wallet.address, balanceWei: "1000000000000000000" }])
+    const fixtureChainId = Number(BigInt(await rpcCall(port, "eth_chainId", []) as string))
+    const startN = await evm.getNonce(wallet.address.toLowerCase() as `0x${string}`)
+
+    // (a) plain value transfer → estimate exactly 21000 (geth parity, no buffer).
+    const xferEst = await rpcCall(port, "eth_estimateGas", [{
+      from: wallet.address, to: `0x${"de".repeat(20)}`, value: "0x1",
+    }]) as string
+    assert.equal(BigInt(xferEst), 21000n,
+      `value transfer must estimate exactly 21000, got ${BigInt(xferEst)} (${xferEst})`)
+
+    // (b) gas-independent contract: estimate must equal the actual gasUsed
+    // exactly. Deploy a pure "return 0x42" contract (no CALL, no gasleft —
+    // gas-independent), call it, and compare estimate to the receipt.
+    const DEPLOY = "0x600a600c60003960" + "0a" + "6000" + "f3" + "604260005260206000f3"
+    const submit = async (raw: string) => {
+      const res = await fetch(`http://127.0.0.1:${port}`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params: [raw] }),
+      })
+      return await res.json() as { result?: string; error?: { message: string } }
+    }
+    const deployTx = await wallet.signTransaction({
+      type: 0, to: null, value: 0n, data: DEPLOY,
+      gasLimit: 200_000n, gasPrice: 1_000_000_000n, nonce: Number(startN), chainId: fixtureChainId,
+    })
+    const deployBody = await submit(deployTx)
+    if (!deployBody.result) return // fixture skips the persistent submission path
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+    const deployReceipt = await rpcCall(port, "eth_getTransactionReceipt", [deployBody.result]) as { contractAddress?: string }
+    if (!deployReceipt?.contractAddress) return
+    const C = deployReceipt.contractAddress
+
+    const callEst = await rpcCall(port, "eth_estimateGas", [{ from: wallet.address, to: C, data: "0x" }]) as string
+    const callTx = await wallet.signTransaction({
+      type: 0, to: C, value: 0n, data: "0x",
+      gasLimit: 100_000n, gasPrice: 1_000_000_000n, nonce: Number(startN) + 1, chainId: fixtureChainId,
+    })
+    const callBody = await submit(callTx)
+    if (!callBody.result) return
+    if (chain.proposeNextBlock) await chain.proposeNextBlock()
+    const callReceipt = await rpcCall(port, "eth_getTransactionReceipt", [callBody.result]) as { gasUsed?: string }
+    if (!callReceipt?.gasUsed) return
+
+    const actual = BigInt(callReceipt.gasUsed)
+    const estimate = BigInt(callEst)
+    assert.equal(estimate, actual,
+      `gas-independent call: estimate ${estimate} must equal actual gasUsed ${actual} exactly (pre-fix it was actual + 10%)`)
+  })
+
   await t.test("#288: eth_compileSolidity rejects oversize source (DoS gate; pre-fix 14.9 KB blocked event loop 5+ min)", async () => {
     // solc.compile is synchronous emscripten WASM. A single moderately
     // large source (500 empty contracts ≈ 15 KB) took 5m20s on 88780,

--- a/node/src/rpc-persistent.test.ts
+++ b/node/src/rpc-persistent.test.ts
@@ -551,7 +551,12 @@ test("RPC+Persistent: historical state queries and transaction schema parity", a
       engine,
       p2p,
     )
-    assert.strictEqual(estimateAtBlock1, "0x5a3c")
+    // #636: at block 1 the contract has no code yet (callAtBlock1 === "0x"),
+    // so the call performs no EVM execution — cost is exactly the 21000
+    // intrinsic gas. Pre-fix eth_estimateGas added a flat +10% buffer and
+    // returned 0x5a3c (23100); it now returns the exact 0x5208 (21000),
+    // matching geth (which never buffers a deterministic estimate).
+    assert.strictEqual(estimateAtBlock1, "0x5208")
     assert.ok(BigInt(String(estimateAtBlock2)) > 0x5208n)
 
     const accessListView = await handleRpcMethod(


### PR DESCRIPTION
## Summary

Closes #636.

`evm.estimateGas` returned `total + total / 10n` — a flat 10% buffer on every estimate. A plain value transfer (deterministically 21000 gas) estimated **23100**; geth returns the exact **21000**.

## Reproduction (88780)

Every estimate was `actual × 1.10` to the wei:

```
value transfer   estimate 23100   actual 21000
contract deploy  estimate 59912   actual 54466
contract call    estimate 47416   actual 43106
```

The buffer also compounds with ethers/viem's own client-side safety margin → double-buffering → inflated `gasLimit` on every tx.

## Root cause

The flat buffer was a crude substitute for a binary search. A single `callRaw` reports gas consumed under a *generous* cap — the exact minimum for gas-independent code (the vast majority) but potentially an under-statement for gas-limit-dependent code (the 63/64 call rule, `gasleft()`-branching). The `+10%` blindly papered over both.

## Fix

`evm.estimateGas`:
- **No EVM execution** (value transfer / call to an EOA, `gasUsed === 0`) → return the intrinsic gas exactly.
- **Otherwise** re-run once with the gas limit set to exactly the observed `gasUsed`:
  - re-run succeeds → code is gas-independent, `gasUsed` is the exact minimum → return it with **no buffer** (geth parity).
  - re-run fails → code is gas-limit-dependent → keep the 10% safety buffer so the estimate can't under-shoot.

Costs one extra `callRaw` per `eth_estimateGas` of a contract call; value transfers cost none.

## Test

`#636` in `rpc-extended.test.ts`: a value transfer estimates exactly `21000`; a gas-independent contract call's estimate equals the receipt's actual `gasUsed` exactly. `rpc-persistent.test.ts:554` updated — the call to a not-yet-deployed contract at block 1 (no execution) now estimates the exact `0x5208` (21000), was `0x5a3c` (23100).

## Test plan

- [x] `node --experimental-strip-types --check` on all 3 files
- [x] `rpc.test.ts`, `viem-toolchain-compat`, `wallet-toolchain-compat`, `precompiles`, `rpc-persistent` — 40/40 pass
- [x] `RPC Extended Methods` suite — 152/152 pass (incl. new #636, siblings #286/#491/#493/#509 green)