### PR TITLE
fix(security): authenticate PoSe witness signing

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -39,6 +39,14 @@
   "poseManagerV2Address": "0xYOUR_POSE_MANAGER_V2_ADDRESS",
   "verifyingContract": "0xYOUR_POSE_MANAGER_V2_ADDRESS",
   "chainId": 18780,
+  "poseWitnessAuthToken": "replace-with-random-witness-token",
+  "witnessNodes": [
+    {
+      "url": "http://127.0.0.1:18780",
+      "witnessIndex": 0,
+      "authToken": "replace-with-random-witness-token"
+    }
+  ],
   "requiredWitnesses": 0,
   "allowEmptyBatchWitnessSubmission": false,
   "tipToleranceBlocks": 10,

--- a/docs/operations-manual.en.md
+++ b/docs/operations-manual.en.md
@@ -573,6 +573,7 @@ The PoSe runtime service exposes these HTTP endpoints:
 ```bash
 COC_DATA_DIR=/data/coc \
 COC_NODE_KEY=0x... \
+COC_POSE_WITNESS_AUTH_TOKEN=... \
   node --experimental-strip-types runtime/coc-node.ts
 ```
 
@@ -582,6 +583,8 @@ COC_NODE_KEY=0x... \
 | `/pose/challenge` | POST | Submit challenge (v1 EIP-191 / v2 EIP-712) |
 | `/pose/receipt` | POST | Submit receipt |
 | `/pose/witness` | POST | Witness attestation (v2 only) |
+
+Security note: `/pose/witness` signs EIP-712 witness attestations. When `COC_POSE_WITNESS_AUTH_TOKEN` or `poseWitnessAuthToken` is configured, every caller must present `Authorization: Bearer <token>`. Without a token, only loopback callers are accepted. Configure matching `authToken` values on remote `witnessNodes`; keep public deployments behind TLS or a private network.
 
 Note: `runtime/coc-node.ts` returns a lightweight service-local health payload (`{"ok":true,"ts":...}`) on `/health`; chain height and peer status should still be checked through node RPC or the metrics server.
 

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "./lib/config.ts";
 import { InMemoryStore } from "./lib/state.ts";
 import { recordChallengeBounded } from "./lib/bounded-challenge-store.ts";
 import { validatePoseWitnessPayload } from "./lib/pose-witness-validator.ts";
+import { isPoseWitnessRequestAuthorized, resolvePoseWitnessAuthToken } from "./lib/pose-witness-auth.ts";
 import { IpfsBlockstore } from "../node/src/ipfs-blockstore.ts";
 import { loadStorageProof, MerkleLeavesCache } from "./lib/storage-proof.ts";
 import { readBoundedBody } from "./lib/pose-body-reader.ts";
@@ -19,6 +20,7 @@ const config = await loadConfig();
 const bind = process.env.COC_NODE_BIND || config.nodeBind || "127.0.0.1";
 const port = Number(process.env.COC_NODE_PORT || config.nodePort || 18780);
 const storageDir = resolveStorageDir(config.dataDir, config.storageDir);
+const poseWitnessAuthToken = resolvePoseWitnessAuthToken(process.env.COC_POSE_WITNESS_AUTH_TOKEN, config.poseWitnessAuthToken);
 
 // Phase C2.1: when FF is on, the receipt handler reads real chunk bytes
 // from the IPFS blockstore rooted at `storageDir` (same path the main
