### PR TITLE
fix(security): keep PoSe emission reward pool backed

### DIFF
--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -512,7 +512,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
         epochFinalized[epochId] = true;
         epochFinalizedAt[epochId] = block.timestamp;
 
-        // --- PoSe Mining Emission: mint new tokens into reward pool ---
+        // --- PoSe Mining Emission: native supply ledger only ---
         if (emissionEnabled && address(cocToken) != address(0)) {
             // Epoch offset from genesis determines the year for decay rate
             uint64 relativeEpoch = epochId >= genesisEpoch ? epochId - genesisEpoch : 0;
@@ -523,12 +523,12 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
             );
             if (emission > 0) {
                 cocToken.mint(address(this), emission);
-                rewardPoolBalance += emission;
                 emit EmissionMinted(epochId, emission);
             }
         }
 
-        // Deduct rewards from pool (now includes freshly minted tokens)
+        // Deduct rewards from the native reward pool. COCToken minting above is
+        // supply accounting only; it does not add spendable native balance here.
         epochTotalReward[epochId] = totalReward;
         if (totalReward > rewardPoolBalance) revert RewardPoolInsufficient();
         if (totalReward > 0) {

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -1037,6 +1037,31 @@ describe("PoSeManagerV2", function () {
       expect(await manager.epochSwept(epochId)).to.equal(true)
       expect(await manager.pendingWithdrawals(foundation.address)).to.equal(expectedCredit)
     })
+
+    it("does not credit bookkeeping emission as spendable native reward balance", async function () {
+      await registerNode(manager, deployer)
+
+      const Token = await ethers.getContractFactory("COCToken")
+      const token = await Token.deploy([deployer.address], [ethers.parseEther("250000000")])
+      await token.waitForDeployment()
+      await token.setMinter(await manager.getAddress())
+      await manager.enableEmission(await token.getAddress(), 0)
+
+      await ethers.provider.send("evm_increaseTime", [4 * 3600])
+      await ethers.provider.send("evm_mine")
+
+      await expect(manager.finalizeEpochV2(1, ethers.ZeroHash, 0, 0, 0))
+        .to.emit(manager, "EmissionMinted")
+
+      expect(await token.totalMinted()).to.be.greaterThan(0n)
+      expect(await manager.rewardPoolBalance()).to.equal(0n)
+
+      const amount = 1n
+      const leaf = ethers.keccak256(ethers.solidityPacked(["uint64", "bytes32", "uint256"], [2, ethers.ZeroHash, amount]))
+      await expect(
+        manager.finalizeEpochV2(2, pairHash(leaf, leaf), amount, 0, 0)
+      ).to.be.revertedWithCustomError(manager, "RewardPoolInsufficient")
+    })
   })
 
   describe("Read helpers", function () {


### PR DESCRIPTION
## Summary

- fixes #650 by stopping PoSeManagerV2 from crediting native rewardPoolBalance with COCToken bookkeeping emission
- keeps COCToken.mint and EmissionMinted for native supply accounting
- requires reward Merkle budgets to remain backed by explicit native reward-pool deposits
- adds regression coverage proving emission mints ledger supply but leaves spendable native reward balance unchanged

## Tests

- cd contracts && npx hardhat test "test/pose-v2.test.cjs"
- cd contracts && npx hardhat test "test/pose-v2-e2e.test.cjs"
- git diff --check

## Notes

This chooses the conservative funding model from #650: rewardPoolBalance tracks only real native COC available for payouts. Protocol/native emission funding can be added later at the chain layer if maintainers choose that architecture.