### PR TITLE
fix(mempool): #638 reject tx with fee cap below MIN_BASE_FEE floor

### DIFF
--- a/node/src/base-fee.ts
+++ b/node/src/base-fee.ts
@@ -11,7 +11,7 @@
 
 const TARGET_GAS_UTILIZATION = 50n // 50%
 const MAX_CHANGE_DENOMINATOR = 8n  // 12.5% max change
-const MIN_BASE_FEE = 1_000_000_000n // 1 gwei floor
+export const MIN_BASE_FEE = 1_000_000_000n // 1 gwei floor
 export const BLOCK_GAS_LIMIT = 30_000_000n // 30M gas limit
 const GAS_LIMIT = BLOCK_GAS_LIMIT
 

--- a/node/src/mempool.test.ts
+++ b/node/src/mempool.test.ts
@@ -202,6 +202,80 @@ describe("Mempool", () => {
     assert.ok(added.hash, "exact-floor tx must be accepted")
   })
 
+  // #638: a tx whose fee cap is below the MIN_BASE_FEE floor (1 gwei) can
+  // never pay baseFee — baseFee never decays below that floor. Pre-fix it
+  // was admitted as `pending`, returned a success hash, and permanently
+  // bricked the sender's head-of-line nonce. Same "unexecutable tx poisons
+  // a nonce slot" class as #334.
+  it("rejects legacy gasPrice below MIN_BASE_FEE floor (#638)", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    const tx = Transaction.from({
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      nonce: 0,
+      gasLimit: 21000n,
+      gasPrice: 999_999_999n, // 1 wei below the 1 gwei floor
+      chainId: CHAIN_ID,
+      data: "0x",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    assert.throws(
+      () => pool.addRawTx(clone.serialized as Hex),
+      /fee cap below minimum base fee: have 999999999, want 1000000000/,
+      "sub-floor legacy gasPrice must be rejected at admission",
+    )
+  })
+
+  it("rejects type-2 maxFeePerGas below MIN_BASE_FEE floor (#638)", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    // Exact #638 reproduction: an EIP-1559 tx with a fee cap under the
+    // baseFee floor — permanently unincludable, yet pre-fix admitted.
+    const tx = Transaction.from({
+      type: 2,
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      nonce: 0,
+      gasLimit: 21000n,
+      maxFeePerGas: 999_999_999n, // below the 1 gwei floor
+      maxPriorityFeePerGas: 0n,
+      chainId: CHAIN_ID,
+      data: "0x",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    assert.throws(
+      () => pool.addRawTx(clone.serialized as Hex),
+      /fee cap below minimum base fee: have 999999999, want 1000000000/,
+      "sub-floor type-2 maxFeePerGas must be rejected at admission",
+    )
+  })
+
+  it("accepts type-2 maxFeePerGas exactly at MIN_BASE_FEE floor (#638)", () => {
+    const pool = new Mempool({ chainId: CHAIN_ID })
+    const wallet = new Wallet(PK1)
+    const tx = Transaction.from({
+      type: 2,
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      nonce: 0,
+      gasLimit: 21000n,
+      maxFeePerGas: 1_000_000_000n, // exactly 1 gwei — the floor
+      maxPriorityFeePerGas: 0n,
+      chainId: CHAIN_ID,
+      data: "0x",
+    })
+    const signed = wallet.signingKey.sign(tx.unsignedHash)
+    const clone = tx.clone()
+    clone.signature = signed
+    const added = pool.addRawTx(clone.serialized as Hex)
+    assert.ok(added.hash, "exact-floor type-2 tx must be accepted")
+  })
+
   it("picks txs in gas price order with nonce continuity", async () => {
     const pool = new Mempool({ chainId: CHAIN_ID })
     signAndAdd(pool, PK1, 0, "0x3b9aca00") // 1 gwei, nonce 0

--- a/node/src/mempool.ts
+++ b/node/src/mempool.ts
@@ -12,6 +12,7 @@
 import { Transaction } from "ethers"
 import type { Hex, MempoolTx } from "./blockchain-types.ts"
 import { createLogger } from "./logger.ts"
+import { MIN_BASE_FEE } from "./base-fee.ts"
 
 const log = createLogger("mempool")
 
@@ -184,6 +185,23 @@ export class Mempool {
     if (gasLimit < intrinsicGasRequired) {
       throw new Error(
         `intrinsic gas too low: have ${gasLimit}, want ${intrinsicGasRequired}`,
+      )
+    }
+    // #638: reject a tx whose fee cap is below the MIN_BASE_FEE floor.
+    // COC's baseFee (base-fee.ts) can never decay below MIN_BASE_FEE, so a
+    // tx whose maxFeePerGas (or legacy gasPrice) is under that floor can
+    // NEVER pay baseFee and thus never be included in a block. Pre-fix
+    // eth_sendRawTransaction still accepted it, returned a hash, and let it
+    // occupy the sender's head-of-line nonce forever — permanently bricking
+    // the account. Same "unexecutable tx poisons a nonce slot" class as
+    // #334 (intrinsic gas); reject at admission, mirroring that fix. This
+    // is deliberately the absolute floor, NOT the current baseFee: a tx
+    // merely below the present baseFee may become includable once baseFee
+    // decays, so only the permanent-impossibility case is rejected here.
+    const feeCap = tx.maxFeePerGas ?? tx.gasPrice ?? 0n
+    if (feeCap < MIN_BASE_FEE) {
+      throw new Error(
+        `fee cap below minimum base fee: have ${feeCap}, want ${MIN_BASE_FEE}`,
       )
     }
   }


### PR DESCRIPTION
## Summary

Fixes #638. During an 88780 stress test, `eth_sendRawTransaction` accepted a type-2 tx whose `maxFeePerGas` was below the baseFee floor (`MIN_BASE_FEE` = 1 gwei) and returned a success hash. The tx was classified `pending` and took the sender's head-of-line nonce — but since COC's baseFee never decays below `MIN_BASE_FEE`, it can never pay baseFee, never be included, and **permanently bricks the account** (every later tx is stuck behind it).

Same "unexecutable tx poisons a nonce slot" class as #334 (gasLimit below intrinsic gas). This fix mirrors #334: **reject at mempool admission**.

## Changes

- `mempool.validateTxStructure()` now rejects a tx whose fee cap (`maxFeePerGas` for type-2, legacy `gasPrice` otherwise) is below `MIN_BASE_FEE`, with `fee cap below minimum base fee: have {feeCap}, want {floor}`.
- The bound is the **absolute `MIN_BASE_FEE` floor, not the current baseFee** — a tx merely below the present baseFee may become includable once baseFee decays, so only the permanent-impossibility case is rejected.
- `MIN_BASE_FEE` is now exported from `base-fee.ts` (single source of truth).

## Scope note

Addresses root cause (1) of #638 (missing admission check). Root causes (2) `pickForBlock` filters but never evicts, and (3) `classifyMempoolPendingQueued` misreports the tx as `pending` — both become moot once (1) blocks every sub-floor tx at the door. Left as-is, matching the minimal scope of the #334 fix. Maintainer may still prefer to also harden (2)/(3) defensively.

## Test plan

- [x] `node/src/mempool.test.ts` — 3 new tests mirroring #334: legacy gasPrice 1 wei below floor throws; type-2 `maxFeePerGas` below floor (the exact #638 repro) throws; type-2 `maxFeePerGas` exactly at the 1 gwei floor accepted
- [x] 28/28 mempool tests pass
- [x] 157/157 pass across base-fee / chain-engine / chain-engine-persistent / rpc / consensus / consensus-bft / fee-oracle / debug-trace / rpc-debug-compatibility / chain-events — no regressions
- [ ] Maintainer: confirm reject-at-admission is the preferred strategy (consistent with #334) vs. also evicting/reclassifying