### PR TITLE
fix(security): harden PoSe batch submission DoS paths

### DIFF
--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -40,6 +40,12 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     mapping(bytes32 => bool) public consumedFaultEvidence;
     mapping(bytes32 => uint64) public challengeFaultEpochPlusOne;
     mapping(address => uint256) public pendingWithdrawals;
+    // Per-epoch guard: a merkleRoot uniquely identifies batch contents, so it
+    // may be submitted at most once per epoch. Without this, witness sigs
+    // (bound only to the root, not to batchId/aggregator) replay across
+    // unlimited cloned batches and bloat epochBatches, causing finalizeEpochV2
+    // DoS (#680).
+    mapping(uint64 => mapping(bytes32 => bool)) public epochMerkleRootUsed;
 
     uint256 public challengeBondMin;
     uint256 public insuranceBalance;
@@ -200,6 +206,10 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
 
         batchId = _batchId(epochId, merkleRoot, summaryHash, msg.sender);
         if (batches[batchId].merkleRoot != bytes32(0)) revert BatchAlreadySubmitted();
+        // One merkleRoot per epoch: blocks duplicate-root clones whose replayed
+        // witness signatures would otherwise bloat epochBatches unboundedly (#680).
+        if (epochMerkleRootUsed[epochId][merkleRoot]) revert BatchAlreadySubmitted();
+        epochMerkleRootUsed[epochId][merkleRoot] = true;
 
         // Verify sample proofs (reuse v1 logic)
         bytes32 sampleCommitment = bytes32(0);

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -201,7 +201,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         if (sampleProofs.length == 0 || sampleProofs.length > type(uint16).max) revert InvalidBatch();
 
         // Validate witness quorum.
-        // Transition mode: allow empty witness set/signatures to avoid deadlock during rollout.
+        // Bootstrap/transition submissions without witness signatures are owner-only.
         _validateWitnessQuorum(epochId, witnessBitmap, witnessSignatures, merkleRoot);
 
         batchId = _batchId(epochId, merkleRoot, summaryHash, msg.sender);
