### PR TITLE
test: stress/chaos/e2e/integration coverage + BFT rate-limiter fix

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,78 @@
+name: Stress & Chaos
+
+# Devnet-dependent test lanes, kept separate from the main Test workflow
+# because they spawn real node processes (start-devnet.sh) rather than
+# in-process fixtures.
+#
+# - stress-probes: every push / PR — boots a 3-node devnet and runs the
+#   chain-dependent EVM/RPC stress probes.
+# - chaos-devnet: weekly + manual only — spawns a 5-node BFT cluster and
+#   injects validator faults (~5 min, too heavy for every PR).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC — chaos soak
+  workflow_dispatch:
+
+concurrency:
+  group: stress-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stress-probes:
+    name: EVM/RPC Stress Probes (3-node devnet)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: cd node && npm install --no-audit --no-fund
+      - run: npm install --no-save ethers
+      - name: Start 3-node devnet
+        run: bash scripts/start-devnet.sh 3
+      - name: Run EVM-coverage + RPC-validation probes
+        run: |
+          # burst-throughput.test.ts is intentionally NOT run here: a
+          # concurrent tx burst triggers the open stateRoot-divergence bug
+          # #642 (it deadlocks BFT). Re-add it once #642 is fixed.
+          node --experimental-strip-types --test --test-force-exit \
+            tests/stress/evm-coverage.test.ts \
+            tests/stress/rpc-validation.test.ts
+        env:
+          COC_STRESS_RPC: http://127.0.0.1:28780
+          NODE_ENV: test
+      - name: Stop devnet
+        if: always()
+        run: bash scripts/stop-devnet.sh 3 || true
+
+  chaos-devnet:
+    name: Consensus Chaos (5-node devnet)
+    # Heavy: spawns 5 node processes and runs validator-fault scenarios
+    # (~5 min). Weekly soak + manual dispatch only — never on a PR.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: cd node && npm install --no-audit --no-fund
+      - run: npm install --no-save ethers
+      - name: Run consensus chaos scenarios
+        run: |
+          # The suite spawns/tears down the devnet itself via start-devnet.sh.
+          node --experimental-strip-types --test --test-force-exit \
+            tests/stress/chaos-devnet.test.ts
+        env:
+          COC_CHAOS_DEVNET: "1"
+          NODE_ENV: test
+      - name: Stop devnet
+        if: always()
+        run: bash scripts/stop-devnet.sh 5 || true

--- a/docs/stress-test-2026-05-17.md
+++ b/docs/stress-test-2026-05-17.md
@@ -1,0 +1,126 @@
+# COC 88780 试验网压力测试报告（Ralph Loop Session）
+
+- **日期**：2026-05-15 ~ 2026-05-17
+- **目标链**：chainId 88780（0x15acc），R3.2 试验网，N=5 validator + 2 observer
+- **RPC 端点**：`http://159.198.36.3:28780`（节点 A）、`http://159.198.36.25:28780`（节点 B）
+- **执行方式**：Ralph loop 自驱动循环（无完成承诺，迭代约 1569 次后人工终止）
+- **任务定义**：对试验网做随机组合压力测试 —— 合约部署、合约执行、IPFS 上传下载；测试后观察试验网状态；发现 bug / 性能瓶颈;发 issue;解决 bug。
+
+---
+
+## 1. 测试覆盖明细
+
+### 1.1 合约部署
+- 全程使用手工汇编字节码 + 标准 init wrapper（`60<len>8060093d393df3` / PUSH2 变体）部署数百个测试合约。
+- `CREATE` / `CREATE2` 操作码 —— 地址确定性、字节码部署正确。
+- **合约工厂模式（CREATE-from-contract）**：部署的合约内部执行 `CREATE` 派生子合约；验证子合约地址遵循 `keccak(rlp(factory, nonce=1))`、子合约独立可调用。
+- `EIP-170`（24576 字节合约大小上限）边界。
+- `EIP-3860` initcode 计费。
+
+### 1.2 合约执行（EVM 层）
+- **全 EVM opcode** 覆盖。
+- **6 个 precompile**：ecrecover(0x01)、sha256(0x02)、identity(0x04)、modexp(0x05)、ecadd(0x06)、ecmul(0x07)。
+- `CALL` / `STATICCALL` / `DELEGATECALL` 语义。
+- `SELFDESTRUCT`：确认为 **Shanghai 语义**（跨交易完整删除账户 + 转移余额），非 Cancun/EIP-6780 受限语义。
+- OOG（out-of-gas）、`REVERT` + revert-data。
+- **EVM fork level 判定 = Shanghai**：PUSH0/EIP-3855 支持、EIP-1153 (TLOAD/TSTORE) 不支持、SELFDESTRUCT 完整删除。
+- EIP-1559 费用机制（baseFee、`MIN_BASE_FEE` 1 gwei 下限、effective gas price）。
+- compute-load：50000 次迭代 SHA3 循环合约，单笔 tx 消耗 3.72M gas，执行正确、gas 计量精确（与 `estimateGas` 精确匹配）。
+
+### 1.3 交易层
+- **交易类型矩阵**：type-0（legacy）、type-1（EIP-2930 access list）、type-2（EIP-1559）—— 三类均正确处理。
+- Receipt 字段正确性：`status`、`type`、`gasUsed`、`cumulativeGasUsed`、`effectiveGasPrice`、`logsBloom`。
+- 交易入块 liveness：提交交易确认在 1-2 块内入块（补监测器只看区块高度的盲区）。
+
+### 1.4 吞吐量 / 性能
+- 多轮 burst 压测（15 ~ 50 笔并发交易）：交易全部入块、计数器状态精确、双节点一致。
+- 区块容量：gasLimit 30M；50 笔简单交易仅占 3.94% —— 链有大量余量。
+- 出块节奏：稳定 ~2.5-3.5s/块，bpm ~20-24，全程无性能退化。
+
+### 1.5 RPC 层
+- **COC 特有 `coc_*` RPC 输入校验探测**：34 次调用（18 正常 + 16 畸形参数）。所有畸形输入（null / object / array / 畸形地址 / 路径穿越式 / 超长字符串）均干净返回 `-32602`，零 `-32603`/HTTP 500/崩溃 —— 边界校验稳健。
+- `eth_getLogs`：地址过滤、topic 过滤、日志内容、宽范围查询性能（5000 块 / 382ms）、inverted-range 错误边界。
+- 历史状态访问：`eth_getCode` 在历史区块、archive state。
+
+### 1.6 真实部署合约
+- **CidRegistry**（@ `0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0`）：单条 `registerCid` + 批量 `registerCidBatch`；register/resolve 往返、事件、HashMismatch revert、不可变性、length-mismatch revert —— 全部正确。
+- **ValidatorRegistry**（只读）：`getActiveValidators`/`activeValidatorCount` —— 链上 0 active validator，确认 88780 BFT 跑 config 集而非 registry-driven（与历史 ValidatorRegistry-driven BFT 回滚一致，非 bug）。
+
+### 1.7 IPFS
+- COC 实现层（blockstore / unixfs / http API / merkle / 纠删码 / tar / mfs / pubsub / wiring / repair）：**本地 332 测试全通过**。
+- 试验网 IPFS HTTP API（端口 5001）+ WebSocket RPC（28781）：**公网未暴露**（节点 B 连接拒绝、节点 A 防火墙过滤）—— 这是正确的安全姿势（5001 为 admin 端口），非缺陷。
+
+### 1.8 共识层观察
+- `#635` 共识 proposer-skip 停产：session 内复现 **4 次**（611s / 605s / 628s 等量级停产）。
+- 部署持续监测器（3 个版本迭代），监控链头推进、停产检测、双节点容错。
+
+### 1.9 双节点一致性
+- 每项测试均交叉对比节点 A / 节点 B 的 code、storage、receipt —— 全程一致，无 fork、无 stateRoot 分歧。
+
+---
+
+## 2. 发现的问题
+
+### 2.1 Bug #638 — mempool under-baseFee 交易冻结账户【已修复】
+- **症状**：type-2 交易 `maxFeePerGas` < baseFee 下限（`MIN_BASE_FEE` = 1 gwei）被 `eth_sendRawTransaction` 接受为 pending，永久占住发送方 head-of-line nonce，账户被冻结。
+- **根因**：`mempool.ts` 准入层缺 feeCap-vs-baseFee 校验（与 #334 intrinsic-gas bug 同类）。
+- **修复**：**PR #639**（chainofclaw/COC）—— 仿 #334 在 `validateTxStructure()` 拒绝 feeCap < `MIN_BASE_FEE`；3 个新测试；mempool 28/28 + 跨 10 文件 157/157 无回归;8/8 CI 全绿。待 maintainer 评审。
+
+### 2.2 Bug #635 — 共识 proposer-skip 停产【修复 PR 进行中】
+- **症状**：validator 瞬时不可达时,其 proposer 槽位使链停产 444-628s。
+- **根因**：PR-1A 快速跳过检测不到"从未提议"的 proposer → 落 600s H15 慢路径。
+- **本 session 贡献**：复现 4 次并在 #635 留数据评论（issuecomment-4467565608），关键新信号 —— 同一 validator flapping 重复触发,触发器是"瞬时不可达"而非罕见硬件死亡。
+- **修复**：PR #641（PR-1M，watchdog 活性提升 proposer），待 merge。
+
+### 2.3 基础设施事件 — 非 COC bug
+- `159.198.36.x` 子网网络抖动,致两 RPC 节点间歇性不可达。
+- 经核实链头全程持续推进 —— 是 ops/网络问题,**非 COC 软件缺陷**;恰恰验证了 N=5 BFT 容错正确工作。未误报为 bug。
+
+---
+
+## 3. 全面性分析
+
+### 3.1 充分覆盖（公网可达面已饱和）
+对**通过公开 HTTP JSON-RPC（端口 28780）可达的表面**,覆盖充分甚至饱和：
+- EVM 执行层（opcode / precompile / CREATE 系 / CALL 系 / SELFDESTRUCT / OOG / revert / fork level）
+- 交易类型矩阵 + receipt 字段
+- 吞吐量 / compute-load / 区块容量
+- COC RPC 输入校验
+- 双节点一致性
+
+### 3.2 覆盖缺口（受访问与风险限制,未覆盖）
+| 领域 | 状态 | 原因 |
+|---|---|---|
+| **IPFS 文件上传/下载（任务明列目标）** | ❌ 未在试验网测 | IPFS HTTP API（5001）公网未暴露;仅本地跑了 332 个实现层单元测试 |
+| **PoSe（Proof-of-Service,COC 核心机制）** | ❌ 未测 | pose-http 端点公网未暴露;无法从外部触发 challenge/receipt 流程 |
+| **治理合约**（GovernanceDAO/Treasury/SoulRegistry/DIDRegistry/PoSeManagerV2） | ⚠️ 基本未测 | 仅测了 CidRegistry + ValidatorRegistry(只读);治理写操作有链停风险 + EIP-712 多步流程复杂,刻意回避 |
+| **WebSocket RPC（eth_subscribe）** | ❌ 未测 | WS 端口 28781 公网未暴露 |
+| **debug RPC / 交易 tracing** | ❌ 未测 | 环境封锁 |
+| **多节点共识混沌测试**（停 validator / 网络分区） | ❌ 未做 | 无节点 shell 访问权限,无法注入故障 |
+| **reorg 处理** | ❌ 未做 | 无法从外部触发 |
+| **P2P / wire / DHT 层** | ❌ 未做 | 非外部可测 |
+| **长时 soak（内存泄漏/退化）** | ⚠️ 部分 | 约数小时连续观察,无专门长跑 |
+
+### 3.3 "测试内容随机组合"的执行评价
+后期迭代的"随机组合"实质重复度偏高(主要是 deploy+execute 组合与 burst 的变体),随机性体现在 runtime 选择而非测试维度的真正多样化。早期迭代(EVM 全面探测、precompile、tx 类型矩阵、CidRegistry、compute-load)覆盖维度丰富;饱和后转入周期性监控,新增覆盖递减。
+
+### 3.4 结论
+- **EVM / RPC / 合约执行层（公网可达面）：覆盖全面,高置信度无 bug。**
+- **COC 系统整体:覆盖不完整。** 三大任务目标中,"合约部署""合约执行"充分完成,**"IPFS 上传下载"因端点未公开而实质未在试验网执行**;PoSe(COC 核心价值机制)、治理合约、共识混沌注入因访问权限与风险约束基本空白。
+- 真实 bug 集中在 COC 特有层(共识 #635、mempool #638),EVM 通用层零 bug —— 符合"通用层成熟、自研层是风险点"的预期。
+
+---
+
+## 4. 建议
+
+1. **补 IPFS 端到端测试**:需在节点本机或具 admin 访问的环境下,通过 `/api/v0/add` + `/api/v0/cat` + `/ipfs/<cid>` 网关跑真实文件上传/下载 —— 当前压测留下的最大缺口。
+2. **补 PoSe 端到端测试**:COC 核心机制,需多节点 devnet + coc-agent/coc-relayer sidecar(参见现有 `tests/multinode-integration/` 与 plan R2.1)。
+3. **治理合约 lifecycle 测试**:在 forked node 上 simulate 后,跑一次完整 GovernanceDAO 提案→投票→执行,避免直接在试验网做有链停风险的写操作。
+4. **共识混沌测试**:需节点 shell 访问以注入 validator 停机/分区故障(参见 `scripts/gcloud/chaos/`)。
+5. **#635 修复跟进**:PR #641(PR-1M)合并后,在 fork-off devnet 验证死 validator 首槽恢复时间。
+6. **压测脚本工程化**:将本 session 的临时探针固化为 `tests/` 下可复用的脚本,避免每轮手写一次性 `sp.mjs`。
+
+---
+
+## 附:测试环境限制说明
+本次压测从**外部客户端**视角执行,仅能访问公开的 HTTP JSON-RPC 端口(28780)。IPFS API、WebSocket、debug RPC、PoSe 端点、节点 shell 均不可达 —— 这既是测试覆盖缺口的主因,也反映了试验网正确的端口暴露安全姿势。完整的 COC 系统验证需要节点侧访问权限。

--- a/docs/testnet-validation-2026-05-17.md
+++ b/docs/testnet-validation-2026-05-17.md
@@ -1,0 +1,90 @@
+# COC 88780 试验网验证报告（WS7 — live 验证）
+
+- **日期**：2026-05-17
+- **目标链**：chainId 88780（0x15acc），R3.2 试验网，N=5 validator + 2 observer
+- **RPC 端点**：`http://159.198.36.3:28780`（节点 A）、`http://159.198.36.25:28780`（节点 B）
+- **执行视角**：外部客户端，仅经公开 HTTP JSON-RPC（端口 28780）
+- **背景**：本报告是 2026-05-17 测试覆盖深度扩展计划 WS7 的产出，承接 `docs/stress-test-2026-05-17.md`。WS5 把当时的临时探针固化为 `tests/stress/` 下可复用套件，本次将其指向 live 88780 执行。
+
+---
+
+## 1. 链状态
+
+| 项 | 值 |
+|---|---|
+| chainId | 88780（`0x15acc`），`net_version` 一致 |
+| 链头 | ~148,500（验证执行期间）|
+| 双节点 | 节点 A / 节点 B 链头一致，均可达 |
+| 部署账户 | Hardhat #0（`0xf39Fd6…92266`），余额充足、nonce ~2063 |
+
+---
+
+## 2. 验证结果
+
+执行命令：
+
+```bash
+COC_STRESS_RPC=http://159.198.36.3:28780 \
+  node --experimental-strip-types --test tests/stress/evm-coverage.test.ts
+COC_STRESS_RPC=http://159.198.36.3:28780 \
+  node --experimental-strip-types --test tests/stress/rpc-validation.test.ts
+```
+
+### 2.1 EVM 执行层 — `evm-coverage.test.ts`：6/6 通过
+
+| 用例 | 结果 |
+|---|---|
+| runtime-pool 合约部署 + 执行（ret2a/sstore/counter/log0/timestamp） | ✅ 字节码部署正确 |
+| CREATE 地址确定性（合约工厂模式，子合约 `keccak(rlp(factory,1))`） | ✅ |
+| SELFDESTRUCT 删码 + 转移余额（Shanghai 语义） | ✅ |
+| 交易类型矩阵 type-0 / type-1 / type-2，receipt.type 正确 | ✅ |
+| 不可执行合约调用以 revert 拒绝 | ✅ |
+| chainId 以 hex quantity 一致暴露 | ✅ |
+
+### 2.2 RPC 输入校验层 — `rpc-validation.test.ts`：9/9 通过
+
+| 用例 | 结果 |
+|---|---|
+| `coc_chainStats` 无参 sanity | ✅ |
+| `coc_getContractInfo` 对全部畸形地址（null/object/array/畸形/路径穿越/超长串/数字/布尔/空串）返 -32602 | ✅ |
+| `coc_getTransactionsByAddress` 畸形地址返 -32602 | ✅ |
+| `coc_getTransactionsByAddress` 畸形 limit/offset 返 -32602 | ✅ |
+| `coc_getContractInfo` 合法地址不误拒 | ✅ |
+| `eth_getLogs` 有界范围（最近 5000 块）返数组 | ✅ |
+| `eth_getLogs` 超限范围返干净 -32602（非 -32603） | ✅ |
+| `eth_getLogs` 反转范围干净处理 | ✅ |
+| 畸形输入轰炸后节点仍健康（`eth_blockNumber` 正常） | ✅ |
+
+---
+
+## 3. 过程中的修正
+
+`rpc-validation.test.ts` 原 `eth_getLogs` 用例查询全链（`fromBlock: 0x0`）。在 148k 块的真链上，节点正确以
+`-32602 "block range too large: max 10000 blocks, got 148535"` 拒绝 —— **这是节点的正确行为**（合理的范围上限），
+缺陷在测试假设。已修正：用例改用有界窗口（最近 5000 块），并新增一条用例把"超限范围 → 干净 -32602、绝不 -32603"
+固化为正式覆盖。本地短链走兼容分支同样通过。
+
+---
+
+## 4. 未覆盖项（受访问权限限制）
+
+下列需 operator/SSH 节点侧访问或对 live testnet 的写授权，外部客户端无法执行：
+
+| 领域 | 原因 |
+|---|---|
+| 88780 上治理提案 lifecycle | 对 live testnet 的写操作，有链上副作用，未授权不做 |
+| IPFS 上传/下载 | IPFS HTTP API（5001）公网未暴露 |
+| PoSe challenge/receipt 端到端 | pose-http 端点公网未暴露 |
+| 共识混沌（停 validator / 分区） | 需节点 shell 注入故障 |
+| `burst-throughput.test.ts` | 刻意未对 88780 跑 —— 并发 burst 会触发未修复的 #642（stateRoot 分歧死锁 BFT），不冲击 live N=5 testnet |
+
+---
+
+## 5. 结论
+
+- **88780 的公网可达面（EVM 执行 + RPC 输入校验）：本次以固化套件复验，15/15 全通过，行为正确。**
+- 相比 2026-05-17 首轮压测的临时探针，本次验证用的是 `tests/stress/` 下可复用、CI 可接入的套件 —— 同一覆盖面已工程化。
+- `eth_getLogs` 的 10000 块范围上限经确认为有意设计，且已转为测试覆盖。
+- COC 系统的 IPFS / PoSe / 治理写 / 共识混沌仍需节点侧访问才能在 live 链验证，与首轮报告的覆盖缺口判断一致。
+
+复跑：`tests/stress/` 套件无链时优雅 skip，指定 `COC_STRESS_RPC` 即对目标链执行；CI 中由 `.github/workflows/stress.yml` 的 `stress-probes` lane 对临时 devnet 自动执行。

--- a/node/src/p2p.test.ts
+++ b/node/src/p2p.test.ts
@@ -246,3 +246,85 @@ describe("P2P inbound security scoring", () => {
     assert.equal(banned.status, 429)
   })
 })
