### PR TITLE
[codex] harden validator slash payouts

### DIFF
--- a/contracts/contracts-src/governance/ValidatorRegistry.sol
+++ b/contracts/contracts-src/governance/ValidatorRegistry.sol
@@ -100,6 +100,7 @@ contract ValidatorRegistry {
     // burn truly leaves circulation; owner can override.
     address public insuranceFund;
     address public burnSink;
+    mapping(address => uint256) public pendingWithdrawals;
 
     // ── Events ───────────────────────────────────────────────────────────
 
@@ -127,6 +128,8 @@ contract ValidatorRegistry {
     event InsuranceFundUpdated(address indexed oldFund, address indexed newFund);
     event BurnSinkUpdated(address indexed oldSink, address indexed newSink);
     event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+    event WithdrawalCredited(address indexed payee, uint256 amount);
+    event WithdrawalClaimed(address indexed payee, uint256 amount);
 
     // ── Errors ───────────────────────────────────────────────────────────
 
@@ -144,6 +147,7 @@ contract ValidatorRegistry {
     error OnlyOwner();
     error TransferFailed();
     error ZeroAddress();
+    error NoPendingWithdrawal();
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert OnlyOwner();
@@ -288,28 +292,30 @@ contract ValidatorRegistry {
                 address effectiveBurnSink = burnSink == address(0)
                     ? address(0x000000000000000000000000000000000000dEaD)
                     : burnSink;
-                if (burnShare > 0) {
-                    (bool okB, ) = payable(effectiveBurnSink).call{ value: burnShare }("");
-                    if (!okB) revert TransferFailed();
-                }
-                if (reporterShare > 0) {
-                    (bool okR, ) = payable(slashRecipient).call{ value: reporterShare }("");
-                    if (!okR) revert TransferFailed();
-                }
-                if (insuranceShare > 0) {
-                    (bool okI, ) = payable(insuranceFund).call{ value: insuranceShare }("");
-                    if (!okI) revert TransferFailed();
-                }
+                _payOrCredit(effectiveBurnSink, burnShare);
+                _payOrCredit(slashRecipient, reporterShare);
+                _payOrCredit(insuranceFund, insuranceShare);
                 emit SlashDistributed(nodeId, burnShare, reporterShare, insuranceShare);
             } else {
                 // Legacy: 100% to slashRecipient. Deployments that haven't
                 // configured insuranceFund retain pre-I5 behaviour.
-                (bool ok, ) = payable(slashRecipient).call{ value: slashAmount }("");
-                if (!ok) revert TransferFailed();
+                _payOrCredit(slashRecipient, slashAmount);
             }
         }
 
         emit ValidatorSlashed(nodeId, slashAmount, reason);
+    }
+
+    /// @notice Claim ETH that could not be delivered during slash payouts.
+    function withdrawPayments() external {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert NoPendingWithdrawal();
+
+        pendingWithdrawals[msg.sender] = 0;
+        (bool ok, ) = msg.sender.call{ value: amount }("");
+        if (!ok) revert TransferFailed();
+
+        emit WithdrawalClaimed(msg.sender, amount);
     }
 
     // ── Views ────────────────────────────────────────────────────────────
@@ -385,6 +391,16 @@ contract ValidatorRegistry {
         }
         _activeNodeIds.pop();
         delete _activeIndex[nodeId];
+    }
+
+    function _payOrCredit(address to, uint256 amount) internal {
+        if (amount == 0 || to == address(0)) return;
+
+        (bool ok, ) = to.call{ value: amount }("");
+        if (!ok) {
+            pendingWithdrawals[to] += amount;
+            emit WithdrawalCredited(to, amount);
+        }
     }
 
     receive() external payable {

--- a/contracts/test/ValidatorRegistry.test.cjs
+++ b/contracts/test/ValidatorRegistry.test.cjs
@@ -57,6 +57,13 @@ async function deployRegistry() {
   return { registry, owner, signers }
 }
 
+async function deployRejectingReceiver() {
+  const Factory = await ethers.getContractFactory("EthRejectingReceiver")
+  const receiver = await Factory.deploy()
+  await receiver.waitForDeployment()
+  return receiver
+}
+
 async function increaseTime(seconds) {
   await ethers.provider.send("evm_increaseTime", [seconds])
   await ethers.provider.send("evm_mine", [])
@@ -326,6 +333,37 @@ describe("ValidatorRegistry: slashValidator()", () => {
     expect(v.stake).to.equal(expected)
   })
 
+  it("credits rejecting legacy slash recipient without blocking slash", async () => {
+    const { registry, nodeId } = await fixture()
+    const receiver = await deployRejectingReceiver()
+    const receiverAddress = await receiver.getAddress()
+    await registry.setSlashRecipient(receiverAddress)
+
+    const expectedSlash = (MIN_STAKE * SLASH_BPS) / BPS_DENOM
+
+    await expect(registry.slashValidator(nodeId, ethers.id("rejecting-recipient")))
+      .to.emit(registry, "WithdrawalCredited")
+      .withArgs(receiverAddress, expectedSlash)
+
+    const v = await registry.getValidator(nodeId)
+    expect(v.stake).to.equal(MIN_STAKE - expectedSlash)
+    expect(v.active).to.equal(false)
+    expect(await registry.activeValidatorCount()).to.equal(0n)
+    expect(await registry.pendingWithdrawals(receiverAddress)).to.equal(expectedSlash)
+
+    await ethers.provider.send("hardhat_setBalance", [receiverAddress, "0x1000000000000000000"])
+    await ethers.provider.send("hardhat_impersonateAccount", [receiverAddress])
+    const receiverSigner = await ethers.getSigner(receiverAddress)
+    try {
+      await expect(
+        registry.connect(receiverSigner).withdrawPayments(),
+      ).to.be.revertedWithCustomError(registry, "TransferFailed")
+    } finally {
+      await ethers.provider.send("hardhat_stopImpersonatingAccount", [receiverAddress])
+    }
+    expect(await registry.pendingWithdrawals(receiverAddress)).to.equal(expectedSlash)
+  })
+
   it("can slash an already-deactivated validator (during lockup)", async () => {
     const { registry, op, nodeId } = await fixture()
     await registry.connect(op).requestUnstake(nodeId)
@@ -468,6 +506,49 @@ describe("ValidatorRegistry: Phase I5 — slash split when insuranceFund set", (
     await registry.connect(owner).slashValidator(nodeId, ethers.id("evidence-i5"))
     const altAfter = await ethers.provider.getBalance(altBurn.address)
     expect(altAfter - altBefore).to.equal(expectedBurn)
+  })
+
+  it("credits rejecting split payout targets without blocking slash", async () => {
+    const { registry, owner, nodeId } = await fixtureWithSplit()
+    const burnReceiver = await deployRejectingReceiver()
+    const reporterReceiver = await deployRejectingReceiver()
+    const insuranceReceiver = await deployRejectingReceiver()
+    const burnAddress = await burnReceiver.getAddress()
+    const reporterAddress = await reporterReceiver.getAddress()
+    const insuranceAddress = await insuranceReceiver.getAddress()
+
+    await registry.connect(owner).setBurnSink(burnAddress)
+    await registry.connect(owner).setSlashRecipient(reporterAddress)
+    await registry.connect(owner).setInsuranceFund(insuranceAddress)
+
+    const expectedSlash = (MIN_STAKE * SLASH_BPS) / BPS_DENOM
+    const expectedBurn = (expectedSlash * SPLIT_BURN_BPS) / BPS_DENOM
+    const expectedReporter = (expectedSlash * SPLIT_REPORTER_BPS) / BPS_DENOM
+    const expectedInsurance = expectedSlash - expectedBurn - expectedReporter
+
+    const tx = await registry.connect(owner).slashValidator(nodeId, ethers.id("rejecting-split"))
+    const receipt = await tx.wait()
+
+    const creditedEvents = receipt.logs.filter((l) => l.fragment?.name === "WithdrawalCredited")
+    expect(creditedEvents.map((event) => event.args[0])).to.deep.equal([
+      burnAddress,
+      reporterAddress,
+      insuranceAddress,
+    ])
+    expect(creditedEvents.map((event) => event.args[1])).to.deep.equal([
+      expectedBurn,
+      expectedReporter,
+      expectedInsurance,
+    ])
+
+    expect(await registry.pendingWithdrawals(burnAddress)).to.equal(expectedBurn)
+    expect(await registry.pendingWithdrawals(reporterAddress)).to.equal(expectedReporter)
+    expect(await registry.pendingWithdrawals(insuranceAddress)).to.equal(expectedInsurance)
+
+    const v = await registry.getValidator(nodeId)
+    expect(v.stake).to.equal(MIN_STAKE - expectedSlash)
+    expect(v.active).to.equal(false)
+    expect(await registry.activeValidatorCount()).to.equal(0n)
   })
 
   it("clearing insuranceFund (setInsuranceFund=0) reverts to legacy 100% behaviour", async () => {

--- a/explorer/src/app/api/verify/route.ts
+++ b/explorer/src/app/api/verify/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createHash, timingSafeEqual } from 'node:crypto'
-import { verifyContract, type VerifyParams } from '@/lib/solc-verify'
+import { safeVerifyInternalErrorMessage, verifyContract, type VerifyParams } from '@/lib/solc-verify'
 import { getVerifyRateLimitClientIp } from '@/lib/verify-client-ip'
 import { getVerifyRateLimitKey } from '@/lib/verify-rate-limit'
 
@@ -169,7 +169,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json(result)
   } catch (err) {
     return NextResponse.json(
-      { verified: false, matchPct: 0, error: err instanceof Error ? err.message : 'Internal server error' },
+      { verified: false, matchPct: 0, error: safeVerifyInternalErrorMessage(err) },
       { status: 500 },
     )
   }

--- a/explorer/src/lib/solc-verify.test.ts
+++ b/explorer/src/lib/solc-verify.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { resolveCompilerVersionTag } from "./solc-verify.ts"
+import {
+  resolveCompilerVersionTag,
+  safeVerifyInternalErrorMessage,
+} from "./solc-verify.ts"
 
 describe("resolveCompilerVersionTag", () => {
   it("maps supported bare versions to full remote tags", () => {
@@ -17,5 +20,16 @@ describe("resolveCompilerVersionTag", () => {
 
   it("returns null for unsupported bare versions", () => {
     assert.equal(resolveCompilerVersionTag("0.8.99"), null)
+  })
+})
+
+describe("safeVerifyInternalErrorMessage", () => {
+  it("does not expose internal exception messages", () => {
+    const message = safeVerifyInternalErrorMessage(
+      new Error("rpc auth token leaked in upstream exception"),
+    )
+
+    assert.equal(message, "Internal verification error")
+    assert.equal(message.includes("token"), false)
   })
 })

--- a/explorer/src/lib/solc-verify.ts
+++ b/explorer/src/lib/solc-verify.ts
@@ -69,6 +69,10 @@ export function resolveCompilerVersionTag(compilerVersion: string): string | nul
   return SOLC_REMOTE_VERSION_TAGS[compilerVersion] ?? null
 }
 
+export function safeVerifyInternalErrorMessage(_error: unknown): string {
+  return 'Internal verification error'
+}
+
 function allowRemoteCompilerLoad(): boolean {
   if (process.env.COC_SOLC_ALLOW_REMOTE === '1') return true
   if (process.env.COC_SOLC_ALLOW_REMOTE === '0') return false
@@ -210,7 +214,7 @@ export async function verifyContract(params: VerifyParams): Promise<VerifyResult
     return {
       verified: false,
       matchPct: 0,
-      error: err instanceof Error ? err.message : 'Unknown verification error',
+      error: safeVerifyInternalErrorMessage(err),
     }
   }
 }


### PR DESCRIPTION
## Summary

- add pull-payment accounting for ValidatorRegistry slash payout recipients
- keep validator slashing live when burn/reporter/insurance targets reject native-token transfers
- sanitize unexpected Explorer Verify API internal error messages
- add regression coverage for rejecting slash payout recipients and verify error hygiene

## Security Impact

`ValidatorRegistry.slashValidator()` previously reverted the whole slash if any configured payout address rejected ETH. That let a bad `slashRecipient`, `burnSink`, or `insuranceFund` configuration block validator deactivation and stake reduction. This PR credits failed slash payouts for later withdrawal so protocol state can still progress.

The Verify API now returns a stable generic error for unexpected internal failures instead of exposing upstream exception text.

## Validation

- `cd contracts && npx hardhat test "test/ValidatorRegistry.test.cjs"`
- `node --experimental-strip-types --test "explorer/src/lib/solc-verify.test.ts"`
- `git diff --check`
