### PR TITLE
[codex] harden PoSe payout paths

### DIFF
--- a/contracts/contracts-src/settlement/IPoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/IPoSeManagerV2.sol
@@ -18,6 +18,8 @@ interface IPoSeManagerV2 {
     event SlashDistributed(bytes32 indexed nodeId, uint256 burned, uint256 challenger, uint256 insurance);
     event EpochFinalizedV2(uint64 indexed epochId, bytes32 rewardRoot, uint256 totalReward);
     event InsuranceDeposited(address indexed depositor, uint256 amount);
+    event WithdrawalCredited(address indexed payee, uint256 amount);
+    event WithdrawalClaimed(address indexed payee, uint256 amount);
 
     // Errors
     error InvalidWitnessQuorum();
@@ -37,6 +39,7 @@ interface IPoSeManagerV2 {
     error InvalidFaultType();
     error RewardPoolInsufficient();
     error RewardBudgetExceeded();
+    error NoPendingWithdrawal();
 
     // Functions
     function initEpochNonce(uint64 epochId) external;
@@ -75,6 +78,8 @@ interface IPoSeManagerV2 {
     function claim(uint64 epochId, bytes32 nodeId, uint256 amount, bytes32[] calldata merkleProof) external;
 
     function depositRewardPool() external payable;
+
+    function withdrawPayments() external;
 
     function getWitnessSet(uint64 epochId) external view returns (bytes32[] memory);
 

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -39,6 +39,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     mapping(uint64 => uint256) public epochClaimedReward;
     mapping(bytes32 => bool) public consumedFaultEvidence;
     mapping(bytes32 => uint64) public challengeFaultEpochPlusOne;
+    mapping(address => uint256) public pendingWithdrawals;
 
     uint256 public challengeBondMin;
     uint256 public insuranceBalance;
@@ -399,9 +400,8 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
 
                 insuranceBalance += insuranceAmount;
 
-                // Transfer challenger reward + refund bond
-                (bool ok,) = payable(record.challenger).call{value: challengerAmount + record.bond}("");
-                if (!ok) revert TransferFailed();
+                // Pay challenger reward + refund bond, or credit for later withdrawal.
+                _payOrCredit(record.challenger, challengerAmount + record.bond);
 
                 if (node.bondAmount == 0) {
                     node.active = false;
@@ -411,9 +411,8 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
                 emit SlashDistributed(record.targetNodeId, burnAmount, challengerAmount, insuranceAmount);
                 emit ChallengeSettled(challengeId, true, slashAmount);
             } else {
-                // Slash cap reached, refund bond
-                (bool ok,) = payable(record.challenger).call{value: record.bond}("");
-                if (!ok) revert TransferFailed();
+                // Slash cap reached, refund bond.
+                _payOrCredit(record.challenger, record.bond);
                 emit ChallengeSettled(challengeId, false, 0);
             }
         } else {
@@ -546,10 +545,9 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         uint256 toFoundation = (unclaimed * EXPIRED_FOUNDATION_BPS) / BPS_DENOMINATOR;
         uint256 toBurn = unclaimed - toFoundation;
 
-        // Transfer 10% to Foundation
+        // Transfer 10% to Foundation, or credit it when the address rejects ETH.
         if (toFoundation > 0 && foundationAddress != address(0)) {
-            (bool ok,) = payable(foundationAddress).call{value: toFoundation}("");
-            require(ok, "foundation transfer failed");
+            _payOrCredit(foundationAddress, toFoundation);
         }
 
         // Burn 90% via COCToken (if emission enabled and token set)
@@ -558,6 +556,18 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         }
 
         emit ExpiredRewardsSwept(epochId, toFoundation, toBurn);
+    }
+
+    /// @notice Claim ETH that could not be delivered during protocol payouts.
+    function withdrawPayments() external override {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert NoPendingWithdrawal();
+
+        pendingWithdrawals[msg.sender] = 0;
+        (bool ok,) = msg.sender.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+
+        emit WithdrawalClaimed(msg.sender, amount);
     }
 
     // --- Witness set computation ---
@@ -771,6 +781,16 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
 
     function _requiredBond(uint8 existingNodeCount) internal pure returns (uint256) {
         return MIN_BOND << existingNodeCount;
+    }
+
+    function _payOrCredit(address to, uint256 amount) internal {
+        if (amount == 0 || to == address(0)) return;
+
+        (bool ok,) = to.call{value: amount}("");
+        if (!ok) {
+            pendingWithdrawals[to] += amount;
+            emit WithdrawalCredited(to, amount);
+        }
     }
 
     function _verifyOwnership(bytes32 nodeId, bytes calldata pubkeyNode, bytes calldata sig) internal view {

--- a/contracts/contracts-src/test-contracts/EthRejectingReceiver.sol
+++ b/contracts/contracts-src/test-contracts/EthRejectingReceiver.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice Test-only helper whose runtime rejects native token payouts.
+contract EthRejectingReceiver {
+    receive() external payable {
+        revert("reject eth");
+    }
+}

--- a/contracts/contracts-src/token/COCToken.sol
+++ b/contracts/contracts-src/token/COCToken.sol
@@ -87,6 +87,7 @@ contract COCToken {
     // ── Minter Management ──────────────────────────────────────────
 
     function setMinter(address newMinter) external onlyOwner {
+        if (newMinter == address(0)) revert ZeroAddress();
         emit MinterUpdated(minter, newMinter);
         minter = newMinter;
     }

--- a/contracts/test/coc-token.test.cjs
+++ b/contracts/test/coc-token.test.cjs
@@ -1,0 +1,30 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+describe("COCToken", function () {
+  let token
+  let owner
+  let minter
+
+  beforeEach(async function () {
+    ;[owner, minter] = await ethers.getSigners()
+
+    const Factory = await ethers.getContractFactory("COCToken")
+    token = await Factory.deploy([owner.address], [ethers.parseEther("250000000")])
+    await token.waitForDeployment()
+  })
+
+  it("rejects zero-address minter updates", async function () {
+    await expect(
+      token.setMinter(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(token, "ZeroAddress")
+  })
+
+  it("allows the owner to set a nonzero minter", async function () {
+    await expect(token.setMinter(minter.address))
+      .to.emit(token, "MinterUpdated")
+      .withArgs(ethers.ZeroAddress, minter.address)
+
+    expect(await token.minter()).to.equal(minter.address)
+  })
+})

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -131,6 +131,60 @@ async function openChallengeAndGetId(manager, commitHash, bond) {
   return manager.interface.parseLog(event).args[0]
 }
 
+async function installRejectingReceiverCode(address) {
+  const Rejecting = await ethers.getContractFactory("EthRejectingReceiver")
+  const rejecting = await Rejecting.deploy()
+  await rejecting.waitForDeployment()
+  const code = await ethers.provider.getCode(await rejecting.getAddress())
+  await ethers.provider.send("hardhat_setCode", [address, code])
+}
+
+async function openRevealedFaultChallenge(manager, challenger, targetNodeId, opts = {}) {
+  const bond = opts.bond ?? ethers.parseEther("0.01")
+  const faultType = opts.faultType ?? 2
+  const label = opts.label ?? "fault"
+  const latestBlock = await ethers.provider.getBlock("latest")
+  const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+  const nonceByte = opts.nonceByte ?? "88"
+
+  const leaf = {
+    epoch: epochId,
+    nodeId: targetNodeId,
+    nonce: "0x" + nonceByte.repeat(16),
+    tipHash: ethers.keccak256(ethers.toUtf8Bytes(`tip-${label}`)),
+    tipHeight: opts.tipHeight ?? 900,
+    latencyMs: opts.latencyMs ?? 1200,
+    resultCode: 2,
+    witnessBitmap: 0,
+  }
+  const evidenceLeafHash = hashEvidenceLeafV2(leaf)
+  const batchId = await submitSingleLeafBatchV2(manager, epochId, evidenceLeafHash)
+  const evidenceData = encodeEvidenceData(batchId, [evidenceLeafHash], leaf)
+  const salt = ethers.keccak256(ethers.toUtf8Bytes(`salt-${label}`))
+  const commitHash = ethers.keccak256(
+    ethers.solidityPacked(
+      ["bytes32", "uint8", "bytes32", "bytes32"],
+      [targetNodeId, faultType, evidenceLeafHash, salt]
+    )
+  )
+
+  const challengerManager = manager.connect(challenger)
+  const challengeId = await openChallengeAndGetId(challengerManager, commitHash, bond)
+  const revealDigest = ethers.keccak256(
+    ethers.solidityPacked(
+      ["string", "bytes32", "bytes32", "uint8", "bytes32", "bytes32", "bytes32"],
+      ["coc-fault:", challengeId, targetNodeId, faultType, evidenceLeafHash, salt, ethers.keccak256(evidenceData)]
+    )
+  )
+  const challengerSig = await challenger.signMessage(ethers.getBytes(revealDigest))
+
+  await challengerManager.revealChallenge(
+    challengeId, targetNodeId, faultType, evidenceLeafHash, salt, evidenceData, challengerSig
+  )
+
+  return { challengeId, bond, epochId, evidenceLeafHash }
+}
+
 describe("PoSeManagerV2", function () {
   let manager
   let deployer
@@ -430,6 +484,48 @@ describe("PoSeManagerV2", function () {
       await manager.settleChallenge(challengeId)
       const settled = await manager.getChallenge(challengeId)
       expect(settled.settled).to.equal(true)
+    })
+
+    it("credits challenger payout when direct ETH transfer fails", async function () {
+      const { nodeId } = await registerNode(manager, deployer)
+      const bond = ethers.parseEther("0.01")
+      await manager.setChallengeBondMin(bond)
+
+      const challenger = ethers.Wallet.createRandom().connect(ethers.provider)
+      await deployer.sendTransaction({ to: challenger.address, value: ethers.parseEther("1") })
+
+      const nodeBefore = await manager.getNode(nodeId)
+      const { challengeId } = await openRevealedFaultChallenge(manager, challenger, nodeId, {
+        bond,
+        label: "reject-payout",
+      })
+      const slashAmount = (nodeBefore.bondAmount * 500n) / 10000n
+      const challengerReward = (slashAmount * 3000n) / 10000n
+      const expectedCredit = bond + challengerReward
+
+      await installRejectingReceiverCode(challenger.address)
+      await ethers.provider.send("evm_increaseTime", [5 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      await expect(manager.settleChallenge(challengeId))
+        .to.emit(manager, "WithdrawalCredited")
+        .withArgs(challenger.address, expectedCredit)
+
+      const settled = await manager.getChallenge(challengeId)
+      expect(settled.settled).to.equal(true)
+      expect(await manager.pendingWithdrawals(challenger.address)).to.equal(expectedCredit)
+
+      await ethers.provider.send("hardhat_setBalance", [challenger.address, "0x1000000000000000000"])
+      await ethers.provider.send("hardhat_impersonateAccount", [challenger.address])
+      const rejectingSigner = await ethers.getSigner(challenger.address)
+      try {
+        await expect(
+          manager.connect(rejectingSigner).withdrawPayments()
+        ).to.be.revertedWithCustomError(manager, "TransferFailed")
+      } finally {
+        await ethers.provider.send("hardhat_stopImpersonatingAccount", [challenger.address])
+      }
+      expect(await manager.pendingWithdrawals(challenger.address)).to.equal(expectedCredit)
     })
 
     it("reverts when reusing the same fault evidence", async function () {
@@ -751,6 +847,33 @@ describe("PoSeManagerV2", function () {
     it("depositInsurance increases insurance balance", async function () {
       await manager.depositInsurance({ value: ethers.parseEther("2") })
       expect(await manager.insuranceBalance()).to.equal(ethers.parseEther("2"))
+    })
+
+    it("credits foundation payout when expired reward sweep receiver rejects ETH", async function () {
+      const foundation = ethers.Wallet.createRandom()
+      await manager.setFoundationAddress(foundation.address)
+      await installRejectingReceiverCode(foundation.address)
+
+      const reward = ethers.parseEther("1")
+      await manager.depositRewardPool({ value: ethers.parseEther("5") })
+
+      await ethers.provider.send("evm_increaseTime", [4 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      const epochId = 1
+      const leaf = ethers.keccak256(ethers.toUtf8Bytes("expired-foundation-credit"))
+      await manager.finalizeEpochV2(epochId, pairHash(leaf, leaf), reward, 0, 0)
+
+      await ethers.provider.send("evm_increaseTime", [8 * 24 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      const expectedCredit = (reward * 1000n) / 10000n
+      await expect(manager.sweepExpiredRewards(epochId))
+        .to.emit(manager, "WithdrawalCredited")
+        .withArgs(foundation.address, expectedCredit)
+
+      expect(await manager.epochSwept(epochId)).to.equal(true)
+      expect(await manager.pendingWithdrawals(foundation.address)).to.equal(expectedCredit)
     })
   })
 


### PR DESCRIPTION
## Summary

- add pull-payment accounting to PoSeManagerV2 protocol payout paths
- credit rejecting challengers/foundation addresses instead of reverting settlement or expired reward sweeping
- reject zero-address COCToken minter updates
- add focused regression tests for rejecting ETH receivers and COCToken minter validation

## Security Impact

PoSe challenge settlement and expired reward sweeping previously depended on direct native-token transfers succeeding. A contract challenger or foundation address that rejected ETH could make those protocol progress paths revert. This PR keeps state transitions live by crediting failed payouts for later withdrawal.

## Validation

- `cd contracts && npx hardhat test "test/pose-v2.test.cjs" "test/coc-token.test.cjs"`
- `cd contracts && npx hardhat test "test/rollup-state-manager.test.cjs" "test/rollup-resolve-reentrancy.test.cjs"`
- `git diff --cached --check` before commit