+
+describe("P2P bft-message dedicated rate limiter", () => {
+  // Regression: a tx-gossip burst that drained the shared 240/60s inbound
+  // budget used to 429 /p2p/bft-message too, starving consensus and wedging
+  // block production. BFT traffic must ride its own generous limiter.
+  it("does not throttle /p2p/bft-message when the shared inbound budget is drained", async () => {
+    const port = 30400 + Math.floor(Math.random() * 200)
+    const p2p = new P2PNode(
+      {
+        bind: "127.0.0.1",
+        port,
+        peers: [],
+        nodeId: "test-node-bft-rl",
+        enableDiscovery: false,
+        inboundRateLimitWindowMs: 60_000,
+        inboundRateLimitMaxRequests: 2, // tiny shared budget
+        inboundBftRateLimitMaxRequests: 1_000, // generous BFT budget
+      },
+      {
+        onTx: async () => {},
+        onBlock: async () => {},
+        onSnapshotRequest: () => ({ height: 0, latestHash: "0x0" as Hex, blocks: [] }) as unknown as ChainSnapshot,
+      },
+    )
+    startedNodes.push(p2p)
+    p2p.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    // Drain the shared budget on a non-BFT route.
+    const peersUrl = `http://127.0.0.1:${port}/p2p/peers`
+    await fetch(peersUrl)
+    await fetch(peersUrl)
+    assert.equal((await fetch(peersUrl)).status, 429, "shared budget exhausted")
+
+    // bft-message rides its own limiter — never rate-limited here.
+    const bftUrl = `http://127.0.0.1:${port}/p2p/bft-message`
+    for (let i = 0; i < 25; i++) {
+      const res = await fetch(bftUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "prepare", height: "1" }),
+      })
+      assert.notEqual(res.status, 429, `bft-message #${i} must not be rate-limited`)
+    }
+  })
+
+  it("throttles /p2p/bft-message once its own budget is exhausted", async () => {
+    const port = 30600 + Math.floor(Math.random() * 200)
+    const p2p = new P2PNode(
+      {
+        bind: "127.0.0.1",
+        port,
+        peers: [],
+        nodeId: "test-node-bft-rl-cap",
+        enableDiscovery: false,
+        inboundBftRateLimitWindowMs: 60_000,
+        inboundBftRateLimitMaxRequests: 2,
+      },
+      {
+        onTx: async () => {},
+        onBlock: async () => {},
+        onSnapshotRequest: () => ({ height: 0, latestHash: "0x0" as Hex, blocks: [] }) as unknown as ChainSnapshot,
+      },
+    )
+    startedNodes.push(p2p)
+    p2p.start()
+    await new Promise((r) => setTimeout(r, 100))
+
+    const bftUrl = `http://127.0.0.1:${port}/p2p/bft-message`
+    const send = () =>
+      fetch(bftUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "prepare", height: "1" }),
+      })
+    assert.notEqual((await send()).status, 429)
+    assert.notEqual((await send()).status, 429)
+    const throttled = await send()
+    assert.equal(throttled.status, 429, "bft-message 429s once its own budget is spent")
+    assert.equal((await throttled.json()).error, "rate limit exceeded")
+  })
+})

