### PR TITLE
fix(security): gate rollup proposers and re-key 88780 ownership

### DIFF
--- a/contracts/contracts-src/governance/FactionRegistry.sol
+++ b/contracts/contracts-src/governance/FactionRegistry.sol
@@ -29,6 +29,7 @@ contract FactionRegistry {
     event ClawRegistered(address indexed account, bytes32 indexed agentId, uint64 registeredAt);
     event IdentityVerified(address indexed account, address indexed verifiedBy);
     event VerifierUpdated(address indexed newVerifier);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error AlreadyRegistered();
     error NotRegistered();
@@ -114,6 +115,13 @@ contract FactionRegistry {
         if (newVerifier == address(0)) revert ZeroAddress();
         verifier = newVerifier;
         emit VerifierUpdated(newVerifier);
+    }
+
+    /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     function getFaction(address account) external view returns (Faction) {

--- a/contracts/contracts-src/governance/GovernanceDAO.sol
+++ b/contracts/contracts-src/governance/GovernanceDAO.sol
@@ -55,6 +55,7 @@ contract GovernanceDAO {
     event ProposalExecuted(uint256 indexed proposalId);
     event ProposalCancelled(uint256 indexed proposalId);
     event ParameterUpdated(string paramName, uint256 newValue);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error NotRegistered();
     error AlreadyVoted();
@@ -223,6 +224,13 @@ contract GovernanceDAO {
 
     function setBicameralEnabled(bool _enabled) external onlyOwner {
         bicameralEnabled = _enabled;
+    }
+
+    /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "zero owner");
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     // View helpers

--- a/contracts/contracts-src/governance/MultiSigWallet.sol
+++ b/contracts/contracts-src/governance/MultiSigWallet.sol
@@ -3,8 +3,11 @@ pragma solidity ^0.8.24;
 
 /**
  * @title MultiSigWallet
- * @dev N-of-M multisig wallet for EVM compatibility testing.
- *      Exercises multi-account interaction, complex storage, and ETH transfers.
+ * @dev N-of-M multisig wallet. Used as the owner of the COC governance and
+ *      settlement contracts so that no single key controls onlyOwner / admin
+ *      functions. Owners and the confirmation threshold are fixed at
+ *      construction; rotating signers requires deploying a fresh wallet and
+ *      transferring ownership to it.
  */
 contract MultiSigWallet {
     struct Transaction {

--- a/contracts/contracts-src/governance/Treasury.sol
+++ b/contracts/contracts-src/governance/Treasury.sol
@@ -38,6 +38,7 @@ contract Treasury {
     event ProposalExecuted(uint256 indexed proposalId, address indexed to, uint256 amount);
     event GovernanceUpdated(address indexed newGovernance);
     event SignerUpdated(uint8 indexed index, address indexed oldSigner, address indexed newSigner);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error NotSigner();
     error NotOwner();
@@ -150,6 +151,13 @@ contract Treasury {
         if (_governance == address(0)) revert ZeroAddress();
         governance = _governance;
         emit GovernanceUpdated(_governance);
+    }
+
+    /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     function replaceSigner(uint8 index, address newSigner) external onlyOwner {

--- a/contracts/contracts-src/rollup/DelayedInbox.sol
+++ b/contracts/contracts-src/rollup/DelayedInbox.sol
@@ -16,6 +16,8 @@ contract DelayedInbox is IDelayedInbox {
     RollupTypes.ForcedTx[] private _queue;
     mapping(uint256 => bool) private _forceIncluded;
 
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+
     modifier onlySequencer() {
         if (msg.sender != sequencer) revert NotSequencer(msg.sender);
         _;
@@ -98,5 +100,13 @@ contract DelayedInbox is IDelayedInbox {
         require(msg.sender == owner, "only owner");
         require(newSequencer != address(0), "zero address");
         sequencer = newSequencer;
+    }
+
+    /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
+    function transferOwnership(address newOwner) external {
+        require(msg.sender == owner, "only owner");
+        require(newOwner != address(0), "zero address");
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 }

--- a/contracts/contracts-src/rollup/IRollupStateManager.sol
+++ b/contracts/contracts-src/rollup/IRollupStateManager.sol
@@ -13,6 +13,8 @@ interface IRollupStateManager {
     event ChallengeResolverUpdated(address indexed oldResolver, address indexed newResolver);
     event WithdrawalCredited(address indexed recipient, uint256 amount);
     event WithdrawalClaimed(address indexed recipient, uint256 amount);
+    event ProposerUpdated(address indexed proposer, bool allowed);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     // ── Errors ──────────────────────────────────────────────────────────
     error OutputAlreadySubmitted(uint64 l2BlockNumber);
@@ -28,6 +30,7 @@ interface IRollupStateManager {
     error BlockNumberNotIncreasing(uint64 provided, uint64 lastSubmitted);
     error OnlyOwner();
     error OnlyChallengeResolver();
+    error NotProposer();
     error ZeroAddress();
     error NoPendingWithdrawal();
     error TransferFailed();

--- a/contracts/contracts-src/rollup/RollupStateManager.sol
+++ b/contracts/contracts-src/rollup/RollupStateManager.sol
@@ -29,6 +29,10 @@ contract RollupStateManager is IRollupStateManager {
     address public owner;
     address public challengeResolver;
     mapping(address => uint256) public pendingWithdrawals;
+    // #683: only allowlisted proposers may submit output roots. Without this
+    // gate any account can submit a max-uint64 block number, jamming
+    // lastSubmittedBlock and permanently bricking all future submissions.
+    mapping(address => bool) public allowedProposers;
 
     modifier onlyOwner() {
         if (msg.sender != owner) revert OnlyOwner();
@@ -40,11 +44,17 @@ contract RollupStateManager is IRollupStateManager {
         _;
     }
 
+    modifier onlyProposer() {
+        if (!allowedProposers[msg.sender]) revert NotProposer();
+        _;
+    }
+
     constructor(
         uint256 challengeWindowSeconds,
         uint256 proposerBondWei,
         uint256 challengerBondWei,
-        address insuranceFundAddress
+        address insuranceFundAddress,
+        address initialProposer
     ) {
         require(challengeWindowSeconds > 0, "challenge window must be > 0");
         require(proposerBondWei > 0, "proposer bond must be > 0");
@@ -55,6 +65,10 @@ contract RollupStateManager is IRollupStateManager {
         insuranceFund = insuranceFundAddress;
         owner = msg.sender;
         challengeResolver = msg.sender;
+        if (initialProposer != address(0)) {
+            allowedProposers[initialProposer] = true;
+            emit ProposerUpdated(initialProposer, true);
+        }
     }
 
     // ── Submit Output Root ──────────────────────────────────────────────
@@ -67,7 +81,7 @@ contract RollupStateManager is IRollupStateManager {
         uint64 l2BlockNumber,
         bytes32 outputRoot,
         bytes32 l2StateRoot
-    ) external payable override {
+    ) external payable override onlyProposer {
         if (msg.value < PROPOSER_BOND) {
             revert InsufficientBond(PROPOSER_BOND, msg.value);
         }
@@ -205,6 +219,26 @@ contract RollupStateManager is IRollupStateManager {
         address oldResolver = challengeResolver;
         challengeResolver = newResolver;
         emit ChallengeResolverUpdated(oldResolver, newResolver);
+    }
+
+    /// @notice Allowlist an address permitted to submit output roots (#683).
+    function addProposer(address proposer) external onlyOwner {
+        if (proposer == address(0)) revert ZeroAddress();
+        allowedProposers[proposer] = true;
+        emit ProposerUpdated(proposer, true);
+    }
+
+    /// @notice Remove an address from the output-root proposer allowlist (#683).
+    function removeProposer(address proposer) external onlyOwner {
+        allowedProposers[proposer] = false;
+        emit ProposerUpdated(proposer, false);
+    }
+
+    /// @notice Transfer contract ownership (admin of the resolver + proposer set).
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     // ── Finalize Output ─────────────────────────────────────────────────

--- a/contracts/contracts-src/settlement/PoSeManagerStorage.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerStorage.sol
@@ -42,6 +42,8 @@ abstract contract PoSeManagerStorage {
     mapping(bytes32 => uint256) public pendingRewards;
     uint16 public constant MAX_REWARD_PER_NODE_BPS = 3000; // 30% cap per node
 
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+
     modifier onlyOwner() {
         require(msg.sender == owner, "not owner");
         _;
@@ -55,6 +57,13 @@ abstract contract PoSeManagerStorage {
     constructor() {
         owner = msg.sender;
         roles[SLASHER_ROLE][msg.sender] = true;
+    }
+
+    /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "zero owner");
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     function _currentEpoch() internal view returns (uint64) {

--- a/contracts/deploy/deploy-rollup.ts
+++ b/contracts/deploy/deploy-rollup.ts
@@ -41,6 +41,7 @@ export async function deployRollupContracts(
   target: RollupDeployTarget,
   deployerKey?: string,
   sequencerAddress?: string,
+  initialProposerAddress?: string,
 ): Promise<DeployResult> {
   const config = resolveRollupConfig(target)
   const pk = deployerKey ?? process.env.DEPLOYER_PRIVATE_KEY
@@ -48,6 +49,8 @@ export async function deployRollupContracts(
 
   const seqAddr = sequencerAddress ?? process.env.SEQUENCER_ADDRESS
   if (!seqAddr) throw new Error("SEQUENCER_ADDRESS is required")
+
+  const proposerAddr = initialProposerAddress ?? config.initialProposerAddress
 
   const provider = new JsonRpcProvider(config.rpcUrl)
   const deployer = new Wallet(pk, provider)
@@ -58,6 +61,7 @@ export async function deployRollupContracts(
   console.log(`  Challenge window: ${config.challengeWindowSeconds}s`)
   console.log(`  Proposer bond: ${config.proposerBondWei} wei`)
   console.log(`  Inclusion delay: ${config.inclusionDelaySeconds}s`)
+  console.log(`  Initial proposer: ${proposerAddr}`)
 
   // Deploy RollupStateManager
   const rsmArtifact = loadArtifact("RollupStateManager")
@@ -67,6 +71,7 @@ export async function deployRollupContracts(
     config.proposerBondWei,
     config.challengerBondWei,
     config.insuranceFundAddress,
+    proposerAddr,
   )
   await rsm.waitForDeployment()
   const rsmAddress = await rsm.getAddress()

--- a/contracts/deploy/rollup-config.ts
+++ b/contracts/deploy/rollup-config.ts
@@ -13,6 +13,10 @@ export interface RollupDeployConfig {
   readonly inclusionDelaySeconds: number
   readonly outputIntervalBlocks: number
   readonly insuranceFundAddress: string
+  // #683: address seeded into the RollupStateManager proposer allowlist at
+  // deploy time. Zero address means no proposer is seeded — the owner must
+  // call addProposer() before any output root can be submitted.
+  readonly initialProposerAddress: string
   readonly confirmations: number
   readonly gasStrategy: "legacy" | "eip1559"
 }
@@ -28,6 +32,7 @@ export const ROLLUP_MAINNET: RollupDeployConfig = {
   inclusionDelaySeconds: 604800,                 // 7 days
   outputIntervalBlocks: 100,
   insuranceFundAddress: process.env.INSURANCE_FUND_ADDRESS ?? "0x0000000000000000000000000000000000000000",
+  initialProposerAddress: process.env.ROLLUP_INITIAL_PROPOSER ?? "0x0000000000000000000000000000000000000000",
   confirmations: 6,
   gasStrategy: "eip1559",
 }
@@ -43,6 +48,7 @@ export const ROLLUP_SEPOLIA: RollupDeployConfig = {
   inclusionDelaySeconds: 600,                    // 10 minutes
   outputIntervalBlocks: 10,
   insuranceFundAddress: process.env.INSURANCE_FUND_ADDRESS ?? "0x0000000000000000000000000000000000000000",
+  initialProposerAddress: process.env.ROLLUP_INITIAL_PROPOSER ?? "0x0000000000000000000000000000000000000000",
   confirmations: 2,
   gasStrategy: "eip1559",
 }
@@ -58,6 +64,7 @@ export const ROLLUP_LOCAL: RollupDeployConfig = {
   inclusionDelaySeconds: 120,                    // 2 minutes
   outputIntervalBlocks: 5,
   insuranceFundAddress: "0x0000000000000000000000000000000000000000",
+  initialProposerAddress: process.env.ROLLUP_INITIAL_PROPOSER ?? "0x0000000000000000000000000000000000000000",
   confirmations: 1,
   gasStrategy: "legacy",
 }

--- a/contracts/scripts/deploy-all-88780.js
+++ b/contracts/scripts/deploy-all-88780.js
@@ -15,10 +15,16 @@
 const { ethers } = require("hardhat")
 const fs = require("fs")
 const path = require("path")
+const { assertSafeDeployer, transferOwnershipChecked } = require("./preflight.js")
 
 async function main() {
   const [deployer] = await ethers.getSigners()
   const network = await ethers.provider.getNetwork()
+
+  // #686: refuse to deploy from a public Hardhat test account.
+  assertSafeDeployer(deployer.address)
+  // #683: address seeded into the RollupStateManager proposer allowlist.
+  const outputProposer = process.env.OUTPUT_PROPOSER_ADDRESS || ethers.ZeroAddress
 
   console.log("=== COC R3.2 88780 Full Contract Deploy ===")
   console.log(`Network:  ${network.name} (chainId: ${network.chainId})`)
@@ -91,6 +97,19 @@ async function main() {
     await poseV2.waitForDeployment()
     deployed.contracts.PoSeManagerV2 = await poseV2.getAddress()
     console.log(`  PoSeManagerV2: ${deployed.contracts.PoSeManagerV2}`)
+    // #685: initialize so DOMAIN_SEPARATOR / challengeBondMin are non-zero.
+    // verifyingContract is the contract's own address — the off-chain witness
+    // signers (runtime/coc-node.ts) build the EIP-712 domain from it too.
+    const challengeBondMin = process.env.POSE_CHALLENGE_BOND_MIN
+      ? BigInt(process.env.POSE_CHALLENGE_BOND_MIN)
+      : ethers.parseEther("0.1")
+    const initTx = await poseV2.initialize(
+      network.chainId,
+      deployed.contracts.PoSeManagerV2,
+      challengeBondMin,
+    )
+    await initTx.wait()
+    console.log(`  PoSeManagerV2.initialize() done (challengeBondMin=${challengeBondMin})`)
   } catch (e) {
     console.log(`  SKIPPED (constructor args mismatch): ${e.message.slice(0, 100)}`)
     deployed.contracts.PoSeManagerV2 = null
@@ -159,6 +178,7 @@ async function main() {
       ethers.parseEther("1"),
       ethers.parseEther("1"),
       deployed.contracts.InsuranceFund || ethers.ZeroAddress,
+      outputProposer,
     )
     await rsm.waitForDeployment()
     deployed.contracts.RollupStateManager = await rsm.getAddress()
@@ -166,6 +186,41 @@ async function main() {
   } catch (e) {
     console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
     deployed.contracts.RollupStateManager = null
+  }
+
+  // --- #686: hand contract ownership to the multisig ---
+  const multisig = process.env.MULTISIG_ADDRESS
+  if (multisig) {
+    console.log("")
+    console.log(`Transferring ownership to multisig ${multisig}...`)
+    const OWNABLE = [
+      "FactionRegistry",
+      "GovernanceDAO",
+      "Treasury",
+      "PoSeManager",
+      "PoSeManagerV2",
+      "ValidatorRegistry",
+      "EquivocationDetector",
+      "DelayedInbox",
+      "RollupStateManager",
+    ]
+    for (const name of OWNABLE) {
+      const addr = deployed.contracts[name]
+      if (!addr) {
+        console.log(`  ${name}: SKIPPED (not deployed)`)
+        continue
+      }
+      const c = await ethers.getContractAt(name, addr)
+      await transferOwnershipChecked(c, name, multisig)
+    }
+    deployed.owner = multisig
+    console.log("Ownership handoff complete — all owners verified == multisig.")
+  } else {
+    deployed.owner = deployer.address
+    console.log("")
+    console.log("WARNING: MULTISIG_ADDRESS not set — contracts remain owned by the")
+    console.log("         deployer. #686 is NOT resolved until ownership is moved")
+    console.log("         to a multisig.")
   }
 
   // Write deployment manifest

--- a/contracts/scripts/deploy-governance.js
+++ b/contracts/scripts/deploy-governance.js
@@ -15,10 +15,14 @@
  */
 
 const { ethers } = require("hardhat")
+const { assertSafeDeployer } = require("./preflight.js")
 
 async function main() {
   const [deployer] = await ethers.getSigners()
   const network = await ethers.provider.getNetwork()
+
+  // #686: refuse to deploy from a public Hardhat test account.
+  assertSafeDeployer(deployer.address)
 
   console.log("=== COC Governance Deployment ===")
   console.log(`Network:  ${network.name} (chainId: ${network.chainId})`)

--- a/contracts/scripts/deploy-multisig-88780.js
+++ b/contracts/scripts/deploy-multisig-88780.js
@@ -1,0 +1,78 @@
+/**
+ * Deploy the MultiSigWallet that owns the COC 88780 contracts (#686).
+ *
+ * Run this FIRST, capture the printed MULTISIG_ADDRESS, then export it so
+ * deploy-governance.js / deploy-all-88780.js hand ownership to this wallet.
+ *
+ * Usage:
+ *   DEPLOYER_PRIVATE_KEY=0x... \
+ *   MULTISIG_OWNERS=0xaaa,0xbbb,0xccc,0xddd,0xeee \
+ *   MULTISIG_THRESHOLD=3 \
+ *     npx hardhat run scripts/deploy-multisig-88780.js --network coc
+ *
+ * MULTISIG_THRESHOLD defaults to a simple majority (floor(N/2)+1).
+ */
+const { ethers } = require("hardhat")
+const { assertSafeDeployer } = require("./preflight.js")
+
+async function main() {
+  const [deployer] = await ethers.getSigners()
+  const network = await ethers.provider.getNetwork()
+
+  // #686: refuse to deploy from a public Hardhat test account.
+  assertSafeDeployer(deployer.address)
+
+  const ownersRaw = process.env.MULTISIG_OWNERS
+  if (!ownersRaw) {
+    throw new Error("MULTISIG_OWNERS is required (comma-separated addresses)")
+  }
+  const owners = ownersRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (owners.length === 0) throw new Error("MULTISIG_OWNERS is empty")
+  for (const o of owners) {
+    if (!ethers.isAddress(o)) throw new Error(`invalid owner address: ${o}`)
+  }
+  const threshold = process.env.MULTISIG_THRESHOLD
+    ? parseInt(process.env.MULTISIG_THRESHOLD, 10)
+    : Math.floor(owners.length / 2) + 1
+  if (!(threshold > 0 && threshold <= owners.length)) {
+    throw new Error(
+      `invalid MULTISIG_THRESHOLD ${threshold} for ${owners.length} owners`,
+    )
+  }
+
+  console.log("=== COC MultiSigWallet Deployment (#686) ===")
+  console.log(`Network:   chainId ${network.chainId}`)
+  console.log(`Deployer:  ${deployer.address}`)
+  console.log(`Owners (${owners.length}):`)
+  for (const o of owners) console.log(`  ${o}`)
+  console.log(`Threshold: ${threshold}-of-${owners.length}`)
+  console.log("")
+
+  const MultiSigWallet = await ethers.getContractFactory("MultiSigWallet")
+  const wallet = await MultiSigWallet.deploy(owners, threshold)
+  await wallet.waitForDeployment()
+  const addr = await wallet.getAddress()
+
+  // Post-deploy verification
+  const onChainOwners = await wallet.getOwners()
+  const onChainRequired = Number(await wallet.required())
+  const ownersMatch =
+    onChainOwners.length === owners.length &&
+    owners.every((o, i) => onChainOwners[i].toLowerCase() === o.toLowerCase())
+  if (!ownersMatch || onChainRequired !== threshold) {
+    console.error("FAIL: post-deploy verification mismatch")
+    process.exit(1)
+  }
+
+  console.log(`MultiSigWallet deployed: ${addr}`)
+  console.log("")
+  console.log(`MULTISIG_ADDRESS=${addr}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/contracts/scripts/deploy-posev2-88780.js
+++ b/contracts/scripts/deploy-posev2-88780.js
@@ -1,13 +1,30 @@
 /**
- * Standalone redeploy of PoSeManagerV2 to 88780 (post-#676 pull-payment fix).
+ * Standalone redeploy of PoSeManagerV2 to 88780.
+ *
  * PoSeManagerV2 has no constructor args and zero on-chain dependents, so a
  * standalone redeploy does not cascade stale cross-references.
+ *
+ * Unlike earlier revisions this script also:
+ *   - refuses public Hardhat test accounts as deployer (#686)
+ *   - calls initialize() right after deploy so DOMAIN_SEPARATOR /
+ *     challengeBondMin are non-zero (#685)
+ *   - hands ownership to MULTISIG_ADDRESS when set (#686)
+ *
+ * Environment:
+ *   DEPLOYER_PRIVATE_KEY    — securely-held deployer key
+ *   POSE_CHALLENGE_BOND_MIN — challenge bond minimum in wei (default 0.1 ETH)
+ *   MULTISIG_ADDRESS        — multisig that should own the contract
  */
 const { ethers } = require("hardhat")
+const { assertSafeDeployer, transferOwnershipChecked } = require("./preflight.js")
 
 async function main() {
   const [deployer] = await ethers.getSigners()
   const network = await ethers.provider.getNetwork()
+
+  // #686: refuse to deploy from a public Hardhat test account.
+  assertSafeDeployer(deployer.address)
+
   console.log(`Network:  chainId ${network.chainId}`)
   console.log(`Deployer: ${deployer.address}`)
   console.log(`Balance:  ${ethers.formatEther(await ethers.provider.getBalance(deployer.address))} ETH`)
@@ -21,20 +38,41 @@ async function main() {
   const addr = await poseV2.getAddress()
   console.log(`  PoSeManagerV2: ${addr}`)
 
+  // #685: initialize immediately so DOMAIN_SEPARATOR / challengeBondMin are
+  // non-zero. verifyingContract is the contract's own address — the off-chain
+  // witness signers (runtime/coc-node.ts) build the EIP-712 domain from it too.
+  const challengeBondMin = process.env.POSE_CHALLENGE_BOND_MIN
+    ? BigInt(process.env.POSE_CHALLENGE_BOND_MIN)
+    : ethers.parseEther("0.1")
+  const initTx = await poseV2.initialize(network.chainId, addr, challengeBondMin)
+  await initTx.wait()
+  console.log(`  PoSeManagerV2.initialize() done (challengeBondMin=${challengeBondMin})`)
+
   // Post-deploy verification
   const code = await ethers.provider.getCode(addr)
-  const owner = await poseV2.owner()
   const initialized = await poseV2.initialized()
+  const domainSeparator = await poseV2.DOMAIN_SEPARATOR()
   console.log("")
   console.log("Verification:")
-  console.log(`  code size:   ${(code.length - 2) / 2} bytes`)
-  console.log(`  owner:       ${owner}  (deployer match: ${owner.toLowerCase() === deployer.address.toLowerCase()})`)
-  console.log(`  initialized: ${initialized}  (expected false — initialize() is owner-gated, deploy-pending)`)
-
-  if (code === "0x" || owner.toLowerCase() !== deployer.address.toLowerCase()) {
+  console.log(`  code size:        ${(code.length - 2) / 2} bytes`)
+  console.log(`  initialized:      ${initialized}`)
+  console.log(`  DOMAIN_SEPARATOR: ${domainSeparator}`)
+  if (code === "0x" || !initialized || domainSeparator === ethers.ZeroHash) {
     console.error("FAIL: post-deploy verification failed")
     process.exit(1)
   }
+
+  // #686: hand ownership to the multisig if configured.
+  const multisig = process.env.MULTISIG_ADDRESS
+  if (multisig) {
+    console.log("")
+    await transferOwnershipChecked(poseV2, "PoSeManagerV2", multisig)
+  } else {
+    console.log("")
+    console.log("WARNING: MULTISIG_ADDRESS not set — PoSeManagerV2 remains owned")
+    console.log("         by the deployer (#686 not resolved).")
+  }
+
   console.log("")
   console.log(`NEW_POSEMANAGERV2=${addr}`)
 }

--- a/contracts/scripts/preflight.js
+++ b/contracts/scripts/preflight.js
@@ -1,0 +1,82 @@
+/**
+ * Deploy-time safety helpers (#686).
+ *
+ * The 88780 contracts were originally deployed with the default Hardhat test
+ * account #0 as deployer — and therefore as owner. That account's private key
+ * is published in every Hardhat install, so every onlyOwner function was
+ * effectively permissionless. These helpers stop that from recurring and make
+ * the post-deploy ownership handoff to a multisig verifiable.
+ */
+
+// Known Hardhat / anvil default test accounts (mnemonic:
+// "test test test test test test test test test test test junk").
+// Their private keys are public — they must never own production contracts.
+const HARDHAT_TEST_ACCOUNTS = new Set(
+  [
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+    "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
+    "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
+    "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+    "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+    "0x976EA74026E726554dB657fA54763abd0C3a0aa9",
+    "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955",
+    "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
+    "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
+    "0xBcd4042DE499D14e55001CcbB24a551F3b954096",
+    "0x71bE63f3384f5fb98995898A86B02Fb2426c5788",
+    "0xFABB0ac9d68B0B445fB7357272Ff202C5651694a",
+    "0x1CBd3b2770909D4e10f157cABC84C7264073C9Ec",
+    "0xdF3e18d64BC6A983f673Ab319CCaE4f1a57C7097",
+    "0xcd3B766CCDd6AE721141F452C550Ca635964ce71",
+    "0x2546BcD3c84621e976D8185a91A922aE77ECEc30",
+    "0xbDA5747bFD65F08deb54cb465eB87D40e51B197E",
+    "0xdD2FD4581271e230360230F9337D5c0430Bf44C0",
+    "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199",
+  ].map((a) => a.toLowerCase()),
+)
+
+/**
+ * Abort the deploy if `address` is a public Hardhat test account, unless
+ * ALLOW_HARDHAT_DEPLOYER=1 is explicitly set (for local hardhat-network runs).
+ */
+function assertSafeDeployer(address) {
+  if (!HARDHAT_TEST_ACCOUNTS.has(String(address).toLowerCase())) return
+  if (process.env.ALLOW_HARDHAT_DEPLOYER === "1") {
+    console.warn(
+      `WARNING: deploying with Hardhat test account ${address} ` +
+        "(ALLOW_HARDHAT_DEPLOYER=1). Never do this on a live network.",
+    )
+    return
+  }
+  console.error(
+    `FATAL: deployer ${address} is a public Hardhat test account — its ` +
+      "private key is public (#686). Set DEPLOYER_PRIVATE_KEY to a securely " +
+      "held key, or set ALLOW_HARDHAT_DEPLOYER=1 for a throwaway local run.",
+  )
+  process.exit(1)
+}
+
+/**
+ * Call transferOwnership on a contract and assert the new owner stuck.
+ * Aborts the deploy if the on-chain owner does not match — a wrong target on
+ * a non-upgradeable contract would lock admin functions forever.
+ */
+async function transferOwnershipChecked(contract, name, multisigAddress) {
+  const tx = await contract.transferOwnership(multisigAddress)
+  await tx.wait()
+  const newOwner = await contract.owner()
+  if (String(newOwner).toLowerCase() !== String(multisigAddress).toLowerCase()) {
+    console.error(
+      `FATAL: ${name}.owner is ${newOwner}, expected ${multisigAddress}`,
+    )
+    process.exit(1)
+  }
+  console.log(`  ${name}: ownership -> ${multisigAddress}`)
+}
+
+module.exports = {
+  HARDHAT_TEST_ACCOUNTS,
+  assertSafeDeployer,
+  transferOwnershipChecked,
+}

--- a/contracts/test/contract-ownership.test.cjs
+++ b/contracts/test/contract-ownership.test.cjs
@@ -1,0 +1,196 @@
+/**
+ * Contract ownership transfer tests (#686).
+ *
+ * Every governance / settlement contract that has an onlyOwner-gated admin
+ * surface must be able to hand ownership to a multisig — otherwise the owner
+ * is permanently stuck on the deploy key (which on 88780 was a public Hardhat
+ * test account). This verifies transferOwnership on each contract that had it
+ * added: owner can transfer, non-owner is rejected, the zero address is
+ * rejected, and admin power follows the new owner.
+ */
+
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+describe("Contract ownership transfer (#686)", function () {
+  let deployer, newOwner, outsider
+
+  beforeEach(async function () {
+    ;[deployer, newOwner, outsider] = await ethers.getSigners()
+  })
+
+  describe("FactionRegistry", function () {
+    let c
+    beforeEach(async function () {
+      c = await (await ethers.getContractFactory("FactionRegistry")).deploy()
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      expect(await c.owner()).to.equal(deployer.address)
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await expect(
+        c.transferOwnership(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(c, "ZeroAddress")
+    })
+
+    it("moves admin power to the new owner", async function () {
+      await c.transferOwnership(newOwner.address)
+      await expect(
+        c.connect(deployer).setVerifier(outsider.address),
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await c.connect(newOwner).setVerifier(outsider.address)
+      expect(await c.verifier()).to.equal(outsider.address)
+    })
+  })
+
+  describe("GovernanceDAO", function () {
+    let c
+    beforeEach(async function () {
+      const fr = await (await ethers.getContractFactory("FactionRegistry")).deploy()
+      await fr.waitForDeployment()
+      c = await (await ethers.getContractFactory("GovernanceDAO")).deploy(
+        await fr.getAddress(),
+      )
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
+        "zero owner",
+      )
+    })
+  })
+
+  describe("Treasury", function () {
+    let c
+    beforeEach(async function () {
+      const accounts = await ethers.getSigners()
+      const signers = accounts.slice(3, 8).map((s) => s.address)
+      c = await (await ethers.getContractFactory("Treasury")).deploy(
+        signers,
+        deployer.address,
+      )
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await expect(
+        c.transferOwnership(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(c, "ZeroAddress")
+    })
+  })
+
+  describe("DelayedInbox", function () {
+    let c
+    beforeEach(async function () {
+      c = await (await ethers.getContractFactory("DelayedInbox")).deploy(
+        3600,
+        deployer.address,
+      )
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWith("only owner")
+      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
+        "zero address",
+      )
+    })
+  })
+
+  describe("PoSeManager (v1)", function () {
+    let c
+    beforeEach(async function () {
+      c = await (await ethers.getContractFactory("PoSeManager")).deploy()
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWith("not owner")
+      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
+        "zero owner",
+      )
+    })
+  })
+
+  describe("PoSeManagerV2", function () {
+    let c
+    beforeEach(async function () {
+      c = await (await ethers.getContractFactory("PoSeManagerV2")).deploy()
+      await c.waitForDeployment()
+    })
+
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(c.transferOwnership(newOwner.address))
+        .to.emit(c, "OwnerUpdated")
+        .withArgs(deployer.address, newOwner.address)
+      expect(await c.owner()).to.equal(newOwner.address)
+    })
+
+    it("rejects a non-owner and the zero address", async function () {
+      await expect(
+        c.connect(outsider).transferOwnership(outsider.address),
+      ).to.be.revertedWith("not owner")
+      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
+        "zero owner",
+      )
+    })
+
+    it("moves admin power to the new owner", async function () {
+      await c.transferOwnership(newOwner.address)
+      await expect(
+        c.connect(deployer).setChallengeBondMin(1),
+      ).to.be.revertedWith("not owner")
+      await c.connect(newOwner).setChallengeBondMin(1)
+      expect(await c.challengeBondMin()).to.equal(1)
+    })
+  })
+})

--- a/contracts/test/multisig-wallet.test.cjs
+++ b/contracts/test/multisig-wallet.test.cjs
@@ -1,0 +1,189 @@
+/**
+ * MultiSigWallet Tests
+ *
+ * Covers the wallet used as the owner of COC governance / settlement
+ * contracts:
+ * - Constructor validation (owner set, threshold bounds, dedup, zero address)
+ * - submit / confirm / execute happy path (N-of-M threshold)
+ * - Threshold enforcement (cannot execute below `required`)
+ * - revoke confirmation
+ * - Access control (non-owners rejected)
+ * - Failed inner call reverts the whole execution (executed flag rolled back)
+ */
+
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+describe("MultiSigWallet", function () {
+  let wallet
+  let signers
+  let owners
+  let outsider
+  let recipient
+
+  const REQUIRED = 3
+
+  beforeEach(async function () {
+    const accounts = await ethers.getSigners()
+    signers = accounts.slice(0, 5)
+    owners = signers.map((s) => s.address)
+    outsider = accounts[5]
+    recipient = accounts[6]
+
+    const Factory = await ethers.getContractFactory("MultiSigWallet")
+    wallet = await Factory.deploy(owners, REQUIRED)
+    await wallet.waitForDeployment()
+  })
+
+  describe("constructor", function () {
+    it("records owners and threshold", async function () {
+      expect(await wallet.required()).to.equal(REQUIRED)
+      expect(await wallet.getOwners()).to.deep.equal(owners)
+      for (const o of owners) {
+        expect(await wallet.isOwner(o)).to.equal(true)
+      }
+      expect(await wallet.isOwner(outsider.address)).to.equal(false)
+    })
+
+    it("rejects empty owner set", async function () {
+      const Factory = await ethers.getContractFactory("MultiSigWallet")
+      await expect(Factory.deploy([], 1)).to.be.revertedWith("Owners required")
+    })
+
+    it("rejects a threshold above the owner count", async function () {
+      const Factory = await ethers.getContractFactory("MultiSigWallet")
+      await expect(Factory.deploy(owners, 6)).to.be.revertedWith(
+        "Invalid required count",
+      )
+    })
+
+    it("rejects a zero threshold", async function () {
+      const Factory = await ethers.getContractFactory("MultiSigWallet")
+      await expect(Factory.deploy(owners, 0)).to.be.revertedWith(
+        "Invalid required count",
+      )
+    })
+
+    it("rejects a zero owner address", async function () {
+      const Factory = await ethers.getContractFactory("MultiSigWallet")
+      await expect(
+        Factory.deploy([owners[0], ethers.ZeroAddress], 1),
+      ).to.be.revertedWith("Invalid owner")
+    })
+
+    it("rejects duplicate owners", async function () {
+      const Factory = await ethers.getContractFactory("MultiSigWallet")
+      await expect(
+        Factory.deploy([owners[0], owners[0]], 1),
+      ).to.be.revertedWith("Duplicate owner")
+    })
+  })
+
+  describe("submit / confirm / execute", function () {
+    const VALUE = ethers.parseEther("1")
+
+    beforeEach(async function () {
+      await signers[0].sendTransaction({
+        to: await wallet.getAddress(),
+        value: ethers.parseEther("5"),
+      })
+    })
+
+    it("executes an ETH transfer once the threshold is met", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, VALUE, "0x")
+
+      await wallet.connect(signers[0]).confirmTransaction(0)
+      await wallet.connect(signers[1]).confirmTransaction(0)
+      await wallet.connect(signers[2]).confirmTransaction(0)
+
+      const before = await ethers.provider.getBalance(recipient.address)
+      await expect(wallet.connect(signers[2]).executeTransaction(0))
+        .to.emit(wallet, "Execute")
+        .withArgs(0)
+      const after = await ethers.provider.getBalance(recipient.address)
+      expect(after - before).to.equal(VALUE)
+    })
+
+    it("rejects execution below the confirmation threshold", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, VALUE, "0x")
+      await wallet.connect(signers[0]).confirmTransaction(0)
+      await wallet.connect(signers[1]).confirmTransaction(0)
+
+      await expect(
+        wallet.connect(signers[1]).executeTransaction(0),
+      ).to.be.revertedWith("Not enough confirmations")
+    })
+
+    it("rejects double execution", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, VALUE, "0x")
+      for (let i = 0; i < REQUIRED; i++) {
+        await wallet.connect(signers[i]).confirmTransaction(0)
+      }
+      await wallet.connect(signers[0]).executeTransaction(0)
+
+      await expect(
+        wallet.connect(signers[0]).executeTransaction(0),
+      ).to.be.revertedWith("Already executed")
+    })
+
+    it("revoking a confirmation drops the count below threshold", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, VALUE, "0x")
+      for (let i = 0; i < REQUIRED; i++) {
+        await wallet.connect(signers[i]).confirmTransaction(0)
+      }
+      await wallet.connect(signers[2]).revokeConfirmation(0)
+
+      await expect(
+        wallet.connect(signers[0]).executeTransaction(0),
+      ).to.be.revertedWith("Not enough confirmations")
+    })
+
+    it("rolls back the executed flag when the inner call reverts", async function () {
+      // Inner call: confirmTransaction(999) on the wallet itself — reverts
+      // because the tx does not exist, so executeTransaction must revert too.
+      const badData = wallet.interface.encodeFunctionData("confirmTransaction", [999])
+      await wallet
+        .connect(signers[0])
+        .submitTransaction(await wallet.getAddress(), 0, badData)
+      for (let i = 0; i < REQUIRED; i++) {
+        await wallet.connect(signers[i]).confirmTransaction(0)
+      }
+
+      await expect(
+        wallet.connect(signers[0]).executeTransaction(0),
+      ).to.be.revertedWith("Execution failed")
+
+      const txn = await wallet.transactions(0)
+      expect(txn.executed).to.equal(false)
+    })
+  })
+
+  describe("access control", function () {
+    it("rejects submitTransaction from a non-owner", async function () {
+      await expect(
+        wallet.connect(outsider).submitTransaction(recipient.address, 0, "0x"),
+      ).to.be.revertedWith("Not owner")
+    })
+
+    it("rejects confirmTransaction from a non-owner", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, 0, "0x")
+      await expect(
+        wallet.connect(outsider).confirmTransaction(0),
+      ).to.be.revertedWith("Not owner")
+    })
+
+    it("rejects confirming a non-existent transaction", async function () {
+      await expect(
+        wallet.connect(signers[0]).confirmTransaction(0),
+      ).to.be.revertedWith("Tx does not exist")
+    })
+
+    it("rejects a double confirmation from the same owner", async function () {
+      await wallet.connect(signers[0]).submitTransaction(recipient.address, 0, "0x")
+      await wallet.connect(signers[0]).confirmTransaction(0)
+      await expect(
+        wallet.connect(signers[0]).confirmTransaction(0),
+      ).to.be.revertedWith("Already confirmed")
+    })
+  })
+})

--- a/contracts/test/rollup-resolve-reentrancy.test.cjs
+++ b/contracts/test/rollup-resolve-reentrancy.test.cjs
@@ -33,6 +33,7 @@ describe("Security: RollupStateManager resolveChallenge reentrancy", function ()
       PROPOSER_BOND,
       CHALLENGER_BOND,
       insuranceFund.address,
+      proposer.address,
     )
     await manager.waitForDeployment()
 

--- a/contracts/test/rollup-state-manager.test.cjs
+++ b/contracts/test/rollup-state-manager.test.cjs
@@ -33,12 +33,16 @@ describe("RollupStateManager", function () {
       PROPOSER_BOND,
       CHALLENGER_BOND,
       insuranceFund.address,
+      proposer.address,
     )
     await manager.waitForDeployment()
 
     const Rejecting = await ethers.getContractFactory("RollupRejectingReceiver")
     rejecting = await Rejecting.deploy(await manager.getAddress())
     await rejecting.waitForDeployment()
+    // RollupRejectingReceiver submits output roots in the rejecting-proposer
+    // tests, so it must be an allowlisted proposer (#683).
+    await manager.addProposer(await rejecting.getAddress())
 
     // Sample data
     sampleStateRoot = ethers.keccak256(ethers.toUtf8Bytes("state-root-1"))
@@ -523,6 +527,106 @@ describe("RollupStateManager", function () {
 
     it("CHALLENGER_BOND returns configured value", async function () {
       expect(await manager.CHALLENGER_BOND()).to.equal(CHALLENGER_BOND)
+    })
+  })
+
+  describe("proposer allowlist (#683)", function () {
+    it("seeds the constructor initialProposer", async function () {
+      expect(await manager.allowedProposers(proposer.address)).to.equal(true)
+      expect(await manager.allowedProposers(challenger.address)).to.equal(false)
+    })
+
+    it("rejects submitOutputRoot from a non-allowlisted account", async function () {
+      await expect(
+        manager
+          .connect(challenger)
+          .submitOutputRoot(100, sampleOutputRoot, sampleStateRoot, {
+            value: PROPOSER_BOND,
+          }),
+      ).to.be.revertedWithCustomError(manager, "NotProposer")
+    })
+
+    it("blocks the max-uint64 jamming grief from an unauthorized account", async function () {
+      // #683: an attacker submitting type(uint64).max would pin lastSubmittedBlock
+      // and revert every future submission. The allowlist rejects them outright.
+      const MAX_U64 = (1n << 64n) - 1n
+      await expect(
+        manager
+          .connect(challenger)
+          .submitOutputRoot(MAX_U64, sampleOutputRoot, sampleStateRoot, {
+            value: PROPOSER_BOND,
+          }),
+      ).to.be.revertedWithCustomError(manager, "NotProposer")
+      expect(await manager.lastSubmittedBlock()).to.equal(0)
+    })
+
+    it("lets the owner add and remove proposers", async function () {
+      await expect(manager.connect(deployer).addProposer(challenger.address))
+        .to.emit(manager, "ProposerUpdated")
+        .withArgs(challenger.address, true)
+      expect(await manager.allowedProposers(challenger.address)).to.equal(true)
+
+      await manager
+        .connect(challenger)
+        .submitOutputRoot(100, sampleOutputRoot, sampleStateRoot, {
+          value: PROPOSER_BOND,
+        })
+
+      await expect(manager.connect(deployer).removeProposer(challenger.address))
+        .to.emit(manager, "ProposerUpdated")
+        .withArgs(challenger.address, false)
+      await expect(
+        manager
+          .connect(challenger)
+          .submitOutputRoot(200, sampleOutputRoot, sampleStateRoot, {
+            value: PROPOSER_BOND,
+          }),
+      ).to.be.revertedWithCustomError(manager, "NotProposer")
+    })
+
+    it("rejects addProposer / removeProposer from a non-owner", async function () {
+      await expect(
+        manager.connect(challenger).addProposer(challenger.address),
+      ).to.be.revertedWithCustomError(manager, "OnlyOwner")
+      await expect(
+        manager.connect(challenger).removeProposer(proposer.address),
+      ).to.be.revertedWithCustomError(manager, "OnlyOwner")
+    })
+
+    it("rejects addProposer with the zero address", async function () {
+      await expect(
+        manager.connect(deployer).addProposer(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(manager, "ZeroAddress")
+    })
+  })
+
+  describe("transferOwnership", function () {
+    it("transfers ownership and emits OwnerUpdated", async function () {
+      await expect(manager.connect(deployer).transferOwnership(challenger.address))
+        .to.emit(manager, "OwnerUpdated")
+        .withArgs(deployer.address, challenger.address)
+      expect(await manager.owner()).to.equal(challenger.address)
+    })
+
+    it("rejects transferOwnership from a non-owner", async function () {
+      await expect(
+        manager.connect(challenger).transferOwnership(challenger.address),
+      ).to.be.revertedWithCustomError(manager, "OnlyOwner")
+    })
+
+    it("rejects transferOwnership to the zero address", async function () {
+      await expect(
+        manager.connect(deployer).transferOwnership(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(manager, "ZeroAddress")
+    })
+
+    it("moves owner-only powers to the new owner", async function () {
+      await manager.connect(deployer).transferOwnership(challenger.address)
+      await expect(
+        manager.connect(deployer).addProposer(insuranceFund.address),
+      ).to.be.revertedWithCustomError(manager, "OnlyOwner")
+      await manager.connect(challenger).addProposer(insuranceFund.address)
+      expect(await manager.allowedProposers(insuranceFund.address)).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Refs #683 by adding an owner-managed RollupStateManager proposer allowlist so unauthorized accounts cannot pin lastSubmittedBlock with an unbounded output submission
- Refs #686 by adding ownership transfer support across the remaining admin-owned contracts and moving MultiSigWallet into the governance contract set for the 88780 owner handoff
- Refs #685 by updating deploy scripts to initialize PoSeManagerV2 after deployment and adding deployment preflight checks against public Hardhat test keys
- updates 88780 deployment scripts to hand ownership to MULTISIG_ADDRESS and adds a standalone multisig deployment script

These three issues are only fully resolved once the 88780 contracts are
redeployed and ownership is handed to the multisig — `Refs` (not `fixes`)
so merging this PR does not auto-close them before the on-chain redeploy.

## Tests

- cd contracts && npx hardhat test "test/contract-ownership.test.cjs" "test/multisig-wallet.test.cjs" "test/rollup-state-manager.test.cjs" "test/rollup-resolve-reentrancy.test.cjs"
- git diff --check HEAD~1..HEAD

## Notes

This is a coordinated testnet redeploy prep change. Existing 88780 contracts still need the operational redeploy / ownership handoff after review and merge.