@@ -362,6 +364,9 @@ const server = http.createServer((req, res) => {
   if (req.method === "POST" && req.url === "/pose/witness") {
     if (!nodeSignerV2) {
       return json(res, 501, { error: "v2 protocol not enabled" });
+    }
+    if (!isPoseWitnessRequestAuthorized(req, poseWitnessAuthToken)) {
+      return json(res, 401, { error: "unauthorized witness request" });
     }
     // #292: body bounded via readBody (1 MB cap). Same DoS class as
     // /pose/challenge — pre-fix used unbounded body accumulation.

--- a/runtime/lib/config.ts
+++ b/runtime/lib/config.ts
@@ -51,7 +51,8 @@ export interface CocRuntimeConfig {
   protocolVersion?: 1 | 2;
   chainId?: number;
   verifyingContract?: string;
-  witnessNodes?: { url: string; witnessIndex: number }[];
+  poseWitnessAuthToken?: string;
+  witnessNodes?: { url: string; witnessIndex: number; authToken?: string }[];
   requiredWitnesses?: number;
   allowEmptyBatchWitnessSubmission?: boolean;
   tipToleranceBlocks?: number;

--- a/runtime/lib/http-client.ts
+++ b/runtime/lib/http-client.ts
@@ -3,10 +3,15 @@ import https from "node:https";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
-export async function requestJson(url: string, method: string, body?: unknown): Promise<{ status?: number; json?: any }> {
+export async function requestJson(
+  url: string,
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status?: number; json?: any }> {
   return new Promise((resolve, reject) => {
     const transport = url.startsWith("https") ? https : http;
-    const req = transport.request(url, { method, headers: { "content-type": "application/json" } }, (res) => {
+    const req = transport.request(url, { method, headers: { "content-type": "application/json", ...headers } }, (res) => {
       let data = "";
       res.on("data", (chunk) => (data += chunk));
       res.on("end", () => {

--- a/runtime/lib/pose-witness-auth.test.ts
+++ b/runtime/lib/pose-witness-auth.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildWitnessAuthHeaders,
+  isPoseWitnessRequestAuthorized,
+  resolvePoseWitnessAuthToken,
+} from "./pose-witness-auth.ts";
+
+function request(remoteAddress: string, authorization?: string | string[]) {
+  return {
+    headers: authorization === undefined ? {} : { authorization },
+    socket: { remoteAddress },
+  };
+}
+
+test("#667: remote /pose/witness requests are rejected when no token is configured", () => {
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10"), undefined), false);
+});
+
+test("#667: loopback /pose/witness requests remain local-dev compatible without a token", () => {
+  for (const ip of ["127.0.0.1", "127.22.33.44", "::1", "0:0:0:0:0:0:0:1", "::ffff:127.0.0.1"]) {
+    assert.equal(isPoseWitnessRequestAuthorized(request(ip), undefined), true, ip);
+  }
+});
+
+test("#667: remote /pose/witness requests require the configured bearer token", () => {
+  const token = "witness-secret";
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10", "Bearer witness-secret"), token), true);
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10", "Bearer wrong"), token), false);
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10", "Basic witness-secret"), token), false);
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10"), token), false);
+  assert.equal(isPoseWitnessRequestAuthorized(request("203.0.113.10", ["Bearer witness-secret"]), token), false);
+});
+
+test("#667: configured tokens are enforced for loopback callers too", () => {
+  const token = "witness-secret";
+  assert.equal(isPoseWitnessRequestAuthorized(request("127.0.0.1"), token), false);
+  assert.equal(isPoseWitnessRequestAuthorized(request("127.0.0.1", "Bearer witness-secret"), token), true);
+});
+
+test("#667: auth token resolution trims env/config values", () => {
+  assert.equal(resolvePoseWitnessAuthToken("  env-token  ", "config-token"), "env-token");
+  assert.equal(resolvePoseWitnessAuthToken("  ", " config-token "), "config-token");
+  assert.equal(resolvePoseWitnessAuthToken(undefined, ""), undefined);
+});
+
+test("#667: witness auth header helper omits empty tokens", () => {
+  assert.deepEqual(buildWitnessAuthHeaders(" secret "), { Authorization: "Bearer secret" });
+  assert.equal(buildWitnessAuthHeaders("   "), undefined);
+  assert.equal(buildWitnessAuthHeaders(undefined), undefined);
+});

--- a/runtime/lib/pose-witness-auth.ts
+++ b/runtime/lib/pose-witness-auth.ts
@@ -1,0 +1,67 @@
+import { timingSafeEqual } from "node:crypto";
+
+export interface PoseWitnessAuthRequest {
+  headers: Record<string, string | string[] | undefined>;
+  socket: {
+    remoteAddress?: string | null;
+  };
+}
+
+export function resolvePoseWitnessAuthToken(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+export function isPoseWitnessRequestAuthorized(
+  req: PoseWitnessAuthRequest,
+  authToken: string | undefined,
+): boolean {
+  if (authToken) {
+    const bearer = readBearerToken(req.headers);
+    return !!bearer && constantTimeEqual(bearer, authToken);
+  }
+  return isLoopbackAddress(req.socket.remoteAddress ?? "");
+}
+
+export function buildWitnessAuthHeaders(authToken?: string): Record<string, string> | undefined {
+  const token = authToken?.trim();
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
+function readBearerToken(headers: Record<string, string | string[] | undefined>): string | null {
+  const raw = headers.authorization;
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(raw.trim());
+  if (!match) {
+    return null;
+  }
+  const token = match[1]?.trim();
+  return token || null;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  const maxLen = Math.max(bufA.length, bufB.length);
+  const paddedA = Buffer.alloc(maxLen);
+  const paddedB = Buffer.alloc(maxLen);
+  bufA.copy(paddedA);
+  bufB.copy(paddedB);
+  return timingSafeEqual(paddedA, paddedB) && bufA.length === bufB.length;
+}
+
+function isLoopbackAddress(ip: string): boolean {
+  if (!ip || ip === "unknown") return false;
+  const stripped = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+  if (stripped === "::1" || stripped === "0:0:0:0:0:0:0:1") return true;
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(stripped)) {
+    const parts = stripped.split(".").map(Number);
+    return parts.every((part) => part >= 0 && part <= 255);
+  }
+  return false;
+}

--- a/runtime/lib/witness-collector.test.ts
+++ b/runtime/lib/witness-collector.test.ts
@@ -140,6 +140,36 @@ describe("witness-collector", () => {
     assert.equal(result.signatures[2], mkSig("3"))
   })
 
+  it("collectBatchWitnessSignatures sends endpoint bearer tokens when configured (#667)", async () => {
+    const merkleRoot = `0x${"ee".repeat(32)}` as Hex32
+    const witnessSet = [`0x${"04".repeat(32)}`] as Hex32[]
+    const validSig = `0x${"aa".repeat(65)}`
+
+    const result = await collectBatchWitnessSignatures(
+      merkleRoot,
+      witnessSet,
+      () => ({ url: "http://witness-token.local", authToken: "batch-secret" }),
+      async (_url, _method, body, headers) => {
+        assert.deepEqual(headers, { Authorization: "Bearer batch-secret" })
+        const payload = body as { witnessIndex: number; nodeId: string; challengeId: string; responseBodyHash: string }
+        return {
+          status: 200,
+          json: {
+            challengeId: payload.challengeId,
+            nodeId: payload.nodeId,
+            responseBodyHash: payload.responseBodyHash,
+            witnessIndex: payload.witnessIndex,
+            witnessSig: validSig,
+          },
+        }
+      },
+    )
+
+    assert.equal(result.bitmap, 0b1)
+    assert.equal(result.signedCount, 1)
+    assert.equal(result.quorumMet, true)
+  })
+
   it("collectBatchWitnessSignatures drops invalid responses and reports quorum miss", async () => {
     const merkleRoot = `0x${"cd".repeat(32)}` as Hex32
     const witnessSet = [
@@ -222,6 +252,43 @@ describe("witness-collector", () => {
 
     assert.equal(result.bitmap, 0b111)
     assert.equal(result.attestations.length, 3)
+    assert.equal(result.quorumMet, true)
+  })
+
+  it("collectWitnesses sends witness bearer tokens when configured (#667)", async () => {
+    const challengeId = `0x${"a1".repeat(32)}` as Hex32
+    const nodeId = `0x${"b2".repeat(32)}` as Hex32
+    const responseBodyHash = `0x${"c3".repeat(32)}` as Hex32
+    const sig = `0x${"dd".repeat(65)}`
+
+    const result = await collectWitnesses(
+      {
+        witnessNodes: [
+          { url: "http://w0.local", witnessIndex: 0, authToken: "witness-secret" },
+        ],
+        requiredWitnesses: 1,
+        timeoutMs: 1000,
+      },
+      challengeId,
+      nodeId,
+      responseBodyHash,
+      async (_url, _method, body, headers) => {
+        assert.deepEqual(headers, { Authorization: "Bearer witness-secret" })
+        const p = body as { witnessIndex: number }
+        return {
+          status: 200,
+          json: {
+            challengeId, nodeId, responseBodyHash,
+            witnessIndex: p.witnessIndex,
+            attestedAtMs: 1n,
+            witnessSig: sig,
+          },
+        }
+      },
+    )
+
+    assert.equal(result.bitmap, 0b1)
+    assert.equal(result.attestations.length, 1)
     assert.equal(result.quorumMet, true)
   })
 

--- a/runtime/lib/witness-collector.ts
+++ b/runtime/lib/witness-collector.ts
@@ -4,9 +4,21 @@
 import type { Hex32 } from "../../services/common/pose-types.ts"
 import type { WitnessAttestation } from "../../services/common/pose-types-v2.ts"
 import { requestJson } from "./http-client.ts"
+import { buildWitnessAuthHeaders } from "./pose-witness-auth.ts"
+
+export interface WitnessNodeConfig {
+  url: string
+  witnessIndex: number
+  authToken?: string
+}
+
+export interface WitnessEndpointConfig {
+  url: string
+  authToken?: string
+}
 
 export interface WitnessCollectorConfig {
-  witnessNodes: { url: string; witnessIndex: number }[]
+  witnessNodes: WitnessNodeConfig[]
   requiredWitnesses: number
   timeoutMs: number
 }
@@ -29,6 +41,7 @@ type WitnessRequestFn = (
   url: string,
   method: string,
   body?: unknown,
+  headers?: Record<string, string>,
 ) => Promise<{ status?: number; json?: any }>
 
 export async function collectWitnesses(
@@ -40,12 +53,17 @@ export async function collectWitnesses(
 ): Promise<CollectResult> {
   const requests = config.witnessNodes.map(async (w) => {
     try {
-      const response = await requestFn(`${w.url}/pose/witness`, "POST", {
-        challengeId,
-        nodeId,
-        responseBodyHash,
-        witnessIndex: w.witnessIndex,
-      })
+      const response = await requestFn(
+        `${w.url}/pose/witness`,
+        "POST",
+        {
+          challengeId,
+          nodeId,
+          responseBodyHash,
+          witnessIndex: w.witnessIndex,
+        },
+        buildWitnessAuthHeaders(w.authToken),
+      )
       const attest = response.json as WitnessAttestation | undefined
       if (!attest) return null
       // The witness index is assigned by the collector, not picked by the
@@ -96,7 +114,7 @@ export async function collectWitnesses(
 export async function collectBatchWitnessSignatures(
   merkleRoot: Hex32,
   witnessSet: Hex32[],
-  resolveEndpoint: (nodeId: Hex32, witnessIndex: number) => string | null,
+  resolveEndpoint: (nodeId: Hex32, witnessIndex: number) => string | WitnessEndpointConfig | null,
   requestFn: WitnessRequestFn = requestJson,
 ): Promise<BatchWitnessCollectResult> {
   const normalizedRoot = merkleRoot.toLowerCase()
@@ -107,15 +125,20 @@ export async function collectBatchWitnessSignatures(
   }
 
   const requests = capped.map(async (nodeId, witnessIndex) => {
-    const url = resolveEndpoint(nodeId, witnessIndex)
-    if (!url) return null
+    const endpoint = normalizeWitnessEndpoint(resolveEndpoint(nodeId, witnessIndex))
+    if (!endpoint) return null
     try {
-      const response = await requestFn(`${url}/pose/witness`, "POST", {
-        challengeId: merkleRoot,
-        nodeId,
-        responseBodyHash: merkleRoot,
-        witnessIndex,
-      })
+      const response = await requestFn(
+        `${endpoint.url}/pose/witness`,
+        "POST",
+        {
+          challengeId: merkleRoot,
+          nodeId,
+          responseBodyHash: merkleRoot,
+          witnessIndex,
+        },
+        buildWitnessAuthHeaders(endpoint.authToken),
+      )
       const attest = response.json as Partial<WitnessAttestation> | undefined
       if (!attest) return null
       if (typeof attest.challengeId !== "string" || attest.challengeId.toLowerCase() !== normalizedRoot) return null
@@ -168,4 +191,10 @@ function popcount(n: number): number {
     v >>>= 1
   }
   return count
+}
+
+function normalizeWitnessEndpoint(raw: string | WitnessEndpointConfig | null): WitnessEndpointConfig | null {
+  if (!raw) return null
+  if (typeof raw === "string") return { url: raw }
+  return raw
 }


### PR DESCRIPTION
## Summary
- require Bearer authentication for configured `/pose/witness` services and allow loopback only when no token is configured
- let witness collectors send per-node witness auth tokens
- document `COC_POSE_WITNESS_AUTH_TOKEN` / `poseWitnessAuthToken` and add regression coverage

## Tests
- node --experimental-strip-types --test "runtime/lib/pose-witness-auth.test.ts"
- node --experimental-strip-types --test "runtime/lib/witness-collector.test.ts"
- node --experimental-strip-types --test "runtime/lib/pose-witness-validator.test.ts"
- node --experimental-strip-types --check "runtime/coc-node.ts"
- node --experimental-strip-types --check "runtime/coc-agent.ts"
- git diff --check

Refs #667 (auth gate only — closes the unauthenticated-attacker vector that fed the #680 chain; the deeper "witness independently verifies" half remains for the maintainer to direct)