### PR TITLE
chore(contracts): redeploy 88780 with the #645-#670 security fixes

### DIFF
--- a/configs/deployed-contracts-88780.json
+++ b/configs/deployed-contracts-88780.json
@@ -1,0 +1,21 @@
+{
+  "network": "coc",
+  "chainId": 88780,
+  "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "deployedAt": "2026-05-18T05:04:29.156Z",
+  "contracts": {
+    "FactionRegistry": "0xe6F314143AE46b5b0594Ae7C88e6A39D36964bb7",
+    "GovernanceDAO": "0x422f02546F2e5E3dE3A52962f0220498030e1669",
+    "Treasury": "0x8f9BE2DA37662Ad5CcfE233CDbBEF5F5C4480666",
+    "SoulRegistry": "0x0C2CbA6148A53F0Aa596a371314cc206B681d0E2",
+    "DIDRegistry": "0xF771D9111454D58D728d731752770B6Bf5Ad35Bf",
+    "CidRegistry": "0x6Ad76BD51eaa41a125945218aBD920a91Afc633E",
+    "PoSeManager": "0x0F9fFED1201De979dBe3A1562463B99bd5e7aB36",
+    "PoSeManagerV2": "0x42c0A0437106284c9aE4a3A3acb0199bF148B3eb",
+    "ValidatorRegistry": "0x112774740cD0D7a3cA68e8F6a7b3d15650821600",
+    "EquivocationDetector": "0x2EFBA7923E9A32A4C239BD2f7Da0c5b0e22a909E",
+    "InsuranceFund": "0x4Af81C96d19315212358f9E4a774bBcC0390B5f0",
+    "DelayedInbox": "0xe7D757FdeB78A806A72A652ac411738DEbC1670E",
+    "RollupStateManager": "0x1CD1a7E4158Eb444bC55AaE2b89bE7E03a4E6Ae5"
+  }
+}

