### PR TITLE
fix(security): harden governance payout delivery

### DIFF
--- a/contracts/contracts-src/governance/InsuranceFund.sol
+++ b/contracts/contracts-src/governance/InsuranceFund.sol
@@ -17,9 +17,13 @@ contract InsuranceFund {
     address public governance;
     uint256 public totalDeposited;
     uint256 public totalWithdrawn;
+    mapping(address => uint256) public pendingWithdrawals;
+    uint256 public pendingWithdrawalTotal;
 
     event Deposited(address indexed from, uint256 amount, uint256 totalDepositedAfter);
     event Withdrawn(address indexed to, uint256 amount, uint256 totalWithdrawnAfter);
+    event WithdrawalCredited(address indexed payee, uint256 amount);
+    event WithdrawalClaimed(address indexed payee, uint256 amount);
     event GovernanceUpdated(address indexed oldGovernance, address indexed newGovernance);
 
     error OnlyGovernance();
@@ -27,6 +31,7 @@ contract InsuranceFund {
     error TransferFailed();
     error InsufficientBalance(uint256 requested, uint256 available);
     error ZeroAddress();
+    error NoPendingWithdrawal();
 
     modifier onlyGovernance() {
         if (msg.sender != governance) revert OnlyGovernance();
@@ -52,13 +57,25 @@ contract InsuranceFund {
     function withdraw(address payable to, uint256 amount) external onlyGovernance {
         if (to == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
-        if (amount > address(this).balance) {
-            revert InsufficientBalance(amount, address(this).balance);
+        uint256 available = _availableBalance();
+        if (amount > available) {
+            revert InsufficientBalance(amount, available);
         }
         totalWithdrawn += amount;
-        (bool ok, ) = to.call{ value: amount }("");
-        if (!ok) revert TransferFailed();
+        _payOrCredit(to, amount);
         emit Withdrawn(to, amount, totalWithdrawn);
+    }
+
+    function withdrawPayments() external {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert NoPendingWithdrawal();
+
+        pendingWithdrawals[msg.sender] = 0;
+        pendingWithdrawalTotal -= amount;
+        (bool ok, ) = msg.sender.call{ value: amount }("");
+        if (!ok) revert TransferFailed();
+
+        emit WithdrawalClaimed(msg.sender, amount);
     }
 
     /// @notice Transfer the governance role. Two-step transfers are not used
@@ -74,5 +91,23 @@ contract InsuranceFund {
     ///         + COINBASE before EIP-6780). Both are surfaced for auditing.
     function balance() external view returns (uint256) {
         return address(this).balance;
+    }
+
+    function availableBalance() external view returns (uint256) {
+        return _availableBalance();
+    }
+
+    function _availableBalance() internal view returns (uint256) {
+        uint256 currentBalance = address(this).balance;
+        return currentBalance > pendingWithdrawalTotal ? currentBalance - pendingWithdrawalTotal : 0;
+    }
+
+    function _payOrCredit(address payable to, uint256 amount) internal {
+        (bool ok, ) = to.call{ value: amount }("");
+        if (!ok) {
+            pendingWithdrawals[to] += amount;
+            pendingWithdrawalTotal += amount;
+            emit WithdrawalCredited(to, amount);
+        }
     }
 }

--- a/contracts/contracts-src/governance/Treasury.sol
+++ b/contracts/contracts-src/governance/Treasury.sol
@@ -31,11 +31,15 @@ contract Treasury {
 
     uint256 public proposalCount;
     mapping(uint256 => Proposal) public proposals;
+    mapping(address => uint256) public pendingWithdrawals;
+    uint256 public pendingWithdrawalTotal;
 
     event Deposit(address indexed from, uint256 amount);
     event ProposalCreated(uint256 indexed proposalId, address indexed to, uint256 amount);
     event ProposalConfirmed(uint256 indexed proposalId, address indexed signer);
     event ProposalExecuted(uint256 indexed proposalId, address indexed to, uint256 amount);
+    event WithdrawalCredited(address indexed payee, uint256 amount);
+    event WithdrawalClaimed(address indexed payee, uint256 amount);
     event GovernanceUpdated(address indexed newGovernance);
     event SignerUpdated(uint8 indexed index, address indexed oldSigner, address indexed newSigner);
 
@@ -52,6 +56,7 @@ contract Treasury {
     error ZeroAddress();
     error DuplicateSigner();
     error InvalidProposal();
+    error NoPendingWithdrawal();
 
     modifier onlySigner() {
         if (!isSigner[msg.sender]) revert NotSigner();
@@ -82,7 +87,7 @@ contract Treasury {
     function proposeWithdrawal(address to, uint256 amount) external onlySigner returns (uint256) {
         if (to == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
-        if (address(this).balance < amount) revert InsufficientBalance();
+        if (_availableBalance() < amount) revert InsufficientBalance();
 
         uint256 id = proposalCount++;
         Proposal storage p = proposals[id];
@@ -121,16 +126,16 @@ contract Treasury {
         Proposal storage p = proposals[proposalId];
         if (p.executed) revert AlreadyExecuted();
         if (p.confirmations < REQUIRED_CONFIRMATIONS) revert NotEnoughConfirmations();
-        if (address(this).balance < p.amount) revert InsufficientBalance();
+        uint256 available = _availableBalance();
+        if (available < p.amount) revert InsufficientBalance();
 
         // Enforce 5% spending cap — amounts exceeding require DAO governance approval
-        uint256 cap = (address(this).balance * SPENDING_CAP_BPS) / 10000;
+        uint256 cap = (available * SPENDING_CAP_BPS) / 10000;
         if (p.amount > cap && !p.governanceApproved) revert ExceedsSpendingCap();
 
         p.executed = true;
 
-        (bool ok,) = payable(p.to).call{value: p.amount}("");
-        if (!ok) revert TransferFailed();
+        _payOrCredit(p.to, p.amount);
 
         emit ProposalExecuted(proposalId, p.to, p.amount);
     }
@@ -163,8 +168,38 @@ contract Treasury {
         emit SignerUpdated(index, old, newSigner);
     }
 
+    function withdrawPayments() external {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert NoPendingWithdrawal();
+
+        pendingWithdrawals[msg.sender] = 0;
+        pendingWithdrawalTotal -= amount;
+        (bool ok,) = msg.sender.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+
+        emit WithdrawalClaimed(msg.sender, amount);
+    }
+
     function getBalance() external view returns (uint256) {
         return address(this).balance;
+    }
+
+    function availableBalance() external view returns (uint256) {
+        return _availableBalance();
+    }
+
+    function _availableBalance() internal view returns (uint256) {
+        uint256 balance = address(this).balance;
+        return balance > pendingWithdrawalTotal ? balance - pendingWithdrawalTotal : 0;
+    }
+
+    function _payOrCredit(address to, uint256 amount) internal {
+        (bool ok,) = payable(to).call{value: amount}("");
+        if (!ok) {
+            pendingWithdrawals[to] += amount;
+            pendingWithdrawalTotal += amount;
+            emit WithdrawalCredited(to, amount);
+        }
     }
 
     receive() external payable {

--- a/contracts/test/InsuranceFund.test.cjs
+++ b/contracts/test/InsuranceFund.test.cjs
@@ -18,6 +18,14 @@ async function deployFund(initialGovernance) {
   return fund
 }
 
+async function installRejectingReceiverCode(address) {
+  const Rejecting = await ethers.getContractFactory("EthRejectingReceiver")
+  const rejecting = await Rejecting.deploy()
+  await rejecting.waitForDeployment()
+  const code = await ethers.provider.getCode(await rejecting.getAddress())
+  await ethers.provider.send("hardhat_setCode", [address, code])
+}
+
 describe("InsuranceFund: deployment", () => {
   it("rejects zero-address governance", async () => {
     const Factory = await ethers.getContractFactory("InsuranceFund")
@@ -67,6 +75,34 @@ describe("InsuranceFund: withdraw", () => {
     expect(recipAfter - recipBefore).to.equal(amount)
     expect(await fund.totalWithdrawn()).to.equal(amount)
     expect(await fund.balance()).to.equal(0n)
+  })
+
+  it("credits a pending withdrawal when the recipient rejects ETH", async () => {
+    const [gov, sender, recipient] = await ethers.getSigners()
+    const fund = await deployFund(gov.address)
+    const amount = ethers.parseEther("1")
+    await sender.sendTransaction({ to: await fund.getAddress(), value: ethers.parseEther("2") })
+    await installRejectingReceiverCode(recipient.address)
+
+    await expect(fund.connect(gov).withdraw(recipient.address, amount))
+      .to.emit(fund, "WithdrawalCredited")
+      .withArgs(recipient.address, amount)
+    expect(await fund.pendingWithdrawals(recipient.address)).to.equal(amount)
+    expect(await fund.pendingWithdrawalTotal()).to.equal(amount)
+    expect(await fund.totalWithdrawn()).to.equal(amount)
+    expect(await fund.availableBalance()).to.equal(amount)
+
+    await expect(
+      fund.connect(gov).withdraw(gov.address, ethers.parseEther("1.5")),
+    ).to.be.revertedWithCustomError(fund, "InsufficientBalance")
+      .withArgs(ethers.parseEther("1.5"), amount)
+
+    await ethers.provider.send("hardhat_setCode", [recipient.address, "0x"])
+    await fund.connect(recipient).withdrawPayments()
+
+    expect(await fund.pendingWithdrawals(recipient.address)).to.equal(0n)
+    expect(await fund.pendingWithdrawalTotal()).to.equal(0n)
+    expect(await fund.balance()).to.equal(amount)
   })
 
   it("non-governance withdraw reverts OnlyGovernance", async () => {

--- a/contracts/test/security-audit.test.cjs
+++ b/contracts/test/security-audit.test.cjs
@@ -56,6 +56,14 @@ async function advanceTime(seconds) {
   await ethers.provider.send("evm_mine")
 }
 
+async function installRejectingReceiverCode(address) {
+  const Rejecting = await ethers.getContractFactory("EthRejectingReceiver")
+  const rejecting = await Rejecting.deploy()
+  await rejecting.waitForDeployment()
+  const code = await ethers.provider.getCode(await rejecting.getAddress())
+  await ethers.provider.send("hardhat_setCode", [address, code])
+}
+
 // ── FactionRegistry Security ────────────────────────────────────────
 
 describe("Security: FactionRegistry", function () {
@@ -514,6 +522,37 @@ describe("Security: Treasury", function () {
     // Execute
     await treasury.executeWithdrawal(proposalId)
     expect(await treasury.getBalance()).to.be.lt(ethers.parseEther("2"))
+  })
+
+  it("credits a pending withdrawal when the proposal recipient rejects ETH", async function () {
+    const amount = ethers.parseEther("0.05")
+    await owner.sendTransaction({
+      to: await treasury.getAddress(),
+      value: ethers.parseEther("2"),
+    })
+    await installRejectingReceiverCode(signer5.address)
+
+    await treasury.proposeWithdrawal(signer5.address, amount)
+    await treasury.connect(user1).confirmWithdrawal(0)
+    await treasury.connect(signer2).confirmWithdrawal(0)
+
+    await expect(treasury.executeWithdrawal(0))
+      .to.emit(treasury, "WithdrawalCredited")
+      .withArgs(signer5.address, amount)
+    expect(await treasury.pendingWithdrawals(signer5.address)).to.equal(amount)
+    expect(await treasury.pendingWithdrawalTotal()).to.equal(amount)
+    expect(await treasury.availableBalance()).to.equal(ethers.parseEther("1.95"))
+
+    await expect(
+      treasury.proposeWithdrawal(user1.address, ethers.parseEther("2")),
+    ).to.be.revertedWithCustomError(treasury, "InsufficientBalance")
+
+    await ethers.provider.send("hardhat_setCode", [signer5.address, "0x"])
+    await treasury.connect(signer5).withdrawPayments()
+
+    expect(await treasury.pendingWithdrawals(signer5.address)).to.equal(0n)
+    expect(await treasury.pendingWithdrawalTotal()).to.equal(0n)
+    expect(await treasury.getBalance()).to.equal(ethers.parseEther("1.95"))
   })
 })
 


### PR DESCRIPTION
## Summary

- Add pull-payment fallback accounting to `Treasury` and `InsuranceFund`.
- Credit failed native-token payouts to `pendingWithdrawals` instead of reverting governance execution.
- Reserve credited funds via `pendingWithdrawalTotal` / `availableBalance()` so they cannot be spent twice before claim.
- Add regression tests for ETH-rejecting recipients and later claim flow.

## Root Cause

`Treasury.executeWithdrawal()` and `InsuranceFund.withdraw()` coupled governance execution to immediate recipient ETH acceptance. If a governance-selected recipient is a contract that rejects native-token transfers, the approved payout reverts instead of completing or reserving funds.

## Validation

- `cd contracts && npx hardhat test "test/InsuranceFund.test.cjs" "test/security-audit.test.cjs"`
- `git diff --check HEAD~1..HEAD`

Fixes #687