### PR TITLE
fix(rpc): validate IPFS CID shape before DHT lookups

### DIFF
--- a/node/src/rpc-extended.test.ts
+++ b/node/src/rpc-extended.test.ts
@@ -2548,7 +2548,7 @@ test("RPC Extended Methods", async (t) => {
     assert.match(okId as string, /^0x[0-9a-f]+$/i, "valid filter must return id")
   })
 
-  await t.test("#146: coc_dhtFindProviders / coc_ipfsFetchBlockFromPeer surface errors via JSON-RPC error field", async () => {
+  await t.test("#146/#515: coc_dhtFindProviders / coc_ipfsFetchBlockFromPeer reject malformed CIDs via JSON-RPC error field", async () => {
     // Pre-fix these handlers returned `{result: {providers: [], error: "..."}}`
     // (or `{result: {bytes: null, error: "..."}}`), wrapping the error
     // inside the result body. Clients that check `response.error` per
@@ -2562,20 +2562,48 @@ test("RPC Extended Methods", async (t) => {
       return await r.json() as { result?: unknown; error?: { code: number; message: string } }
     }
     // (a) coc_dhtFindProviders with no/empty/bad CID → -32602
-    for (const params of [[], [""], ["not-a-cid\nwith-newline"], ["x".repeat(513)], ["../path"]]) {
+    const invalidCidParams = [
+      [],
+      [""],
+      ["not-a-cid\nwith-newline"],
+      ["x".repeat(513)],
+      ["../path"],
+      ["bad-cid"],
+      ["deadbeef"],
+      ["not-a-cid"],
+    ]
+    for (const params of invalidCidParams) {
       const j = await probeError("coc_dhtFindProviders", params)
       assert.ok(j.error, `coc_dhtFindProviders(${JSON.stringify(params)}) must error, got result=${JSON.stringify(j.result)}`)
       assert.equal(j.error!.code, -32602)
+      assert.match(j.error!.message, /invalid cid|cid must/i)
       assert.equal(j.result, undefined, "errors must be in error field, not result body")
     }
     // (b) coc_ipfsFetchBlockFromPeer same shape
-    for (const params of [[], [""], ["foo\0bar"]]) {
+    for (const params of [...invalidCidParams, ["foo\0bar"]]) {
       const j = await probeError("coc_ipfsFetchBlockFromPeer", params)
       assert.ok(j.error)
       assert.equal(j.error!.code, -32602)
+      assert.match(j.error!.message, /invalid cid|cid must/i)
       assert.equal(j.result, undefined)
     }
-    // (c) coc_resolveDid / coc_getDIDDocument on a node without DID config
+    // (c) Valid CIDv0/v1 shapes still reach the DHT/fetch hooks instead
+    // of being rejected as malformed. The fixture has no DHT/fetch hook
+    // installed, so the expected no-data result remains deterministic.
+    const validCids = [
+      "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG",
+      "bafkqaaa",
+      "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy",
+    ]
+    for (const cid of validCids) {
+      const providers = await probeError("coc_dhtFindProviders", [cid])
+      assert.equal(providers.error, undefined, `valid cid ${cid} must not be -32602`)
+      assert.deepEqual(providers.result, { providers: [] })
+      const fetched = await probeError("coc_ipfsFetchBlockFromPeer", [cid])
+      assert.equal(fetched.error, undefined, `valid cid ${cid} must not be -32602`)
+      assert.deepEqual(fetched.result, { bytes: null })
+    }
+    // (d) coc_resolveDid / coc_getDIDDocument on a node without DID config
     // → -32601 method not available (not -32603 internal-error).
     // #432: shape-valid args still hit the -32601 path (DID resolver not
     // configured); garbage input (empty params) gets -32602 via the new
@@ -4183,7 +4211,7 @@ test("RPC Extended Methods", async (t) => {
       })
       return await r.json() as { error?: { code: number; message: string }; result?: unknown }
     }
-    const validCid = "bafy-some-real-cid"
+    const validCid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy"
     // Non-string excludePeerId → -32602
     for (const bad of [123, true, false, 1.5, {}, [1, 2]]) {
       const r = await probe([validCid, bad])
@@ -4218,7 +4246,7 @@ test("RPC Extended Methods", async (t) => {
       })
       return await r.json() as { error?: { code: number; message: string }; result?: unknown }
     }
-    const validCid = "bafy-real-cid"
+    const validCid = "bafybeibbaty5wl7jqgcwyouemb5jerxoisdoxwldqdue5dd6evw6lgalhy"
     // Non-integer or negative maxK → -32602
     for (const bad of [true, false, "huge", {}, [1, 2], -1, -5, 0, 1.5, 1.7]) {
       const r = await probe([validCid, bad])

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -136,6 +136,31 @@ export function isLoopbackAddress(ip: string): boolean {
   return false
 }
 
+function requireRpcCidParam(params: unknown[], index: number = 0): string {
+  const rawCid = params[index]
+  if (typeof rawCid !== "string" || rawCid.length === 0) {
+    invalidParams("cid must be a non-empty string")
+  }
+  if (!isValidRpcCidShape(rawCid)) {
+    invalidParams("invalid cid: expected CIDv0 base58btc or CIDv1 base32 string")
+  }
+  return rawCid
+}
+
+function isValidRpcCidShape(cid: string): boolean {
+  if (!cid || cid.length > 100) return false
+  if (cid.trim() !== cid) return false
+  if (/[\/\\]|\.\.|\0|\s/.test(cid)) return false
+
+  if (cid.startsWith("Qm")) {
+    return cid.length === 46 && /^Qm[1-9A-HJ-NP-Za-km-z]+$/.test(cid)
+  }
+  if (cid.startsWith("b") || cid.startsWith("B")) {
+    return cid.length >= 8 && /^[bB][a-z2-7]+$/.test(cid)
+  }
+  return false
+}
+
 /** JSON stringify that serializes bigint values as hex strings (EVM RPC convention). */
 export function jsonStringify(obj: unknown): string {
   return JSON.stringify(obj, (_key, value) =>
@@ -2449,16 +2474,11 @@ async function handleRpc(
       // #146: pre-fix this returned errors wrapped in `result.error`,
       // which clients that check `response.error` per JSON-RPC §5
       // never noticed. Switch to -32602 structured throws + sanitize
-      // CID shape against path traversal / control chars (same
-      // isValidCid policy as the IPFS HTTP layer).
-      const rawCid = (payload.params ?? [])[0]
-      if (typeof rawCid !== "string" || rawCid.length === 0) {
-        invalidParams("cid must be a non-empty string")
-      }
-      if (rawCid.length > 512 || /[\/\\]|\.\.|\0|\s/.test(rawCid)) {
-        invalidParams("invalid cid: contains illegal characters or exceeds 512 chars")
-      }
-      const cid = rawCid
+      // CID shape using the same base58-v0 / base32-v1 policy as the
+      // IPFS HTTP layer. Pre-fix this accepted "bad-cid" and returned an
+      // empty provider list indistinguishable from a valid CID with no
+      // providers (#515).
+      const cid = requireRpcCidParam(payload.params ?? [])
       // #251: pre-fix `Number(... ?? 3)` silently mapped any malformed
       // maxK (true → 1, "huge" → NaN→3, {} → NaN→3, -5 → fallback 3,
       // 1.7 → 1 via Math.floor) to a clamped default. Clients passing
@@ -2483,14 +2503,7 @@ async function handleRpc(
       // transport the blob.
       // #146: same fix as coc_dhtFindProviders — structured error in
       // the `error` field, not embedded in `result`.
-      const rawCid = (payload.params ?? [])[0]
-      if (typeof rawCid !== "string" || rawCid.length === 0) {
-        invalidParams("cid must be a non-empty string")
-      }
-      if (rawCid.length > 512 || /[\/\\]|\.\.|\0|\s/.test(rawCid)) {
-        invalidParams("invalid cid: contains illegal characters or exceeds 512 chars")
-      }
-      const cid = rawCid
+      const cid = requireRpcCidParam(payload.params ?? [])
       // #250: pre-fix `String((payload.params ?? [])[1] ?? "")` silently
       // coerced numbers/bools to ad-hoc peer IDs ("123", "true"), passing
       // bogus exclude-filters to fetchBlockFromPeer. Same anti-pattern as


### PR DESCRIPTION
## Summary
- add shared RPC CID shape validation matching the IPFS HTTP gateway policy
- reject malformed `coc_dhtFindProviders` / `coc_ipfsFetchBlockFromPeer` CIDs with `-32602` instead of silent empty results
- extend RPC regression tests for fake CID strings and valid CIDv0/CIDv1 happy paths

## Tests
- node --experimental-strip-types --test "node/src/rpc-extended.test.ts"
- node --experimental-strip-types --check "node/src/rpc.ts"
- git diff --check

Closes #515