--- a/contracts/scripts/deploy-all-88780.js
+++ b/contracts/scripts/deploy-all-88780.js
@@ -1,0 +1,183 @@
+/**
+ * Deploy ALL COC contracts to 88780 R3.2 testnet
+ *
+ * Run AFTER scripts/deploy-governance.js (which deploys FactionRegistry/DAO/Treasury).
+ * Picks up existing governance addresses from env if provided.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... \
+ *   COC_RPC_URL=http://209.74.64.88:38780 \
+ *   COC_CHAIN_ID=88780 \
+ *   FACTION_REGISTRY=0x... GOVERNANCE_DAO=0x... TREASURY=0x... \
+ *     npx hardhat run scripts/deploy-all-88780.js --network coc
+ */
+
+const { ethers } = require("hardhat")
+const fs = require("fs")
+const path = require("path")
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+  const network = await ethers.provider.getNetwork()
+
+  console.log("=== COC R3.2 88780 Full Contract Deploy ===")
+  console.log(`Network:  ${network.name} (chainId: ${network.chainId})`)
+  console.log(`Deployer: ${deployer.address}`)
+  const bal = await ethers.provider.getBalance(deployer.address)
+  console.log(`Balance:  ${ethers.formatEther(bal)} ETH`)
+  console.log("")
+
+  const deployed = {
+    network: "coc",
+    chainId: Number(network.chainId),
+    deployer: deployer.address,
+    deployedAt: new Date().toISOString(),
+    contracts: {},
+  }
+
+  // Pre-existing governance from deploy-governance.js (if env set)
+  if (process.env.FACTION_REGISTRY) deployed.contracts.FactionRegistry = process.env.FACTION_REGISTRY
+  if (process.env.GOVERNANCE_DAO) deployed.contracts.GovernanceDAO = process.env.GOVERNANCE_DAO
+  if (process.env.TREASURY) deployed.contracts.Treasury = process.env.TREASURY
+
+  // Skip already-deployed contracts (if env addresses set, no need to redeploy)
+  const skipExisting = process.env.SKIP_EXISTING === "1"
+  if (skipExisting) {
+    console.log("(SKIP_EXISTING=1: only deploying contracts missing from env)")
+  }
+
+  // 1. SoulRegistry (no constructor args)
+  console.log("Deploying SoulRegistry...")
+  const SoulRegistry = await ethers.getContractFactory("SoulRegistry")
+  const soulRegistry = await SoulRegistry.deploy()
+  await soulRegistry.waitForDeployment()
+  deployed.contracts.SoulRegistry = await soulRegistry.getAddress()
+  console.log(`  SoulRegistry: ${deployed.contracts.SoulRegistry}`)
+
+  // 2. DIDRegistry (depends on SoulRegistry)
+  console.log("Deploying DIDRegistry...")
+  const DIDRegistry = await ethers.getContractFactory("DIDRegistry")
+  const didRegistry = await DIDRegistry.deploy(deployed.contracts.SoulRegistry)
+  await didRegistry.waitForDeployment()
+  deployed.contracts.DIDRegistry = await didRegistry.getAddress()
+  console.log(`  DIDRegistry:  ${deployed.contracts.DIDRegistry}`)
+
+  // 3. CidRegistry (no constructor args)
+  console.log("Deploying CidRegistry...")
+  const CidRegistry = await ethers.getContractFactory("CidRegistry")
+  const cidRegistry = await CidRegistry.deploy()
+  await cidRegistry.waitForDeployment()
+  deployed.contracts.CidRegistry = await cidRegistry.getAddress()
+  console.log(`  CidRegistry:  ${deployed.contracts.CidRegistry}`)
+
+  // 4. PoSeManager v1
+  console.log("Deploying PoSeManager (v1)...")
+  try {
+    const PoSeManager = await ethers.getContractFactory("PoSeManager")
+    const poseV1 = await PoSeManager.deploy()
+    await poseV1.waitForDeployment()
+    deployed.contracts.PoSeManager = await poseV1.getAddress()
+    console.log(`  PoSeManager:  ${deployed.contracts.PoSeManager}`)
+  } catch (e) {
+    console.log(`  SKIPPED (constructor args mismatch): ${e.message.slice(0, 100)}`)
+    deployed.contracts.PoSeManager = null
+  }
+
+  // 5. PoSeManager v2
+  console.log("Deploying PoSeManagerV2...")
+  try {
+    const PoSeManagerV2 = await ethers.getContractFactory("PoSeManagerV2")
+    const poseV2 = await PoSeManagerV2.deploy()
+    await poseV2.waitForDeployment()
+    deployed.contracts.PoSeManagerV2 = await poseV2.getAddress()
+    console.log(`  PoSeManagerV2: ${deployed.contracts.PoSeManagerV2}`)
+  } catch (e) {
+    console.log(`  SKIPPED (constructor args mismatch): ${e.message.slice(0, 100)}`)
+    deployed.contracts.PoSeManagerV2 = null
+  }
+
+  // 6. ValidatorRegistry (no args expected, on-chain validator stake registry)
+  console.log("Deploying ValidatorRegistry...")
+  try {
+    const ValidatorRegistry = await ethers.getContractFactory("ValidatorRegistry")
+    const vr = await ValidatorRegistry.deploy()
+    await vr.waitForDeployment()
+    deployed.contracts.ValidatorRegistry = await vr.getAddress()
+    console.log(`  ValidatorRegistry: ${deployed.contracts.ValidatorRegistry}`)
+  } catch (e) {
+    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
+    deployed.contracts.ValidatorRegistry = null
+  }
+
+  // 7. EquivocationDetector (depends on ValidatorRegistry)
+  console.log("Deploying EquivocationDetector...")
+  try {
+    const ED = await ethers.getContractFactory("EquivocationDetector")
+    const ed = await ED.deploy(deployed.contracts.ValidatorRegistry)
+    await ed.waitForDeployment()
+    deployed.contracts.EquivocationDetector = await ed.getAddress()
+    console.log(`  EquivocationDetector: ${deployed.contracts.EquivocationDetector}`)
+  } catch (e) {
+    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
+    deployed.contracts.EquivocationDetector = null
+  }
+
+  // 8. InsuranceFund (initial governance = GovernanceDAO)
+  console.log("Deploying InsuranceFund...")
+  try {
+    const IF = await ethers.getContractFactory("InsuranceFund")
+    const insurance = await IF.deploy(deployed.contracts.GovernanceDAO)
+    await insurance.waitForDeployment()
+    deployed.contracts.InsuranceFund = await insurance.getAddress()
+    console.log(`  InsuranceFund: ${deployed.contracts.InsuranceFund}`)
+  } catch (e) {
+    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
+    deployed.contracts.InsuranceFund = null
+  }
+
+  // 9. DelayedInbox (rollup): (inclusionDelaySeconds, sequencerAddress)
+  console.log("Deploying DelayedInbox...")
+  try {
+    const DI = await ethers.getContractFactory("DelayedInbox")
+    // 24-hour inclusion delay, deployer as initial sequencer (testnet)
+    const di = await DI.deploy(86400, deployer.address)
+    await di.waitForDeployment()
+    deployed.contracts.DelayedInbox = await di.getAddress()
+    console.log(`  DelayedInbox: ${deployed.contracts.DelayedInbox}`)
+  } catch (e) {
+    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
+    deployed.contracts.DelayedInbox = null
+  }
+
+  // 10. RollupStateManager: (challengeWindowSeconds, proposerBondWei, challengerBondWei, insuranceFundAddress)
+  console.log("Deploying RollupStateManager...")
+  try {
+    const RSM = await ethers.getContractFactory("RollupStateManager")
+    // 24h challenge window, 1 ETH bonds (testnet), InsuranceFund as recipient
+    const rsm = await RSM.deploy(
+      86400,
+      ethers.parseEther("1"),
+      ethers.parseEther("1"),
+      deployed.contracts.InsuranceFund || ethers.ZeroAddress,
+    )
+    await rsm.waitForDeployment()
+    deployed.contracts.RollupStateManager = await rsm.getAddress()
+    console.log(`  RollupStateManager: ${deployed.contracts.RollupStateManager}`)
+  } catch (e) {
+    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
+    deployed.contracts.RollupStateManager = null
+  }
+
+  // Write deployment manifest
+  const outPath = path.join(__dirname, "..", "..", "configs", "deployed-contracts-88780.json")
+  fs.writeFileSync(outPath, JSON.stringify(deployed, null, 2))
+  console.log("")
+  console.log("=== Deployment Summary ===")
+  console.log(JSON.stringify(deployed, null, 2))
+  console.log(`\nManifest: ${outPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/contracts/scripts/deploy-governance.js
+++ b/contracts/scripts/deploy-governance.js
@@ -43,9 +43,25 @@ async function main() {
   console.log(`  GovernanceDAO:   ${daoAddr}`)
 
   // 3. Deploy Treasury
+  // Treasury constructor is (address[5] _signers, address _governance).
+  // Signers default to the five chainId-88780 validators; override with
+  // TREASURY_SIGNERS (comma-separated, exactly 5 addresses).
   console.log("Deploying Treasury...")
+  const DEFAULT_TREASURY_SIGNERS = [
+    "0xde4e7889aa9007318ff261b1ee675f1305153590",
+    "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9",
+    "0xdefc8430388093fdfacb0a929fedc14d2e631d19",
+    "0xcc64096600c1759d7aaea91166837a5873175867",
+    "0x5e773c9359a6bb416bdfffe0c9aac9f568bd11ae",
+  ]
+  const treasurySigners = process.env.TREASURY_SIGNERS
+    ? process.env.TREASURY_SIGNERS.split(",").map((s) => s.trim())
+    : DEFAULT_TREASURY_SIGNERS
+  if (treasurySigners.length !== 5) {
+    throw new Error(`Treasury requires exactly 5 signers, got ${treasurySigners.length}`)
+  }
   const Treasury = await ethers.getContractFactory("Treasury")
-  const treasury = await Treasury.deploy(daoAddr)
+  const treasury = await Treasury.deploy(treasurySigners, daoAddr)
   await treasury.waitForDeployment()
   const treasuryAddr = await treasury.getAddress()
   console.log(`  Treasury:        ${treasuryAddr}`)

--- a/contracts/scripts/test-deployed-88780.js
+++ b/contracts/scripts/test-deployed-88780.js
@@ -1,0 +1,165 @@
+/**
+ * Smoke test all deployed contracts on 88780 R3.2 testnet.
+ * Reads from each contract + does 1 sample mutation to verify on-chain.
+ */
+const { ethers } = require("hardhat")
+const fs = require("fs")
+const path = require("path")
+
+async function main() {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "..", "configs", "deployed-contracts-88780.json"), "utf8"),
+  )
+  const { contracts } = manifest
+  const [deployer] = await ethers.getSigners()
+  console.log(`=== Smoke test deployed contracts on chainId ${manifest.chainId} ===`)
+  console.log(`Deployer: ${deployer.address}`)
+  console.log("")
+
+  const results = {}
+
+  // 1. FactionRegistry — read owner
+  {
+    const c = await ethers.getContractAt("FactionRegistry", contracts.FactionRegistry)
+    const owner = await c.owner()
+    const ok = owner.toLowerCase() === deployer.address.toLowerCase()
+    results.FactionRegistry = { read_owner: owner, pass: ok }
+    console.log(`[FactionRegistry] owner=${owner} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 2. GovernanceDAO — read params
+  {
+    const c = await ethers.getContractAt("GovernanceDAO", contracts.GovernanceDAO)
+    const vp = await c.votingPeriod()
+    const td = await c.timelockDelay()
+    const tr = await c.treasury()
+    const ok = vp === 259200n && td === 86400n && tr.toLowerCase() === contracts.Treasury.toLowerCase()
+    results.GovernanceDAO = { votingPeriod: vp.toString(), timelock: td.toString(), treasury: tr, pass: ok }
+    console.log(`[GovernanceDAO] votingPeriod=${vp}s timelock=${td}s treasury=${tr} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 3. Treasury — read governance + signer[0]
+  {
+    const c = await ethers.getContractAt("Treasury", contracts.Treasury)
+    const gov = await c.governance()
+    const s0 = await c.signers(0)
+    const ok = gov.toLowerCase() === contracts.GovernanceDAO.toLowerCase()
+    results.Treasury = { governance: gov, signer0: s0, pass: ok }
+    console.log(`[Treasury] governance=${gov} signer[0]=${s0} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 4. SoulRegistry — count zero
+  {
+    const c = await ethers.getContractAt("SoulRegistry", contracts.SoulRegistry)
+    const code = await ethers.provider.getCode(contracts.SoulRegistry)
+    const hasCode = code.length > 2
+    results.SoulRegistry = { codeBytes: (code.length - 2) / 2, pass: hasCode }
+    console.log(`[SoulRegistry] code=${(code.length - 2) / 2} bytes ${hasCode ? "✓" : "✗"}`)
+  }
+
+  // 5. DIDRegistry — has soulRegistry binding
+  {
+    const c = await ethers.getContractAt("DIDRegistry", contracts.DIDRegistry)
+    const sr = await c.soulRegistry()
+    const ok = sr.toLowerCase() === contracts.SoulRegistry.toLowerCase()
+    results.DIDRegistry = { soulRegistry: sr, pass: ok }
+    console.log(`[DIDRegistry] soulRegistry=${sr} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 6. CidRegistry — code exists
+  {
+    const code = await ethers.provider.getCode(contracts.CidRegistry)
+    const ok = code.length > 2
+    results.CidRegistry = { codeBytes: (code.length - 2) / 2, pass: ok }
+    console.log(`[CidRegistry] code=${(code.length - 2) / 2} bytes ${ok ? "✓" : "✗"}`)
+  }
+
+  // 7. PoSeManager (v1) — code exists
+  {
+    const code = await ethers.provider.getCode(contracts.PoSeManager)
+    const ok = code.length > 2
+    results.PoSeManager = { codeBytes: (code.length - 2) / 2, pass: ok }
+    console.log(`[PoSeManager] code=${(code.length - 2) / 2} bytes ${ok ? "✓" : "✗"}`)
+  }
+
+  // 8. PoSeManagerV2 — code exists
+  {
+    const code = await ethers.provider.getCode(contracts.PoSeManagerV2)
+    const ok = code.length > 2
+    results.PoSeManagerV2 = { codeBytes: (code.length - 2) / 2, pass: ok }
+    console.log(`[PoSeManagerV2] code=${(code.length - 2) / 2} bytes ${ok ? "✓" : "✗"}`)
+  }
+
+  // 9. ValidatorRegistry
+  {
+    const code = await ethers.provider.getCode(contracts.ValidatorRegistry)
+    const ok = code.length > 2
+    results.ValidatorRegistry = { codeBytes: (code.length - 2) / 2, pass: ok }
+    console.log(`[ValidatorRegistry] code=${(code.length - 2) / 2} bytes ${ok ? "✓" : "✗"}`)
+  }
+
+  // 10. EquivocationDetector — validatorRegistry binding
+  {
+    const c = await ethers.getContractAt("EquivocationDetector", contracts.EquivocationDetector)
+    const vr = await c.validatorRegistry()
+    const ok = vr.toLowerCase() === contracts.ValidatorRegistry.toLowerCase()
+    results.EquivocationDetector = { validatorRegistry: vr, pass: ok }
+    console.log(`[EquivocationDetector] validatorRegistry=${vr} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 11. InsuranceFund — governance binding
+  {
+    const c = await ethers.getContractAt("InsuranceFund", contracts.InsuranceFund)
+    const gov = await c.governance()
+    const ok = gov.toLowerCase() === contracts.GovernanceDAO.toLowerCase()
+    results.InsuranceFund = { governance: gov, pass: ok }
+    console.log(`[InsuranceFund] governance=${gov} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 12. DelayedInbox — sequencer binding
+  {
+    const c = await ethers.getContractAt("DelayedInbox", contracts.DelayedInbox)
+    const seq = await c.sequencer()
+    const ok = seq.toLowerCase() === deployer.address.toLowerCase()
+    results.DelayedInbox = { sequencer: seq, pass: ok }
+    console.log(`[DelayedInbox] sequencer=${seq} ${ok ? "✓" : "✗"}`)
+  }
+
+  // 13. RollupStateManager — code exists
+  {
+    const code = await ethers.provider.getCode(contracts.RollupStateManager)
+    const ok = code.length > 2
+    results.RollupStateManager = { codeBytes: (code.length - 2) / 2, pass: ok }
+    console.log(`[RollupStateManager] code=${(code.length - 2) / 2} bytes ${ok ? "✓" : "✗"}`)
+  }
+
+  // Mutation test: send 1 ETH from deployer to v1 validator address to verify chain accepts tx
+  console.log("")
+  console.log("=== Mutation test: send 1 ETH to v1 validator ===")
+  const v1addr = "0xde4e7889aa9007318ff261b1ee675f1305153590"
+  const balBefore = await ethers.provider.getBalance(v1addr)
+  const tx = await deployer.sendTransaction({ to: v1addr, value: ethers.parseEther("1") })
+  const rcpt = await tx.wait()
+  const balAfter = await ethers.provider.getBalance(v1addr)
+  const delta = balAfter - balBefore
+  const mutationOk = delta === ethers.parseEther("1")
+  console.log(`  tx ${tx.hash.slice(0, 20)}... block ${rcpt.blockNumber} status=${rcpt.status} delta=${ethers.formatEther(delta)} ETH ${mutationOk ? "✓" : "✗"}`)
+
+  // Summary
+  console.log("")
+  console.log("=== Summary ===")
+  const passed = Object.values(results).filter((r) => r.pass).length + (mutationOk ? 1 : 0)
+  const total = Object.keys(results).length + 1
+  console.log(`${passed}/${total} tests passed`)
+  for (const [name, r] of Object.entries(results)) {
+    console.log(`  ${r.pass ? "✓" : "✗"} ${name}`)
+  }
+  console.log(`  ${mutationOk ? "✓" : "✗"} ETH transfer mutation`)
+
+  if (passed < total) process.exit(1)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/docs/r3-2-prod-candidate-testnet-88780.md
+++ b/docs/r3-2-prod-candidate-testnet-88780.md
@@ -34,8 +34,11 @@ All 7 keys must be **distinct** (no shared anvil keys like in current 18780).
 - [ ] Update `scripts/gcloud/config.env` to add `COC_PROD_CANDIDATE_CHAIN_ID=88780`
 - [ ] Provision 5 GCP VMs reusing R1 fixture template
 - [ ] Bring up validators 6+7 on lab hardware
-- [ ] Deploy contracts via `contracts/deploy-all-registries-newchain.mjs`
-  (parameterized for chain 88780)
+- [x] Deploy contracts via `contracts/scripts/deploy-governance.js` then
+  `contracts/scripts/deploy-all-88780.js` (`COC_RPC_URL` / `COC_CHAIN_ID=88780`).
+  All 13 deployed addresses are recorded in `configs/deployed-contracts-88780.json`
+  — the canonical manifest. Last redeploy 2026-05-18 carried the #645–#670
+  security-audit contract fixes.
 - [ ] All 7 validators stake 32 ETH into ValidatorRegistry
 - [ ] All 7 register in PoSeManagerV2 with serviceFlags=7
 - [ ] enableEmission with COC token (real ERC20, not deployer-as-stub)


### PR DESCRIPTION
## Summary

The security-audit batch (#645–#664, #666–#670; merged via #665 / #646) fixed **9 of the 13** COC contracts — signature malleability, reentrancy CEI, stale-guardian recycling, non-transitive revocation, scope-narrowing escape, multi-slash replay, governance quorum griefing, input-validation hardening.

COC contracts are **non-upgradeable**, so chainId 88780 was still running the pre-fix (vulnerable) instances from 2026-05-12. This PR records a **full fresh redeploy of all 13 contracts** to 88780 carrying the security fixes.

## Deploy result (chainId 88780, 2026-05-18)

`deploy-governance.js` + `deploy-all-88780.js` → all 13 deployed; `test-deployed-88780.js` → **14/14** (owner/binding/code-size + ETH-transfer mutation, block 175298).

New addresses are in `configs/deployed-contracts-88780.json` (the canonical manifest). The 2026-05-12 contracts are abandoned (non-upgradeable → new addresses); their state loss is minimal — they were dormant (governance unexercised, ValidatorRegistry disabled, PoSe services unwired). Core validator/observer nodes do not reference contract addresses, so no node restart was involved.

## Changes

- `configs/deployed-contracts-88780.json` — **new** canonical manifest of the 13 redeployed addresses.
- `contracts/scripts/deploy-governance.js` — fix: Treasury's constructor is `(address[5] _signers, address _governance)`; the script passed only `_governance`. Now passes the five 88780 validators as signers (override via `TREASURY_SIGNERS`).
- `contracts/scripts/deploy-all-88780.js`, `test-deployed-88780.js` — track the 88780 deploy + smoke-test tooling (force-added past the repo-wide `*.js` ignore, matching the already-tracked `deploy-governance.js`).
- `docs/r3-2-prod-candidate-testnet-88780.md` — correct the contract-deploy step to the real scripts + manifest.

## Test plan

- [x] Contract unit tests — 434/434 (`cd contracts && npm test`)
- [x] `test-deployed-88780.js` against live 88780 — 14/14
- [ ] CI

Follow-up: the `@chainofclaw/soul` package's 88780 manifest (separate claw-mem repo) is updated to the new addresses in its own PR.