### PR TITLE
fix(consensus): PR-1M liveness-based proposer skip (#635)

### DIFF
--- a/node/src/bft-proposer-skip.test.ts
+++ b/node/src/bft-proposer-skip.test.ts
@@ -6,6 +6,7 @@ import {
   NO_PROGRESS_STAGGER_MS,
   PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS,
   PROPOSER_UNREACHABLE_TTL_MS,
+  PROPOSER_MISS_ROUND_TIMEOUT_MS,
 } from "./consensus.ts"
 
 /**
@@ -21,6 +22,12 @@ import {
  *   3. checkNoProgressWatchdog 当 stuck proposer 不可达时,fast-path 用
  *      PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS (15s) 替代 600s 触发 fallback
  *   4. unreachable 标记 60s TTL,持续 unreachable 期间会被 BFT timeout / wire 事件刷新
+ *
+ * PR-1M (chainofclaw/COC#635): markProposerUnreachable 的唯一触发源
+ * onProposerStuck 只在收到 propose 后才会 fire。"完全停止 propose" 的 validator
+ * 永远不会被标记,每个 slot 都落 600s 慢路径(88780 2026-05-16 实测 444-624s/slot)。
+ * 修复:checkNoProgressWatchdog 在链停滞超过 PROPOSER_MISS_ROUND_TIMEOUT_MS 后,
+ * 直接基于活性把卡住的 peer proposer 提升为 unreachable —— 不依赖是否收到 propose。
  */
 
 const VALIDATORS_5 = ["node-1", "node-2", "node-3", "node-4", "node-5"]
@@ -119,25 +126,83 @@ test("PR-1A: fast watchdog fires at 15s when stuck proposer marked unreachable",
   assert.equal((c as any).noProgressProposerOverride, true, "fast watchdog arms when proposer unreachable")
 })
 
