### PR TITLE
fix: residual stateRoot divergence from stale storage-trie eviction (#671)

### DIFF
--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3590,6 +3590,15 @@ async function resolveHistoricalExecutionContext(
     const height = await Promise.resolve(chain.getHeight())
     const block = await Promise.resolve(chain.getBlockByNumber(height))
     return {
+      // #642/#671: surface the latest committed block's stateRoot so callRaw
+      // resolves an *isolated* state manager (forkAtStateRoot) for eth_call /
+      // eth_estimateGas — exactly as the safe/finalized branch below already
+      // does. Without it, callRaw fell back to the shared this.vm.stateManager
+      // and runCall's checkpoint/revert raced applyBlock's checkpoint on the
+      // same PersistentStateTrie — a latent #642-class shared-trie race. The
+      // latest block's stateRoot is committed, so the fork's nodes are all
+      // DB-resident.
+      stateRoot: block?.stateRoot,
       blockNumber: height,
       ...buildExecutionContextFromBlock(block),
     }

--- a/node/src/storage/state-trie.test.ts
+++ b/node/src/storage/state-trie.test.ts
@@ -840,3 +840,73 @@ test("PersistentStateTrie: computeStateRoot syncs dirty storage tries before rea
     "computeStateRoot must reflect storage writes (account record synced from dirty storage trie)",
   )
 })
+
+test("PersistentStateTrie: #671 — getStorageTrie must not evict a dirty in-flight storage trie", async () => {
+  // #671 (residual #642-class race). PersistentStateTrie.put() writes the
+  // account trie at `await this.trie.put(...)` BEFORE it refreshes
+  // accountCache. A concurrent storage reader entering getStorageTrie()
+  // during that await window passes the *pre-SSTORE* storageRoot. The cached
+  // storage trie's live root no longer matches it, so getStorageTrie's
+  // stale-cache guard DELETES the trie — discarding the uncommitted writes
+  // held in its open checkpoint frame. The in-flight applyBlock then commits
+  // a storageRoot that omits this block's writes → a divergent stateRoot
+  // that deadlocks BFT on the next empty block.
+  //
+  // This drives that exact interleave deterministically: it recreates the
+  // accountCache-stale window by hand, then asserts the block's commit still
+  // reflects the in-frame write.
+  const db = new MemoryDatabase()
+  const trie = new PersistentStateTrie(db)
+  await trie.init()
+
+  const C = "0xc0ffee0000000000000000000000000000000c0c"
+  const slot = "0x" + "00".repeat(32)
+  const v0 = "0x" + "00".repeat(31) + "07"
+  const v1 = "0x" + "00".repeat(31) + "2a"
+  const pokeAccountCache = (storageRoot: string, base: Record<string, unknown>) => {
+    ;(trie as unknown as { accountCache: Map<string, unknown> }).accountCache.set(C, {
+      ...base,
+      storageRoot,
+    })
+  }
+
+  // Block 1: give C a committed storage slot. C's storage trie is then cached
+  // in `storageTries` with no open checkpoint frame.
+  await trie.checkpoint()
+  await trie.putStorageAt(C, slot, v0)
+  await trie.commit()
+  const rootAfterBlock1 = (await trie.get(C))!.storageRoot
+
+  // Block 2 begins (mimics applyBlock): checkpoint() opens a frame on the
+  // account trie AND on every cached storage trie — including C's.
+  await trie.checkpoint()
+  // SSTORE v1 — lands in C's storage-trie checkpoint frame (in-memory only).
+  await trie.putStorageAt(C, slot, v1)
+  const cAccount = (await trie.get(C))!
+  const rootAfterBlock2Write = cAccount.storageRoot
+  assert.notStrictEqual(rootAfterBlock2Write, rootAfterBlock1, "v1 advanced C's storage root")
+
+  // Simulate a concurrent reader that captured C's account during put()'s
+  // `await this.trie.put` window — accountCache still holds the pre-v1
+  // storageRoot. Recreate that state, then issue a storage read: it routes
+  // getStorageTrie(C, <stale root>).
+  pokeAccountCache(rootAfterBlock1, cAccount)
+  await trie.getStorageAt(C, "0x" + "00".repeat(31) + "01")
+
+  // Restore accountCache to the post-write root, exactly as applyBlock's
+  // put() does once its await window closes.
+  pokeAccountCache(rootAfterBlock2Write, cAccount)
+
+  // applyBlock commits block 2.
+  await trie.commit()
+
+  // The committed state MUST still carry v1. If getStorageTrie evicted C's
+  // dirty storage trie, its frame (holding v1) was dropped and commit stamped
+  // the stale root — this read returns v0, the #671 divergence.
+  const committed = await trie.getStorageAt(C, slot)
+  assert.strictEqual(
+    BigInt(committed),
+    BigInt(v1),
+    "#671: block-2 SSTORE survived a concurrent stale-root storage read",
+  )
+})

