### PR TITLE
fix(security): bound finalizeEpochV2 + close settleChallenge CEI gap

### DIFF
--- a/contracts/contracts-src/settlement/IPoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/IPoSeManagerV2.sol
@@ -40,6 +40,7 @@ interface IPoSeManagerV2 {
     error RewardPoolInsufficient();
     error RewardBudgetExceeded();
     error NoPendingWithdrawal();
+    error BatchesNotProcessed();
 
     // Functions
     function initEpochNonce(uint64 epochId) external;
@@ -66,6 +67,10 @@ interface IPoSeManagerV2 {
     ) external;
 
     function settleChallenge(bytes32 challengeId) external;
+
+    function processEpochBatches(uint64 epochId, uint256 maxBatches) external;
+
+    function getEpochBatchCount(uint64 epochId) external view returns (uint256);
 
     function finalizeEpochV2(
         uint64 epochId,

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -23,6 +23,9 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     uint16 public constant SLASH_INSURANCE_BPS = 2000;      // 20% to insurance
     uint64 public constant REVEAL_WINDOW_EPOCHS = 2;
     uint64 public constant ADJUDICATION_WINDOW_EPOCHS = 2;
+    // #680: max epoch batches finalizeEpochV2 / processEpochBatches walk per
+    // call — sized to stay well under the block gas limit even at this many.
+    uint256 public constant FINALIZE_BATCH_BUDGET = 200;
     uint256 internal constant SECP256K1N_HALF =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
@@ -46,6 +49,11 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     // unlimited cloned batches and bloat epochBatches, causing finalizeEpochV2
     // DoS (#680).
     mapping(uint64 => mapping(bytes32 => bool)) public epochMerkleRootUsed;
+    // #680: cursor for paginated finalizeEpochV2 — count of epochBatches[epochId]
+    // already walked. finalizeEpochV2 cannot complete until the cursor reaches
+    // the array length, so an unbounded epochBatches array can no longer
+    // OOG-brick epoch finalization.
+    mapping(uint64 => uint256) public epochBatchCursor;
 
     uint256 public challengeBondMin;
     uint256 public insuranceBalance;
@@ -410,13 +418,16 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
 
                 insuranceBalance += insuranceAmount;
 
-                // Pay challenger reward + refund bond, or credit for later withdrawal.
-                _payOrCredit(record.challenger, challengerAmount + record.bond);
-
                 if (node.bondAmount == 0) {
                     node.active = false;
                     _removeActiveNode(record.targetNodeId);
                 }
+
+                // Pay challenger reward + refund bond, or credit for later
+                // withdrawal. Done last so every state effect — slash
+                // accounting, node deactivation — precedes this external call
+                // to the attacker-controlled challenger (#677, CEI ordering).
+                _payOrCredit(record.challenger, challengerAmount + record.bond);
 
                 emit SlashDistributed(record.targetNodeId, burnAmount, challengerAmount, insuranceAmount);
                 emit ChallengeSettled(challengeId, true, slashAmount);
@@ -432,6 +443,47 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         }
     }
 