-test("PR-1A: without unreachable evidence, slow path (600s) governs", async () => {
-  const mockChain = mkMockChain(VALIDATORS_5)
+test("PR-1M: watchdog promotes a never-proposing proposer to unreachable past the miss-round window", async () => {
+  // #635: a validator that stops proposing entirely produces no propose,
+  // so onProposerStuck never fires and PR-1A never marks it. The watchdog
+  // must self-detect the stall on a pure-liveness basis.
   const c = new ConsensusEngine(
-    mockChain,
+    mkMockChain(VALIDATORS_5),
     mkMockP2p(),
     { blockTimeMs: 1000, syncIntervalMs: 300_000 },
     { bft: mkMockBft(), nodeId: "node-2" },
   )
 
-  // No markProposerUnreachable call. Even at 30s elapsed (well past fast threshold),
-  // the override must NOT arm — without evidence we keep the conservative behaviour.
-  ;(c as any).lastBftProgressAtMs = Date.now() - 30_000
+  // No markProposerUnreachable call, no reachabilityProvider — zero PR-1A
+  // evidence. Below the miss-round window: not promoted, override stays off.
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_MISS_ROUND_TIMEOUT_MS - 3_000)
   await (c as any).checkNoProgressWatchdog()
-  assert.equal((c as any).noProgressProposerOverride, false, "no evidence: slow path")
+  assert.equal((c as any).isProposerUnreachable("node-1"), false, "below window: not promoted")
+  assert.equal((c as any).noProgressProposerOverride, false, "below window: override not armed")
 
-  // Slow path eventually fires at NO_PROGRESS_TIMEOUT_MS as before
-  ;(c as any).lastBftProgressAtMs = Date.now() - (NO_PROGRESS_TIMEOUT_MS + 5_000)
+  // Past the miss-round window: the watchdog promotes node-1 to unreachable
+  // and — because the promotion drops baseTimeoutMs to the 15s fast path —
+  // arms the override on the same tick.
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_MISS_ROUND_TIMEOUT_MS + 10_000)
   await (c as any).checkNoProgressWatchdog()
-  assert.equal((c as any).noProgressProposerOverride, true, "slow path still works")
+  assert.equal((c as any).isProposerUnreachable("node-1"), true, "past window: liveness-promoted to unreachable")
+  assert.equal((c as any).noProgressProposerOverride, true, "past window: fast path arms via PR-1M")
+})
+
+test("PR-1M: miss-round promotion is suppressed during startup grace", async () => {
+  // During PR-1H startup grace the wire mesh has not converged; a stalled
+  // slot may be a transient cold-start artifact, not a dead validator.
+  // PR-1M must not promote — the slow path stands until grace expires.
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-2" },
+  )
+  ;(c as any).startedAtMs = Date.now() - 5_000 // 5s in — well inside 60s grace
+
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_MISS_ROUND_TIMEOUT_MS + 30_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).isProposerUnreachable("node-1"), false, "no liveness promotion during grace")
+  assert.equal((c as any).noProgressProposerOverride, false, "fast path stays disarmed during grace")
+})
+
+test("PR-1M: miss-round promotion is suppressed on N<4 clusters", async () => {
+  // PR-1J/PR-1L disable the PR-1A fast path entirely below 4 validators
+  // (skip-then-quorum math breaks down); PR-1M honors the same contract.
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-2", validatorCountProvider: () => 3 },
+  )
+  ;(c as any).startedAtMs = Date.now() - 90_000 // past grace
+
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_MISS_ROUND_TIMEOUT_MS + 30_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).isProposerUnreachable("node-1"), false, "no liveness promotion on N=3")
+  assert.equal((c as any).noProgressProposerOverride, false, "fast path stays disarmed on N=3")
+})
+
+test("PR-1M: stuck proposer is never self-promoted (self-stuck has its own J2.2 path)", async () => {
+  // The miss-round promotion only applies to PEER proposers. When the local
+  // node is itself the stuck proposer, markProposerUnreachable must not be
+  // reached for self — self-stuck is handled by the J2.2 force-clear path.
+  const c = new ConsensusEngine(
+    mkMockChain(VALIDATORS_5),
+    mkMockP2p(),
+    { blockTimeMs: 1000, syncIntervalMs: 300_000 },
+    { bft: mkMockBft(), nodeId: "node-1" }, // node-1 == expectedProposer(1)
+  )
+
+  ;(c as any).lastBftProgressAtMs = Date.now() - (PROPOSER_MISS_ROUND_TIMEOUT_MS + 30_000)
+  await (c as any).checkNoProgressWatchdog()
+  assert.equal((c as any).isProposerUnreachable("node-1"), false, "self is never liveness-promoted")
+  assert.equal((c as any).noProgressProposerOverride, false, "self-stuck path does not arm rotation override")
 })
 
 test("PR-1A: fast path respects rotation stagger across multiple fallbacks", async () => {
@@ -433,5 +498,28 @@ test("PR-1A: TTL constant is reasonable", () => {
   assert.ok(
     PROPOSER_UNREACHABLE_TTL_MS <= NO_PROGRESS_TIMEOUT_MS,
     "TTL <= slow timeout",
+  )
+})
+
+test("PR-1M: miss-round window relates sensibly to the other thresholds", () => {
+  // Required invariants:
+  //   FAST < MISS_ROUND  — larger than FAST so a round about to resolve is
+  //     not falsely promoted, and so the override arms on the same watchdog
+  //     tick the liveness mark is set (baseTimeoutMs drops to FAST).
+  //   MISS_ROUND < TTL   — the mark must outlive the detection window so it
+  //     cannot expire before the fast-path override fires.
+  //   MISS_ROUND < NO_PROGRESS_TIMEOUT_MS — the liveness path must beat the
+  //     conservative H15 slow path (the whole point of #635).
+  assert.ok(
+    PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS < PROPOSER_MISS_ROUND_TIMEOUT_MS,
+    "fast timeout < miss-round window",
+  )
+  assert.ok(
+    PROPOSER_MISS_ROUND_TIMEOUT_MS < PROPOSER_UNREACHABLE_TTL_MS,
+    "miss-round window < TTL",
+  )
+  assert.ok(
+    PROPOSER_MISS_ROUND_TIMEOUT_MS < NO_PROGRESS_TIMEOUT_MS,
+    "miss-round window < slow timeout",
   )
 })

--- a/node/src/consensus.test.ts
+++ b/node/src/consensus.test.ts
@@ -1,7 +1,13 @@
 import test, { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { ChainEngine } from "./chain-engine.ts"
-import { ConsensusEngine, NO_PROGRESS_TIMEOUT_MS, NO_PROGRESS_STAGGER_MS } from "./consensus.ts"
+import {
+  ConsensusEngine,
+  NO_PROGRESS_TIMEOUT_MS,
+  NO_PROGRESS_STAGGER_MS,
+  PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS,
+  PROPOSER_MISS_ROUND_TIMEOUT_MS,
+} from "./consensus.ts"
 import type { SnapSyncProvider } from "./consensus.ts"
 import { EvmChain } from "./evm.ts"
 import { hashBlockPayload, zeroHash } from "./hash.ts"
@@ -553,8 +559,9 @@ test("Phase H15 stagger: only fallback proposer arms override, not all nodes", a
   //
   // Setup: 3-validator chain [node-1, node-2, node-3]. Height 0 → stuck height 1.
   // expectedProposer(1) = node-1 (stuck). Fallback = expectedProposer(2) = node-2.
-  // node-2 should fire at elapsed ≥ NO_PROGRESS_TIMEOUT_MS. node-3 fires at
-  // ≥ NO_PROGRESS_TIMEOUT_MS + NO_PROGRESS_STAGGER_MS. node-1 never fires.
+  // Post-PR-1M the watchdog self-marks node-1 on a liveness basis, so node-2
+  // fires once the stall passes the miss-round window and node-3 one stagger
+  // interval later. node-1 (the stuck proposer) never fires.
 
   const validators = ["node-1", "node-2", "node-3"]
   const stuckHeight = 1n // height we're stuck on
@@ -580,26 +587,35 @@ test("Phase H15 stagger: only fallback proposer arms override, not all nodes", a
     return (c as any).noProgressProposerOverride === true
   }
 
-  // Threshold values relative to live constants — keeps the assertions
-  // accurate even if the timeout is retuned (was 120s pre-558b697, 600s now).
-  const PRIMARY_BELOW = NO_PROGRESS_TIMEOUT_MS - 5_000
-  const PRIMARY_ABOVE = NO_PROGRESS_TIMEOUT_MS + 5_000
-  const SECONDARY_BELOW = NO_PROGRESS_TIMEOUT_MS + NO_PROGRESS_STAGGER_MS - 5_000
-  const SECONDARY_ABOVE = NO_PROGRESS_TIMEOUT_MS + NO_PROGRESS_STAGGER_MS + 5_000
+  // PR-1M (#635): the watchdog self-marks the stuck proposer once the stall
+  // exceeds PROPOSER_MISS_ROUND_TIMEOUT_MS, so the base drops to the 15s fast
+  // path even with no onProposerStuck evidence. The stagger SPACING is
+  // unchanged (NO_PROGRESS_STAGGER_MS) — only the base shifts from the 600s
+  // slow path to the fast path. Primary fallback's effective arm point is
+  // therefore max(FAST, MISS_ROUND); each subsequent fallback adds one stagger.
+  const FAST = PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS
+  const STAG = NO_PROGRESS_STAGGER_MS
+  const PRIMARY_ARM = Math.max(FAST, PROPOSER_MISS_ROUND_TIMEOUT_MS)
+  const SECONDARY_ARM = FAST + STAG
 
-  // Stuck proposer (node-1) never arms override even far past secondary threshold.
-  assert.equal(await watchdogFires("node-1", SECONDARY_ABOVE), false, "stuck proposer never arms override")
+  // Stuck proposer (node-1) never arms override even far past the slow path.
+  assert.equal(
+    await watchdogFires("node-1", NO_PROGRESS_TIMEOUT_MS + STAG + 5_000),
+    false,
+    "stuck proposer never arms override",
+  )
 
-  // Primary fallback (node-2, offset=1) arms at elapsed ≥ NO_PROGRESS_TIMEOUT_MS.
-  assert.equal(await watchdogFires("node-2", PRIMARY_BELOW), false, "node-2 does NOT fire below primary threshold")
-  assert.equal(await watchdogFires("node-2", PRIMARY_ABOVE), true,  "node-2 fires above primary threshold")
+  // Primary fallback (node-2, offset=1) arms once the stall passes the
+  // miss-round window (PR-1M promotes node-1, base becomes FAST).
+  assert.equal(await watchdogFires("node-2", PRIMARY_ARM - 5_000), false, "node-2 does NOT fire below primary threshold")
+  assert.equal(await watchdogFires("node-2", PRIMARY_ARM + 5_000), true,  "node-2 fires above primary threshold")
 
-  // Secondary fallback (node-3, offset=2) fires at ≥ NO_PROGRESS_TIMEOUT_MS + stagger.
-  assert.equal(await watchdogFires("node-3", PRIMARY_ABOVE), false, "node-3 does NOT fire below secondary threshold")
-  assert.equal(await watchdogFires("node-3", SECONDARY_ABOVE), true, "node-3 fires above secondary threshold")
+  // Secondary fallback (node-3, offset=2) fires one stagger interval later.
+  assert.equal(await watchdogFires("node-3", SECONDARY_ARM - 5_000), false, "node-3 does NOT fire below secondary threshold")
+  assert.equal(await watchdogFires("node-3", SECONDARY_ARM + 5_000), true, "node-3 fires above secondary threshold")
 
   // Without nodeId the watchdog is disabled (safe fallback)
-  assert.equal(await watchdogFires("", SECONDARY_ABOVE * 2), false, "no-nodeId: watchdog disabled")
+  assert.equal(await watchdogFires("", NO_PROGRESS_TIMEOUT_MS * 2), false, "no-nodeId: watchdog disabled")
 })
 
 test("Phase J2.2: self-stuck proposer with active round force-clears its own BFT round", async () => {

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -99,6 +99,30 @@ const NO_PROGRESS_MAX_VALIDATORS = 10
 export const PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS = 15_000
 export const PROPOSER_UNREACHABLE_TTL_MS = 60_000
 
+// PR-1M (2026-05-17, chainofclaw/COC#635): liveness-based miss-round window.
+//
+// onProposerStuck — the BFT coordinator callback that feeds PR-1A's
+// `unreachableProposers` marks — only fires when a propose was actually
+// RECEIVED for the stuck round (it reads `activeRound.proposedBlock.proposer`).
+// A validator that stops proposing ENTIRELY never produces that propose, so
+// onProposerStuck never fires, so it is never marked, so every one of its
+// rotation slots falls through to the multi-minute H15 slow path — degrading
+// the chain to <1 bpm on a single-validator outage (#635: 88780 2026-05-16,
+// 0xb939e5 proposed 10x then went silent → 444-624s halt per slot).
+//
+// checkNoProgressWatchdog promotes a peer proposer into the unreachable set
+// once the chain has been stalled at its slot for this long — a
+// propose-independent liveness trigger that complements onProposerStuck.
+// Must satisfy FAST < MISS_ROUND < TTL: larger than FAST so a round about to
+// resolve is not falsely promoted and so the override arms on the same tick
+// the mark is set; smaller than TTL so the mark cannot expire before the
+// override fires. The watchdog samples at NO_PROGRESS_STAGGER_MS granularity,
+// so keep this below that interval for first-tick detection.
+// Env-overridable via COC_PROPOSER_MISS_ROUND_TIMEOUT_MS.
+export const PROPOSER_MISS_ROUND_TIMEOUT_MS = Number(
+  process.env.COC_PROPOSER_MISS_ROUND_TIMEOUT_MS ?? 20_000,
+)
+
 /**
  * PR-1H (2026-05-11): startup grace period for PR-1A's fast-path. Within
  * `PROPOSER_REACHABILITY_STARTUP_GRACE_MS` after consensus.start(),
@@ -519,12 +543,42 @@ export class ConsensusEngine {
     const stuckProposerId = this.chain.expectedProposer(stuckHeight).toLowerCase()
     const localNodeId = this.nodeId?.toLowerCase()
 
+    // PR-1M (2026-05-17, #635): liveness-based unreachability promotion.
+    // onProposerStuck cannot see a validator that stops proposing entirely
+    // (no propose → no `activeRound.proposedBlock` → callback never fires),
+    // so such a proposer is never marked and its slots fall through to the
+    // slow path. The watchdog itself holds a propose-independent signal:
+    // `elapsed` is how long the chain has not progressed and `stuckProposerId`
+    // owns the non-advancing slot. Once that stall exceeds the miss-round
+    // window the proposer has demonstrably failed to drive its round — so
+    // promote it into `unreachableProposers` here, which makes `baseTimeoutMs`
+    // below resolve to the 15s fast path on this same tick. markProposerUnreachable
+    // already enforces the PR-1H startup-grace and PR-1J N<4 gates, so this
+    // inherits the same false-positive protections as the onProposerStuck path
+    // (during grace / on tiny clusters the mark no-ops and the slow path stands).
+    if (
+      stuckProposerId !== localNodeId
+      && elapsed >= PROPOSER_MISS_ROUND_TIMEOUT_MS
+      && !this.isProposerUnreachable(stuckProposerId)
+    ) {
+      this.markProposerUnreachable(stuckProposerId)
+      if (this.isProposerUnreachable(stuckProposerId)) {
+        log.warn("PR-1M: no progress at proposer slot past miss-round window — marking unreachable", {
+          stuckProposerId,
+          stuckHeight: stuckHeight.toString(),
+          elapsedMs: elapsed,
+          missRoundTimeoutMs: PROPOSER_MISS_ROUND_TIMEOUT_MS,
+        })
+      }
+    }
+
     // PR-1A: if we have direct evidence the stuck proposer is unreachable
     // (recent BFT round timed out at their slot, or wire socket is closed),
     // bypass the conservative 600s H15 timeout. The fast path keeps the same
     // rotation-stagger logic so only one fallback fires per tick — preventing
     // the 2026-05-02 equivocation storm — but with FAST=15s as the base
     // threshold instead of SLOW=600s. Falls through to slow path otherwise.
+    // PR-1M may have just promoted the stuck proposer above on a liveness basis.
     const stuckUnreachable = this.isProposerUnreachable(stuckProposerId)
     const baseTimeoutMs = stuckUnreachable
       ? PROPOSER_UNREACHABLE_FAST_TIMEOUT_MS


### PR DESCRIPTION
## Summary

Fixes #635 — a down validator's proposer slot halts the chain ~7-10 min before the skip engages.

**Root cause.** PR-1A's fast 15s proposer-skip only engages when the stuck proposer is in `unreachableProposers`. That set has exactly one writer: the BFT coordinator's `onProposerStuck` callback — which fires *only when a propose message was actually received* for the stuck round (it reads `activeRound.proposedBlock.proposer`). A validator that **stops proposing entirely** never produces that propose, so `onProposerStuck` never fires, so it is never marked, so every one of its rotation slots falls through to the conservative 600s H15 slow path. On 88780 (2026-05-16) this dropped the chain to 0.92 bpm with `0xb939e5` silently down — 444-624s per dead slot.

**Fix (PR-1M).** `checkNoProgressWatchdog` already holds a propose-independent liveness signal: `elapsed` (how long the chain has not progressed) and `stuckProposerId` (who owns the non-advancing slot). Once `elapsed` exceeds `PROPOSER_MISS_ROUND_TIMEOUT_MS` the proposer has demonstrably failed to drive its round regardless of whether it ever sent a propose — so the watchdog promotes it into `unreachableProposers` directly. `baseTimeoutMs` then resolves to the 15s fast path on the same tick.

## Changes

- `node/src/consensus.ts`
  - New `PROPOSER_MISS_ROUND_TIMEOUT_MS` constant (default `20_000`, env `COC_PROPOSER_MISS_ROUND_TIMEOUT_MS`). Invariant `FAST < MISS_ROUND < TTL`.
  - `checkNoProgressWatchdog`: promote a peer `stuckProposerId` via `markProposerUnreachable` once `elapsed >= PROPOSER_MISS_ROUND_TIMEOUT_MS`.
- `node/src/bft-proposer-skip.test.ts`, `node/src/consensus.test.ts` — updated stale assertions + new PR-1M tests.

## Why it is safe

- PR-1M reuses `markProposerUnreachable`, which already enforces the **PR-1H startup-grace** and **PR-1J N<4** gates — so it inherits the same false-positive protections as the `onProposerStuck` path (during grace / on N<4 the promotion no-ops and the slow path stands).
- Self is never promoted (`stuckProposerId !== localNodeId` guard); self-stuck keeps its J2.2 force-clear path.
- The rotation **stagger** (equivocation-storm guard, 2026-05-02) is untouched — only the base timeout shifts from SLOW to FAST.
- `PR-1M` is complementary to `onProposerStuck`, not a replacement: the latter still gives faster (round-timeout-driven) evidence when a propose *is* received.

## Test plan

- [x] `node --experimental-strip-types --test node/src/{consensus,consensus-bft,bft-proposer-skip,consensus-*}.test.ts node/src/bft*.test.ts` — 164/164 pass
- [x] New tests: liveness promotion past the window; suppressed during startup grace; suppressed on N<4; self never promoted; threshold-invariant sanity
- [ ] 88780 soak: stop one validator, confirm its slots skip in ~one watchdog interval instead of 7-10 min

## Notes

First-detection latency is bounded by the watchdog sampling period (`NO_PROGRESS_STAGGER_MS`, 30s) — so a dead validator's *first* slot still costs ~one tick, but every subsequent slot is fast. Driving first-detection into the issue's ideal 10-20s band would require a faster watchdog tick (decoupled from the stagger interval); deliberately left as a separate tuning change to keep this PR's blast radius minimal.