### PR TITLE
fix(security): harden DID delegation revocation

### DIFF
--- a/contracts/contracts-src/governance/DIDRegistry.sol
+++ b/contracts/contracts-src/governance/DIDRegistry.sol
@@ -44,6 +44,7 @@ contract DIDRegistry {
         bytes32 scopeHash;      // keccak256 of canonical scope encoding
         uint64  issuedAt;
         uint64  expiresAt;
+        uint64  revocationEpoch;
         uint8   depth;          // chain depth (0 = direct from principal)
         bool    revoked;
     }
@@ -366,9 +367,10 @@ contract DIDRegistry {
             DelegationRecord storage parent = delegations[parentDelegation];
             if (parent.delegator == bytes32(0)) revert DelegationNotFound();
             if (parent.revoked) revert DelegationAlreadyRevoked();
-            // Emergency revocation must also block chain extension — it only
-            // bumps globalRevocationEpoch, never the per-record `revoked` flag.
-            if (parent.issuedAt < globalRevocationEpoch[parent.delegator]) revert DelegationAlreadyRevoked();
+            // Emergency revocation must also block chain extension. Use a
+            // monotonic epoch instead of timestamp ordering so same-block
+            // grants cannot survive a global revoke.
+            if (parent.revocationEpoch != globalRevocationEpoch[parent.delegator]) revert DelegationAlreadyRevoked();
             if (parent.expiresAt < uint64(block.timestamp)) revert DelegationExpired();
             // Delegatee of parent must be our delegator
             if (parent.delegatee != delegator) revert NotOwner();
@@ -396,6 +398,7 @@ contract DIDRegistry {
             scopeHash: scopeHash,
             issuedAt: uint64(block.timestamp),
             expiresAt: expiresAt,
+            revocationEpoch: globalRevocationEpoch[delegator],
             depth: depth,
             revoked: false
         });
@@ -432,8 +435,8 @@ contract DIDRegistry {
 
     /// @notice Revoke all delegations from an agent (emergency)
     function revokeAllDelegations(bytes32 agentId) external onlySoulOwner(agentId) {
-        globalRevocationEpoch[agentId] = uint64(block.timestamp);
-        emit GlobalRevocationSet(agentId, uint64(block.timestamp));
+        globalRevocationEpoch[agentId] += 1;
+        emit GlobalRevocationSet(agentId, globalRevocationEpoch[agentId]);
     }
 
     /// @notice Get delegations issued by an agent
@@ -452,7 +455,7 @@ contract DIDRegistry {
             if (d.delegator == bytes32(0)) return false;
             if (d.revoked) return false;
             if (d.expiresAt < uint64(block.timestamp)) return false;
-            if (d.issuedAt < globalRevocationEpoch[d.delegator]) return false;
+            if (d.revocationEpoch != globalRevocationEpoch[d.delegator]) return false;
             if (d.depth == 0) return true; // reached the root — chain is clean
             cur = d.parentDelegation;
         }

--- a/contracts/test/did-delegation-chain-revocation.test.cjs
+++ b/contracts/test/did-delegation-chain-revocation.test.cjs
@@ -126,6 +126,48 @@ describe("Security: DIDRegistry delegation chain revocation", function () {
     expect(await did.isDelegationValid(bc)).to.equal(false)
   })
 
+  it("emergency revokeAllDelegations invalidates a delegation granted in the same block", async function () {
+    const exp = (await ethers.provider.getBlock("latest")).timestamp + 100_000
+    const nonce = await did.nonces(aId)
+    const scopeHash = rnd()
+    const sig = await ownerA.signTypedData(didDomain, GRANT_DELEGATION_TYPES, {
+      delegator: aId,
+      delegatee: bId,
+      parentDelegation: ethers.ZeroHash,
+      scopeHash,
+      expiresAt: exp,
+      depth: 0,
+      nonce,
+    })
+    const txNonce = await ethers.provider.getTransactionCount(ownerA.address)
+
+    await ethers.provider.send("evm_setAutomine", [false])
+    try {
+      const grantTx = await did.connect(ownerA).grantDelegation(
+        aId,
+        bId,
+        ethers.ZeroHash,
+        scopeHash,
+        exp,
+        0,
+        sig,
+        { nonce: txNonce },
+      )
+      const revokeTx = await did.connect(ownerA).revokeAllDelegations(aId, { nonce: txNonce + 1 })
+      await ethers.provider.send("evm_mine")
+
+      const grantRc = await grantTx.wait()
+      await revokeTx.wait()
+      const ev = grantRc.logs.find((l) => l.fragment && l.fragment.name === "DelegationGranted")
+      const delegationId = ev.args[0]
+
+      expect(await did.isDelegationValid(delegationId)).to.equal(false)
+    } finally {
+      await ethers.provider.send("evm_setAutomine", [true])
+      await ethers.provider.send("evm_mine")
+    }
+  })
+
   it("a chain cannot be extended off an emergency-revoked parent", async function () {
     const exp = (await ethers.provider.getBlock("latest")).timestamp + 100_000
     const ab = await grantId(ownerA, aId, bId, ethers.ZeroHash, exp, 0)


### PR DESCRIPTION
## Summary

- fixes #694 by replacing timestamp-based global delegation revocation checks with a per-agent monotonic revocation epoch
- stores the current revocation epoch on each DelegationRecord and validates the epoch for records and parent-chain extension
- adds same-block grantDelegation + revokeAllDelegations regression coverage

## Tests

- cd contracts && npx hardhat test "test/did-delegation-chain-revocation.test.cjs"
- cd contracts && npx hardhat test "test/DIDRegistry.test.cjs"
- git diff --check

Note: unrelated local explorer changes were left unstaged and are not part of this PR.