### PR TITLE
fix(snap-sync): serialize forceSnapSync state import against applyBlock (#671)

### DIFF
--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -1098,11 +1098,19 @@ export class PersistentChainEngine {
    * accountCache/dirtyAddresses mid-iteration — so the node's committed
    * stateRoot drifts from its actual trie state (#642 deadlock).
    *
-   * The callback must be SHORT (a snapshot/flush), not a full block replay:
-   * it blocks applyBlock for its whole duration. Rejections stay with the
-   * caller's returned promise and do not poison the queue.
+   * Keep the callback as short as practical — it blocks applyBlock for its
+   * whole duration. A snapshot/flush is ideal; the snap-sync state import
+   * (#671) is necessarily longer, but blocking applyBlock during a full state
+   * reset is correct, not a hazard. Rejections stay with the caller's
+   * returned promise and do not poison the queue.
+   *
+   * Public so the snap-sync recovery path (the importStateSnapshot /
+   * setStateRoot adapters in index.ts) can serialize its shared-trie
+   * mutations against applyBlock too — #671: forceSnapSync ran the state
+   * import unsynchronized, so an in-flight applyBlock interleaved with it,
+   * corrupted the trie, and left the node permanently unable to recover.
    */
-  private runStateExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  runStateExclusive<T>(fn: () => Promise<T>): Promise<T> {
     const prior = this.applyQueue
     const current = prior.then(fn, fn)
     this.applyQueue = current.then(() => {}, () => {})

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -1448,8 +1448,16 @@ export class ConsensusEngine {
             }
           }
 
+          // #671: importStateSnapshot is passed trustedStateRoot as the
+          // expected root — it commits the imported state and verifies the
+          // resulting root equals it (throwing otherwise), then pins it. A
+          // separate setStateRoot() call here is redundant AND unsafe: the
+          // import now runs inside the engine's state-exclusive queue, so a
+          // queued applyBlock can run between this line and a separate
+          // setStateRoot() and would then be rolled back over. Pinning the
+          // root inside importStateSnapshot's own critical section keeps
+          // import + root-set atomic.
           const importResult = await this.snapSync.importStateSnapshot(stateSnap, trustedStateRoot)
-          await this.snapSync.setStateRoot(trustedStateRoot)
 
           // Restore governance (hash already validated above)
           if (importResult.validators && this.snapSync.restoreGovernance) {

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -681,11 +681,27 @@ if (bftEnabled) {
               try {
                 // With trie overlay protecting LevelDB, a full EVM reset +
                 // rebuild from persisted blocks is safe and guarantees clean state.
-                const pe = chain as any
-                if (pe.evm?.resetExecution && pe.rebuildFromPersisted) {
+                // #671: the reset + rebuild mutates the shared state trie
+                // (resetExecution recreates the VM; rebuildFromPersisted does
+                // setStateRoot / block replay). Unserialized, it raced a
+                // concurrent (gossiped) applyBlock and corrupted the trie —
+                // run it on the engine's state-exclusive queue. rebuildFrom
+                // Persisted already resets the EVM internally, so the explicit
+                // resetExecution() is only the height==0 edge.
+                const pe = chain as {
+                  evm?: { resetExecution?: () => Promise<void> }
+                  rebuildFromPersisted?: (h: bigint) => Promise<void>
+                  runStateExclusive?: <T>(fn: () => Promise<T>) => Promise<T>
+                }
+                if (pe.evm?.resetExecution && pe.rebuildFromPersisted && pe.runStateExclusive) {
                   const currentHeight = await Promise.resolve(chain.getHeight())
-                  await pe.evm.resetExecution()
-                  if (currentHeight > 0n) await pe.rebuildFromPersisted(currentHeight)
+                  await pe.runStateExclusive(async () => {
+                    if (currentHeight > 0n) {
+                      await pe.rebuildFromPersisted!(currentHeight)
+                    } else {
+                      await pe.evm!.resetExecution!()
+                    }
+                  })
                 }
                 await applyWithTimeout(true)
                 log.info("BFT onFinalized: EVM reset + retry succeeded", { height: block.number.toString() })
@@ -1200,12 +1216,33 @@ if (stateTrie && config.enableSnapSync) {
       }
     },
     async importStateSnapshot(snapshot: unknown, expectedStateRoot?: string) {
-      return await importStateSnapshot(trieRef, snapshot as StateSnapshot, expectedStateRoot)
+      // #671: importStateSnapshot does checkpoint / put / putStorageAt / commit
+      // on the shared PersistentStateTrie. forceSnapSync ran this completely
+      // unserialized against applyBlock, so an in-flight applyBlock interleaved
+      // with the import at an `await` boundary, corrupted the trie, and the
+      // node could never recover (forceSnapSync returned ok:false forever →
+      // chain deadlock). Run the import — AND pin the resulting root — inside
+      // the engine's state-exclusive queue so applyBlock cannot interleave.
+      // Pinning the root in the SAME critical section makes import+setStateRoot
+      // atomic: no applyBlock can slip between them and then be rolled back.
+      const runExclusive = (persistentEngine as { runStateExclusive?: <T>(fn: () => Promise<T>) => Promise<T> }).runStateExclusive
+      const doImport = async () => {
+        const result = await importStateSnapshot(trieRef, snapshot as StateSnapshot, expectedStateRoot)
+        if (expectedStateRoot && typeof trieRef.setStateRoot === "function") {
+          await trieRef.setStateRoot(expectedStateRoot)
+        }
+        return result
+      }
+      return runExclusive ? await runExclusive(doImport) : await doImport()
     },
     async setStateRoot(root: string) {
-      if (typeof trieRef.setStateRoot === "function") {
-        await trieRef.setStateRoot(root)
-      }
+      if (typeof trieRef.setStateRoot !== "function") return
+      // #671: serialize the root-set against applyBlock too. The forceSnapSync
+      // path no longer calls this separately (importStateSnapshot pins the
+      // root atomically above); kept for any other caller.
+      const runExclusive = (persistentEngine as { runStateExclusive?: <T>(fn: () => Promise<T>) => Promise<T> }).runStateExclusive
+      const setIt = () => trieRef.setStateRoot!(root)
+      if (runExclusive) { await runExclusive(setIt) } else { await setIt() }
     },
     restoreGovernance(validators: Array<{ id: string; address: string; stake: bigint; active: boolean }>) {
       if (hasGovernance(chain) && chain.governance && typeof (chain.governance as { initGenesis?: unknown }).initGenesis === "function") {


### PR DESCRIPTION
## Summary

Fixes the **dominant** cause of the flaky `EVM/RPC Stress Probes` CI lane — the residual #642-class stateRoot divergence tracked in #671.

`forceSnapSync` (the H11 divergence-recovery path) ran `importStateSnapshot` / `setStateRoot` — `checkpoint` / `put` / `putStorageAt` / `commit` on the shared `PersistentStateTrie` — **completely unserialized against `applyBlock`**. Under load an in-flight `applyBlock` interleaves with the snapshot import at an `await` boundary, corrupting the trie. Recovery then returns `ok:false`, the node never recovers, keeps re-diverging, and the chain deadlocks.

Reproduced locally on a 2-core-pinned 3-node devnet (mimics CI's `ubuntu-latest` runner). Node logs show it unambiguously:

```
15.582  forceSnapSync: starting state-snapshot import (height 6)
15.598..15.607  applyBlock h7 — checkpoint / applyBlockContext / commitState / stateTrie.commit / db.batch  ← runs INSIDE the snap import
15.638  state snapshot imported (setStateRoot → clears accountCache/storageTries/dirtyAddresses)
15.639  snap block import rejected: incoming tip not ahead {incomingTip:6, currentHeight:7} → ok:false
```

## Fix

Route the snap-sync state mutations through the engine's existing `runStateExclusive` queue (the #643 idiom), so they cannot interleave with `applyBlock`:

- `runStateExclusive` is now **public** on `PersistentChainEngine`.
- The `importStateSnapshot` adapter runs the import **and pins the resulting state root inside one exclusive critical section** — import + root-set is atomic, so no `applyBlock` can slip between them and then be rolled back.
- `consensus.ts` drops the now-redundant separate `setStateRoot()` call (`importStateSnapshot` already commits + verifies + pins the verified root; a separate call is both redundant and, once serialized, unsafe).
- The BFT `onFinalized` recovery path's `resetExecution` + `rebuildFromPersisted` runs inside `runStateExclusive` too.

No consensus decision logic touched — only the serialization of shared-trie mutations (state/execution layer).

## Verification

2-core-pinned 3-node devnet running `tests/stress/evm-coverage.test.ts`:

| | result |
|---|---|
| **before** | test 5 stalls — 60s `tx.wait` timeout, node-3 permanently diverged, `forceSnapSync` returns `ok:false` forever, chain deadlocked |
| **after**  | 6/6 pass, all three validators stay synced (height 40) |

## Test plan

- [x] chain-engine-persistent + consensus + consensus-bft + snap-sync + state-snapshot(+import-storage) + p2p-snapshot-provider + persistent-state-manager + state-trie + state-race + snap-then-apply + snapshot-manager — **159/159**
- [x] 2-core devnet repro — before: deadlock; after: evm-coverage 6/6, validators synced
- [ ] CI: full node + stress lanes

Closes #671