@@ -684,15 +684,21 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         bytes[] calldata witnessSignatures,
         bytes32 merkleRoot
     ) internal view {
+        bytes32[] memory witnessSet = getWitnessSet(epochId);
+        uint256 m = witnessSet.length;
+
+        if (m == 0) {
+            if (msg.sender != owner) revert InvalidWitnessQuorum();
+            if (witnessBitmap != 0 || witnessSignatures.length != 0) revert InvalidWitnessQuorum();
+            return;
+        }
+
         if (witnessBitmap == 0 && witnessSignatures.length == 0) {
-            if (!allowEmptyWitnessSubmission && getWitnessSet(epochId).length > 0) {
+            if (!allowEmptyWitnessSubmission || msg.sender != owner) {
                 revert InvalidWitnessQuorum();
             }
             return;
         }
-        bytes32[] memory witnessSet = getWitnessSet(epochId);
-        uint256 m = witnessSet.length;
-        if (m == 0) return; // no witnesses required if no active nodes
 
         uint256 required = (2 * m + 2) / 3; // ceil(2m/3)
         uint256 count = 0;

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -83,7 +83,7 @@ function pairHash(a, b) {
   return ethers.keccak256(ethers.solidityPacked(["bytes32", "bytes32"], [x, y]))
 }
 
-async function submitSingleLeafBatchV2(manager, epochId, leafHash) {
+async function submitSingleLeafBatchV2(manager, epochId, leafHash, submitter = manager) {
   const sampleProofs = [{ leaf: leafHash, merkleProof: [leafHash], leafIndex: 0 }]
   const sampleCommitment = ethers.keccak256(
     ethers.solidityPacked(["bytes32", "uint32", "bytes32"], [ethers.ZeroHash, 0, leafHash])
@@ -91,7 +91,7 @@ async function submitSingleLeafBatchV2(manager, epochId, leafHash) {
   const summaryHash = ethers.keccak256(
     ethers.solidityPacked(["uint64", "bytes32", "bytes32", "uint32"], [epochId, pairHash(leafHash, leafHash), sampleCommitment, 1])
   )
-  const tx = await manager.submitBatchV2(
+  const tx = await submitter.submitBatchV2(
     epochId,
     pairHash(leafHash, leafHash),
     summaryHash,
@@ -313,6 +313,36 @@ describe("PoSeManagerV2", function () {
       await expect(
         submitSingleLeafBatchV2(manager, epochId, leafHash)
       ).to.be.revertedWithCustomError(manager, "InvalidWitnessQuorum")
+    })
+  })
+
+  describe("submitBatchV2 duplicate root guard", function () {
+    it("rejects the same merkle root for an epoch from a different submitter", async function () {
+      const [, otherSubmitter] = await ethers.getSigners()
+      const latestBlock = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+      const leafHash = ethers.keccak256(ethers.toUtf8Bytes("duplicate-root-same-epoch"))
+
+      await submitSingleLeafBatchV2(manager, epochId, leafHash)
+
+      await expect(
+        submitSingleLeafBatchV2(manager, epochId, leafHash, manager.connect(otherSubmitter))
+      ).to.be.revertedWithCustomError(manager, "BatchAlreadySubmitted")
+
+      expect(await manager.getEpochBatchIds(epochId)).to.have.lengthOf(1)
+    })
+
+    it("allows the same merkle root in a different epoch", async function () {
+      const latestBlock = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+      const priorEpochId = epochId - 1
+      const leafHash = ethers.keccak256(ethers.toUtf8Bytes("duplicate-root-different-epoch"))
+
+      await submitSingleLeafBatchV2(manager, priorEpochId, leafHash)
+      await submitSingleLeafBatchV2(manager, epochId, leafHash)
+
+      expect(await manager.getEpochBatchIds(priorEpochId)).to.have.lengthOf(1)
+      expect(await manager.getEpochBatchIds(epochId)).to.have.lengthOf(1)
     })
   })
 

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -83,7 +83,30 @@ function pairHash(a, b) {
   return ethers.keccak256(ethers.solidityPacked(["bytes32", "bytes32"], [x, y]))
 }
 
-async function submitSingleLeafBatchV2(manager, epochId, leafHash, submitter = manager) {
+const WITNESS_TYPEHASH = ethers.keccak256(
+  ethers.toUtf8Bytes("WitnessAttestation(bytes32 challengeId,bytes32 nodeId,bytes32 responseBodyHash,uint8 witnessIndex)")
+)
+
+async function signWitness(manager, witness, merkleRoot, witnessIndex = 0) {
+  const domainSeparator = await manager.DOMAIN_SEPARATOR()
+  const structHash = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["bytes32", "bytes32", "bytes32", "bytes32", "uint8"],
+      [WITNESS_TYPEHASH, merkleRoot, witness.nodeId, merkleRoot, witnessIndex],
+    )
+  )
+  const digest = ethers.keccak256(ethers.concat(["0x1901", domainSeparator, structHash]))
+  return witness.operator.signingKey.sign(digest).serialized
+}
+
+async function submitSingleLeafBatchV2(
+  manager,
+  epochId,
+  leafHash,
+  submitter = manager,
+  witnessBitmap = 0,
+  witnessSignatures = [],
+) {
   const sampleProofs = [{ leaf: leafHash, merkleProof: [leafHash], leafIndex: 0 }]
   const sampleCommitment = ethers.keccak256(
     ethers.solidityPacked(["bytes32", "uint32", "bytes32"], [ethers.ZeroHash, 0, leafHash])
@@ -96,8 +119,8 @@ async function submitSingleLeafBatchV2(manager, epochId, leafHash, submitter = m
     pairHash(leafHash, leafHash),
     summaryHash,
     sampleProofs,
-    0,
-    [],
+    witnessBitmap,
+    witnessSignatures,
   )
   const receipt = await tx.wait()
   const event = receipt.logs.find((l) => {
@@ -303,6 +326,27 @@ describe("PoSeManagerV2", function () {
   })
 
   describe("submitBatchV2 witness mode", function () {
+    it("rejects non-owner empty witness submissions when no witness set exists", async function () {
+      const [, otherSubmitter] = await ethers.getSigners()
+      const latestBlock = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+      const leafHash = ethers.keccak256(ethers.toUtf8Bytes("no-witness-non-owner"))
+
+      await expect(
+        submitSingleLeafBatchV2(manager, epochId, leafHash, manager.connect(otherSubmitter))
+      ).to.be.revertedWithCustomError(manager, "InvalidWitnessQuorum")
+    })
+
+    it("allows owner empty witness submissions when no witness set exists", async function () {
+      const latestBlock = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+      const leafHash = ethers.keccak256(ethers.toUtf8Bytes("no-witness-owner"))
+
+      await submitSingleLeafBatchV2(manager, epochId, leafHash)
+
+      expect(await manager.getEpochBatchIds(epochId)).to.have.lengthOf(1)
+    })
+
     it("reverts empty witness submissions when transition mode is disabled", async function () {
       await registerNode(manager, deployer)
       await manager.setAllowEmptyWitnessSubmission(false)
@@ -314,19 +358,35 @@ describe("PoSeManagerV2", function () {
         submitSingleLeafBatchV2(manager, epochId, leafHash)
       ).to.be.revertedWithCustomError(manager, "InvalidWitnessQuorum")
     })
+
+    it("rejects non-owner empty witness submissions when transition mode is enabled", async function () {
+      const [, otherSubmitter] = await ethers.getSigners()
+      await registerNode(manager, deployer)
+      const latestBlock = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+      const leafHash = ethers.keccak256(ethers.toUtf8Bytes("empty-witness-non-owner"))
+
+      await expect(
+        submitSingleLeafBatchV2(manager, epochId, leafHash, manager.connect(otherSubmitter))
+      ).to.be.revertedWithCustomError(manager, "InvalidWitnessQuorum")
+    })
   })
 
   describe("submitBatchV2 duplicate root guard", function () {
     it("rejects the same merkle root for an epoch from a different submitter", async function () {
       const [, otherSubmitter] = await ethers.getSigners()
+      const witness = await registerNode(manager, deployer)
+      await manager.setAllowEmptyWitnessSubmission(false)
       const latestBlock = await ethers.provider.getBlock("latest")
       const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
       const leafHash = ethers.keccak256(ethers.toUtf8Bytes("duplicate-root-same-epoch"))
+      const merkleRoot = pairHash(leafHash, leafHash)
+      const witnessSignature = await signWitness(manager, witness, merkleRoot)
 
-      await submitSingleLeafBatchV2(manager, epochId, leafHash)
+      await submitSingleLeafBatchV2(manager, epochId, leafHash, manager, 1, [witnessSignature])
 
       await expect(
-        submitSingleLeafBatchV2(manager, epochId, leafHash, manager.connect(otherSubmitter))
+        submitSingleLeafBatchV2(manager, epochId, leafHash, manager.connect(otherSubmitter), 1, [witnessSignature])
       ).to.be.revertedWithCustomError(manager, "BatchAlreadySubmitted")
 
       expect(await manager.getEpochBatchIds(epochId)).to.have.lengthOf(1)


### PR DESCRIPTION
## Summary

- Add a per-epoch Merkle-root guard to `PoSeManagerV2.submitBatchV2`.
- Reject cloned batch submissions that reuse an already accepted root for the same epoch.
- Restrict no-witness bootstrap and transition submissions to the contract owner.
- Add regression coverage for duplicate-root replay and non-owner empty-witness spam paths.

## Root Cause

`submitBatchV2` derives `batchId` from `msg.sender`, while witness signatures are bound to the Merkle root rather than the submitter. A caller could replay a valid batch from many addresses, append duplicate-root batch ids to `epochBatches[epochId]`, and make `finalizeEpochV2` exceed the block gas limit.

Separately, the no-witness path accepted empty witness submissions when the witness set was empty, and accepted any caller when the empty-witness transition flag was enabled. That left a distinct-root spam path even after duplicate-root replay was blocked.

## Validation

- `cd contracts && npx hardhat test "test/pose-v2.test.cjs"`
- `cd contracts && npx hardhat test "test/pose-v2-e2e.test.cjs"`
- `git diff --check`

Refs #680 (partial — duplicate-root + empty-witness paths only; full fix needs finalizeEpochV2 pagination, see issue)
Fixes #682