### PR TITLE
fix(security): harden foundation vesting payouts

### DIFF
--- a/contracts/contracts-src/token/FoundationVesting.sol
+++ b/contracts/contracts-src/token/FoundationVesting.sol
@@ -23,15 +23,21 @@ contract FoundationVesting {
     uint256 public totalReleased;
     uint256 public quarterStart;
     uint256 public quarterReleased;
+    mapping(address => uint256) public pendingWithdrawals;
+    uint256 public pendingWithdrawalTotal;
 
     event Released(address indexed to, uint256 amount);
+    event WithdrawalCredited(address indexed payee, uint256 amount);
+    event WithdrawalClaimed(address indexed payee, uint256 amount);
     event BeneficiaryUpdated(address indexed oldBeneficiary, address indexed newBeneficiary);
 
     error NotOwner();
     error NotBeneficiary();
     error NothingToRelease();
     error QuarterlyCapExceeded();
+    error TransferFailed();
     error ZeroAddress();
+    error NoPendingWithdrawal();
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert NotOwner();
@@ -76,10 +82,10 @@ contract FoundationVesting {
     function quarterlyRemaining() public view returns (uint256) {
         if (block.timestamp >= quarterStart + QUARTER) {
             // New quarter — full budget available
-            uint256 balance = address(this).balance;
-            return (balance * QUARTERLY_CAP_BPS) / 10000;
+            uint256 currentBalance = _availableBalance();
+            return (currentBalance * QUARTERLY_CAP_BPS) / 10000;
         }
-        uint256 balance = address(this).balance;
+        uint256 balance = _availableBalance();
         uint256 cap = (balance * QUARTERLY_CAP_BPS) / 10000;
         return cap > quarterReleased ? cap - quarterReleased : 0;
     }
@@ -100,23 +106,51 @@ contract FoundationVesting {
         }
 
         // Enforce quarterly cap
-        uint256 balance = address(this).balance;
+        uint256 balance = _availableBalance();
         uint256 cap = (balance * QUARTERLY_CAP_BPS) / 10000;
         if (quarterReleased + amount > cap) revert QuarterlyCapExceeded();
 
         totalReleased += amount;
         quarterReleased += amount;
 
-        (bool ok,) = payable(beneficiary).call{value: amount}("");
-        require(ok, "transfer failed");
-
+        _payOrCredit(payable(beneficiary), amount);
         emit Released(beneficiary, amount);
+    }
+
+    function withdrawPayments() external {
+        uint256 amount = pendingWithdrawals[msg.sender];
+        if (amount == 0) revert NoPendingWithdrawal();
+
+        pendingWithdrawals[msg.sender] = 0;
+        pendingWithdrawalTotal -= amount;
+        (bool ok,) = msg.sender.call{value: amount}("");
+        if (!ok) revert TransferFailed();
+
+        emit WithdrawalClaimed(msg.sender, amount);
+    }
+
+    function availableBalance() external view returns (uint256) {
+        return _availableBalance();
     }
 
     function updateBeneficiary(address newBeneficiary) external onlyOwner {
         if (newBeneficiary == address(0)) revert ZeroAddress();
         emit BeneficiaryUpdated(beneficiary, newBeneficiary);
         beneficiary = newBeneficiary;
+    }
+
+    function _availableBalance() internal view returns (uint256) {
+        uint256 balance = address(this).balance;
+        return balance > pendingWithdrawalTotal ? balance - pendingWithdrawalTotal : 0;
+    }
+
+    function _payOrCredit(address payable to, uint256 amount) internal {
+        (bool ok,) = to.call{value: amount}("");
+        if (!ok) {
+            pendingWithdrawals[to] += amount;
+            pendingWithdrawalTotal += amount;
+            emit WithdrawalCredited(to, amount);
+        }
     }
 
     // Accept ETH deposits (for initial funding)

--- a/contracts/test/foundation-vesting.test.cjs
+++ b/contracts/test/foundation-vesting.test.cjs
@@ -1,0 +1,63 @@
+/**
+ * FoundationVesting security regression tests.
+ */
+
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+async function deployVesting(beneficiary) {
+  const Factory = await ethers.getContractFactory("FoundationVesting")
+  const vesting = await Factory.deploy(beneficiary)
+  await vesting.waitForDeployment()
+  return vesting
+}
+
+async function installRejectingReceiverCode(address) {
+  const Rejecting = await ethers.getContractFactory("EthRejectingReceiver")
+  const rejecting = await Rejecting.deploy()
+  await rejecting.waitForDeployment()
+  const code = await ethers.provider.getCode(await rejecting.getAddress())
+  await ethers.provider.send("hardhat_setCode", [address, code])
+}
+
+describe("FoundationVesting: release payments", () => {
+  it("credits pending withdrawal when beneficiary rejects ETH", async () => {
+    const [, funder, beneficiary] = await ethers.getSigners()
+    const vesting = await deployVesting(beneficiary.address)
+    const amount = ethers.parseEther("10")
+    const funding = ethers.parseEther("100")
+
+    await funder.sendTransaction({ to: await vesting.getAddress(), value: funding })
+    await installRejectingReceiverCode(beneficiary.address)
+
+    await expect(vesting.connect(beneficiary).release(amount))
+      .to.emit(vesting, "WithdrawalCredited")
+      .withArgs(beneficiary.address, amount)
+      .and.to.emit(vesting, "Released")
+      .withArgs(beneficiary.address, amount)
+
+    expect(await vesting.pendingWithdrawals(beneficiary.address)).to.equal(amount)
+    expect(await vesting.pendingWithdrawalTotal()).to.equal(amount)
+    expect(await vesting.availableBalance()).to.equal(funding - amount)
+    expect(await vesting.totalReleased()).to.equal(amount)
+
+    await ethers.provider.send("hardhat_setCode", [beneficiary.address, "0x"])
+
+    await expect(vesting.connect(beneficiary).withdrawPayments())
+      .to.emit(vesting, "WithdrawalClaimed")
+      .withArgs(beneficiary.address, amount)
+
+    expect(await vesting.pendingWithdrawals(beneficiary.address)).to.equal(0n)
+    expect(await vesting.pendingWithdrawalTotal()).to.equal(0n)
+    expect(await vesting.availableBalance()).to.equal(funding - amount)
+    expect(await ethers.provider.getBalance(await vesting.getAddress())).to.equal(funding - amount)
+  })
+
+  it("rejects withdrawPayments without pending credit", async () => {
+    const [, beneficiary] = await ethers.getSigners()
+    const vesting = await deployVesting(beneficiary.address)
+
+    await expect(vesting.connect(beneficiary).withdrawPayments())
+      .to.be.revertedWithCustomError(vesting, "NoPendingWithdrawal")
+  })
+})


### PR DESCRIPTION
## Summary

- fixes #689 by replacing FoundationVesting's revert-on-failed direct payout with a pull-payment fallback
- reserves rejected payouts in pendingWithdrawals and excludes them from available balance / quarterly cap calculations
- adds regression coverage for ETH-rejecting beneficiaries and pending withdrawal claims

## Tests

- cd contracts && npx hardhat test "test/foundation-vesting.test.cjs"
- cd contracts && npx hardhat test "test/security-audit.test.cjs"
- git diff --check