+    // --- #680: paginated batch processing for epoch finalization ---
+
+    /// @notice Number of batches recorded for an epoch (epochBatches is internal).
+    function getEpochBatchCount(uint64 epochId) external view override returns (uint256) {
+        return epochBatches[epochId].length;
+    }
+
+    /// @dev Walk up to `maxBatches` of epochBatches[epochId] from the cursor:
+    ///      mark dispute-elapsed, non-disputed batches finalized, accumulate the
+    ///      valid count, and advance epochBatchCursor. Behaviour per batch is
+    ///      identical to the old single-pass loop — only the iteration is split.
+    function _processBatches(uint64 epochId, uint256 maxBatches) internal {
+        bytes32[] storage batchIds = epochBatches[epochId];
+        uint256 cursor = epochBatchCursor[epochId];
+        uint256 end = cursor + maxBatches;
+        if (end > batchIds.length) end = batchIds.length;
+        if (end == cursor) return;
+
+        uint32 validCount = epochValidBatchCount[epochId];
+        for (uint256 i = cursor; i < end; i++) {
+            PoSeTypes.BatchRecord storage batch = batches[batchIds[i]];
+            if (batch.finalized || batch.disputed) continue;
+            if (_currentEpoch() <= batch.disputeDeadlineEpoch) continue;
+            batch.finalized = true;
+            validCount += 1;
+        }
+        epochValidBatchCount[epochId] = validCount;
+        epochBatchCursor[epochId] = end;
+    }
+
+    /// @notice #680: grind a page of an epoch's batches toward finalization.
+    ///         Permissionless — purely deterministic bookkeeping, so finalization
+    ///         cannot be blocked even if the owner key is unavailable. Lets a
+    ///         large epochBatches array be cleared across several txs instead of
+    ///         OOG-bricking finalizeEpochV2 in one unbounded loop.
+    function processEpochBatches(uint64 epochId, uint256 maxBatches) external override {
+        if (epochFinalized[epochId]) revert EpochAlreadyFinalized();
+        if (_currentEpoch() <= epochId + DISPUTE_WINDOW_EPOCHS) revert DisputeWindowNotElapsed();
+        _processBatches(epochId, maxBatches);
+    }
+
     // --- Epoch finalization (allows 0 batches) ---
     function finalizeEpochV2(
         uint64 epochId,
@@ -445,20 +497,15 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         if (totalReward > 0 && rewardRoot == bytes32(0)) revert InvalidBatch();
         if (totalReward > rewardPoolBalance) revert RewardPoolInsufficient();
 
-        // Finalize all valid batches for this epoch
-        bytes32[] storage batchIds = epochBatches[epochId];
-        uint32 validCount = 0;
+        // #680: process a bounded page of batches inline, then require the whole
+        // array to have been walked. Epochs with <= FINALIZE_BATCH_BUDGET batches
+        // (the normal case — typically 1-5) finalize in this single call; larger
+        // epochs need processEpochBatches() pre-grinding, so this can never exceed
+        // the block gas limit and permanently brick finalization.
+        _processBatches(epochId, FINALIZE_BATCH_BUDGET);
+        if (epochBatchCursor[epochId] != epochBatches[epochId].length) revert BatchesNotProcessed();
 
-        for (uint256 i = 0; i < batchIds.length; i++) {
-            PoSeTypes.BatchRecord storage batch = batches[batchIds[i]];
-            if (batch.finalized || batch.disputed) continue;
-            if (_currentEpoch() <= batch.disputeDeadlineEpoch) continue;
-            batch.finalized = true;
-            validCount += 1;
-        }
-
-        // v2: empty epochs are allowed (validCount can be 0)
-        epochValidBatchCount[epochId] = validCount;
+        // v2: empty epochs are allowed (epochValidBatchCount can be 0)
         epochRewardRoots[epochId] = rewardRoot;
         epochSlashTotal[epochId] = slashTotal;
         epochTreasuryDelta[epochId] = treasuryDelta;

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -434,6 +434,78 @@ describe("PoSeManagerV2", function () {
     })
   })
 