--- a/node/src/storage/state-trie.ts
+++ b/node/src/storage/state-trie.ts
@@ -769,7 +769,19 @@ export class PersistentStateTrie implements IStateTrie {
       // Verify cached trie root matches expected storage root to prevent stale reads
       const cachedRoot = bytesToHex(storageTrie.root())
       const emptyRoot = "0x" + "0".repeat(64)
-      if (storageRoot !== emptyRoot && cachedRoot !== storageRoot) {
+      // #671: a `cachedRoot !== storageRoot` mismatch is genuine staleness
+      // ONLY when the cached trie holds no uncommitted in-block state. If the
+      // address is dirty, or the trie still carries an open checkpoint frame,
+      // the cached trie IS the authoritative in-flight one — its root
+      // legitimately differs from the pre-SSTORE storageRoot a concurrent
+      // reader may pass after observing put()'s accountCache-refresh window
+      // (put() advances the storage trie before it updates accountCache).
+      // Evicting it here would discard the frame's uncommitted writes, so an
+      // in-flight applyBlock commits a storageRoot omitting this block's
+      // writes — a #642-class stateRoot divergence that deadlocks BFT on the
+      // next empty block. Only evict a genuinely stale *clean* cache entry.
+      const inFlight = this.dirtyAddresses.has(address) || storageTrie.hasCheckpoints()
+      if (storageRoot !== emptyRoot && cachedRoot !== storageRoot && !inFlight) {
         // Stale cache — discard and recreate
         this.storageTries.delete(address)
         storageTrie = undefined


### PR DESCRIPTION
## Summary

Two real fixes for shared-state races in the #642 family. (See note below — this PR does **not** fully close #671; the dominant CI-stress-lane staller is a separate follow-up PR.)

### 1. `fix(state-trie)` — stale storage-trie eviction

`PersistentStateTrie.put()` advances the **account trie** (`await this.trie.put`) **before** it refreshes `accountCache`. A concurrent storage reader entering `getStorageTrie()` during that await window reads the **pre-SSTORE** `storageRoot` from `accountCache` and passes it down.

`getStorageTrie()`'s stale-cache guard then sees the cached storage trie's live root no longer matches that (stale) root and **deletes the trie** — discarding the uncommitted writes held in its **open checkpoint frame**. The in-flight `applyBlock` then reads the recreated trie's stale root in `commit()` and stamps a `storageRoot` that **omits this block's writes** — a #642-class stateRoot divergence.

**Fix:** a `cachedRoot !== storageRoot` mismatch is genuine staleness only when the cached trie holds no uncommitted in-block state. Exempt addresses that are **dirty** or whose trie still carries an **open checkpoint frame**. Deterministic regression test in `state-trie.test.ts` (RED→GREEN).

### 2. `fix(rpc)` — isolate eth_call/estimateGas at latest

`resolveHistoricalExecutionContext`'s `latest` branch omitted `stateRoot`, so `eth_call`/`eth_estimateGas` at `latest` ran `runCall` against the shared `this.vm.stateManager` instead of an isolated `forkAtStateRoot`. Surfacing the latest committed block's `stateRoot` isolates that path.

## Note — #671 is NOT fully closed by this PR

Local reproduction (2-core-pinned 3-node devnet, mimicking CI's runner) pinned the **dominant** cause of the flaky `EVM/RPC Stress Probes` lane to a **third, independent race**: `forceSnapSync` (the H11 divergence-recovery path) runs `importStateSnapshot`/`setStateRoot` on the shared `PersistentStateTrie` **unserialized against `applyBlock`** — node logs show an `applyBlock` executing in the exact middle of a snapshot import. That corrupts the trie, recovery returns `ok:false`, the node never recovers, and the chain deadlocks.

That race is **out of scope here** and lands in a separate follow-up PR (route the snapshot-import / state-reset through `runStateExclusive`, same idiom as #643). The two fixes in this PR are real and independently correct, but the stress lane will stay red until the follow-up lands — so this PR's red `EVM/RPC Stress Probes` check is a **pre-existing flaky failure unrelated to this diff**.

## Investigation notes

- eth_call CheckpointDB-frame stealing — hypothesised, then **experimentally refuted** (deterministic harness, 3170 concurrent calls, 0 divergence).
- `getStorageTrie` stale-cache eviction — reproduced deterministically, fixed.
- forceSnapSync vs applyBlock — reproduced locally, root-caused, deferred to a follow-up PR.
- No consensus/BFT logic touched.

## Test plan

- [x] `state-trie.test.ts` — new deterministic regression test (RED→GREEN), 33/33
- [x] storage + chain-engine-persistent + evm + speculative-execution + stateroot-verification — 148/148
- [x] `chain-concurrency.race.test.ts` incl. #642 — 4/4, divergences=0
- [x] 9/10 CI checks green; the red `EVM/RPC Stress Probes` is the pre-existing forceSnapSync flake (see note)

Refs #671
