### PR TITLE
fix(chain): serialize speculative stateRoot compute against applyBlock (#642)

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -775,46 +775,7 @@ export class PersistentChainEngine {
     // without stateRoot" — hash-only quorum for that round. This is the same
     // fail-open contract the previous stub promised.
     if (!this.stateTrie) return undefined
-
-    // Phase R2 (2026-05-06): refuse speculative compute when our chain tip
-    // doesn't match the proposed block's parent. Two failure modes this
-    // closes:
-    //   (a) we're mid-applyBlock for the parent height — trie's committed
-    //       root is still N-1, but the block claims parent=N. Computing
-    //       against N-1's state would produce a wrong stateRoot and our
-    //       prepare vote would poison BFT quorum.
-    //   (b) we have an off-by-one / fork-choice gap — same outcome.
-    // Returning undefined falls through to hash-only quorum (BftCoordinator
-    // contract), which is safe for liveness; we just skip stating a stateRoot
-    // we couldn't produce honestly.
-    const localTip = await this.getTip()
-    const expectedParentHash = block.parentHash?.toLowerCase()
-    const localTipHash = localTip?.hash?.toLowerCase()
-    if (expectedParentHash && localTipHash && expectedParentHash !== localTipHash) {
-      log.warn("Phase R2: speculative compute aborted — parent mismatch", {
-        height: block.number.toString(),
-        blockParent: expectedParentHash,
-        localTip: localTipHash,
-      })
-      return undefined
-    }
-
-    // Phase R2: force a sync pass on the parent trie so any dirty storage
-    // sub-tries (e.g. BEACON_ROOTS write from the previous applyBlock that
-    // hasn't yet propagated its storageRoot into the account record) are
-    // flushed into the trie before we shallowCopy. Without this, the fork
-    // inherits a stale account record whose storageRoot points at the
-    // pre-write state, and computeStateRoot returns a non-canonical root.
-    // computeStateRoot is idempotent + cheap when dirtyAddresses is empty;
-    // it's a defensive flush, not a fast path.
-    try {
-      await this.stateTrie.computeStateRoot()
-    } catch (err) {
-      log.warn("Phase R2: parent-trie sync threw — continuing with potentially stale fork", {
-        height: block.number.toString(),
-        error: String(err),
-      })
-    }
+    const stateTrie = this.stateTrie
 
     // Phase H1 diagnostic: env-gated detailed logging to identify the
     // mechanism behind the recurring proposer-vs-non-proposer divergence
@@ -868,9 +829,59 @@ export class PersistentChainEngine {
       return adversarial as Hex
     }
 
+    // #642: take the parent snapshot — the Phase-R2 parent-tip check, the
+    // dirty-storage flush, and forkForDryRun — under the same FIFO queue as
+    // applyBlock. Run unsynchronized, computeStateRoot()'s `trie.put` and the
+    // shallowCopy land in a checkpoint frame that an in-flight applyBlock is
+    // concurrently mutating, corrupting the shared PersistentStateTrie so the
+    // node's committed stateRoot no longer matches its trie — surfacing as a
+    // proposer-vs-voter divergence on the next empty block and a permanent
+    // BFT deadlock. The fork returned here is an immutable point-in-time
+    // snapshot, so the replay below runs OUTSIDE the lock and never blocks
+    // consensus.
     let dryTrie: IStateTrie | null = null
     try {
-      dryTrie = await this.stateTrie.forkForDryRun()
+      dryTrie = await this.runStateExclusive(async (): Promise<IStateTrie | null> => {
+        // Phase R2 (2026-05-06): refuse speculative compute when our chain
+        // tip doesn't match the proposed block's parent. Computing against
+        // the wrong parent state would poison our BFT prepare vote. Checked
+        // inside the queue so the tip cannot advance before the fork is taken.
+        const localTip = await this.getTip()
+        const expectedParentHash = block.parentHash?.toLowerCase()
+        const localTipHash = localTip?.hash?.toLowerCase()
+        if (expectedParentHash && localTipHash && expectedParentHash !== localTipHash) {
+          log.warn("Phase R2: speculative compute aborted — parent mismatch", {
+            height: block.number.toString(),
+            blockParent: expectedParentHash,
+            localTip: localTipHash,
+          })
+          return null
+        }
+        // Phase R2: flush dirty storage sub-tries into their account records
+        // before shallowCopy so the fork doesn't inherit a stale storageRoot
+        // pointer (e.g. a BEACON_ROOTS write from the previous applyBlock).
+        // Idempotent + cheap when dirtyAddresses is empty; race-free here
+        // because the queue excludes any concurrent applyBlock.
+        try {
+          await stateTrie.computeStateRoot()
+        } catch (err) {
+          log.warn("Phase R2: parent-trie sync threw — continuing with potentially stale fork", {
+            height: block.number.toString(),
+            error: String(err),
+          })
+        }
+        return await stateTrie.forkForDryRun()
+      })
+    } catch (err) {
+      log.warn("speculative stateRoot compute: parent snapshot failed", {
+        height: block.number.toString(),
+        error: String(err),
+      })
+      return undefined
+    }
+    if (!dryTrie) return undefined
+
+    try {
       // Phase H1 diag point 1: state of fork BEFORE any block context
       await dumpBeaconState(dryTrie, "post-fork")
 
@@ -1071,6 +1082,30 @@ export class PersistentChainEngine {
     // Absorb rejections into the chain-tracking promise so the next caller's
     // `then(run, run)` continues; per-caller rejection is still exposed via `current`.
     this.applyQueue = current.catch(() => {})
+    return current
+  }
+
+  /**
+   * #642: serialize an operation that snapshots or mutates the shared
+   * PersistentStateTrie / EVM state manager against applyBlock (and against
+   * other such operations) by chaining it onto the same FIFO queue.
+   *
+   * applyBlock is not the only writer of the shared trie: speculativelyCompute-
+   * StateRoot's Phase-R2 dirty-storage flush does `trie.put` on it, and
+   * forkForDryRun's shallowCopy must observe a consistent root. Run those
+   * unsynchronized, they interleave with an in-flight applyBlock at an `await`
+   * boundary — landing writes in the wrong checkpoint frame and mutating
+   * accountCache/dirtyAddresses mid-iteration — so the node's committed
+   * stateRoot drifts from its actual trie state (#642 deadlock).
+   *
+   * The callback must be SHORT (a snapshot/flush), not a full block replay:
+   * it blocks applyBlock for its whole duration. Rejections stay with the
+   * caller's returned promise and do not poison the queue.
+   */
+  private runStateExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const prior = this.applyQueue
+    const current = prior.then(fn, fn)
+    this.applyQueue = current.then(() => {}, () => {})
     return current
   }
 

--- a/tests/chain-concurrency.race.test.ts
+++ b/tests/chain-concurrency.race.test.ts
@@ -26,6 +26,9 @@ import { join } from "node:path"
 import { Transaction, Wallet, parseEther } from "ethers"
 import { EvmChain } from "../node/src/evm.ts"
 import { PersistentChainEngine } from "../node/src/chain-engine-persistent.ts"
+import { LevelDatabase } from "../node/src/storage/db.ts"
+import { PersistentStateTrie } from "../node/src/storage/state-trie.ts"
+import { PersistentStateManager } from "../node/src/storage/persistent-state-manager.ts"
 import type { Hex } from "../node/src/chain-engine-types.ts"
 
 const CHAIN_ID = 18780
@@ -247,5 +250,137 @@ describe("chain-concurrency race (reproduce testnet applyBlock hang)", () => {
 
     console.log(`  A+B+C+D: txSent=${stats.txSent} blocks=${stats.blocksProduced} reads=${stats.reads} reapplies=${stats.reapplies}`)
     assert.ok(stats.txSent > 50 && stats.blocksProduced > 5)
+  })
+
+})
+
+/**
+ * #642 regression — stateRoot divergence under a concurrent tx burst.
+ *
+ * Unlike the harness above (which runs the engine with no separate persistent
+ * state trie), this suite wires the FULL persistent stack — a
+ * PersistentStateTrie-backed EVM — so speculativelyComputeStateRoot exercises
+ * the real fork/flush path that #642 corrupts.
+ */
+describe("#642 — speculative stateRoot consistency under concurrent burst", () => {
+  let tmpDir: string
+  let stateDb: LevelDatabase
+  let evm: EvmChain
+  let engine: PersistentChainEngine
+  let wallet: Wallet
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "stateroot-642-"))
+    stateDb = new LevelDatabase(tmpDir, "state")
+    await stateDb.open()
+    const trie = new PersistentStateTrie(stateDb)
+    await trie.init()
+    const stateManager = new PersistentStateManager(trie)
+    evm = await EvmChain.create(CHAIN_ID, stateManager)
+    engine = new PersistentChainEngine(
+      {
+        dataDir: tmpDir,
+        nodeId: "node-1",
+        chainId: CHAIN_ID,
+        validators: ["node-1"],
+        finalityDepth: 2,
+        maxTxPerBlock: 100,
+        minGasPriceWei: 1n,
+        prefundAccounts: [
+          { address: FUNDER_ADDR, balanceWei: parseEther("1000000").toString() },
+        ],
+        stateTrie: trie,
+      },
+      evm,
+    )
+    await engine.init()
+    wallet = new Wallet(FUNDER_KEY)
+  })
+
+  afterEach(async () => {
+    try { await engine.close() } catch {}
+    try { await stateDb.close() } catch {}
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+  })
+
+  it("speculative stateRoot agrees with applied root under concurrent load", async () => {
+    // #642: a concurrent tx burst raced speculativelyComputeStateRoot's
+    // shared-trie flush against an in-flight applyBlock, corrupting the
+    // PersistentStateTrie so a node's speculative root diverged from the root
+    // it actually committed — surfacing at the next empty block as a
+    // proposer-vs-voter stateRoot mismatch and a permanent BFT deadlock.
+    //
+    // Invariant under test: for every proposed block, every non-undefined
+    // speculativelyComputeStateRoot() result MUST equal the canonical
+    // post-apply stateRoot — even while a burst of tx admissions and
+    // gossip-style applyBlock re-deliveries run concurrently. A single
+    // divergence is the bug.
+    const stats = { blocks: 0, specChecks: 0, divergences: 0, reapplies: 0 }
+    const seenBlocks: Array<{ number: bigint; hash: Hex }> = []
+
+    await withDeadline("#642", (async () => {
+      const deadline = Date.now() + WORKER_DURATION_MS
+      let nonce = 0
+
+      // Burst tx admission — keeps the mempool loaded so proposed blocks carry
+      // txs (and drain to empty blocks, the exact #642 trigger surface).
+      const txWorker = (async () => {
+        while (Date.now() < deadline && nonce < 4000) {
+          try { await engine.addRawTx(signTx(wallet, nonce)); nonce++ }
+          catch { await new Promise((r) => setTimeout(r, 3)) }
+        }
+      })()
+
+      // Proposer + 3-voter simulation: build the next block (unapplied), have
+      // three concurrent voters speculatively compute its stateRoot — racing
+      // each other and the gossip-applyBlock worker below — then apply it and
+      // compare every speculative result against the canonical post-apply
+      // root. With the shared-trie access serialized, all three voters and the
+      // applied root must agree on every block; a divergence is the #642 bug.
+      const proposerWorker = (async () => {
+        while (Date.now() < deadline) {
+          const block = await engine.proposeNextBlock(true /* deferApply */)
+          if (!block) { await new Promise((r) => setTimeout(r, 8)); continue }
+          const specRoots = await Promise.all([
+            engine.speculativelyComputeStateRoot(block).catch(() => undefined),
+            engine.speculativelyComputeStateRoot(block).catch(() => undefined),
+            engine.speculativelyComputeStateRoot(block).catch(() => undefined),
+          ])
+          await engine.applyBlock(block, true)
+          const applied = await engine.getBlockByHash(block.hash)
+          const canonical = applied?.stateRoot
+          stats.blocks++
+          seenBlocks.push({ number: block.number, hash: block.hash })
+          for (const r of specRoots) {
+            if (r === undefined) continue // fail-open (parent moved) — allowed
+            stats.specChecks++
+            if (canonical !== undefined && r !== canonical) stats.divergences++
+          }
+        }
+      })()
+
+      // Gossip-style concurrent applyBlock — re-delivers recent blocks so an
+      // applyBlock checkpoint overlaps the speculative computes above (this is
+      // the interleave that corrupted the shared trie pre-fix).
+      const gossipWorker = (async () => {
+        while (Date.now() < deadline) {
+          const pick = seenBlocks[seenBlocks.length - 1]
+          if (pick) {
+            try {
+              const full = await engine.getBlockByHash(pick.hash)
+              if (full) { await engine.applyBlock(full); stats.reapplies++ }
+            } catch {}
+          }
+          await new Promise((r) => setTimeout(r, 2))
+        }
+      })()
+
+      await Promise.all([txWorker, proposerWorker, gossipWorker])
+    })())
+
+    console.log(`  #642: blocks=${stats.blocks} specChecks=${stats.specChecks} divergences=${stats.divergences} reapplies=${stats.reapplies}`)
+    assert.ok(stats.blocks > 5, `expected >5 blocks, got ${stats.blocks}`)
+    assert.ok(stats.specChecks > 10, `expected >10 speculative checks, got ${stats.specChecks}`)
+    assert.equal(stats.divergences, 0, `#642: speculative stateRoot diverged from applied root ${stats.divergences}x`)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #642 — a concurrent transaction burst silently diverges one validator's state trie, surfacing at the next empty block as a proposer-vs-voter `stateRoot` mismatch that deadlocks BFT.

**Root cause.** The devnet/prod path runs `PersistentChainEngine`. Its `PersistentStateTrie` carries shared mutable state — the v6 `CheckpointDB` frame stack, `accountCache`, `dirtyAddresses`. `applyBlock` is serialized against itself by a FIFO queue (`applyQueue`), but `speculativelyComputeStateRoot` is **not** on that queue, yet it mutates the same shared trie: its Phase-R2 "defensive flush" calls `this.stateTrie.computeStateRoot()` (which does `await trie.put(...)`), and `forkForDryRun()`'s `shallowCopy` must observe a consistent root. Run unsynchronized, these interleave with an in-flight `applyBlock` at `await` boundaries — a `trie.put` lands in `applyBlock`'s checkpoint frame, `dirtyAddresses` is mutated mid-iteration — leaving one node's **committed `stateRoot` out of sync with its actual trie**. Sequential load never interleaves; only the concurrent burst does. The drift is invisible until the next *empty* block, whose `stateRoot` directly exposes the corrupt post-parent state.

**Fix.** Generalize `applyBlock`'s queue into `runStateExclusive()` and take the speculative path's **parent snapshot** — the Phase-R2 parent-tip check, the dirty-storage flush, and `forkForDryRun()` — under it. The returned fork is an immutable point-in-time snapshot, so the (already isolated) block replay still runs *outside* the lock and never blocks consensus. Entirely in the state/execution layer — **no BFT/consensus code changed**.

## Changes

- `node/src/chain-engine-persistent.ts`
  - New `runStateExclusive<T>()` — generalizes the `applyQueue` FIFO so non-`applyBlock` shared-trie operations serialize against `applyBlock`.
  - `speculativelyComputeStateRoot()` — the parent-tip check + dirty-storage flush + `forkForDryRun()` now run inside `runStateExclusive()`; the isolated fork replay stays outside the lock.
- `tests/chain-concurrency.race.test.ts` — new `#642` suite wiring the full persistent stack (`PersistentStateTrie`-backed EVM), asserting every speculative root agrees with the canonical post-apply root under concurrent burst + gossip-applyBlock load.

## Test plan

- [x] 3-node BFT devnet (`start-devnet.sh 3`) + 40-tx concurrent burst → chain does **not** deadlock; all 3 validators agree on `stateRoot` **and** `blockHash` (verified at block 80). Pre-fix, #642 reproduces a deadlock here.
- [x] `node/src/{chain-engine,consensus,bft,evm,mempool}*.test.ts` + `node/src/storage/*.test.ts` — 379/379 pass.
- [x] Full `node/src` suite — 1815/1817 pass; the 2 failures (`Block Production Throughput`, `IpfsHttpServer`) both pass in isolation — flaky under concurrent-devnet CPU/port load, unrelated to this change.
- [x] New `#642` concurrency regression test passes.

## Notes / follow-ups

- The new regression test is a concurrency **guard** (it exercises the exact methods and locks the invariant); a deterministic single-process reproduction of the multi-node race is impractical — the devnet soak is the functional proof.
- Out of scope (separate hardening): isolating read-only EVM paths (`eth_call`/`eth_estimateGas` on the live `this.vm`) and the mempool per-sender admission race. Neither is exercised by the #642 sendTransaction burst.