+  describe("finalizeEpochV2 pagination (#680)", function () {
+    it("paginates a large epoch: finalizeEpochV2 reverts BatchesNotProcessed until pre-ground", async function () {
+      const budget = Number(await manager.FINALIZE_BATCH_BUDGET())
+      const block = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(block.timestamp) / 3600)
+      const count = budget + 1
+
+      for (let i = 0; i < count; i++) {
+        const leaf = ethers.keccak256(ethers.toUtf8Bytes(`pagination-batch-${i}`))
+        await submitSingleLeafBatchV2(manager, epochId, leaf)
+      }
+      expect(await manager.getEpochBatchCount(epochId)).to.equal(BigInt(count))
+
+      // dispute window must elapse before any batch can be finalized
+      await ethers.provider.send("evm_increaseTime", [8 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      // a single finalize call cannot clear > FINALIZE_BATCH_BUDGET batches inline
+      await expect(manager.finalizeEpochV2(epochId, ethers.ZeroHash, 0, 0, 0))
+        .to.be.revertedWithCustomError(manager, "BatchesNotProcessed")
+
+      // pre-grind the surplus, then finalize walks the final page inline and completes
+      await manager.processEpochBatches(epochId, budget - 50)
+      expect(await manager.epochBatchCursor(epochId)).to.equal(BigInt(budget - 50))
+
+      await manager.finalizeEpochV2(epochId, ethers.ZeroHash, 0, 0, 0)
+      expect(await manager.epochFinalized(epochId)).to.equal(true)
+      expect(await manager.epochBatchCursor(epochId)).to.equal(BigInt(count))
+      expect(await manager.epochValidBatchCount(epochId)).to.equal(BigInt(count))
+    })
+
+    it("finalizes a <= budget epoch in a single call", async function () {
+      const block = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(block.timestamp) / 3600)
+
+      for (let i = 0; i < 3; i++) {
+        const leaf = ethers.keccak256(ethers.toUtf8Bytes(`small-epoch-batch-${i}`))
+        await submitSingleLeafBatchV2(manager, epochId, leaf)
+      }
+
+      await ethers.provider.send("evm_increaseTime", [8 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      await manager.finalizeEpochV2(epochId, ethers.ZeroHash, 0, 0, 0)
+      expect(await manager.epochFinalized(epochId)).to.equal(true)
+      expect(await manager.epochValidBatchCount(epochId)).to.equal(3n)
+      expect(await manager.epochBatchCursor(epochId)).to.equal(3n)
+    })
+
+    it("processEpochBatches reverts once the epoch is finalized", async function () {
+      const block = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(block.timestamp) / 3600)
+      await submitSingleLeafBatchV2(manager, epochId, ethers.keccak256(ethers.toUtf8Bytes("done-epoch")))
+
+      await ethers.provider.send("evm_increaseTime", [8 * 3600])
+      await ethers.provider.send("evm_mine")
+      await manager.finalizeEpochV2(epochId, ethers.ZeroHash, 0, 0, 0)
+
+      await expect(manager.processEpochBatches(epochId, 100))
+        .to.be.revertedWithCustomError(manager, "EpochAlreadyFinalized")
+    })
+
+    it("processEpochBatches reverts before the dispute window elapses", async function () {
+      const block = await ethers.provider.getBlock("latest")
+      const epochId = Math.floor(Number(block.timestamp) / 3600)
+      await submitSingleLeafBatchV2(manager, epochId, ethers.keccak256(ethers.toUtf8Bytes("fresh-epoch")))
+
+      await expect(manager.processEpochBatches(epochId, 100))
+        .to.be.revertedWithCustomError(manager, "DisputeWindowNotElapsed")
+    })
+  })
+
   describe("Merkle reward claim", function () {
     it("claim with valid proof succeeds", async function () {
       const { operator, nodeId } = await registerNode(manager, deployer)

--- a/runtime/coc-relayer.ts
+++ b/runtime/coc-relayer.ts
@@ -123,7 +123,9 @@ const poseV2Abi = [
   "function openChallenge(bytes32 commitHash) payable returns (bytes32 challengeId)",
   "function revealChallenge(bytes32 challengeId, bytes32 targetNodeId, uint8 faultType, bytes32 evidenceLeafHash, bytes32 salt, bytes evidenceData, bytes challengerSig)",
   "function settleChallenge(bytes32 challengeId)",
-  "function getEpochBatchIds(uint64 epochId) view returns (bytes32[])",
+  "function getEpochBatchCount(uint64 epochId) view returns (uint256)",
+  "function processEpochBatches(uint64 epochId, uint256 maxBatches)",
+  "function epochBatchCursor(uint64 epochId) view returns (uint256)",
   "function epochFinalized(uint64 epochId) view returns (bool)",
   "function epochRewardRoots(uint64 epochId) view returns (bytes32)",
   "function rewardPoolBalance() view returns (uint256)",
@@ -505,7 +507,7 @@ async function tryFinalizeV2(): Promise<void> {
   } catch { /* proceed to try finalize */ }
 
   try {
-    const batchIds: string[] = await poseV2Contract.getEpochBatchIds(BigInt(candidate));
+    const batchCount: bigint = await poseV2Contract.getEpochBatchCount(BigInt(candidate));
 
     let rewardRoot = "0x" + "0".repeat(64);
     let totalReward = 0n;
@@ -513,10 +515,10 @@ async function tryFinalizeV2(): Promise<void> {
     let treasuryDelta = 0n;
     let settledManifestToPersist: ReturnType<typeof createSettledRewardManifest> | null = null;
 
-    if (batchIds.length > 0) {
+    if (batchCount > 0n) {
       const validation = loadAndValidateManifest(rewardManifestDir, candidate, { allowEmpty: true });
       if (validation.status !== "ok") {
-        log.warn("finalizeV2 skipped", { epochId: candidate, reason: validation.status, batches: batchIds.length, missingNodeIds: validation.missingNodeIds });
+        log.warn("finalizeV2 skipped", { epochId: candidate, reason: validation.status, batches: Number(batchCount), missingNodeIds: validation.missingNodeIds });
         return;
       }
       const manifest = validation.manifest!;
@@ -575,6 +577,36 @@ async function tryFinalizeV2(): Promise<void> {
 
     }
 
+    // #680: finalizeEpochV2 walks at most FINALIZE_BATCH_BUDGET (200) batches
+    // inline. For larger epochs, pre-grind the surplus via processEpochBatches
+    // so the finalize tx can never exceed the block gas limit. A rare
+    // BatchesNotProcessed revert (a batch landing mid-grind) is left to the
+    // next relayer tick — lastFinalizeEpoch is not advanced on failure.
+    const FINALIZE_BATCH_BUDGET = 200n;
+    if (batchCount > FINALIZE_BATCH_BUDGET) {
+      const grindTarget = batchCount - FINALIZE_BATCH_BUDGET;
+      let cursor: bigint = await retryAsync(
+        () => poseV2Contract.epochBatchCursor(BigInt(candidate)) as Promise<bigint>,
+        txRetryOptions,
+      );
+      while (cursor < grindTarget) {
+        const grindTx = await retryAsync(
+          () => poseV2Contract.processEpochBatches(BigInt(candidate), 500n),
+          txRetryOptions,
+        );
+        await retryAsync(() => grindTx.wait(), txRetryOptions);
+        cursor = await retryAsync(
+          () => poseV2Contract.epochBatchCursor(BigInt(candidate)) as Promise<bigint>,
+          txRetryOptions,
+        );
+      }
+      log.info("finalizeV2 pre-ground large epoch", {
+        epochId: candidate,
+        batchCount: batchCount.toString(),
+        cursor: cursor.toString(),
+      });
+    }
+
     const tx = await retryAsync(
       () => poseV2Contract.finalizeEpochV2(
         BigInt(candidate),
@@ -592,7 +624,7 @@ async function tryFinalizeV2(): Promise<void> {
       epochId: candidate,
       txHash: tx.hash,
       status: receipt?.status,
-      batches: batchIds.length,
+      batches: Number(batchCount),
       totalReward: totalReward.toString(),
     });
     if (settledManifestToPersist) {


### PR DESCRIPTION
## Summary

Resolves the two remaining open PoSe contract security issues.

### #680 — unbounded `finalizeEpochV2` loop DoS (High)

`finalizeEpochV2` looped `epochBatches[epochId]` with no bound. PR #681's `epochMerkleRootUsed` guard only blocks *same-root* replay; an attacker submitting batches with **distinct** roots still bloats the array until the finalize tx exceeds the block gas limit — permanently freezing epoch finalization and **all** rewards.

**Fix — paginate the loop:**
- New `epochBatchCursor` (per-epoch count of batches walked) + `FINALIZE_BATCH_BUDGET = 200`.
- New permissionless `processEpochBatches(epochId, maxBatches)` grinds the batch loop in bounded pages (deterministic bookkeeping — can't be blocked even if the owner key is unavailable).
- `finalizeEpochV2` keeps its signature: walks up to `FINALIZE_BATCH_BUDGET` inline, then requires `epochBatchCursor == epochBatches.length`, else reverts `BatchesNotProcessed`.
- Normal epochs (1–5 batches) still finalize in a **single call**; large epochs are pre-ground. Finalization is now **always completable** regardless of batch count.
- Per-batch behaviour is identical to the old single-pass loop — only the iteration is split, so the finalized end-state is unchanged.
- New getter `getEpochBatchCount` (the `epochBatches` array is `internal`).
- `coc-relayer.ts` `tryFinalizeV2` pre-grinds large epochs via `processEpochBatches` before `finalizeEpochV2`; switched from `getEpochBatchIds` (returns the whole array) to the lighter `getEpochBatchCount`.

### #677 — `settleChallenge` CEI gap (Low / defense-in-depth)

`settleChallenge` made the `_payOrCredit` external call to the attacker-controlled challenger **before** `node.active = false` + `_removeActiveNode`, with no reentrancy guard. Reordered so every state effect precedes the interaction (CEI). Pure reorder — no paid amount depends on `node.active`.

## Tests

- `contracts/test/pose-v2.test.cjs` — 4 new pagination tests: `> budget` epoch reverts `BatchesNotProcessed` until pre-ground then finalizes with the correct `epochValidBatchCount`; `<= budget` epoch finalizes in one call; `processEpochBatches` reverts post-finalization and pre-dispute-window.
- #677 is a pure reorder of the `slashAmount > 0` branch already exercised by the existing `settleChallenge` fault-path tests. (The inner `node.bondAmount == 0` deactivation sub-branch is not independently reachable through `settleChallenge` — slash is capped at 5%/epoch — so no separate behavioural test is added.)
- `cd contracts && npm test` — 449 passing, no regression. `coc-relayer.test.ts` green.

Fixes #677
Fixes #680