### PR TITLE
fix(security): invalidate stale soul recovery requests

### DIFF
--- a/contracts/contracts-src/governance/SoulRegistry.sol
+++ b/contracts/contracts-src/governance/SoulRegistry.sol
@@ -44,6 +44,7 @@ contract SoulRegistry {
         address newOwner;
         address initiator;
         uint64  initiatedAt;
+        uint64  recoveryEpoch;
         uint8   approvalCount;
         uint8   guardianSnapshot; // active guardian count at initiation
         bool    executed;
@@ -127,6 +128,7 @@ contract SoulRegistry {
     mapping(bytes32 => RecoveryGuardian[]) internal _guardians;
     mapping(bytes32 => RecoveryRequest) public recoveryRequests;
     mapping(bytes32 => mapping(address => bool)) public recoveryApprovals;
+    mapping(bytes32 => uint64) public recoveryEpoch;
     mapping(bytes32 => uint64) public nonces;
 
     // Resurrection storage
@@ -249,6 +251,7 @@ contract SoulRegistry {
         // owner's guardians and resurrection key, which could seize it.
         delete _guardians[agentId];
         delete resurrectionConfigs[agentId];
+        recoveryEpoch[agentId] += 1;
 
         souls[agentId] = SoulIdentity({
             agentId: agentId,
@@ -472,6 +475,7 @@ contract SoulRegistry {
             newOwner: newOwner,
             initiator: msg.sender,
             initiatedAt: uint64(block.timestamp),
+            recoveryEpoch: recoveryEpoch[agentId],
             approvalCount: 1,
             guardianSnapshot: uint8(activeCount),
             executed: false
@@ -508,6 +512,7 @@ contract SoulRegistry {
         // invalidates any recovery request aimed at a prior incarnation.
         if (!soul.active) revert SoulNotActive();
         if (req.initiatedAt < soul.registeredAt) revert RecoveryNotFound();
+        if (req.recoveryEpoch != recoveryEpoch[req.agentId]) revert RecoveryNotFound();
 
         uint256 snapshotCount = uint256(req.guardianSnapshot);
         uint256 threshold = (snapshotCount * 2 + 2) / 3; // ceil(2/3)
@@ -525,6 +530,7 @@ contract SoulRegistry {
         delete ownerToAgent[oldOwner];
         soul.owner = req.newOwner;
         ownerToAgent[req.newOwner] = req.agentId;
+        recoveryEpoch[req.agentId] += 1;
 
         emit RecoveryCompleted(requestId, req.agentId, req.newOwner);
     }

--- a/contracts/test/soul-registry-stale-recovery.test.cjs
+++ b/contracts/test/soul-registry-stale-recovery.test.cjs
@@ -34,7 +34,7 @@ function randomBytes32() {
 
 describe("Security: SoulRegistry stale recovery state", function () {
   let registry, domain
-  let alice, bob, guardian, attacker
+  let alice, bob, guardian, guardian2, attacker
 
   async function register(signer, agentId, identityCid, nonce) {
     const sig = await signer.signTypedData(domain, REGISTER_SOUL_TYPES, {
@@ -47,7 +47,7 @@ describe("Security: SoulRegistry stale recovery state", function () {
   }
 
   beforeEach(async function () {
-    ;[alice, bob, guardian, attacker] = await ethers.getSigners()
+    ;[alice, bob, guardian, guardian2, attacker] = await ethers.getSigners()
     const Factory = await ethers.getContractFactory("SoulRegistry")
     registry = await Factory.deploy()
     await registry.waitForDeployment()
@@ -106,5 +106,33 @@ describe("Security: SoulRegistry stale recovery state", function () {
     const soul = await registry.getSoul(agentId)
     expect(soul.owner).to.equal(alice.address)
     expect(soul.active).to.equal(true)
+  })
+
+  it("a pending recovery from a previous owner epoch cannot execute after ownership changes", async function () {
+    const agentId = randomBytes32()
+    await register(alice, agentId, randomBytes32(), 0)
+    await registry.connect(alice).addGuardian(agentId, guardian.address)
+    await registry.connect(alice).addGuardian(agentId, guardian2.address)
+
+    const staleTx = await registry.connect(guardian).initiateRecovery(agentId, attacker.address)
+    const staleReceipt = await staleTx.wait()
+    const staleRequestId = staleReceipt.logs.find((log) => log.fragment?.name === "RecoveryInitiated").args[0]
+    await registry.connect(guardian2).approveRecovery(staleRequestId)
+
+    const validTx = await registry.connect(guardian).initiateRecovery(agentId, bob.address)
+    const validReceipt = await validTx.wait()
+    const validRequestId = validReceipt.logs.find((log) => log.fragment?.name === "RecoveryInitiated").args[0]
+    await registry.connect(guardian2).approveRecovery(validRequestId)
+
+    await ethers.provider.send("evm_increaseTime", [86401])
+    await ethers.provider.send("evm_mine")
+
+    await registry.completeRecovery(validRequestId)
+    expect((await registry.getSoul(agentId)).owner).to.equal(bob.address)
+
+    await expect(
+      registry.completeRecovery(staleRequestId),
+    ).to.be.revertedWithCustomError(registry, "RecoveryNotFound")
+    expect((await registry.getSoul(agentId)).owner).to.equal(bob.address)
   })
 })


### PR DESCRIPTION
## Summary

- fixes #691 by binding SoulRegistry recovery requests to a per-agent recovery epoch
- increments the epoch on registration/re-registration and successful recovery, invalidating older pending requests
- adds regression coverage for two pre-approved recovery requests where one becomes stale after ownership changes

## Tests

- cd contracts && npx hardhat test "test/soul-registry-stale-recovery.test.cjs"
- cd contracts && npx hardhat test "test/SoulRegistry.test.cjs"
- git diff --check

Note: the FoundationVesting compile shadow warning is from current main and is addressed separately in draft PR #690.