--- a/node/src/p2p.ts
+++ b/node/src/p2p.ts
@@ -107,6 +107,14 @@ export interface P2PConfig {
   peerMaxAgeMs?: number
   inboundRateLimitWindowMs?: number
   inboundRateLimitMaxRequests?: number
+  /**
+   * Dedicated rate-limit budget for /p2p/bft-message. Consensus traffic gets
+   * its own generous limiter so a tx-gossip burst on the shared inbound
+   * budget cannot throttle BFT messages and deadlock block production.
+   * Defaults: 60_000 ms window, 1200 requests.
+   */
+  inboundBftRateLimitWindowMs?: number
+  inboundBftRateLimitMaxRequests?: number
   enableInboundAuth?: boolean
   inboundAuthMode?: "off" | "monitor" | "enforce"
   authMaxClockSkewMs?: number
@@ -397,6 +405,11 @@ export class P2PNode {
   // forceSnapSync actually needed to fetch peer state during divergence
   // recovery, peers responded 429 because the budget was already drained.
   private readonly chainSnapshotRateLimiter: RateLimiter
+  // Dedicated limiter for /p2p/bft-message. Consensus traffic must not share
+  // the general inbound budget — a tx-gossip burst or BFT-timeout re-broadcast
+  // storm could starve it and deadlock the chain (the shared limiter defeated
+  // the ban-exemption already wired for bft-message).
+  private readonly bftMessageRateLimiter: RateLimiter
   private readonly authNonceTracker: PersistentAuthNonceTracker
   public readonly seenTx = new BoundedSet<Hex>(50_000)
   public readonly seenBlocks = new BoundedSet<Hex>(10_000)
@@ -465,9 +478,23 @@ export class P2PNode {
     const chainSnapLimit = (cfg as unknown as { inboundChainSnapshotRateLimitMaxRequests?: number })
       .inboundChainSnapshotRateLimitMaxRequests ?? 120
     this.chainSnapshotRateLimiter = new RateLimiter(60_000, chainSnapLimit)
+    // Dedicated, high-capacity limiter for /p2p/bft-message. BFT traffic is
+    // signature-authenticated downstream and bounded by the consensus
+    // protocol (propose/prepare/commit per round, scaling with validator
+    // count). Sharing the 240/60s general inbound budget let a tx-gossip
+    // burst — and the extra rounds spawned by a single BFT timeout — starve
+    // consensus messages, deadlocking block production: rejected bft-messages
+    // forced round timeouts, whose re-broadcasts drove yet more rejections.
+    // Steady-state inbound is ~3 msgs/round × peers × ~20 rounds/min; 1200/60s
+    // leaves >4x headroom and still bounds garbage-flood CPU cost.
+    this.bftMessageRateLimiter = new RateLimiter(
+      cfg.inboundBftRateLimitWindowMs ?? 60_000,
+      cfg.inboundBftRateLimitMaxRequests ?? 1200,
+    )
     setInterval(() => this.inboundRateLimiter.cleanup(), 300_000).unref()
     setInterval(() => this.stateSnapshotRateLimiter.cleanup(), 300_000).unref()
     setInterval(() => this.chainSnapshotRateLimiter.cleanup(), 300_000).unref()
+    setInterval(() => this.bftMessageRateLimiter.cleanup(), 300_000).unref()
     setInterval(() => this.authNonceTracker.cleanup(), 300_000).unref()
     if (cfg.authNonceRegistryPath) {
       setInterval(() => this.authNonceTracker.compact(), 60 * 60 * 1000).unref()
@@ -531,12 +558,20 @@ export class P2PNode {
         res.end(serializeJson({ error: "peer temporarily banned" }))
         return
       }
-      if ((req.url ?? "").startsWith("/p2p/") && !this.inboundRateLimiter.allow(clientIp)) {
-        this.rateLimitedRequests += 1
-        this.scoring.recordTimeout(inboundIpPeerId)
-        res.writeHead(429, { "content-type": "application/json" })
-        res.end(serializeJson({ error: "rate limit exceeded" }))
-        return
+      if (url.startsWith("/p2p/")) {
+        // Consensus messages use their own generous limiter so a tx-gossip
+        // burst on the shared budget can never throttle BFT into a deadlock.
+        const isBft = url === "/p2p/bft-message"
+        const limiter = isBft ? this.bftMessageRateLimiter : this.inboundRateLimiter
+        if (!limiter.allow(clientIp)) {
+          this.rateLimitedRequests += 1
+          // A throttled BFT message must never escalate to a peer ban — that
+          // would knock the validator off the consensus path entirely.
+          if (!isBft) this.scoring.recordTimeout(inboundIpPeerId)
+          res.writeHead(429, { "content-type": "application/json" })
+          res.end(serializeJson({ error: "rate limit exceeded" }))
+          return
+        }
       }
 
       if (req.method === "GET" && req.url === "/p2p/chain-snapshot") {

--- a/scripts/lib/probe-runtimes.ts
+++ b/scripts/lib/probe-runtimes.ts
@@ -1,0 +1,94 @@
+/**
+ * EVM runtime bytecode pool for COC stress / probe scripts.
+ *
+ * Captures the hand-assembled runtimes exercised during the 2026-05-17
+ * Ralph-loop stress session so they become reusable instead of being
+ * re-typed inline each run. All values are raw runtime hex (no 0x prefix);
+ * wrap with `wrapInitCode()` from ./wallet.ts before deploying.
+ */
+
+/** Static single-purpose runtimes, keyed by behaviour. */
+export const RUNTIMES: Readonly<Record<string, string>> = Object.freeze({
+  // returns the 32-byte word 0x2a
+  ret2a: "602a60005260206000f3",
+  // SSTORE 0x2a into slot 0, STOP
+  sstore: "602a60005500",
+  // slot0 = slot0 + 1, STOP  (call repeatedly to count)
+  counter: "60005460010160005500",
+  // emit LOG0 of a 32-byte word
+  log0: "602a60005260206000a000",
+  // returns block.timestamp
+  timestamp: "4260005260206000f3",
+  // returns block.number
+  number: "4360005260206000f3",
+  // returns msg.sender
+  caller: "3360005260206000f3",
+  // returns remaining gas
+  gasleft: "5a60005260206000f3",
+  // returns chainid
+  chainid: "4660005260206000f3",
+  // returns self balance
+  selfbalance: "4760005260206000f3",
+  // returns tx gasprice
+  gasprice: "3a60005260206000f3",
+  // returns tx.origin
+  origin: "3260005260206000f3",
+  // returns block.coinbase
+  coinbase: "4160005260206000f3",
+  // returns block gas limit
+  gaslimit: "4560005260206000f3",
+  // returns PREVRANDAO / difficulty
+  prevrandao: "4460005260206000f3",
+  // returns MSIZE
+  msize: "5960005260206000f3",
+  // returns calldatasize
+  calldatasize: "3660005260206000f3",
+  // unconditional REVERT with empty data
+  revert: "60006000fd",
+  // infinite JUMP loop — consumes all gas (OOG)
+  oogLoop: "5b600056",
+})
+
+/**
+ * Factory runtime: when invoked, internally CREATEs a child whose runtime is
+ * `ret2a`, and SSTOREs the child address into slot 0.
+ * Child init code is the 19-byte `wrapInitCode(ret2a)` packed into one PUSH32.
+ */
+export const FACTORY_RET2A: string =
+  "7f" +
+  "00".repeat(13) +
+  "600a8060093d393df3" + RUNTIMES.ret2a + // 19-byte child init
+  "6000" + "52" +   // MSTORE word @0
+  "6013" + "600d" + "6000" + // length=19, offset=13, value=0
+  "f0" +             // CREATE
+  "6000" + "55" +   // SSTORE child addr -> slot 0
+  "00"               // STOP
+
+/**
+ * Build a compute-heavy runtime: a bounded loop running `iterations` rounds of
+ * KECCAK256 over a 32-byte memory word. Useful for gas-metering / compute-load
+ * probes. `iterations` must be 1..65535.
+ */
+export function buildComputeLoop(iterations: number): string {
+  if (!Number.isInteger(iterations) || iterations < 1 || iterations > 65535) {
+    throw new Error(`iterations out of range (1..65535): ${iterations}`)
+  }
+  const count = iterations.toString(16).padStart(4, "0")
+  // PUSH2 count; JUMPDEST(pc3); PUSH1 32; PUSH1 0; SHA3; PUSH1 0; MSTORE;
+  // PUSH1 1; SWAP1; SUB; DUP1; PUSH2 0x0003; JUMPI; STOP
+  return "61" + count + "5b" + "6020" + "6000" + "20" + "6000" + "52" +
+    "6001" + "90" + "03" + "80" + "6003" + "57" + "00"
+}
+
+/** Build a SELFDESTRUCT runtime that sends the balance to `beneficiary`. */
+export function buildSelfdestruct(beneficiary: string): string {
+  const addr = beneficiary.replace(/^0x/, "").toLowerCase()
+  if (addr.length !== 40) throw new Error(`bad beneficiary address: ${beneficiary}`)
+  return "73" + addr + "ff" // PUSH20 <addr> SELFDESTRUCT
+}
+
+/** Pick `n` distinct runtime names at random (for random-combo stress runs). */
+export function pickRuntimes(n: number): string[] {
+  const names = Object.keys(RUNTIMES)
+  return names.sort(() => Math.random() - 0.5).slice(0, Math.min(n, names.length))
+}

--- a/scripts/lib/rpc-helper.ts
+++ b/scripts/lib/rpc-helper.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared JSON-RPC helper for COC stress / probe scripts.
+ *
+ * Consolidates the ad-hoc `rpc()` fetch wrappers previously duplicated across
+ * scripts/stress-advanced.ts, scripts/tps-benchmark.ts and the throwaway
+ * Ralph-loop probes. Pure functions, no shared mutable state.
+ */
+
+export interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0"
+  id: number
+  result?: T
+  error?: { code: number; message: string; data?: unknown }
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+/**
+ * Raw JSON-RPC call. Returns the full envelope (result OR error).
+ * Throws only on network / non-JSON failure.
+ */
+export async function rpc<T = unknown>(
+  url: string,
+  method: string,
+  params: unknown[] = [],
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<JsonRpcResponse<T>> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+  const text = await res.text()
+  try {
+    return JSON.parse(text) as JsonRpcResponse<T>
+  } catch {
+    throw new Error(`non-JSON RPC response (http ${res.status}): ${text.slice(0, 120)}`)
+  }
+}
+
+/** JSON-RPC call that returns `.result` or throws on `.error`. */
+export async function rpcResult<T = unknown>(
+  url: string,
+  method: string,
+  params: unknown[] = [],
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<T> {
+  const r = await rpc<T>(url, method, params, timeoutMs)
+  if (r.error) {
+    throw new Error(`RPC ${method} error ${r.error.code}: ${r.error.message}`)
+  }
+  if (r.result === undefined) {
+    throw new Error(`RPC ${method} returned neither result nor error`)
+  }
+  return r.result
+}
+
+/** Current head block number as a JS number. */
+export async function getHead(url: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<number> {
+  const hex = await rpcResult<string>(url, "eth_blockNumber", [], timeoutMs)
+  return parseInt(hex, 16)
+}
+
+/** Best-effort head; returns null instead of throwing (for monitoring loops). */
+export async function tryGetHead(url: string, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<number | null> {
+  try {
+    return await getHead(url, timeoutMs)
+  } catch {
+    return null
+  }
+}
+
+export interface HeadSkew {
+  heads: Record<string, number | null>
+  reachable: number
+  /** max - min across reachable nodes; null if <2 reachable. */
+  skew: number | null
+}
+
+/** Query several endpoints and report head divergence (cross-node consistency). */
+export async function crossCheckHeads(urls: string[], timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<HeadSkew> {
+  const entries = await Promise.all(
+    urls.map(async (u) => [u, await tryGetHead(u, timeoutMs)] as const),
+  )
+  const heads: Record<string, number | null> = {}
+  for (const [u, h] of entries) heads[u] = h
+  const live = entries.map(([, h]) => h).filter((h): h is number => h !== null)
+  return {
+    heads,
+    reachable: live.length,
+    skew: live.length >= 2 ? Math.max(...live) - Math.min(...live) : null,
+  }
+}
+
+export interface TxReceipt {
+  blockNumber: string
+  status: string
+  gasUsed: string
+  cumulativeGasUsed: string
+  effectiveGasPrice?: string
+  contractAddress: string | null
+  logs: unknown[]
+  logsBloom: string
+}
+
+/** Poll `eth_getTransactionReceipt` until mined or the deadline passes. */
+export async function waitForReceipt(
+  url: string,
+  hash: string,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<TxReceipt | null> {
+  const timeoutMs = opts.timeoutMs ?? 60_000
+  const pollMs = opts.pollMs ?? 1_500
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const r = await rpc<TxReceipt | null>(url, "eth_getTransactionReceipt", [hash])
+    if (r.result) return r.result
+    await new Promise((res) => setTimeout(res, pollMs))
+  }
+  return null
+}

--- a/scripts/lib/wallet.ts
+++ b/scripts/lib/wallet.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared wallet / bytecode helpers for COC stress / probe scripts.
+ *
+ * Consolidates the signing + init-wrapper logic previously duplicated across
+ * scripts/tps-benchmark.ts (signTx / signDeployTx) and the Ralph-loop probes.
+ */
+
+import { ethers, Wallet, Transaction, HDNodeWallet, JsonRpcProvider } from "ethers"
+
+/** Hardhat / anvil deterministic dev mnemonic — funded on COC test chains. */
+export const TEST_MNEMONIC =
+  "test test test test test test test test test test test junk"
+
+/** Hardhat account #0 private key (10M ETH on COC genesis). */
+export const FUNDED_PK =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+/** Derive an HD wallet at the standard path, connected to `provider`. */
+export function hdWallet(provider: JsonRpcProvider, index = 0): HDNodeWallet {
+  return HDNodeWallet.fromPhrase(
+    TEST_MNEMONIC,
+    undefined,
+    `m/44'/60'/0'/0/${index}`,
+  ).connect(provider)
+}
+
+/**
+ * Wrap runtime bytecode in a minimal CODECOPY init stub so it can be deployed.
+ *   small (<256 B): `60<len> 80 6009 3d39 3d 3df3` + runtime
+ *   large (≥256 B): PUSH2 length variant `61<len2> 80 600a 3d39 3d 3df3` + runtime
+ */
+export function wrapInitCode(runtime: string): string {
+  const rt = runtime.replace(/^0x/, "")
+  const len = rt.length / 2
+  if (!Number.isInteger(len)) throw new Error("runtime hex has odd length")
+  if (len < 256) {
+    const lenHex = len.toString(16).padStart(2, "0")
+    return "0x60" + lenHex + "8060093d393df3" + rt
+  }
+  if (len < 65536) {
+    const lenHex = len.toString(16).padStart(4, "0")
+    return "0x61" + lenHex + "80600a3d393df3" + rt
+  }
+  throw new Error(`runtime too large to wrap: ${len} bytes`)
+}
+
+/** Sign a value-transfer tx (legacy type-0). */
+export function signTransfer(
+  wallet: Wallet | HDNodeWallet,
+  opts: { nonce: number; to: string; value?: bigint; chainId: number; gasLimit?: bigint; gasPrice?: bigint },
+): string {
+  const tx = Transaction.from({
+    to: opts.to,
+    value: opts.value ?? 0n,
+    nonce: opts.nonce,
+    gasLimit: opts.gasLimit ?? 21000n,
+    gasPrice: opts.gasPrice ?? 2_000_000_000n,
+    chainId: opts.chainId,
+    data: "0x",
+  })
+  return finalize(wallet, tx)
+}
+
+/** Sign a contract-creation tx from already-wrapped init code. */
+export function signDeploy(
+  wallet: Wallet | HDNodeWallet,
+  opts: { nonce: number; initCode: string; chainId: number; gasLimit?: bigint; gasPrice?: bigint },
+): string {
+  const tx = Transaction.from({
+    nonce: opts.nonce,
+    gasLimit: opts.gasLimit ?? 300_000n,
+    gasPrice: opts.gasPrice ?? 2_000_000_000n,
+    chainId: opts.chainId,
+    data: opts.initCode,
+  })
+  return finalize(wallet, tx)
+}
+
+/** Sign a contract-call tx (type-0). */
+export function signCall(
+  wallet: Wallet | HDNodeWallet,
+  opts: { nonce: number; to: string; data?: string; value?: bigint; chainId: number; gasLimit?: bigint; gasPrice?: bigint },
+): string {
+  const tx = Transaction.from({
+    to: opts.to,
+    data: opts.data ?? "0x",
+    value: opts.value ?? 0n,
+    nonce: opts.nonce,
+    gasLimit: opts.gasLimit ?? 100_000n,
+    gasPrice: opts.gasPrice ?? 2_000_000_000n,
+    chainId: opts.chainId,
+  })
+  return finalize(wallet, tx)
+}
+
+function finalize(wallet: Wallet | HDNodeWallet, tx: Transaction): string {
+  const signed = wallet.signingKey.sign(tx.unsignedHash)
+  const clone = tx.clone()
+  clone.signature = signed
+  return clone.serialized
+}
+
+/** Deterministic CREATE address for `from` at `nonce` (re-export for convenience). */
+export function createAddress(from: string, nonce: number): string {
+  return ethers.getCreateAddress({ from, nonce })
+}

--- a/tests/e2e/ipfs-e2e-extended.test.ts
+++ b/tests/e2e/ipfs-e2e-extended.test.ts
@@ -1,0 +1,768 @@
+/**
+ * IPFS End-to-End Tests — Extended Coverage
+ *
+ * Companion suite to ipfs-e2e.test.ts. Covers functionality the base suite
+ * does not exercise end-to-end over HTTP:
+ *   1. Admin auth gate (block/rm, repo/gc, pin/rm) — loopback vs. token vs.
+ *      anonymous non-loopback caller.
+ *   2. Gateway HTTP Range (206 partial content) + HEAD parity.
+ *   3. Concurrent /api/v0/add uploads — unique CIDs, all independently catable.
+ *   4. MFS round-trip — mkdir → write → read → ls → stat → rm.
+ *   5. Pubsub round-trip — publish reaches a subscriber.
+ *
+ * Same conventions as the base suite: node:test, node:assert/strict, explicit
+ * .ts import extensions, random ports, tmpdir cleanup.
+ */
+
+import { describe, it, before, after } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { networkInterfaces } from "node:os"
+import { CID } from "multiformats/cid"
+import { sha256 } from "multiformats/hashes/sha2"
+import { IpfsBlockstore } from "../../node/src/ipfs-blockstore.ts"
+import { UnixFsBuilder } from "../../node/src/ipfs-unixfs.ts"
+import { IpfsHttpServer } from "../../node/src/ipfs-http.ts"
+import { IpfsMfs } from "../../node/src/ipfs-mfs.ts"
+import { IpfsPubsub } from "../../node/src/ipfs-pubsub.ts"
+
+function multipart(
+  filename: string,
+  content: string,
+): { body: string; contentType: string } {
+  const boundary =
+    "----E2EBound" + Date.now() + Math.random().toString(36).slice(2, 8)
+  const body = [
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="file"; filename="${filename}"`,
+    "Content-Type: application/octet-stream",
+    "",
+    content,
+    `--${boundary}--`,
+    "",
+  ].join("\r\n")
+  return { body, contentType: `multipart/form-data; boundary=${boundary}` }
+}
+
+function randomPort(): number {
+  return 30000 + Math.floor(Math.random() * 10000)
+}
+
+/**
+ * Compute a genuine raw-block CIDv1 (codec=0x55, sha-256) for the given
+ * bytes — the same encoding `storeRawBlock` uses — WITHOUT putting it in
+ * any blockstore. The result is a syntactically valid, fully-decodable
+ * CID that is guaranteed missing from a fresh server, so a gateway probe
+ * exercises the 404 (block-not-found) path rather than the 400
+ * (invalid-CID) path.
+ */
+async function unstoredRawCid(bytes: Uint8Array): Promise<string> {
+  const digest = await sha256.digest(bytes)
+  return CID.createV1(0x55, digest).toString()
+}
+
+/**
+ * First non-internal IPv4 address of the host, or null when the machine
+ * only has loopback. The admin auth gate (#344) treats loopback as always
+ * authorized, so exercising the token branch over HTTP requires connecting
+ * via a non-loopback address.
+ */
+function firstNonLoopbackIPv4(): string | null {
+  for (const addrs of Object.values(networkInterfaces())) {
+    for (const a of addrs ?? []) {
+      if (a.family === "IPv4" && !a.internal) return a.address
+    }
+  }
+  return null
+}
+
+// ── 1. Admin Auth Gate ────────────────────────────────────────────────
+//
+// #344/#460: block/rm, repo/gc and pin/rm are state-destroying. The gate
+// in isIpfsAdminAuthorized() allows: (a) any loopback caller, OR (b) a
+// non-loopback caller presenting a matching X-COC-IPFS-Admin-Token header
+// when adminAuthToken is configured. A non-loopback caller without a valid
+// token gets 403.
+//
+// To drive the non-loopback branch over real HTTP we bind to 0.0.0.0 and
+// connect via the host's LAN IP — req.socket.remoteAddress is then the
+// non-loopback address (it is NOT spoofable via headers).
+
+describe("IPFS E2E Extended — Admin Auth Gate", () => {
+  const GATED_ROUTES = [
+    "/api/v0/block/rm",
+    "/api/v0/repo/gc",
+    "/api/v0/pin/rm",
+  ]
+  const lanIp = firstNonLoopbackIPv4()
+
+  let tmpDir: string
+  let server: IpfsHttpServer
+  let loopbackBase: string
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-auth-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+
+    const port = randomPort()
+    loopbackBase = `http://127.0.0.1:${port}`
+
+    // Bind to 0.0.0.0 so the server is reachable both via loopback and,
+    // when available, via the host LAN IP (non-loopback).
+    server = new IpfsHttpServer(
+      {
+        bind: "0.0.0.0",
+        port,
+        storageDir: tmpDir,
+        nodeId: "e2e-auth-node",
+        adminAuthToken: "e2e-secret-token-abc",
+      },
+      store,
+      unixfs,
+    )
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+  })
+
+  after(async () => {
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  /** Upload a file via /api/v0/add and return its CID. */
+  async function addFile(content: string): Promise<string> {
+    const { body, contentType } = multipart("admin.txt", content)
+    const res = await fetch(`${loopbackBase}/api/v0/add`, {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body,
+    })
+    const json = (await res.json()) as Record<string, string>
+    return json.Hash
+  }
+
+  it("loopback caller is allowed on all gated routes (succeeds, not 403)", async () => {
+    // pin/rm requires a genuinely-pinned CID (kubo parity: 404 if not
+    // pinned), so upload + pin one first. block/rm + repo/gc are
+    // idempotent and 200 regardless.
+    const pinCid = await addFile(`admin-pin-${Math.random()}`)
+    const pinAddRes = await fetch(
+      `${loopbackBase}/api/v0/pin/add?arg=${pinCid}`,
+      { method: "POST" },
+    )
+    assert.equal(pinAddRes.status, 200, "pin/add precondition must succeed")
+
+    const blockCid = await addFile(`admin-block-${Math.random()}`)
+
+    const probes: Array<{ route: string; url: string }> = [
+      { route: "/api/v0/pin/rm", url: `${loopbackBase}/api/v0/pin/rm?arg=${pinCid}` },
+      { route: "/api/v0/block/rm", url: `${loopbackBase}/api/v0/block/rm?arg=${blockCid}` },
+      { route: "/api/v0/repo/gc", url: `${loopbackBase}/api/v0/repo/gc` },
+    ]
+    for (const { route, url } of probes) {
+      const res = await fetch(url, { method: "POST" })
+      assert.notEqual(
+        res.status,
+        403,
+        `loopback must not be forbidden on ${route}`,
+      )
+      assert.equal(res.status, 200, `loopback should succeed on ${route}`)
+    }
+  })
+
+  it("non-loopback caller without token gets 403 on all gated routes", async (t) => {
+    if (!lanIp) {
+      t.skip("no non-loopback IPv4 interface available on this host")
+      return
+    }
+    const lanBase = `http://${lanIp}:${server["cfg"].port}`
+    for (const route of GATED_ROUTES) {
+      const url =
+        route === "/api/v0/repo/gc"
+          ? `${lanBase}${route}`
+          : `${lanBase}${route}?arg=bafkreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+      const res = await fetch(url, { method: "POST" })
+      assert.equal(res.status, 403, `non-loopback must be 403 on ${route}`)
+      const json = (await res.json()) as { error: string }
+      assert.equal(json.error, "forbidden", `error code mismatch on ${route}`)
+    }
+  })
+
+  it("non-loopback caller with wrong token gets 403", async (t) => {
+    if (!lanIp) {
+      t.skip("no non-loopback IPv4 interface available on this host")
+      return
+    }
+    const lanBase = `http://${lanIp}:${server["cfg"].port}`
+    for (const route of GATED_ROUTES) {
+      const url =
+        route === "/api/v0/repo/gc"
+          ? `${lanBase}${route}`
+          : `${lanBase}${route}?arg=bafkreiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "x-coc-ipfs-admin-token": "totally-wrong-token" },
+      })
+      assert.equal(res.status, 403, `wrong token must be 403 on ${route}`)
+    }
+  })
+
+  it("non-loopback caller with correct token succeeds on all gated routes", async (t) => {
+    if (!lanIp) {
+      t.skip("no non-loopback IPv4 interface available on this host")
+      return
+    }
+    const lanBase = `http://${lanIp}:${server["cfg"].port}`
+    // Real CIDs so the handler bodies (not just the gate) succeed:
+    // pin/rm needs a pinned CID, block/rm needs a present block.
+    const pinCid = await addFile(`token-pin-${Math.random()}`)
+    await fetch(`${loopbackBase}/api/v0/pin/add?arg=${pinCid}`, {
+      method: "POST",
+    })
+    const blockCid = await addFile(`token-block-${Math.random()}`)
+
+    const probes: Array<{ route: string; url: string }> = [
+      { route: "/api/v0/pin/rm", url: `${lanBase}/api/v0/pin/rm?arg=${pinCid}` },
+      { route: "/api/v0/block/rm", url: `${lanBase}/api/v0/block/rm?arg=${blockCid}` },
+      { route: "/api/v0/repo/gc", url: `${lanBase}/api/v0/repo/gc` },
+    ]
+    for (const { route, url } of probes) {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "x-coc-ipfs-admin-token": "e2e-secret-token-abc" },
+      })
+      assert.equal(
+        res.status,
+        200,
+        `correct token must succeed on ${route}, got ${res.status}`,
+      )
+    }
+  })
+})
+
+describe("IPFS E2E Extended — Admin Auth Gate (no token configured)", () => {
+  // Without adminAuthToken configured, the gate is loopback-only: a
+  // non-loopback caller is always 403 regardless of any header it sends.
+  const lanIp = firstNonLoopbackIPv4()
+  let tmpDir: string
+  let server: IpfsHttpServer
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-notoken-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+    const port = randomPort()
+    server = new IpfsHttpServer(
+      { bind: "0.0.0.0", port, storageDir: tmpDir, nodeId: "e2e-notoken-node" },
+      store,
+      unixfs,
+    )
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+  })
+
+  after(async () => {
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("non-loopback caller is 403 even when presenting a token header", async (t) => {
+    if (!lanIp) {
+      t.skip("no non-loopback IPv4 interface available on this host")
+      return
+    }
+    const lanBase = `http://${lanIp}:${server["cfg"].port}`
+    const res = await fetch(`${lanBase}/api/v0/repo/gc`, {
+      method: "POST",
+      headers: { "x-coc-ipfs-admin-token": "anything" },
+    })
+    assert.equal(res.status, 403)
+  })
+
+  it("loopback caller still succeeds with no token configured", async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${server["cfg"].port}/api/v0/repo/gc`,
+      { method: "POST" },
+    )
+    assert.equal(res.status, 200)
+  })
+})
+
+// ── 2. Gateway HTTP Range + HEAD ──────────────────────────────────────
+
+describe("IPFS E2E Extended — Gateway Range + HEAD", () => {
+  let tmpDir: string
+  let server: IpfsHttpServer
+  let base: string
+  let cid: string
+  // 64 distinct bytes so partial slices are unambiguous.
+  const content = Array.from({ length: 64 }, (_, i) =>
+    String.fromCharCode(65 + (i % 26)),
+  ).join("")
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-range-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+    const port = randomPort()
+    base = `http://127.0.0.1:${port}`
+    server = new IpfsHttpServer(
+      { bind: "127.0.0.1", port, storageDir: tmpDir, nodeId: "e2e-range-node" },
+      store,
+      unixfs,
+    )
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+
+    const { body, contentType } = multipart("range.txt", content)
+    const res = await fetch(`${base}/api/v0/add`, {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body,
+    })
+    const json = (await res.json()) as Record<string, string>
+    cid = json.Hash
+  })
+
+  after(async () => {
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("Range bytes=N-M returns 206 with the exact partial body", async () => {
+    const res = await fetch(`${base}/ipfs/${cid}`, {
+      headers: { Range: "bytes=10-19" },
+    })
+    assert.equal(res.status, 206)
+    assert.equal(
+      res.headers.get("content-range"),
+      `bytes 10-19/${content.length}`,
+    )
+    assert.equal(res.headers.get("accept-ranges"), "bytes")
+    const text = await res.text()
+    assert.equal(text, content.slice(10, 20))
+    assert.equal(text.length, 10)
+  })
+
+  it("open-ended Range bytes=N- returns 206 to end of file", async () => {
+    const res = await fetch(`${base}/ipfs/${cid}`, {
+      headers: { Range: "bytes=50-" },
+    })
+    assert.equal(res.status, 206)
+    assert.equal(
+      res.headers.get("content-range"),
+      `bytes 50-${content.length - 1}/${content.length}`,
+    )
+    assert.equal(await res.text(), content.slice(50))
+  })
+
+  it("suffix Range bytes=-N returns 206 with the last N bytes", async () => {
+    const res = await fetch(`${base}/ipfs/${cid}`, {
+      headers: { Range: "bytes=-8" },
+    })
+    assert.equal(res.status, 206)
+    assert.equal(await res.text(), content.slice(-8))
+  })
+
+  it("unsatisfiable Range (start past EOF) returns 416", async () => {
+    const res = await fetch(`${base}/ipfs/${cid}`, {
+      headers: { Range: `bytes=${content.length + 100}-` },
+    })
+    assert.equal(res.status, 416)
+    assert.equal(
+      res.headers.get("content-range"),
+      `bytes */${content.length}`,
+    )
+  })
+
+  it("HEAD mirrors GET headers without a body", async () => {
+    const getRes = await fetch(`${base}/ipfs/${cid}`)
+    const getBody = await getRes.text()
+    assert.equal(getRes.status, 200)
+
+    const headRes = await fetch(`${base}/ipfs/${cid}`, { method: "HEAD" })
+    assert.equal(headRes.status, 200)
+    // HEAD must carry the same framing headers as GET...
+    assert.equal(
+      headRes.headers.get("content-length"),
+      getRes.headers.get("content-length"),
+    )
+    assert.equal(
+      headRes.headers.get("content-type"),
+      getRes.headers.get("content-type"),
+    )
+    assert.equal(
+      headRes.headers.get("accept-ranges"),
+      getRes.headers.get("accept-ranges"),
+    )
+    assert.equal(
+      headRes.headers.get("content-length"),
+      String(getBody.length),
+    )
+    // ...but no body.
+    const headBody = await headRes.text()
+    assert.equal(headBody, "")
+  })
+
+  it("HEAD on a missing CID returns 404 with no body", async () => {
+    // A genuine, fully-decodable raw-block CID whose bytes were never
+    // stored — exercises the 404 not-found path (not the 400 invalid-CID
+    // path that a malformed CID string would hit).
+    const missing = await unstoredRawCid(
+      new TextEncoder().encode(`never-stored-${Math.random()}`),
+    )
+    const res = await fetch(`${base}/ipfs/${missing}`, { method: "HEAD" })
+    assert.equal(res.status, 404)
+    assert.equal(await res.text(), "")
+  })
+})
+
+// ── 3. Concurrent Uploads ─────────────────────────────────────────────
+
+describe("IPFS E2E Extended — Concurrent Uploads", () => {
+  let tmpDir: string
+  let server: IpfsHttpServer
+  let base: string
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-concurrent-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+    const port = randomPort()
+    base = `http://127.0.0.1:${port}`
+    server = new IpfsHttpServer(
+      { bind: "127.0.0.1", port, storageDir: tmpDir, nodeId: "e2e-concurrent-node" },
+      store,
+      unixfs,
+    )
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+  })
+
+  after(async () => {
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("10 parallel /api/v0/add calls each yield a unique, retrievable CID", async () => {
+    const N = 10
+    const contents = Array.from(
+      { length: N },
+      (_, i) => `concurrent-upload-payload-#${i}-${Math.random().toString(36).slice(2)}`,
+    )
+
+    // Fire all uploads in parallel.
+    const addResults = await Promise.all(
+      contents.map(async (content, i) => {
+        const { body, contentType } = multipart(`file-${i}.txt`, content)
+        const res = await fetch(`${base}/api/v0/add`, {
+          method: "POST",
+          headers: { "content-type": contentType },
+          body,
+        })
+        assert.equal(res.status, 200, `upload ${i} should succeed`)
+        const json = (await res.json()) as Record<string, string>
+        assert.ok(json.Hash, `upload ${i} must return a Hash`)
+        return json.Hash
+      }),
+    )
+
+    // Distinct contents → distinct CIDs.
+    const uniqueCids = new Set(addResults)
+    assert.equal(
+      uniqueCids.size,
+      N,
+      `expected ${N} unique CIDs, got ${uniqueCids.size}`,
+    )
+
+    // Each CID independently retrievable with the exact original bytes.
+    await Promise.all(
+      addResults.map(async (cid, i) => {
+        const res = await fetch(`${base}/api/v0/cat?arg=${cid}`, {
+          method: "POST",
+        })
+        assert.equal(res.status, 200, `cat of upload ${i} should succeed`)
+        assert.equal(await res.text(), contents[i], `cat ${i} content mismatch`)
+      }),
+    )
+  })
+
+  it("identical concurrent uploads dedupe to the same CID", async () => {
+    // Content-addressing: the same bytes must always yield the same CID,
+    // even across simultaneous uploads.
+    const content = "identical-payload-for-dedup-check"
+    const cids = await Promise.all(
+      Array.from({ length: 5 }, async () => {
+        const { body, contentType } = multipart("dup.txt", content)
+        const res = await fetch(`${base}/api/v0/add`, {
+          method: "POST",
+          headers: { "content-type": contentType },
+          body,
+        })
+        const json = (await res.json()) as Record<string, string>
+        return json.Hash
+      }),
+    )
+    assert.equal(new Set(cids).size, 1, "identical content must share one CID")
+  })
+})
+
+// ── 4. MFS Round-Trip ─────────────────────────────────────────────────
+
+describe("IPFS E2E Extended — MFS Round-Trip", () => {
+  let tmpDir: string
+  let server: IpfsHttpServer
+  let base: string
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-mfs-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+    const mfs = new IpfsMfs(store, unixfs)
+    const port = randomPort()
+    base = `http://127.0.0.1:${port}`
+    server = new IpfsHttpServer(
+      { bind: "127.0.0.1", port, storageDir: tmpDir, nodeId: "e2e-mfs-node" },
+      store,
+      unixfs,
+    )
+    server.attachSubsystems({ mfs })
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+  })
+
+  after(async () => {
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("full lifecycle: mkdir → write → read → ls → stat → rm", async () => {
+    const dir = "/e2e-roundtrip"
+    const filePath = `${dir}/doc.txt`
+    const payload = "mfs round-trip payload"
+
+    // mkdir (with parents)
+    const mkdirRes = await fetch(
+      `${base}/api/v0/files/mkdir?arg=${dir}&parents=true`,
+      { method: "POST" },
+    )
+    assert.equal(mkdirRes.status, 200, "mkdir should succeed")
+
+    // write
+    const writeRes = await fetch(
+      `${base}/api/v0/files/write?arg=${filePath}&create=true`,
+      { method: "POST", body: new TextEncoder().encode(payload) },
+    )
+    assert.equal(writeRes.status, 200, "write should succeed")
+
+    // read back
+    const readRes = await fetch(
+      `${base}/api/v0/files/read?arg=${filePath}`,
+      { method: "POST" },
+    )
+    assert.equal(readRes.status, 200, "read should succeed")
+    assert.equal(await readRes.text(), payload, "read content mismatch")
+
+    // ls the directory — file must appear
+    const lsRes = await fetch(`${base}/api/v0/files/ls?arg=${dir}`, {
+      method: "POST",
+    })
+    assert.equal(lsRes.status, 200, "ls should succeed")
+    const lsJson = (await lsRes.json()) as {
+      Entries: Array<{ Name: string; Type: number; Size: number }>
+    }
+    const entry = lsJson.Entries.find((e) => e.Name === "doc.txt")
+    assert.ok(entry, "ls must list the written file")
+    assert.equal(entry!.Type, 0, "file entry Type must be 0")
+
+    // stat the file — kubo-compat PascalCase shape
+    const statRes = await fetch(
+      `${base}/api/v0/files/stat?arg=${filePath}`,
+      { method: "POST" },
+    )
+    assert.equal(statRes.status, 200, "stat should succeed")
+    const statJson = (await statRes.json()) as Record<string, unknown>
+    assert.equal(statJson.Type, "file")
+    assert.equal(statJson.Size, payload.length, "stat Size must match payload")
+    assert.ok(statJson.Hash, "stat must return a Hash")
+
+    // rm the file
+    const rmRes = await fetch(
+      `${base}/api/v0/files/rm?arg=${filePath}`,
+      { method: "POST" },
+    )
+    assert.equal(rmRes.status, 200, "rm should succeed")
+
+    // ls again — directory must be empty
+    const lsAfterRes = await fetch(`${base}/api/v0/files/ls?arg=${dir}`, {
+      method: "POST",
+    })
+    assert.equal(lsAfterRes.status, 200)
+    const lsAfterJson = (await lsAfterRes.json()) as {
+      Entries: Array<{ Name: string }>
+    }
+    assert.equal(
+      lsAfterJson.Entries.length,
+      0,
+      "directory must be empty after rm",
+    )
+
+    // read of the removed file → 404
+    const readGoneRes = await fetch(
+      `${base}/api/v0/files/read?arg=${filePath}`,
+      { method: "POST" },
+    )
+    assert.equal(readGoneRes.status, 404, "read of removed file must be 404")
+  })
+
+  it("nested directories: mkdir -p then write deep, ls each level", async () => {
+    const deep = "/lvl1/lvl2/lvl3"
+    const mkdirRes = await fetch(
+      `${base}/api/v0/files/mkdir?arg=${deep}&parents=true`,
+      { method: "POST" },
+    )
+    assert.equal(mkdirRes.status, 200)
+
+    const writeRes = await fetch(
+      `${base}/api/v0/files/write?arg=${deep}/nested.txt&create=true`,
+      { method: "POST", body: new TextEncoder().encode("deep file") },
+    )
+    assert.equal(writeRes.status, 200)
+
+    // Each intermediate level should be listable.
+    for (const level of ["/lvl1", "/lvl1/lvl2", "/lvl1/lvl2/lvl3"]) {
+      const res = await fetch(`${base}/api/v0/files/ls?arg=${level}`, {
+        method: "POST",
+      })
+      assert.equal(res.status, 200, `ls ${level} should succeed`)
+    }
+
+    const readRes = await fetch(
+      `${base}/api/v0/files/read?arg=${deep}/nested.txt`,
+      { method: "POST" },
+    )
+    assert.equal(readRes.status, 200)
+    assert.equal(await readRes.text(), "deep file")
+  })
+})
+
+// ── 5. Pubsub Round-Trip ──────────────────────────────────────────────
+
+describe("IPFS E2E Extended — Pubsub Round-Trip", () => {
+  let tmpDir: string
+  let server: IpfsHttpServer
+  let base: string
+  let pubsub: IpfsPubsub
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ipfs-e2e-pubsub-"))
+    const store = new IpfsBlockstore(tmpDir)
+    await store.init()
+    const unixfs = new UnixFsBuilder(store)
+    pubsub = new IpfsPubsub({ nodeId: "e2e-pubsub-node" })
+    pubsub.start()
+    const port = randomPort()
+    base = `http://127.0.0.1:${port}`
+    server = new IpfsHttpServer(
+      { bind: "127.0.0.1", port, storageDir: tmpDir, nodeId: "e2e-pubsub-node" },
+      store,
+      unixfs,
+    )
+    server.attachSubsystems({ pubsub })
+    server.start()
+    await new Promise((r) => setTimeout(r, 200))
+  })
+
+  after(async () => {
+    pubsub.stop()
+    await server.stop()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("publish via HTTP delivers the message to a local subscriber", async () => {
+    const topic = "e2e-roundtrip-topic"
+    const received: string[] = []
+    const handler = (msg: { data: Uint8Array }) => {
+      received.push(new TextDecoder().decode(msg.data))
+    }
+    pubsub.subscribe(topic, handler)
+    try {
+      const res = await fetch(
+        `${base}/api/v0/pubsub/pub?arg=${topic}`,
+        { method: "POST", body: new TextEncoder().encode("round-trip message") },
+      )
+      assert.equal(res.status, 200)
+      const json = (await res.json()) as { ok: boolean }
+      assert.equal(json.ok, true)
+      // Subscribers run synchronously inside publish() in this impl.
+      assert.equal(received.length, 1, "subscriber must receive exactly one")
+      assert.equal(received[0], "round-trip message")
+    } finally {
+      pubsub.unsubscribe(topic, handler)
+    }
+  })
+
+  it("multiple subscribers on one topic all receive the publish", async () => {
+    const topic = "e2e-fanout-topic"
+    const seenA: string[] = []
+    const seenB: string[] = []
+    const handlerA = (msg: { data: Uint8Array }) =>
+      seenA.push(new TextDecoder().decode(msg.data))
+    const handlerB = (msg: { data: Uint8Array }) =>
+      seenB.push(new TextDecoder().decode(msg.data))
+    pubsub.subscribe(topic, handlerA)
+    pubsub.subscribe(topic, handlerB)
+    try {
+      const res = await fetch(
+        `${base}/api/v0/pubsub/pub?arg=${topic}`,
+        { method: "POST", body: new TextEncoder().encode("fanout payload") },
+      )
+      assert.equal(res.status, 200)
+      assert.deepEqual(seenA, ["fanout payload"])
+      assert.deepEqual(seenB, ["fanout payload"])
+    } finally {
+      pubsub.unsubscribe(topic, handlerA)
+      pubsub.unsubscribe(topic, handlerB)
+    }
+  })
+
+  it("pubsub/ls reports the active topic, and drops it after unsubscribe", async () => {
+    const topic = "e2e-ls-lifecycle-topic"
+    const handler = () => {}
+    pubsub.subscribe(topic, handler)
+
+    const lsRes = await fetch(`${base}/api/v0/pubsub/ls`, { method: "POST" })
+    assert.equal(lsRes.status, 200)
+    const lsJson = (await lsRes.json()) as { Strings: string[] }
+    assert.ok(
+      lsJson.Strings.includes(topic),
+      "ls must list the subscribed topic",
+    )
+
+    pubsub.unsubscribe(topic, handler)
+    const lsAfterRes = await fetch(`${base}/api/v0/pubsub/ls`, {
+      method: "POST",
+    })
+    const lsAfterJson = (await lsAfterRes.json()) as { Strings: string[] }
+    assert.ok(
+      !lsAfterJson.Strings.includes(topic),
+      "ls must drop the topic after the last unsubscribe",
+    )
+  })
+
+  it("publish to a topic with no subscribers still returns 200", async () => {
+    const res = await fetch(
+      `${base}/api/v0/pubsub/pub?arg=e2e-no-subscribers`,
+      { method: "POST", body: new TextEncoder().encode("into the void") },
+    )
+    assert.equal(res.status, 200)
+  })
+})

--- a/tests/integration/governance-treasury-spend.integration.test.ts
+++ b/tests/integration/governance-treasury-spend.integration.test.ts
@@ -1,0 +1,554 @@
+/**
+ * R2.2 — GovernanceDAO extended-coverage E2E (M8 follow-up)
+ *
+ * Complements governance-dao-lifecycle.integration.test.ts (which already
+ * covers: FactionRegistry HUMAN registration, a single-chamber FreeText
+ * propose→vote→queue→execute lifecycle, a Treasury ETH-spend execution via
+ * DAO.execute(), and the early-queue / double-execute revert guards).
+ *
+ * This file adds the governance paths NOT exercised there:
+ *   1. Treasury 5% spend cap + 3-of-5 multisig: a within-cap signer
+ *      withdrawal succeeds; an over-cap one reverts (ExceedsSpendingCap)
+ *      until the DAO grants governanceApprove via a real execute() call;
+ *      under-confirmed withdrawals revert (NotEnoughConfirmations).
+ *   2. Real bicameral voting: CLAW voters registered via FactionRegistry,
+ *      bicameralEnabled = true — a proposal passes only when BOTH chambers
+ *      reach approvalPercent, and is rejected when only one chamber does.
+ *   3. Rejection paths: a proposal with against-majority and a proposal
+ *      with sub-quorum turnout both end Rejected; queue() leaves them
+ *      un-queued and execute() reverts (NotQueued).
+ *   4. Parameter-change proposal: an execute()-driven call to
+ *      Treasury.governanceApprove flips on-chain state (governanceApproved
+ *      false → true), proving executionData parameter mutation works.
+ *
+ * Same hardhat-node-spawn pattern as governance-dao-lifecycle.integration.
+ */
+import assert from "node:assert/strict"
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { createServer } from "node:net"
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+import {
+  Contract,
+  ContractFactory,
+  Interface,
+  JsonRpcProvider,
+  Wallet,
+  ZeroAddress,
+  keccak256,
+  parseEther,
+  toUtf8Bytes,
+} from "ethers"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, "..", "..")
+const contractsDir = join(repoRoot, "contracts")
+const artifactsDir = join(contractsDir, "artifacts", "contracts-src", "governance")
+
+const hardhatCliRoot = join(repoRoot, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
+const hardhatCliContracts = join(contractsDir, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
+const hardhatCli = existsSync(hardhatCliRoot) ? hardhatCliRoot : hardhatCliContracts
+
+// Anvil 0..9 default keys (also what hardhat-node prefunds).
+const DEPLOYER_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+// Indices 1..4: HUMAN-chamber voters / Treasury multisig signers.
+const ANVIL_KEYS = [
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d", // 1
+  "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a", // 2
+  "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6", // 3
+  "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a", // 4
+  "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba", // 5
+  "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e", // 6
+  "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356", // 7
+  "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97", // 8
+  "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6", // 9
+]
+
+function loadArtifact(name: string): { abi: unknown[]; bytecode: string } {
+  const path = join(artifactsDir, `${name}.sol`, `${name}.json`)
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer()
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        server.close()
+        reject(new Error("failed to allocate free port"))
+        return
+      }
+      const { port } = address
+      server.close((err) => (err ? reject(err) : resolve(port)))
+    })
+    server.on("error", reject)
+  })
+}
+
+interface HardhatHandle {
+  process: ChildProcessWithoutNullStreams
+  url: string
+  stop: () => Promise<void>
+}
+
+async function startHardhatNode(port: number): Promise<HardhatHandle> {
+  if (!existsSync(hardhatCli)) {
+    throw new Error(`hardhat CLI not found at ${hardhatCliRoot} or ${hardhatCliContracts}; run npm install first`)
+  }
+  const child = spawn(process.execPath, [hardhatCli, "node", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: contractsDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  let output = ""
+  child.stdout.on("data", (c) => { output += String(c) })
+  child.stderr.on("data", (c) => { output += String(c) })
+
+  const url = `http://127.0.0.1:${port}`
+  const probe = new JsonRpcProvider(url)
+  const startedAt = Date.now()
+
+  try {
+    while (Date.now() - startedAt < 20_000) {
+      if (child.exitCode !== null) {
+        throw new Error(`hardhat exited early: code=${child.exitCode}\n${output}`)
+      }
+      try {
+        await probe.getBlockNumber()
+        return {
+          process: child,
+          url,
+          stop: async () => {
+            if (child.exitCode !== null) return
+            child.kill("SIGTERM")
+            await new Promise<void>((resolve) => {
+              const timer = setTimeout(() => {
+                if (child.exitCode === null) child.kill("SIGKILL")
+              }, 3_000)
+              child.once("exit", () => { clearTimeout(timer); resolve() })
+            })
+          },
+        }
+      } catch {
+        await new Promise((r) => setTimeout(r, 200))
+      }
+    }
+    child.kill("SIGKILL")
+    throw new Error(`hardhat did not start in time\n${output}`)
+  } finally {
+    probe.destroy()
+  }
+}
+
+/**
+ * Deploys FactionRegistry + GovernanceDAO + Treasury, shrinks the voting
+ * window to the 1-day minimum and sets timelock to 0, funds the Treasury,
+ * and returns ready-to-use contract handles bound to the deployer.
+ *
+ * The Treasury's 5 multisig signers are anvil wallets 0..4 (the deployer
+ * plus indices 1..3 and 4), so the 3-of-5 path is genuinely exercisable.
+ */
+async function deployGovernanceStack(provider: JsonRpcProvider) {
+  const deployer = new Wallet(DEPLOYER_KEY, provider)
+  let nonce = await provider.getTransactionCount(deployer.address)
+  const txOpts = (): { nonce: number } => ({ nonce: nonce++ })
+
+  const fr = await new ContractFactory(
+    loadArtifact("FactionRegistry").abi,
+    loadArtifact("FactionRegistry").bytecode,
+    deployer,
+  ).deploy(txOpts())
+  await fr.waitForDeployment()
+
+  const dao = await new ContractFactory(
+    loadArtifact("GovernanceDAO").abi,
+    loadArtifact("GovernanceDAO").bytecode,
+    deployer,
+  ).deploy(await fr.getAddress(), txOpts())
+  await dao.waitForDeployment()
+
+  // 5 real multisig signers: deployer + anvil 1..4.
+  const signerWallets = [deployer, ...ANVIL_KEYS.slice(0, 4).map((k) => new Wallet(k, provider))]
+  const signerAddrs = signerWallets.map((w) => w.address) as [string, string, string, string, string]
+  const treasury = await new ContractFactory(
+    loadArtifact("Treasury").abi,
+    loadArtifact("Treasury").bytecode,
+    deployer,
+  ).deploy(signerAddrs, await dao.getAddress(), txOpts())
+  await treasury.waitForDeployment()
+
+  await (await (dao.setTreasury(await treasury.getAddress(), txOpts()) as any)).wait()
+  await (await (dao.setVotingPeriod(86400, txOpts()) as any)).wait()
+  await (await (dao.setTimelockDelay(0, txOpts()) as any)).wait()
+
+  // Fund treasury with 100 ETH so cap math is round (cap = 5 ETH).
+  await (await deployer.sendTransaction({ to: await treasury.getAddress(), value: parseEther("100"), ...txOpts() })).wait()
+
+  return { deployer, txOpts, fr, dao, treasury, signerWallets }
+}
+
+/** Fast-forward the hardhat clock past the (already shrunk) voting window. */
+async function fastForwardPastVoting(provider: JsonRpcProvider): Promise<void> {
+  await provider.send("evm_increaseTime", [86401])
+  await provider.send("evm_mine", [])
+}
+
+/**
+ * Net balance change of `address` caused by the tx mined in `receipt`,
+ * measured at the receipt's block versus its parent. Explicit block tags
+ * sidestep ethers v6's "latest" balance caching, which can otherwise
+ * report a stale value immediately after tx.wait() resolves.
+ */
+async function balanceDeltaOf(
+  provider: JsonRpcProvider,
+  address: string,
+  receipt: { blockNumber: number },
+): Promise<bigint> {
+  const at = await provider.getBalance(address, receipt.blockNumber)
+  const before = await provider.getBalance(address, receipt.blockNumber - 1)
+  return at - before
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Scenario 1 — Treasury 5% spend cap + 3-of-5 multisig
+ * ──────────────────────────────────────────────────────────────────────── */
+test("Treasury: 3-of-5 multisig + 5% spend cap (within-cap ok, over-cap needs governance)",
+  { timeout: 120_000 },
+  async () => {
+    const port = await getFreePort()
+    const node = await startHardhatNode(port)
+    let provider: JsonRpcProvider | null = null
+    try {
+      provider = new JsonRpcProvider(node.url)
+      const { deployer, txOpts, fr, dao, treasury, signerWallets } = await deployGovernanceStack(provider)
+      const treasuryAddr = await treasury.getAddress()
+
+      // Prefund the 4 non-deployer signers so they can send confirmations.
+      for (const w of signerWallets.slice(1)) {
+        await (await deployer.sendTransaction({ to: w.address, value: parseEther("1"), ...txOpts() })).wait()
+      }
+      // Per-signer nonce tracker (each signer's first tx is nonce 0).
+      const signerNonce = new Map<string, number>()
+      const next = (w: Wallet): { nonce: number } => {
+        const n = signerNonce.get(w.address) ?? 0
+        signerNonce.set(w.address, n + 1)
+        return { nonce: n }
+      }
+      // deployer shares its tracked nonce with txOpts() — keep it consistent.
+      const proposeAs = signerWallets[0]! // deployer
+
+      // ── 1a. Within-cap withdrawal (cap = 5% of 100 = 5 ETH) ──────────────
+      // Recipient is a pure-numeric address — no EIP-55 checksum ambiguity.
+      const recipient = "0x0000000000000000000000000000000000001234"
+      const inCapAmount = parseEther("4") // < 5 ETH cap
+
+      // proposeWithdrawal from deployer counts confirmation #1.
+      await (await (treasury.connect(proposeAs).proposeWithdrawal(recipient, inCapAmount, txOpts()) as any)).wait()
+      const wId0 = 0n
+
+      // ── 1b. Under-confirmed execute reverts (only 1/3 confirmations) ─────
+      await assert.rejects(
+        () => treasury.connect(proposeAs).getFunction("executeWithdrawal").staticCall(wId0),
+        (err: Error) => /NotEnoughConfirmations|reverted/i.test(err.message),
+        "executeWithdrawal must revert with only 1 confirmation",
+      )
+
+      // Signers 1 and 2 confirm → reaches 3/5.
+      await (await (treasury.connect(signerWallets[1]!).confirmWithdrawal(wId0, next(signerWallets[1]!)) as any)).wait()
+      await (await (treasury.connect(signerWallets[2]!).confirmWithdrawal(wId0, next(signerWallets[2]!)) as any)).wait()
+
+      // Now 3/5 — within-cap withdrawal executes.
+      const execRcpt0 = await (await (treasury.connect(proposeAs).executeWithdrawal(wId0, txOpts()) as any)).wait()
+      assert.equal(
+        await balanceDeltaOf(provider, recipient, execRcpt0),
+        inCapAmount,
+        "recipient received within-cap 4 ETH",
+      )
+
+      // ── 1c. Over-cap withdrawal reverts even with 3/5 confirmations ──────
+      // Treasury balance is now 96 ETH → cap = 4.8 ETH. Request 20 ETH.
+      const overCapAmount = parseEther("20")
+      await (await (treasury.connect(proposeAs).proposeWithdrawal(recipient, overCapAmount, txOpts()) as any)).wait()
+      const wId1 = 1n
+      await (await (treasury.connect(signerWallets[1]!).confirmWithdrawal(wId1, next(signerWallets[1]!)) as any)).wait()
+      await (await (treasury.connect(signerWallets[2]!).confirmWithdrawal(wId1, next(signerWallets[2]!)) as any)).wait()
+
+      await assert.rejects(
+        () => treasury.connect(proposeAs).getFunction("executeWithdrawal").staticCall(wId1),
+        (err: Error) => /ExceedsSpendingCap|reverted/i.test(err.message),
+        "over-cap withdrawal must revert without governance approval",
+      )
+
+      // ── 1d. DAO grants governanceApprove via a real execute() proposal ──
+      await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
+      const approveData = treasuryIface.encodeFunctionData("governanceApprove", [wId1])
+      await (await (dao.connect(deployer).createProposal(
+        3, // ProposalType.TreasurySpend
+        "Approve over-cap Treasury withdrawal #1",
+        keccak256(toUtf8Bytes("governance ratifies the 20 ETH over-cap withdrawal")),
+        treasuryAddr,
+        approveData,
+        0,
+        txOpts(),
+      ) as any)).wait()
+      const proposalId = 1n
+      await (await (dao.connect(deployer).vote(proposalId, 1, txOpts()) as any)).wait()
+      await fastForwardPastVoting(provider)
+      await (await (dao.connect(deployer).queue(proposalId, txOpts()) as any)).wait()
+      await (await (dao.connect(deployer).execute(proposalId, txOpts()) as any)).wait()
+
+      // ── 1e. After governance approval the over-cap withdrawal succeeds ──
+      const execRcpt1 = await (await (treasury.connect(proposeAs).executeWithdrawal(wId1, txOpts()) as any)).wait()
+      assert.equal(
+        await balanceDeltaOf(provider, recipient, execRcpt1),
+        overCapAmount,
+        "over-cap 20 ETH paid after governance approval",
+      )
+    } finally {
+      provider?.destroy()
+      await node.stop()
+    }
+  })
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Scenario 2 — Real bicameral (two-chamber) voting
+ * ──────────────────────────────────────────────────────────────────────── */
+test("GovernanceDAO bicameral: passes only when BOTH HUMAN and CLAW chambers approve",
+  { timeout: 120_000 },
+  async () => {
+    const port = await getFreePort()
+    const node = await startHardhatNode(port)
+    let provider: JsonRpcProvider | null = null
+    try {
+      provider = new JsonRpcProvider(node.url)
+      const { deployer, txOpts, fr, dao } = await deployGovernanceStack(provider)
+
+      // Enable bicameral mode — both chambers must independently hit 60%.
+      await (await (dao.connect(deployer).setBicameralEnabled(true, txOpts()) as any)).wait()
+      assert.equal(await dao.bicameralEnabled(), true)
+
+      // 2 HUMAN voters (anvil 1,2) + 2 CLAW voters (anvil 3,4).
+      const humans = ANVIL_KEYS.slice(0, 2).map((k) => new Wallet(k, provider!))
+      const claws = ANVIL_KEYS.slice(2, 4).map((k) => new Wallet(k, provider!))
+      for (const w of [...humans, ...claws]) {
+        await (await deployer.sendTransaction({ to: w.address, value: parseEther("1"), ...txOpts() })).wait()
+      }
+      // deployer registers HUMAN too (3 HUMAN total).
+      await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      for (const w of humans) {
+        await (await (fr.connect(w).registerHuman({ nonce: 0 }) as any)).wait()
+      }
+      // CLAW registration needs an ECDSA attestation. FactionRegistry expects
+      // a signature recoverable to msg.sender over the eth-signed-message of
+      // keccak256(abi.encodePacked(agentId, msg.sender)). ethers' signMessage
+      // applies the "\x19Ethereum Signed Message:\n" prefix, so signing the
+      // raw 32-byte inner hash reproduces the contract's expectation exactly.
+      for (let i = 0; i < claws.length; i++) {
+        const w = claws[i]!
+        const agentId = keccak256(toUtf8Bytes(`coc-agent-${i}`))
+        // abi.encodePacked(bytes32, address) == 32-byte hash || 20-byte addr
+        const packed = agentId + w.address.slice(2).toLowerCase()
+        const innerHash = keccak256(packed)
+        const attestation = await w.signMessage(Buffer.from(innerHash.slice(2), "hex"))
+        await (await (fr.connect(w).registerClaw(agentId, attestation, { nonce: 0 }) as any)).wait()
+      }
+      assert.equal(await fr.humanCount(), 3n, "3 HUMAN registered")
+      assert.equal(await fr.clawCount(), 2n, "2 CLAW registered")
+
+      const proposalIface = (proposer: Wallet, title: string) =>
+        dao.connect(proposer).createProposal(
+          5, // FreeText — lifecycle only, no execution side effect
+          title,
+          keccak256(toUtf8Bytes(title)),
+          ZeroAddress,
+          "0x",
+          0,
+          txOpts(),
+        ) as any
+
+      // ── 2a. Only HUMAN chamber approves → bicameral FAILS ───────────────
+      // Proposal 1: all 3 HUMAN FOR, both CLAW AGAINST.
+      await (await proposalIface(deployer, "Bicameral: human-only support")).wait()
+      const p1 = 1n
+      await (await (dao.connect(deployer).vote(p1, 1, txOpts()) as any)).wait()
+      await (await (dao.connect(humans[0]!).vote(p1, 1, { nonce: 1 }) as any)).wait()
+      await (await (dao.connect(humans[1]!).vote(p1, 1, { nonce: 1 }) as any)).wait()
+      await (await (dao.connect(claws[0]!).vote(p1, 0, { nonce: 1 }) as any)).wait()
+      await (await (dao.connect(claws[1]!).vote(p1, 0, { nonce: 1 }) as any)).wait()
+
+      await fastForwardPastVoting(provider)
+      await (await (dao.connect(deployer).queue(p1, txOpts()) as any)).wait()
+      assert.equal(
+        await dao.getProposalState(p1),
+        2n, // Rejected
+        "human-only-approved proposal must be Rejected under bicameral",
+      )
+      await assert.rejects(
+        () => dao.getFunction("execute").staticCall(p1),
+        (err: Error) => /NotQueued|reverted/i.test(err.message),
+        "execute() must revert for a bicameral-rejected proposal",
+      )
+
+      // ── 2b. BOTH chambers approve → bicameral PASSES ────────────────────
+      // Proposal 2: all 3 HUMAN FOR, both CLAW FOR.
+      await (await proposalIface(deployer, "Bicameral: both chambers support")).wait()
+      const p2 = 2n
+      await (await (dao.connect(deployer).vote(p2, 1, txOpts()) as any)).wait()
+      await (await (dao.connect(humans[0]!).vote(p2, 1, { nonce: 2 }) as any)).wait()
+      await (await (dao.connect(humans[1]!).vote(p2, 1, { nonce: 2 }) as any)).wait()
+      await (await (dao.connect(claws[0]!).vote(p2, 1, { nonce: 2 }) as any)).wait()
+      await (await (dao.connect(claws[1]!).vote(p2, 1, { nonce: 2 }) as any)).wait()
+
+      await fastForwardPastVoting(provider)
+      await (await (dao.connect(deployer).queue(p2, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(p2), 3n, "both-chambers proposal must be Queued")
+      await (await (dao.connect(deployer).execute(p2, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(p2), 4n, "both-chambers proposal Executed")
+    } finally {
+      provider?.destroy()
+      await node.stop()
+    }
+  })
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Scenario 3 — Rejection paths (against-majority + sub-quorum)
+ * ──────────────────────────────────────────────────────────────────────── */
+test("GovernanceDAO rejection paths: against-majority and sub-quorum proposals cannot be enacted",
+  { timeout: 120_000 },
+  async () => {
+    const port = await getFreePort()
+    const node = await startHardhatNode(port)
+    let provider: JsonRpcProvider | null = null
+    try {
+      provider = new JsonRpcProvider(node.url)
+      const { deployer, txOpts, fr, dao } = await deployGovernanceStack(provider)
+
+      // 5 HUMAN voters: deployer + anvil 1..4 (single-chamber / simple majority).
+      const voters = ANVIL_KEYS.slice(0, 4).map((k) => new Wallet(k, provider!))
+      for (const w of voters) {
+        await (await deployer.sendTransaction({ to: w.address, value: parseEther("1"), ...txOpts() })).wait()
+      }
+      await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      for (const w of voters) {
+        await (await (fr.connect(w).registerHuman({ nonce: 0 }) as any)).wait()
+      }
+      assert.equal(await fr.humanCount(), 5n, "5 HUMAN registered")
+
+      const mkProposal = (title: string) =>
+        dao.connect(deployer).createProposal(
+          5, title, keccak256(toUtf8Bytes(title)), ZeroAddress, "0x", 0, txOpts(),
+        ) as any
+
+      // ── 3a. Against-majority: 5 votes cast (quorum met), 1 FOR / 4 AGAINST ─
+      await (await mkProposal("Rejection: against-majority")).wait()
+      const p1 = 1n
+      await (await (dao.connect(deployer).vote(p1, 1, txOpts()) as any)).wait() // FOR
+      for (const w of voters) {
+        await (await (dao.connect(w).vote(p1, 0, { nonce: 1 }) as any)).wait() // AGAINST
+      }
+      const totals1 = await dao.getVoteTotals(p1)
+      assert.equal(totals1[0], 1n, "1 forVotesHuman")
+      assert.equal(totals1[1], 4n, "4 againstVotesHuman")
+
+      await fastForwardPastVoting(provider)
+      // getProposalState should already report Rejected (approval 20% < 60%).
+      assert.equal(await dao.getProposalState(p1), 2n, "against-majority proposal Rejected pre-queue")
+      await (await (dao.connect(deployer).queue(p1, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(p1), 2n, "still Rejected after queue()")
+      await assert.rejects(
+        () => dao.getFunction("execute").staticCall(p1),
+        (err: Error) => /NotQueued|reverted/i.test(err.message),
+        "execute() must revert for an against-majority proposal",
+      )
+
+      // ── 3b. Sub-quorum: only 1 of 5 registered voters turns out (20% < 40%) ─
+      await (await mkProposal("Rejection: sub-quorum turnout")).wait()
+      const p2 = 2n
+      await (await (dao.connect(deployer).vote(p2, 1, txOpts()) as any)).wait() // single FOR vote
+      const totals2 = await dao.getVoteTotals(p2)
+      assert.equal(totals2[0], 1n, "1 forVotesHuman")
+
+      await fastForwardPastVoting(provider)
+      assert.equal(await dao.getProposalState(p2), 2n, "sub-quorum proposal Rejected (turnout below quorum)")
+      await (await (dao.connect(deployer).queue(p2, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(p2), 2n, "sub-quorum still Rejected after queue()")
+      await assert.rejects(
+        () => dao.getFunction("execute").staticCall(p2),
+        (err: Error) => /NotQueued|reverted/i.test(err.message),
+        "execute() must revert for a sub-quorum proposal",
+      )
+    } finally {
+      provider?.destroy()
+      await node.stop()
+    }
+  })
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Scenario 4 — Parameter-change proposal (executionData mutates on-chain state)
+ * ──────────────────────────────────────────────────────────────────────── */
+test("GovernanceDAO parameter-change: execute() runs executionData and mutates target state",
+  { timeout: 120_000 },
+  async () => {
+    const port = await getFreePort()
+    const node = await startHardhatNode(port)
+    let provider: JsonRpcProvider | null = null
+    try {
+      provider = new JsonRpcProvider(node.url)
+      const { deployer, txOpts, fr, dao, treasury, signerWallets } = await deployGovernanceStack(provider)
+      const treasuryAddr = await treasury.getAddress()
+
+      // Prepare an over-cap Treasury withdrawal proposal whose
+      // `governanceApproved` flag is the parameter the DAO will flip.
+      await (await deployer.sendTransaction({ to: signerWallets[1]!.address, value: parseEther("1"), ...txOpts() })).wait()
+      // Pure-numeric address — avoids EIP-55 checksum validation.
+      const recipient = "0x0000000000000000000000000000000000005678"
+      const overCap = parseEther("50") // > 5 ETH cap on 100 ETH balance
+      await (await (treasury.connect(deployer).proposeWithdrawal(recipient, overCap, txOpts()) as any)).wait()
+      const wId = 0n
+
+      // Read the parameter BEFORE the governance proposal executes.
+      // Treasury.proposals(id) returns the public-mapping tuple; the
+      // `governanceApproved` bool is the 5th field (index 4).
+      const treasuryReader = new Contract(treasuryAddr, loadArtifact("Treasury").abi as any, provider)
+      const preState = await treasuryReader.proposals(wId)
+      assert.equal(preState[4], false, "governanceApproved starts false")
+
+      // ── Governance proposal that calls Treasury.governanceApprove(wId) ──
+      await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
+      const execData = treasuryIface.encodeFunctionData("governanceApprove", [wId])
+
+      await (await (dao.connect(deployer).createProposal(
+        2, // ProposalType.ParameterChange
+        "ParameterChange: enable over-cap Treasury withdrawal #0",
+        keccak256(toUtf8Bytes("flip Treasury proposal #0 governanceApproved to true")),
+        treasuryAddr,
+        execData,
+        0,
+        txOpts(),
+      ) as any)).wait()
+      const proposalId = 1n
+
+      await (await (dao.connect(deployer).vote(proposalId, 1, txOpts()) as any)).wait()
+      await fastForwardPastVoting(provider)
+      await (await (dao.connect(deployer).queue(proposalId, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(proposalId), 3n, "parameter-change proposal Queued")
+
+      // Parameter is still unchanged until execute() runs.
+      const midState = await treasuryReader.proposals(wId)
+      assert.equal(midState[4], false, "governanceApproved still false before execute()")
+
+      await (await (dao.connect(deployer).execute(proposalId, txOpts()) as any)).wait()
+      assert.equal(await dao.getProposalState(proposalId), 4n, "parameter-change proposal Executed")
+
+      // ── Assert the parameter ACTUALLY changed on the target contract ────
+      const postState = await treasuryReader.proposals(wId)
+      assert.equal(postState[4], true, "governanceApproved flipped to true by execute()")
+    } finally {
+      provider?.destroy()
+      await node.stop()
+    }
+  })

--- a/tests/integration/pose-v2-settlement.integration.test.ts
+++ b/tests/integration/pose-v2-settlement.integration.test.ts
@@ -1,0 +1,755 @@
+/**
+ * PoSe v2 settlement — hardhat-node integration tests (non-docker)
+ *
+ * Deepens coverage of currently-thin areas of PoSeManagerV2.sol that the
+ * existing contract-level hardhat suite (contracts/test/pose-v2*.test.cjs)
+ * and the off-chain pipeline tests do NOT exercise:
+ *
+ *   1. Reward double-claim + reward-budget overflow (RewardBudgetExceeded)
+ *      and the 7-day claim window expiry guard.
+ *   2. Witness quorum boundary — a batch with REAL witness signatures: one
+ *      below quorum (rejected), one at exactly quorum (accepted), plus a
+ *      forged-signature rejection. No existing test ever passes a non-empty
+ *      witnessBitmap/witnessSignatures pair, so the on-chain ecrecover path
+ *      in _validateWitnessQuorum is otherwise dead-untested.
+ *   3. Fault-proof dispute lifecycle — the permissionless commit → reveal →
+ *      settle flow for an INVALID dispute (faultType mismatch / wrong
+ *      challenger signature) where the bond is forfeited to insurance, plus
+ *      double-settle and reveal-window-missed guards.
+ *   4. Epoch finalization edge cases — early finalize (DisputeWindowNotElapsed)
+ *      and reward-pool-insufficient guard.
+ *
+ * Uses the proven hardhat-node-spawn pattern from
+ * governance-dao-lifecycle.integration.test.ts. evm_setNextBlockTimestamp
+ * lets us land transactions on deterministic epoch boundaries
+ * (epoch = floor(block.timestamp / 3600)) which the witness-set selection
+ * and dispute windows depend on.
+ */
+import assert from "node:assert/strict"
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { createServer } from "node:net"
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+import {
+  AbiCoder,
+  ContractFactory,
+  JsonRpcProvider,
+  Wallet,
+  ZeroHash,
+  getBytes,
+  keccak256,
+  parseEther,
+  solidityPacked,
+  solidityPackedKeccak256,
+  toUtf8Bytes,
+} from "ethers"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, "..", "..")
+const contractsDir = join(repoRoot, "contracts")
+const artifactsDir = join(contractsDir, "artifacts", "contracts-src", "settlement")
+
+const hardhatCliRoot = join(repoRoot, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
+const hardhatCliContracts = join(contractsDir, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
+const hardhatCli = existsSync(hardhatCliRoot) ? hardhatCliRoot : hardhatCliContracts
+
+// Anvil/hardhat-node default funded key #0.
+const DEPLOYER_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+// ---------------------------------------------------------------------------
+//  Hardhat node spawn helpers (copied from governance-*.integration.test.ts)
+// ---------------------------------------------------------------------------
+
+function loadArtifact(name: string): { abi: unknown[]; bytecode: string } {
+  const path = join(artifactsDir, `${name}.sol`, `${name}.json`)
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer()
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        server.close()
+        reject(new Error("failed to allocate free port"))
+        return
+      }
+      const { port } = address
+      server.close((err) => (err ? reject(err) : resolve(port)))
+    })
+    server.on("error", reject)
+  })
+}
+
+interface HardhatHandle {
+  process: ChildProcessWithoutNullStreams
+  url: string
+  stop: () => Promise<void>
+}
+
+async function startHardhatNode(port: number): Promise<HardhatHandle> {
+  if (!existsSync(hardhatCli)) {
+    throw new Error(`hardhat CLI not found at ${hardhatCliRoot} or ${hardhatCliContracts}; run npm install first`)
+  }
+  const child = spawn(process.execPath, [hardhatCli, "node", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: contractsDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  let output = ""
+  child.stdout.on("data", (c) => { output += String(c) })
+  child.stderr.on("data", (c) => { output += String(c) })
+
+  const url = `http://127.0.0.1:${port}`
+  const probe = new JsonRpcProvider(url)
+  const startedAt = Date.now()
+
+  try {
+    while (Date.now() - startedAt < 20_000) {
+      if (child.exitCode !== null) {
+        throw new Error(`hardhat exited early: code=${child.exitCode}\n${output}`)
+      }
+      try {
+        await probe.getBlockNumber()
+        return {
+          process: child,
+          url,
+          stop: async () => {
+            if (child.exitCode !== null) return
+            child.kill("SIGTERM")
+            await new Promise<void>((resolve) => {
+              const timer = setTimeout(() => {
+                if (child.exitCode === null) child.kill("SIGKILL")
+              }, 3_000)
+              child.once("exit", () => { clearTimeout(timer); resolve() })
+            })
+          },
+        }
+      } catch {
+        await new Promise((r) => setTimeout(r, 200))
+      }
+    }
+    child.kill("SIGKILL")
+    throw new Error(`hardhat did not start in time\n${output}`)
+  } finally {
+    probe.destroy()
+  }
+}
+
+// ---------------------------------------------------------------------------
+//  PoSe v2 domain helpers (mirror the contract + off-chain libraries)
+// ---------------------------------------------------------------------------
+
+const EPOCH_SECONDS = 3600
+
+/** keccak256 pair-hash with sorted leaves — mirrors MerkleProofLite. */
+function pairHash(a: string, b: string): string {
+  const [x, y] = a.toLowerCase() <= b.toLowerCase() ? [a, b] : [b, a]
+  return solidityPackedKeccak256(["bytes32", "bytes32"], [x, y])
+}
+
+interface MerkleTree {
+  root: string
+  layers: string[][]
+}
+
+function buildMerkleTree(leaves: string[]): MerkleTree {
+  if (leaves.length === 0) return { root: ZeroHash, layers: [] }
+  if (leaves.length === 1) {
+    const root = pairHash(leaves[0]!, leaves[0]!)
+    return { root, layers: [leaves, [root]] }
+  }
+  const layers: string[][] = [leaves.slice()]
+  while (layers[layers.length - 1]!.length > 1) {
+    const layer = layers[layers.length - 1]!
+    const next: string[] = []
+    for (let i = 0; i < layer.length; i += 2) {
+      const left = layer[i]!
+      const right = layer[i + 1] ?? layer[i]!
+      next.push(pairHash(left, right))
+    }
+    layers.push(next)
+  }
+  return { root: layers[layers.length - 1]![0]!, layers }
+}
+
+function buildMerkleProof(layers: string[][], index: number): string[] {
+  const proof: string[] = []
+  let cursor = index
+  for (let d = 0; d < layers.length - 1; d++) {
+    const layer = layers[d]!
+    const siblingIndex = cursor % 2 === 0 ? cursor + 1 : cursor - 1
+    const sibling = layer[siblingIndex] ?? layer[cursor]!
+    proof.push(sibling)
+    cursor = Math.floor(cursor / 2)
+  }
+  return proof
+}
+
+interface EvidenceLeafV2 {
+  epoch: number
+  nodeId: string
+  nonce: string
+  tipHash: string
+  tipHeight: number
+  latencyMs: number
+  resultCode: number
+  witnessBitmap: number
+}
+
+function hashEvidenceLeafV2(leaf: EvidenceLeafV2): string {
+  return solidityPackedKeccak256(
+    ["uint64", "bytes32", "bytes16", "bytes32", "uint64", "uint32", "uint8", "uint32"],
+    [leaf.epoch, leaf.nodeId, leaf.nonce, leaf.tipHash, leaf.tipHeight, leaf.latencyMs, leaf.resultCode, leaf.witnessBitmap],
+  )
+}
+
+function encodeEvidenceData(batchId: string, merkleProof: string[], leaf: EvidenceLeafV2): string {
+  return AbiCoder.defaultAbiCoder().encode(
+    [
+      "bytes32",
+      "bytes32[]",
+      "tuple(uint64 epoch,bytes32 nodeId,bytes16 nonce,bytes32 tipHash,uint64 tipHeight,uint32 latencyMs,uint8 resultCode,uint32 witnessBitmap)",
+    ],
+    [batchId, merkleProof, leaf],
+  )
+}
+
+function computeCommitHash(targetNodeId: string, faultType: number, evidenceLeafHash: string, salt: string): string {
+  return solidityPackedKeccak256(
+    ["bytes32", "uint8", "bytes32", "bytes32"],
+    [targetNodeId, faultType, evidenceLeafHash, salt],
+  )
+}
+
+function computeRevealDigest(
+  challengeId: string,
+  targetNodeId: string,
+  faultType: number,
+  evidenceLeafHash: string,
+  salt: string,
+  evidenceData: string,
+): string {
+  return solidityPackedKeccak256(
+    ["string", "bytes32", "bytes32", "uint8", "bytes32", "bytes32", "bytes32"],
+    ["coc-fault:", challengeId, targetNodeId, faultType, evidenceLeafHash, salt, keccak256(evidenceData)],
+  )
+}
+
+function buildSummaryHash(
+  epochId: number,
+  merkleRoot: string,
+  sampleProofs: { leaf: string; merkleProof: string[]; leafIndex: number }[],
+): string {
+  let rolling = ZeroHash
+  for (const proof of sampleProofs) {
+    rolling = solidityPackedKeccak256(["bytes32", "uint32", "bytes32"], [rolling, proof.leafIndex, proof.leaf])
+  }
+  return solidityPackedKeccak256(
+    ["uint64", "bytes32", "bytes32", "uint32"],
+    [epochId, merkleRoot, rolling, sampleProofs.length],
+  )
+}
+
+function hashRewardLeaf(epochId: number, nodeId: string, amount: bigint): string {
+  return solidityPackedKeccak256(["uint64", "bytes32", "uint256"], [epochId, nodeId, amount])
+}
+
+/**
+ * EIP-712 witness attestation hash — mirrors PoSeManagerV2._validateWitnessQuorum.
+ *   witnessHash = keccak256(\x19\x01 || DOMAIN_SEPARATOR ||
+ *      keccak256(abi.encode(WITNESS_TYPEHASH, merkleRoot, nodeId, merkleRoot, witnessIndex)))
+ */
+const WITNESS_TYPEHASH = solidityPackedKeccak256(
+  ["string"],
+  ["WitnessAttestation(bytes32 challengeId,bytes32 nodeId,bytes32 responseBodyHash,uint8 witnessIndex)"],
+)
+
+function witnessDigest(domainSeparator: string, merkleRoot: string, nodeId: string, witnessIndex: number): string {
+  const structHash = keccak256(
+    AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "bytes32", "bytes32", "bytes32", "uint8"],
+      [WITNESS_TYPEHASH, merkleRoot, nodeId, merkleRoot, witnessIndex],
+    ),
+  )
+  return keccak256(solidityPacked(["bytes2", "bytes32", "bytes32"], ["0x1901", domainSeparator, structHash]))
+}
+
+// ---------------------------------------------------------------------------
+//  Contract-driving helpers
+// ---------------------------------------------------------------------------
+
+interface Ctx {
+  provider: JsonRpcProvider
+  deployer: Wallet
+  manager: any
+  nextNonce: () => { nonce: number }
+}
+
+/** Register a fresh node; returns its operator wallet + nodeId + pubkey. */
+async function registerNode(ctx: Ctx, bondEth = "1"): Promise<{ operator: Wallet; nodeId: string }> {
+  const operator = Wallet.createRandom().connect(ctx.provider)
+  await (await ctx.deployer.sendTransaction({ to: operator.address, value: parseEther("5"), ...ctx.nextNonce() })).wait()
+
+  const pubkey = operator.signingKey.publicKey
+  const nodeId = keccak256(pubkey)
+  const serviceCommitment = keccak256(toUtf8Bytes("svc"))
+  const endpointCommitment = keccak256(toUtf8Bytes(`ep-${Date.now()}-${Math.random()}`))
+  const metadataHash = keccak256(toUtf8Bytes("meta"))
+  const messageHash = solidityPackedKeccak256(
+    ["string", "bytes32", "address"],
+    ["coc-register:", nodeId, operator.address],
+  )
+  const ownershipSig = await operator.signMessage(getBytes(messageHash))
+
+  await (
+    await ctx.manager
+      .connect(operator)
+      .registerNode(nodeId, pubkey, 7, serviceCommitment, endpointCommitment, metadataHash, ownershipSig, "0x", {
+        value: parseEther(bondEth),
+        nonce: 0,
+      })
+  ).wait()
+  return { operator, nodeId }
+}
+
+/** Land the next block exactly inside the given epoch. */
+async function setEpoch(provider: JsonRpcProvider, epoch: number, offsetSeconds = 60): Promise<void> {
+  const ts = epoch * EPOCH_SECONDS + offsetSeconds
+  await provider.send("evm_setNextBlockTimestamp", [ts])
+  await provider.send("evm_mine", [])
+}
+
+/** Advance time by whole epochs. */
+async function advanceEpochs(provider: JsonRpcProvider, epochs: number): Promise<void> {
+  await provider.send("evm_increaseTime", [epochs * EPOCH_SECONDS])
+  await provider.send("evm_mine", [])
+}
+
+async function currentEpoch(provider: JsonRpcProvider): Promise<number> {
+  const block = await provider.getBlock("latest")
+  return Math.floor(Number(block!.timestamp) / EPOCH_SECONDS)
+}
+
+async function deployManager(ctx: Omit<Ctx, "manager">): Promise<any> {
+  const art = loadArtifact("PoSeManagerV2")
+  const factory = new ContractFactory(art.abi, art.bytecode, ctx.deployer)
+  const manager = await factory.deploy(ctx.nextNonce())
+  await manager.waitForDeployment()
+  const chainId = (await ctx.provider.getNetwork()).chainId
+  await (await manager.initialize(chainId, await manager.getAddress(), parseEther("0.01"), ctx.nextNonce())).wait()
+  return manager
+}
+
+async function extractArg(manager: any, receipt: any, eventName: string, argIndex: number): Promise<any> {
+  for (const log of receipt.logs) {
+    try {
+      const parsed = manager.interface.parseLog(log)
+      if (parsed?.name === eventName) return parsed.args[argIndex]
+    } catch {
+      // not our event
+    }
+  }
+  throw new Error(`event ${eventName} not found`)
+}
+
+// ---------------------------------------------------------------------------
+//  Test 1 — Reward double-claim, budget overflow, expiry window
+// ---------------------------------------------------------------------------
+
+test("PoSe v2: reward claim — double-claim, budget overflow, and expiry window", { timeout: 120_000 }, async () => {
+  const port = await getFreePort()
+  const node = await startHardhatNode(port)
+  let provider: JsonRpcProvider | null = null
+  try {
+    provider = new JsonRpcProvider(node.url)
+    const deployer = new Wallet(DEPLOYER_KEY, provider)
+    let n = await provider.getTransactionCount(deployer.address)
+    const ctx: Ctx = {
+      provider,
+      deployer,
+      manager: null,
+      nextNonce: () => ({ nonce: n++ }),
+    }
+    ctx.manager = await deployManager(ctx)
+    const manager = ctx.manager
+
+    await (await manager.setAllowEmptyWitnessSubmission(true, ctx.nextNonce())).wait()
+    await (await manager.depositRewardPool({ value: parseEther("10"), ...ctx.nextNonce() })).wait()
+
+    const { operator, nodeId } = await registerNode(ctx)
+
+    // Finalize an epoch that is safely in the past.
+    await advanceEpochs(provider, 5)
+    const epochId = 1
+    const amount = parseEther("1")
+    const leaf = hashRewardLeaf(epochId, nodeId, amount)
+    const tree = buildMerkleTree([leaf])
+    await (await manager.finalizeEpochV2(epochId, tree.root, amount, 0, 0, ctx.nextNonce())).wait()
+
+    const proof = buildMerkleProof(tree.layers, 0)
+
+    // First claim succeeds and credits the operator. Balances are read at
+    // explicit block tags — ethers' provider caches getBalance("latest")
+    // results, which would otherwise mask the post-claim delta.
+    const claimTx = await manager.connect(operator).claim(epochId, nodeId, amount, proof, { nonce: 1 })
+    const claimReceipt = await claimTx.wait()
+    const claimBlock: number = claimReceipt.blockNumber
+    const gas = claimReceipt.gasUsed * claimReceipt.gasPrice
+    const balBefore = await provider.getBalance(operator.address, claimBlock - 1)
+    const balAfter = await provider.getBalance(operator.address, claimBlock)
+    assert.equal(balAfter + gas - balBefore, amount, "first claim pays out the full amount")
+    assert.equal(await manager.rewardClaimed(epochId, nodeId), true)
+
+    // Second claim of the SAME leaf must revert with AlreadyClaimed.
+    await assert.rejects(
+      () => manager.connect(operator).claim.staticCall(epochId, nodeId, amount, proof),
+      (err: Error) => /AlreadyClaimed|reverted/i.test(err.message),
+      "double-claim of the same reward leaf must revert",
+    )
+
+    // ── Reward-budget overflow: a leaf whose amount exceeds epochTotalReward.
+    const { nodeId: nodeId2 } = await registerNode(ctx)
+    const epoch2 = 2
+    const budget = parseEther("1")
+    const overAmount = parseEther("2") // leaf claims more than the epoch budget
+    const leaf2 = hashRewardLeaf(epoch2, nodeId2, overAmount)
+    const tree2 = buildMerkleTree([leaf2])
+    // finalize epoch2 with totalReward = budget (< overAmount), root proves leaf2.
+    await (await manager.finalizeEpochV2(epoch2, tree2.root, budget, 0, 0, ctx.nextNonce())).wait()
+    await assert.rejects(
+      () => manager.claim.staticCall(epoch2, nodeId2, overAmount, buildMerkleProof(tree2.layers, 0)),
+      (err: Error) => /RewardBudgetExceeded|reverted/i.test(err.message),
+      "claiming above the epoch reward budget must revert",
+    )
+
+    // ── Claim window expiry: after REWARD_CLAIM_WINDOW (7 days) claim reverts.
+    const { operator: op3, nodeId: nodeId3 } = await registerNode(ctx)
+    const epoch3 = 3
+    const amt3 = parseEther("1")
+    const leaf3 = hashRewardLeaf(epoch3, nodeId3, amt3)
+    const tree3 = buildMerkleTree([leaf3])
+    await (await manager.finalizeEpochV2(epoch3, tree3.root, amt3, 0, 0, ctx.nextNonce())).wait()
+    // Jump past the 7-day window.
+    await provider.send("evm_increaseTime", [7 * 24 * 3600 + 60])
+    await provider.send("evm_mine", [])
+    await assert.rejects(
+      () => manager.connect(op3).claim.staticCall(epoch3, nodeId3, amt3, buildMerkleProof(tree3.layers, 0)),
+      (err: Error) => /claim window expired|reverted/i.test(err.message),
+      "claim after the 7-day window must revert",
+    )
+  } finally {
+    provider?.destroy()
+    await node.stop()
+  }
+})
+
+// ---------------------------------------------------------------------------
+//  Test 2 — Witness quorum boundary (real EIP-712 witness signatures)
+// ---------------------------------------------------------------------------
+
+test("PoSe v2: witness quorum boundary — below quorum rejected, at quorum accepted", { timeout: 120_000 }, async () => {
+  const port = await getFreePort()
+  const node = await startHardhatNode(port)
+  let provider: JsonRpcProvider | null = null
+  try {
+    provider = new JsonRpcProvider(node.url)
+    const deployer = new Wallet(DEPLOYER_KEY, provider)
+    let n = await provider.getTransactionCount(deployer.address)
+    const ctx: Ctx = { provider, deployer, manager: null, nextNonce: () => ({ nonce: n++ }) }
+    ctx.manager = await deployManager(ctx)
+    const manager = ctx.manager
+    // strict mode: empty witness sets are NOT allowed when active nodes exist.
+    const domainSeparator = await manager.DOMAIN_SEPARATOR()
+
+    // Register a single node → witness set is exactly [node0], m=1, required=1.
+    const { operator } = await registerNode(ctx)
+
+    const epoch = await currentEpoch(provider) + 1
+    await setEpoch(provider, epoch)
+    await (await manager.initEpochNonce(epoch, ctx.nextNonce())).wait()
+
+    const witnessSet: string[] = await manager.getWitnessSet(epoch)
+    assert.equal(witnessSet.length, 1, "single active node → 1-member witness set")
+    const required: bigint = await manager.getRequiredWitnessCount(epoch)
+    assert.equal(required, 1n, "ceil(2*1/3) == 1")
+
+    // Build a one-leaf batch.
+    const leafHash = hashEvidenceLeafV2({
+      epoch,
+      nodeId: witnessSet[0]!,
+      nonce: `0x${"a1".repeat(16)}`,
+      tipHash: keccak256(toUtf8Bytes("tip")),
+      tipHeight: 100,
+      latencyMs: 50,
+      resultCode: 0,
+      witnessBitmap: 1,
+    })
+    const tree = buildMerkleTree([leafHash])
+    const sampleProofs = [{ leaf: leafHash, merkleProof: buildMerkleProof(tree.layers, 0), leafIndex: 0 }]
+    const summaryHash = buildSummaryHash(epoch, tree.root, sampleProofs)
+
+    // ── Case A: bitmap below quorum (no bits) is rejected in strict mode.
+    await assert.rejects(
+      () => manager.submitBatchV2.staticCall(epoch, tree.root, summaryHash, sampleProofs, 0, []),
+      (err: Error) => /InvalidWitnessQuorum|reverted/i.test(err.message),
+      "empty witness bitmap in strict mode must revert",
+    )
+
+    // ── Case B: bitmap at quorum but signature count short → revert.
+    await assert.rejects(
+      () => manager.submitBatchV2.staticCall(epoch, tree.root, summaryHash, sampleProofs, 0b1, []),
+      (err: Error) => /InvalidWitnessQuorum|reverted/i.test(err.message),
+      "bitmap bit set without a matching signature must revert",
+    )
+
+    // ── Case C: bitmap at quorum with a FORGED signature (wrong signer) → revert.
+    const stranger = Wallet.createRandom()
+    const forgedSig = await stranger.signMessage(getBytes(witnessDigest(domainSeparator, tree.root, witnessSet[0]!, 0)))
+    await assert.rejects(
+      () => manager.submitBatchV2.staticCall(epoch, tree.root, summaryHash, sampleProofs, 0b1, [forgedSig]),
+      (err: Error) => /InvalidWitnessQuorum|reverted/i.test(err.message),
+      "witness signature from a non-operator must revert",
+    )
+
+    // ── Case D: bitmap at quorum with a VALID operator signature → accepted.
+    // _validateWitnessQuorum recovers a raw ecrecover over the EIP-712 digest
+    // (NOT the \x19Ethereum-prefixed personal_sign), so sign the digest raw.
+    const validSig = operator.signingKey.sign(witnessDigest(domainSeparator, tree.root, witnessSet[0]!, 0)).serialized
+    const okTx = await manager.submitBatchV2(epoch, tree.root, summaryHash, sampleProofs, 0b1, [validSig], ctx.nextNonce())
+    const okReceipt = await okTx.wait()
+    const batchId = await extractArg(manager, okReceipt, "BatchSubmittedV2", 1)
+    assert.notEqual(batchId, ZeroHash, "batch with a valid at-quorum witness signature is accepted")
+    const stored = await manager.getBatch(batchId)
+    assert.equal(stored.merkleRoot, tree.root, "accepted batch is persisted with the submitted root")
+  } finally {
+    provider?.destroy()
+    await node.stop()
+  }
+})
+
+// ---------------------------------------------------------------------------
+//  Test 3 — Fault-proof dispute lifecycle: invalid dispute forfeits the bond
+// ---------------------------------------------------------------------------
+
+test("PoSe v2: fault-proof dispute — invalid dispute forfeits bond, valid one slashes", { timeout: 120_000 }, async () => {
+  const port = await getFreePort()
+  const node = await startHardhatNode(port)
+  let provider: JsonRpcProvider | null = null
+  try {
+    provider = new JsonRpcProvider(node.url)
+    const deployer = new Wallet(DEPLOYER_KEY, provider)
+    let n = await provider.getTransactionCount(deployer.address)
+    const ctx: Ctx = { provider, deployer, manager: null, nextNonce: () => ({ nonce: n++ }) }
+    ctx.manager = await deployManager(ctx)
+    const manager = ctx.manager
+    await (await manager.setAllowEmptyWitnessSubmission(true, ctx.nextNonce())).wait()
+    await (await manager.setChallengeBondMin(parseEther("0.01"), ctx.nextNonce())).wait()
+
+    const { nodeId } = await registerNode(ctx)
+    const epoch = await currentEpoch(provider)
+
+    // ── INVALID dispute: open a challenge, never reveal → settle forfeits the
+    //    whole bond to the insurance fund (not a slash).
+    const bond = parseEther("0.05")
+    const phantomCommit = keccak256(toUtf8Bytes("phantom-commit"))
+    const openTx = await manager.openChallenge(phantomCommit, { value: bond, ...ctx.nextNonce() })
+    const openReceipt = await openTx.wait()
+    const lostChallengeId = await extractArg(manager, openReceipt, "ChallengeOpened", 0)
+
+    // Settling before the reveal deadline must revert (still revealable).
+    await assert.rejects(
+      () => manager.settleChallenge.staticCall(lostChallengeId),
+      (err: Error) => /ChallengeNotRevealed|reverted/i.test(err.message),
+      "settling an unrevealed challenge before its deadline must revert",
+    )
+
+    // Past the reveal window → settle moves the bond to insurance.
+    await advanceEpochs(provider, 3)
+    const insuranceBefore = await manager.insuranceBalance()
+    await (await manager.settleChallenge(lostChallengeId, ctx.nextNonce())).wait()
+    const insuranceAfter = await manager.insuranceBalance()
+    assert.equal(insuranceAfter - insuranceBefore, bond, "unrevealed challenge forfeits the full bond to insurance")
+
+    // Double-settle of the same challenge must revert.
+    await assert.rejects(
+      () => manager.settleChallenge.staticCall(lostChallengeId),
+      (err: Error) => /ChallengeAlreadySettled|reverted/i.test(err.message),
+      "settling an already-settled challenge must revert",
+    )
+
+    // ── faultType=1 (DoubleSig) must be rejected at reveal: it requires a
+    //    dedicated equivocation proof, not the evidence-leaf format.
+    const epoch2 = await currentEpoch(provider)
+    const leafDS: EvidenceLeafV2 = {
+      epoch: epoch2,
+      nodeId,
+      nonce: `0x${"d1".repeat(16)}`,
+      tipHash: keccak256(toUtf8Bytes("ds-tip")),
+      tipHeight: 200,
+      latencyMs: 80,
+      resultCode: 2,
+      witnessBitmap: 0,
+    }
+    const leafHashDS = hashEvidenceLeafV2(leafDS)
+    const treeDS = buildMerkleTree([leafHashDS])
+    const sampleProofsDS = [{ leaf: leafHashDS, merkleProof: buildMerkleProof(treeDS.layers, 0), leafIndex: 0 }]
+    const summaryDS = buildSummaryHash(epoch2, treeDS.root, sampleProofsDS)
+    const submitDS = await manager.submitBatchV2(epoch2, treeDS.root, summaryDS, sampleProofsDS, 0, [], ctx.nextNonce())
+    const batchIdDS = await extractArg(manager, await submitDS.wait(), "BatchSubmittedV2", 1)
+    const evidenceDataDS = encodeEvidenceData(batchIdDS, buildMerkleProof(treeDS.layers, 0), leafDS)
+
+    const saltDS = keccak256(toUtf8Bytes("ds-salt"))
+    const faultTypeDS = 1
+    const commitDS = computeCommitHash(nodeId, faultTypeDS, leafHashDS, saltDS)
+    const chDS = await extractArg(
+      manager,
+      await (await manager.openChallenge(commitDS, { value: bond, ...ctx.nextNonce() })).wait(),
+      "ChallengeOpened",
+      0,
+    )
+    const digestDS = computeRevealDigest(chDS, nodeId, faultTypeDS, leafHashDS, saltDS, evidenceDataDS)
+    const sigDS = await deployer.signMessage(getBytes(digestDS))
+    await assert.rejects(
+      () => manager.revealChallenge.staticCall(chDS, nodeId, faultTypeDS, leafHashDS, saltDS, evidenceDataDS, sigDS),
+      (err: Error) => /InvalidFaultProof|reverted/i.test(err.message),
+      "faultType=1 (DoubleSig) via the evidence-leaf format must revert at reveal",
+    )
+
+    // ── faultType MISMATCH: reveal a faultType=3 (Timeout) against a leaf whose
+    //    resultCode is 2 (InvalidSig) → reveal reverts (objective check fails).
+    const leafMM: EvidenceLeafV2 = { ...leafDS, nonce: `0x${"e2".repeat(16)}`, tipHash: keccak256(toUtf8Bytes("mm-tip")) }
+    const leafHashMM = hashEvidenceLeafV2(leafMM)
+    const treeMM = buildMerkleTree([leafHashMM])
+    const sampleProofsMM = [{ leaf: leafHashMM, merkleProof: buildMerkleProof(treeMM.layers, 0), leafIndex: 0 }]
+    const summaryMM = buildSummaryHash(epoch2, treeMM.root, sampleProofsMM)
+    const submitMM = await manager.submitBatchV2(epoch2, treeMM.root, summaryMM, sampleProofsMM, 0, [], ctx.nextNonce())
+    const batchIdMM = await extractArg(manager, await submitMM.wait(), "BatchSubmittedV2", 1)
+    const evidenceDataMM = encodeEvidenceData(batchIdMM, buildMerkleProof(treeMM.layers, 0), leafMM)
+    const saltMM = keccak256(toUtf8Bytes("mm-salt"))
+    const faultTypeMM = 3 // Timeout, but leaf.resultCode == 2
+    const commitMM = computeCommitHash(nodeId, faultTypeMM, leafHashMM, saltMM)
+    const chMM = await extractArg(
+      manager,
+      await (await manager.openChallenge(commitMM, { value: bond, ...ctx.nextNonce() })).wait(),
+      "ChallengeOpened",
+      0,
+    )
+    const digestMM = computeRevealDigest(chMM, nodeId, faultTypeMM, leafHashMM, saltMM, evidenceDataMM)
+    const sigMM = await deployer.signMessage(getBytes(digestMM))
+    await assert.rejects(
+      () => manager.revealChallenge.staticCall(chMM, nodeId, faultTypeMM, leafHashMM, saltMM, evidenceDataMM, sigMM),
+      (err: Error) => /InvalidFaultProof|reverted/i.test(err.message),
+      "faultType not matching the leaf resultCode must revert at reveal",
+    )
+
+    // ── VALID dispute end-to-end: faultType=2 against a resultCode=2 leaf.
+    const nodeBondBefore = (await manager.getNode(nodeId)).bondAmount
+    const saltOk = keccak256(toUtf8Bytes("ok-salt"))
+    const faultTypeOk = 2
+    const commitOk = computeCommitHash(nodeId, faultTypeOk, leafHashDS, saltOk)
+    const chOk = await extractArg(
+      manager,
+      await (await manager.openChallenge(commitOk, { value: bond, ...ctx.nextNonce() })).wait(),
+      "ChallengeOpened",
+      0,
+    )
+    const digestOk = computeRevealDigest(chOk, nodeId, faultTypeOk, leafHashDS, saltOk, evidenceDataDS)
+    const sigOk = await deployer.signMessage(getBytes(digestOk))
+    await (
+      await manager.revealChallenge(chOk, nodeId, faultTypeOk, leafHashDS, saltOk, evidenceDataDS, sigOk, ctx.nextNonce())
+    ).wait()
+    const revealed = await manager.getChallenge(chOk)
+    assert.equal(revealed.revealed, true, "valid fault proof reveals successfully")
+
+    // Settle before the adjudication window must revert.
+    await assert.rejects(
+      () => manager.settleChallenge.staticCall(chOk),
+      (err: Error) => /AdjudicationWindowNotElapsed|reverted/i.test(err.message),
+      "settling before the adjudication window must revert",
+    )
+
+    await advanceEpochs(provider, 5)
+    await (await manager.settleChallenge(chOk, ctx.nextNonce())).wait()
+    const nodeBondAfter = (await manager.getNode(nodeId)).bondAmount
+    assert.ok(nodeBondAfter < nodeBondBefore, "a confirmed fault slashes the target node's bond")
+    const settled = await manager.getChallenge(chOk)
+    assert.equal(settled.settled, true, "valid challenge settles")
+  } finally {
+    provider?.destroy()
+    await node.stop()
+  }
+})
+
+// ---------------------------------------------------------------------------
+//  Test 4 — Epoch finalization edge cases
+// ---------------------------------------------------------------------------
+
+test("PoSe v2: epoch finalization — early finalize and reward-pool guards", { timeout: 120_000 }, async () => {
+  const port = await getFreePort()
+  const node = await startHardhatNode(port)
+  let provider: JsonRpcProvider | null = null
+  try {
+    provider = new JsonRpcProvider(node.url)
+    const deployer = new Wallet(DEPLOYER_KEY, provider)
+    let n = await provider.getTransactionCount(deployer.address)
+    const ctx: Ctx = { provider, deployer, manager: null, nextNonce: () => ({ nonce: n++ }) }
+    ctx.manager = await deployManager(ctx)
+    const manager = ctx.manager
+    await (await manager.setAllowEmptyWitnessSubmission(true, ctx.nextNonce())).wait()
+
+    // ── Early finalize: the current (or too-recent) epoch is inside the
+    //    dispute window → DisputeWindowNotElapsed.
+    const nowEpoch = await currentEpoch(provider)
+    await assert.rejects(
+      () => manager.finalizeEpochV2.staticCall(nowEpoch, ZeroHash, 0, 0, 0),
+      (err: Error) => /DisputeWindowNotElapsed|reverted/i.test(err.message),
+      "finalizing the current epoch (inside dispute window) must revert",
+    )
+
+    // ── Empty epoch finalize: a past epoch with no batches finalizes cleanly.
+    await advanceEpochs(provider, 5)
+    const emptyEpoch = 1
+    await (await manager.finalizeEpochV2(emptyEpoch, ZeroHash, 0, 0, 0, ctx.nextNonce())).wait()
+    assert.equal(await manager.epochFinalized(emptyEpoch), true, "empty past epoch finalizes")
+    assert.equal(await manager.epochRewardRoots(emptyEpoch), ZeroHash, "empty epoch has a zero reward root")
+    assert.equal(await manager.epochValidBatchCount(emptyEpoch), 0n, "empty epoch records 0 valid batches")
+
+    // ── Double finalize of the same epoch must revert.
+    await assert.rejects(
+      () => manager.finalizeEpochV2.staticCall(emptyEpoch, ZeroHash, 0, 0, 0),
+      (err: Error) => /EpochAlreadyFinalized|reverted/i.test(err.message),
+      "double-finalizing an epoch must revert",
+    )
+
+    // ── Reward-pool insufficient: finalize with totalReward > rewardPoolBalance.
+    const richEpoch = 2
+    const rewardRoot = keccak256(toUtf8Bytes("non-empty-root"))
+    await assert.rejects(
+      () => manager.finalizeEpochV2.staticCall(richEpoch, rewardRoot, parseEther("100"), 0, 0),
+      (err: Error) => /RewardPoolInsufficient|reverted/i.test(err.message),
+      "finalizing with a reward larger than the pool must revert",
+    )
+
+    // ── totalReward > 0 with a zero reward root must revert (InvalidBatch).
+    await assert.rejects(
+      () => manager.finalizeEpochV2.staticCall(richEpoch, ZeroHash, parseEther("1"), 0, 0),
+      (err: Error) => /InvalidBatch|reverted/i.test(err.message),
+      "a non-zero reward with a zero root must revert",
+    )
+
+    // ── Funded finalize succeeds and deducts from the reward pool.
+    await (await manager.depositRewardPool({ value: parseEther("5"), ...ctx.nextNonce() })).wait()
+    const poolBefore = await manager.rewardPoolBalance()
+    const payout = parseEther("3")
+    await (await manager.finalizeEpochV2(richEpoch, rewardRoot, payout, 0, 0, ctx.nextNonce())).wait()
+    const poolAfter = await manager.rewardPoolBalance()
+    assert.equal(poolBefore - poolAfter, payout, "finalize deducts the epoch reward from the pool")
+    assert.equal(await manager.epochTotalReward(richEpoch), payout, "epochTotalReward records the payout")
+  } finally {
+    provider?.destroy()
+    await node.stop()
+  }
+})

--- a/tests/stress/burst-throughput.test.ts
+++ b/tests/stress/burst-throughput.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Burst-throughput stress test — captures the Ralph-loop (2026-05-17) burst
+ * probes as a reusable suite: concurrent tx admission, counter-state exactness
+ * under load, block-capacity headroom, and compute-load gas metering.
+ *
+ * Targets a live chain via COC_STRESS_RPC (default 127.0.0.1:18780). The whole
+ * suite skips gracefully when no chain is reachable, so it is CI-safe.
+ *
+ * Run: COC_STRESS_RPC=http://host:port node --experimental-strip-types --test tests/stress/burst-throughput.test.ts
+ */
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { ethers } from "ethers"
+import { tryGetHead } from "../../scripts/lib/rpc-helper.ts"
+import { hdWallet, wrapInitCode } from "../../scripts/lib/wallet.ts"
+import { RUNTIMES, buildComputeLoop } from "../../scripts/lib/probe-runtimes.ts"
+
+const RPC = process.env.COC_STRESS_RPC ?? "http://127.0.0.1:18780"
+const BURST = Number(process.env.COC_STRESS_BURST ?? 25)
+// Tx-sending suites need an exclusively-owned funded account: when several
+// run concurrently against one chain, give each a distinct funded index via
+// COC_STRESS_WALLET_INDEX, or run them sequentially.
+const WALLET_INDEX = Number(process.env.COC_STRESS_WALLET_INDEX ?? 0)
+const reachable = (await tryGetHead(RPC)) !== null
+
+const provider = reachable ? new ethers.JsonRpcProvider(RPC) : null
+const wallet = provider ? hdWallet(provider, WALLET_INDEX) : null
+
+describe("Burst throughput (live chain)", { skip: !reachable ? `no chain at ${RPC}` : false }, () => {
+  it(`admits ${BURST} concurrent tx and counts state exactly`, async () => {
+    const p = provider!, w = wallet!
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const C = (await (await w.sendTransaction({
+      data: wrapInitCode(RUNTIMES.counter), nonce: nonce++, gasLimit: 200000n,
+    })).wait(1, 60000))!.contractAddress!
+
+    const base = nonce
+    const sent = await Promise.all(
+      Array.from({ length: BURST }, (_, i) =>
+        w.sendTransaction({ to: C, nonce: base + i, gasLimit: 60000n }),
+      ),
+    )
+    const receipts = await Promise.all(sent.map((tx) => tx.wait(1, 90000)))
+    for (const [i, rc] of receipts.entries()) {
+      assert.equal(rc?.status, 1, `burst tx ${i} status`)
+    }
+    const slot0 = await p.getStorage(C, 0)
+    assert.equal(BigInt(slot0), BigInt(BURST), "counter slot == burst size (no lost/double tx)")
+  })
+
+  it("block has ample headroom — burst occupies a small fraction of gasLimit", async () => {
+    const p = provider!
+    const head = await p.getBlock("latest", false)
+    assert.ok(head, "latest block present")
+    const limit = head!.gasLimit
+    const used = head!.gasUsed
+    assert.ok(limit >= 15_000_000n, `gasLimit healthy (got ${limit})`)
+    const pctUsed = limit > 0n ? Number((used * 10000n) / limit) / 100 : 0
+    assert.ok(pctUsed < 95, `block not saturated (used ${pctUsed}%)`)
+  })
+
+  it("compute-load contract meters gas precisely (estimateGas == receipt.gasUsed)", async () => {
+    const p = provider!, w = wallet!
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const loop = buildComputeLoop(2000)
+    const C = (await (await w.sendTransaction({
+      data: wrapInitCode(loop), nonce: nonce++, gasLimit: 1_000_000n,
+    })).wait(1, 60000))!.contractAddress!
+
+    const est = await p.estimateGas({ from: w.address, to: C })
+    const rc = await (await w.sendTransaction({
+      to: C, nonce: nonce++, gasLimit: est * 2n,
+    })).wait(1, 60000)
+    assert.equal(rc?.status, 1, "compute-load tx status")
+    assert.equal(rc!.gasUsed, est, "receipt.gasUsed matches estimateGas exactly")
+  })
+
+  it("sustains block production during the burst (head advances)", async () => {
+    const p = provider!
+    const before = await p.getBlockNumber()
+    await new Promise((r) => setTimeout(r, 8000))
+    const after = await p.getBlockNumber()
+    assert.ok(after > before, `head advanced (${before} -> ${after})`)
+  })
+})

--- a/tests/stress/chaos-devnet.test.ts
+++ b/tests/stress/chaos-devnet.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Consensus chaos test against a real process devnet.
+ *
+ * Replaces the deprecated docker-compose multinode chaos scenarios. Drives a
+ * genuine BFT cluster spawned by scripts/start-devnet.sh and injects faults
+ * via scripts/{stop,start}-devnet-node.sh (single-node stop/restart, leveldb +
+ * config preserved). Covers: liveness under one fault, validator rejoin/catch-
+ * up, rolling restart, and the N=5 fault boundary (two down breaches 3f+1).
+ *
+ * Opt-in — spawns N node processes (~minutes). Skips unless COC_CHAOS_DEVNET=1.
+ *
+ * Run: COC_CHAOS_DEVNET=1 node --experimental-strip-types --test tests/stress/chaos-devnet.test.ts
+ */
+import { describe, it, before, beforeEach, after } from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { tryGetHead, rpcResult } from "../../scripts/lib/rpc-helper.ts"
+
+const ENABLED = process.env.COC_CHAOS_DEVNET === "1"
+const NODES = Number(process.env.COC_CHAOS_NODES ?? 5)
+const BASE_RPC = 28780
+const REPO = new URL("../..", import.meta.url).pathname
+
+const rpcUrl = (id: number) => `http://127.0.0.1:${BASE_RPC + (id - 1)}`
+
+function sh(script: string, args: string[], timeoutMs = 120_000): void {
+  execFileSync("bash", [`scripts/${script}`, ...args], {
+    cwd: REPO,
+    stdio: "pipe",
+    timeout: timeoutMs,
+  })
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+/** Highest head across all reachable nodes; -1 if none reachable. */
+async function clusterHead(): Promise<number> {
+  const heads = await Promise.all(
+    Array.from({ length: NODES }, (_, i) => tryGetHead(rpcUrl(i + 1))),
+  )
+  const live = heads.filter((h): h is number => h !== null)
+  return live.length ? Math.max(...live) : -1
+}
+
+/** Poll `id` until its head climbs by >= minDelta, or the deadline passes. */
+async function waitHeadAdvance(id: number, from: number, minDelta: number, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs
+  let last = from
+  while (Date.now() < deadline) {
+    const h = await tryGetHead(rpcUrl(id))
+    if (h !== null) {
+      last = h
+      if (h - from >= minDelta) return h
+    }
+    await sleep(2000)
+  }
+  return last
+}
+
+/** Wait until node `id` has caught up to within 2 blocks of the cluster head. */
+async function waitRejoin(id: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const mine = await tryGetHead(rpcUrl(id))
+    const cluster = await clusterHead()
+    if (mine !== null && cluster >= 0 && mine >= cluster - 2) return
+    await sleep(2000)
+  }
+}
+
+/**
+ * Restart any unreachable node and wait until the whole cluster is reachable
+ * and roughly in sync. Keeps each chaos scenario independent — a scenario that
+ * aborts mid-fault must not leave a node down for the next one.
+ */
+async function ensureClusterUp(): Promise<void> {
+  for (let id = 1; id <= NODES; id++) {
+    if ((await tryGetHead(rpcUrl(id))) === null) {
+      try {
+        sh("start-devnet-node.sh", [String(NODES), String(id)])
+      } catch {
+        /* node may already be restarting — recheck below */
+      }
+    }
+  }
+  const deadline = Date.now() + 90_000
+  while (Date.now() < deadline) {
+    const heads = await Promise.all(
+      Array.from({ length: NODES }, (_, i) => tryGetHead(rpcUrl(i + 1))),
+    )
+    if (heads.every((h): h is number => h !== null)) {
+      const max = Math.max(...(heads as number[]))
+      const min = Math.min(...(heads as number[]))
+      if (max - min <= 3) return
+    }
+    await sleep(2000)
+  }
+}
+
+describe("consensus chaos (process devnet)", { skip: !ENABLED ? "set COC_CHAOS_DEVNET=1 to run" : false }, () => {
+  before(() => {
+    // start-devnet.sh blocks until every node is ready (or fails loudly).
+    sh("start-devnet.sh", [String(NODES)], 180_000)
+  })
+
+  // Each scenario starts from a whole, in-sync cluster so an aborted fault
+  // never cascades into the next test.
+  beforeEach(ensureClusterUp)
+
+  after(() => {
+    try {
+      sh("stop-devnet.sh", [String(NODES)], 60_000)
+    } catch {
+      /* best-effort teardown */
+    }
+  })
+
+  it("baseline: every validator advances and stays in consensus", async () => {
+    const start = await clusterHead()
+    assert.ok(start >= 0, "cluster reachable at start")
+    const after = await waitHeadAdvance(1, start, 3, 30_000)
+    assert.ok(after - start >= 3, `head advanced from ${start} to ${after}`)
+
+    // No fork: every node reports the same stateRoot for a settled block.
+    const settled = `0x${(after - 2).toString(16)}`
+    const roots = await Promise.all(
+      Array.from({ length: NODES }, async (_, i) => {
+        const b = await rpcResult<{ stateRoot: string }>(rpcUrl(i + 1), "eth_getBlockByNumber", [settled, false])
+        return b.stateRoot
+      }),
+    )
+    assert.equal(new Set(roots).size, 1, `all ${NODES} nodes agree on stateRoot @${settled}`)
+  })
+
+  it("single validator down — chain stays live, rejoins and catches up on restart", async () => {
+    const before = await clusterHead()
+    sh("stop-devnet-node.sh", [String(NODES), String(NODES)]) // drop the last validator
+
+    // N-1 validators still meet the 3f+1 quorum — chain must keep producing.
+    const live = await waitHeadAdvance(1, before, 3, 40_000)
+    assert.ok(live - before >= 3, `chain advanced with one validator down (${before} -> ${live})`)
+
+    // Restart it; it must rejoin and catch up to the cluster head.
+    sh("start-devnet-node.sh", [String(NODES), String(NODES)])
+    const target = await clusterHead()
+    const rejoined = await waitHeadAdvance(NODES, 0, target, 90_000)
+    assert.ok(rejoined >= target - 2, `restarted validator caught up (${rejoined} vs cluster ${target})`)
+  })
+
+  it("rolling restart — no stall while never more than one validator is down", async () => {
+    let head = await clusterHead()
+    for (let id = 2; id <= NODES; id++) {
+      sh("stop-devnet-node.sh", [String(NODES), String(id)])
+      const duringDown = await waitHeadAdvance(1, head, 2, 40_000)
+      assert.ok(duringDown - head >= 2, `chain live while node-${id} down (${head} -> ${duringDown})`)
+      sh("start-devnet-node.sh", [String(NODES), String(id)])
+      await waitRejoin(id, 90_000) // it must fully rejoin before the next node drops
+      head = await clusterHead()
+    }
+    const final = await waitHeadAdvance(1, head, 3, 40_000)
+    assert.ok(final - head >= 3, "chain healthy after the full rolling restart")
+  })
+
+  it("dual validator down breaches the N=5 fault bound — chain stalls, recovers on restore", async () => {
+    assert.equal(NODES, 5, "fault-boundary scenario is calibrated for N=5")
+    const before = await clusterHead()
+    sh("stop-devnet-node.sh", [String(NODES), "4"])
+    sh("stop-devnet-node.sh", [String(NODES), "5"])
+
+    // 3 of 5 < ceil(2*5/3)=4 quorum — consensus cannot finalize.
+    const stalled = await waitHeadAdvance(1, before, 8, 25_000)
+    assert.ok(stalled - before <= 2, `chain stalled with 2/5 down (delta ${stalled - before})`)
+
+    // Restore one — quorum (4/5) is back, the chain must resume.
+    sh("start-devnet-node.sh", [String(NODES), "4"])
+    const resumed = await waitHeadAdvance(1, stalled, 3, 60_000)
+    assert.ok(resumed - stalled >= 3, `chain resumed after restoring quorum (${stalled} -> ${resumed})`)
+
+    sh("start-devnet-node.sh", [String(NODES), "5"]) // restore full set for teardown
+  })
+})

--- a/tests/stress/evm-coverage.test.ts
+++ b/tests/stress/evm-coverage.test.ts
@@ -1,0 +1,99 @@
+/**
+ * EVM coverage stress test — captures the Ralph-loop (2026-05-17) EVM probes
+ * as a reusable suite: runtime-pool deploy+execute, CREATE determinism,
+ * factory (CREATE-from-contract), SELFDESTRUCT, and the tx-type matrix.
+ *
+ * Targets a live chain via COC_STRESS_RPC (default 127.0.0.1:18780). The whole
+ * suite skips gracefully when no chain is reachable, so it is CI-safe.
+ *
+ * Run: COC_STRESS_RPC=http://host:port node --experimental-strip-types --test tests/stress/evm-coverage.test.ts
+ */
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { ethers } from "ethers"
+import { rpcResult, tryGetHead, waitForReceipt } from "../../scripts/lib/rpc-helper.ts"
+import { hdWallet, wrapInitCode, createAddress } from "../../scripts/lib/wallet.ts"
+import { RUNTIMES, FACTORY_RET2A, buildSelfdestruct } from "../../scripts/lib/probe-runtimes.ts"
+
+const RPC = process.env.COC_STRESS_RPC ?? "http://127.0.0.1:18780"
+// Tx-sending suites need an exclusively-owned funded account: when several
+// run concurrently against one chain, give each a distinct funded index via
+// COC_STRESS_WALLET_INDEX, or run them sequentially.
+const WALLET_INDEX = Number(process.env.COC_STRESS_WALLET_INDEX ?? 0)
+const reachable = (await tryGetHead(RPC)) !== null
+
+const provider = reachable ? new ethers.JsonRpcProvider(RPC) : null
+const wallet = provider ? hdWallet(provider, WALLET_INDEX) : null
+
+describe("EVM coverage (live chain)", { skip: !reachable ? `no chain at ${RPC}` : false }, () => {
+  it("deploys + executes runtime-pool contracts", async () => {
+    const p = provider!, w = wallet!
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    for (const name of ["ret2a", "sstore", "counter", "log0", "timestamp"]) {
+      const tx = await w.sendTransaction({ data: wrapInitCode(RUNTIMES[name]), nonce: nonce++, gasLimit: 250000n })
+      const rc = await tx.wait(1, 60000)
+      assert.equal(rc?.status, 1, `${name} deploy status`)
+      const code = await p.getCode(rc!.contractAddress!)
+      assert.equal(code, "0x" + RUNTIMES[name], `${name} runtime bytecode`)
+    }
+  })
+
+  it("CREATE address is deterministic (factory pattern)", async () => {
+    const p = provider!, w = wallet!
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const drc = await (await w.sendTransaction({ data: wrapInitCode(FACTORY_RET2A), nonce: nonce++, gasLimit: 300000n })).wait(1, 60000)
+    const factory = drc!.contractAddress!
+    const crc = await (await w.sendTransaction({ to: factory, nonce: nonce++, gasLimit: 300000n })).wait(1, 60000)
+    assert.equal(crc?.status, 1, "factory invoke status")
+    const slot0 = await p.getStorage(factory, 0)
+    const childAddr = ethers.getAddress("0x" + slot0.slice(26))
+    assert.equal(childAddr.toLowerCase(), createAddress(factory, 1).toLowerCase(), "child == keccak(rlp(factory,1))")
+    assert.equal(await p.getCode(childAddr), "0x" + RUNTIMES.ret2a, "child runtime deployed")
+  })
+
+  it("SELFDESTRUCT deletes code + transfers balance (Shanghai)", async () => {
+    const p = provider!, w = wallet!
+    const beneficiary = ethers.Wallet.createRandom().address
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const fund = ethers.parseEther("0.001")
+    const drc = await (await w.sendTransaction({ data: wrapInitCode(buildSelfdestruct(beneficiary)), nonce: nonce++, gasLimit: 250000n, value: fund })).wait(1, 60000)
+    const s = drc!.contractAddress!
+    assert.notEqual(await p.getCode(s), "0x", "pre: code present")
+    await (await w.sendTransaction({ to: s, nonce: nonce++, gasLimit: 100000n })).wait(1, 60000)
+    assert.equal(await p.getCode(s), "0x", "post: code deleted")
+    assert.equal(await p.getBalance(beneficiary), fund, "balance transferred to beneficiary")
+  })
+
+  it("accepts tx types 0 / 1 / 2 with correct receipt.type", async () => {
+    const p = provider!, w = wallet!
+    const net = await p.getNetwork()
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const C = (await (await w.sendTransaction({ data: wrapInitCode(RUNTIMES.counter), nonce: nonce++, gasLimit: 200000n })).wait(1, 60000))!.contractAddress!
+    const gp = 2_000_000_000n
+    const variants = [
+      { type: 0, txReq: { to: C, type: 0, gasPrice: gp } },
+      { type: 1, txReq: { to: C, type: 1, gasPrice: gp, accessList: [{ address: C, storageKeys: ["0x" + "00".repeat(32)] }] } },
+      { type: 2, txReq: { to: C, type: 2, maxFeePerGas: gp * 2n, maxPriorityFeePerGas: 1_000_000_000n } },
+    ]
+    for (const v of variants) {
+      const rc = await (await w.sendTransaction({ ...v.txReq, nonce: nonce++, gasLimit: 60000n })).wait(1, 60000)
+      assert.equal(rc?.status, 1, `type-${v.type} status`)
+      const full = await p.getTransaction(rc!.hash)
+      assert.equal(full?.type, v.type, `type-${v.type} receipt type`)
+    }
+  })
+
+  it("rejects an unexecutable contract call with revert", async () => {
+    const p = provider!, w = wallet!
+    let nonce = await p.getTransactionCount(w.address, "pending")
+    const C = (await (await w.sendTransaction({ data: wrapInitCode(RUNTIMES.revert), nonce: nonce++, gasLimit: 200000n })).wait(1, 60000))!.contractAddress!
+    await assert.rejects(() => p.call({ to: C, data: "0x" }), "revert runtime must throw on eth_call")
+  })
+
+  it("chainId is exposed consistently as hex quantity", async () => {
+    const hex = await rpcResult<string>(RPC, "eth_chainId")
+    assert.match(hex, /^0x[0-9a-f]+$/, "eth_chainId hex-quantity format")
+  })
+})
+
+void waitForReceipt // referenced for lint parity; receipt polling available to extenders

--- a/tests/stress/rpc-validation.test.ts
+++ b/tests/stress/rpc-validation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * RPC input-validation stress test — captures the Ralph-loop (2026-05-17)
+ * coc_* malformed-input probes as a reusable suite: every malformed param must
+ * return a clean -32602 (invalid params), never -32603 / HTTP 500 / crash.
+ *
+ * Targets a live chain via COC_STRESS_RPC (default 127.0.0.1:18780). The whole
+ * suite skips gracefully when no chain is reachable, so it is CI-safe.
+ *
+ * Run: COC_STRESS_RPC=http://host:port node --experimental-strip-types --test tests/stress/rpc-validation.test.ts
+ */
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { rpc, tryGetHead } from "../../scripts/lib/rpc-helper.ts"
+
+const RPC = process.env.COC_STRESS_RPC ?? "http://127.0.0.1:18780"
+const reachable = (await tryGetHead(RPC)) !== null
+
+const INVALID_PARAMS = -32602
+const INTERNAL_ERROR = -32603
+
+/** Malformed values an address/string param should reject with -32602. */
+const MALFORMED: ReadonlyArray<readonly [string, unknown]> = [
+  ["null", null],
+  ["object", { evil: true }],
+  ["array", [1, 2, 3]],
+  ["not-an-address", "not-an-address"],
+  ["path-traversal", "../../../../etc/passwd"],
+  ["oversized-string", "0x" + "f".repeat(4096)],
+  ["empty-string", ""],
+  ["number", 12345],
+  ["boolean", true],
+]
+
+describe("RPC input validation (live chain)", { skip: !reachable ? `no chain at ${RPC}` : false }, () => {
+  it("coc_chainStats responds cleanly (no-param sanity)", async () => {
+    const r = await rpc(RPC, "coc_chainStats", [])
+    assert.equal(r.error, undefined, "coc_chainStats must not error")
+    assert.notEqual(r.result, undefined, "coc_chainStats returns a result")
+  })
+
+  it("coc_getContractInfo rejects every malformed address with -32602", async () => {
+    for (const [label, value] of MALFORMED) {
+      const r = await rpc(RPC, "coc_getContractInfo", [value])
+      assert.ok(r.error, `${label}: must produce an error envelope`)
+      assert.notEqual(r.error!.code, INTERNAL_ERROR, `${label}: must not be -32603 internal error`)
+      assert.equal(r.error!.code, INVALID_PARAMS, `${label}: must be -32602 invalid params`)
+    }
+  })
+
+  it("coc_getTransactionsByAddress rejects malformed address with -32602", async () => {
+    for (const [label, value] of MALFORMED) {
+      const r = await rpc(RPC, "coc_getTransactionsByAddress", [value])
+      assert.ok(r.error, `${label}: must produce an error envelope`)
+      assert.notEqual(r.error!.code, INTERNAL_ERROR, `${label}: must not be -32603 internal error`)
+      assert.equal(r.error!.code, INVALID_PARAMS, `${label}: must be -32602 invalid params`)
+    }
+  })
+
+  it("coc_getTransactionsByAddress rejects malformed limit/offset with -32602", async () => {
+    const valid = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    for (const bad of [-1, 0, 99_999_999, "lots", {}, [5]]) {
+      const r = await rpc(RPC, "coc_getTransactionsByAddress", [valid, bad])
+      assert.ok(r.error, `limit=${JSON.stringify(bad)}: must error`)
+      assert.notEqual(r.error!.code, INTERNAL_ERROR, `limit=${JSON.stringify(bad)}: not -32603`)
+      assert.equal(r.error!.code, INVALID_PARAMS, `limit=${JSON.stringify(bad)}: -32602`)
+    }
+  })
+
+  it("coc_getContractInfo accepts a well-formed address (no -32602)", async () => {
+    const r = await rpc(RPC, "coc_getContractInfo", ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"])
+    assert.equal(r.error, undefined, "valid address must not be rejected")
+  })
+
+  it("eth_getLogs accepts a bounded recent range and returns an array", async () => {
+    const headRes = await rpc<string>(RPC, "eth_blockNumber", [])
+    const head = parseInt(headRes.result ?? "0x0", 16)
+    // A bounded window — full genesis-to-head exceeds the node's range cap on
+    // any long-lived chain (see the over-cap test below).
+    const from = `0x${Math.max(0, head - 5000).toString(16)}`
+    const r = await rpc<unknown[]>(RPC, "eth_getLogs", [{ fromBlock: from, toBlock: headRes.result ?? "latest" }])
+    assert.equal(r.error, undefined, "bounded-range eth_getLogs must not error")
+    assert.ok(Array.isArray(r.result), "eth_getLogs returns an array")
+  })
+
+  it("eth_getLogs rejects an over-cap block range cleanly (-32602, not -32603)", async () => {
+    // Genesis-to-head on a long chain exceeds the node's max-range cap; the
+    // node must reject it as invalid params, never crash with an internal error.
+    const headRes = await rpc<string>(RPC, "eth_blockNumber", [])
+    const r = await rpc(RPC, "eth_getLogs", [{ fromBlock: "0x0", toBlock: headRes.result ?? "latest" }])
+    if (r.error) {
+      assert.notEqual(r.error.code, INTERNAL_ERROR, "over-cap range must not be -32603")
+      assert.equal(r.error.code, INVALID_PARAMS, "over-cap range → -32602 invalid params")
+    } else {
+      assert.ok(Array.isArray(r.result), "short chain: full range still returns an array")
+    }
+  })
+
+  it("eth_getLogs rejects an inverted block range cleanly", async () => {
+    const r = await rpc(RPC, "eth_getLogs", [{ fromBlock: "0x1000000", toBlock: "0x1" }])
+    if (r.error) {
+      assert.notEqual(r.error.code, INTERNAL_ERROR, "inverted range must not be -32603")
+    } else {
+      assert.ok(Array.isArray(r.result), "inverted range degrades to empty array")
+    }
+  })
+
+  it("never crashes the node — chain still answers after the malformed barrage", async () => {
+    const r = await rpc<string>(RPC, "eth_blockNumber", [])
+    assert.equal(r.error, undefined, "node still healthy")
+    assert.match(r.result ?? "", /^0x[0-9a-f]+$/, "eth_blockNumber hex quantity")
+  })
+})


### PR DESCRIPTION
## Summary

Two commits from the 2026-05-17 testnet stress-test follow-up.

**`fix(p2p)` — dedicated rate limiter for BFT consensus messages**
`/p2p/bft-message` was throttled by the shared 240/60s inbound rate limiter
even though both ban checks already exempt it. Under load (tx-gossip bursts,
BFT-timeout re-broadcasts) consensus messages were 429'd, rounds timed out,
and block production deadlocked. Adds a dedicated high-capacity
`bftMessageRateLimiter` (1200/60s, configurable) and stops throttled BFT
messages from feeding peer scoring so they can never escalate to a ban.

**`test` — stress/chaos/e2e/integration coverage + CI lane**
- `scripts/lib/` — shared JSON-RPC / wallet / EVM-runtime helpers
- `tests/stress/` — EVM coverage, burst throughput, RPC validation probes
  plus a process-devnet consensus chaos suite (single/dual fault, rolling
  restart); all skip gracefully when no chain is reachable
- `tests/e2e/ipfs-e2e-extended` — IPFS admin-auth gate, gateway Range/HEAD,
  concurrent uploads, MFS and pubsub round-trips
- `tests/integration/` — governance Treasury-spend + bicameral lifecycle and
  PoSeManagerV2 settlement (reward claim, witness quorum, fault proof)
- `.github/workflows/stress.yml` — devnet-backed stress lane on PR + a
  weekly/manual 5-node consensus chaos lane

## Notes

The stress suite surfaced a stateRoot-divergence bug under concurrent tx
bursts — tracked as #642, fixed separately in #643. `burst-throughput.test.ts`
is intentionally excluded from the blocking CI lane until #642 lands.

## Test plan

- [x] node p2p suite — 12/12 (incl. 2 new bft-limiter regression tests)
- [x] IPFS E2E — 52/52
- [x] governance + PoSe v2 integration — 4/4 each
- [x] consensus chaos (5-node process devnet) — 4/4
- [x] stress probes — 14/14 on a local devnet and the live 88780 testnet