### PR TITLE
docs: record the gen-4 88780 multisig redeploy + contract security batch

### DIFF
--- a/docs/88780-redeploy-2026-05-19.md
+++ b/docs/88780-redeploy-2026-05-19.md
@@ -1,0 +1,111 @@
+# 88780 testnet — full contract redeploy with multisig owner (2026-05-19)
+
+## Summary
+
+The 88780 contracts were redeployed in full on 2026-05-19 to carry a batch of
+security fixes and to move ownership off the public Hardhat test key onto a
+3-of-5 MultiSigWallet. This is the 4th 88780 contract deployment generation;
+all 13 contract addresses changed.
+
+This deploy resolves the last three "needs-redeploy" findings from the spring
+2026 security audit: **#683** (RollupStateManager unbounded `submitOutputRoot`),
+**#685** (PoSeManagerV2 deployed-but-uninitialized), **#686** (every contract
+owned by the public Hardhat test key).
+
+## Change set merged into `main`
+
+Six PRs (all squash-merged to `main`):
+
+| PR | Squash | Fixes | What it changes |
+|---|---|---|---|
+| #696 | `ae39bc2` | #684 | Move `solc.compile` to a worker thread with hard timeout (explorer `/api/verify`) |
+| #688 | `87d1dd3` | #687 | Pull-payment fallback for Treasury + InsuranceFund payouts (credit on ETH-rejecting recipient) |
+| #690 | `5600cf7` | #689 | Pull-payment fallback for FoundationVesting |
+| #692 | `8795c5b` | #691 | Per-agent `recoveryEpoch` invalidates stale SoulRegistry recovery requests |
+| #695 | `401dd27` | #694 | Monotonic `globalRevocationEpoch` for DIDRegistry (replaces timestamp comparison; closes same-block grant escape) |
+| #697 | `e084db2` | Refs #683/#685/#686 | RollupStateManager `onlyProposer` allowlist; `transferOwnership` added across the admin contracts; new `governance/MultiSigWallet.sol`; `deploy-all-88780.js` initializes PoSeManagerV2 then transfers ownership; new `scripts/deploy-multisig-88780.js`; `scripts/preflight.js` blocks the 20 public Hardhat test keys from being used as deployer |
+
+Contract test suite on the merged `main`: **494 passing**, no regression.
+
+## On-chain redeploy
+
+| Role | Address | Notes |
+|---|---|---|
+| Deployer | `0xB4E943F5F34b763fC78598a9e528995B4CDe786a` | freshly-generated non-public BIP-39 key, funded with 100 ETH from `0xf39Fd6…` |
+| MultiSigWallet (3-of-5) | `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E` | owner of every contract below; 5 signer keys at `~/.coc/keys/88780-multisig/` (chmod 600, **never committed**) |
+| FactionRegistry | `0x4e8D87c4c8c5C875E997869BdA49F2F23FD3E477` | |
+| GovernanceDAO | `0xa05372DAB9b508608929343cb44e8e4952E73e3D` | |
+| Treasury | `0x065DaA120059D47721d2bA399E58A8adB237b72c` | |
+| SoulRegistry | `0x7efCE13d3F9789706fF8D499C04f7359621dF9ca` | |
+| DIDRegistry | `0x8Ff6B68eE22E7Ff7D47DCd39b6E66296AAcBfDcB` | |
+| CidRegistry | `0x0e293244057dcB1Db9Ea92ab8615ccFba101Af60` | |
+| PoSeManager | `0x0a9b85B2267969b162Dd9980A0Fc10FFe5175341` | |
+| PoSeManagerV2 | `0x0db48354cc99e5Dd1249E733C054B8B118E2979d` | initialized at deploy: `DOMAIN_SEPARATOR=0xde7491bb…`, `challengeBondMin=0.1 ETH` |
+| ValidatorRegistry | `0xdcEd0d37A50DE953c256CeDa08b3f19aeB06a6d3` | |
+| EquivocationDetector | `0xe1ae640A1Ab655A55c090687018Da6b530bB49f2` | |
+| InsuranceFund | `0x1cf5E3A5143331522d2d4879e7EB5850DfDff799` | |
+| DelayedInbox | `0x368b4978550A8DDb4051Dd2d4e77FEA0d2490F14` | |
+| RollupStateManager | `0x25AAa477Ae72257AE7382c193285d852BC78284A` | non-allowlisted `submitOutputRoot` reverts (#683 proposer allowlist live) |
+
+The canonical source of truth is `configs/deployed-contracts-88780.json`
+(synced to the `@chainofclaw/soul` 88780 manifest via claw-mem PR #48).
+
+## Procedure
+
+```bash
+# 1. Generate keys: 5 multisig owners + 1 deployer (fresh BIP-39).
+#    Store under ~/.coc/keys/ with chmod 600. Never commit.
+
+# 2. Fund the fresh deployer from 0xf39Fd6… with ~100 ETH on 88780.
+
+# 3. Deploy the MultiSigWallet (preflight.js refuses public Hardhat keys here).
+export DEPLOYER_PRIVATE_KEY=<fresh-non-public-key>
+export COC_RPC_URL=http://209.74.64.88:38780 COC_CHAIN_ID=88780
+export MULTISIG_OWNERS=<5 comma-separated addresses> MULTISIG_THRESHOLD=3
+npx hardhat run scripts/deploy-multisig-88780.js --network coc
+# -> MULTISIG_ADDRESS=0x...
+
+# 4. Deploy governance, owned by the multisig.
+export MULTISIG_ADDRESS=<from step 3>
+npx hardhat run scripts/deploy-governance.js --network coc
+# -> FactionRegistry / GovernanceDAO / Treasury addresses
+
+# 5. Deploy the remaining 10 contracts. The script also calls
+#    PoSeManagerV2.initialize() and then transfers ownership of all 13
+#    contracts to the multisig in one run.
+export FACTION_REGISTRY=... GOVERNANCE_DAO=... TREASURY=...
+npx hardhat run scripts/deploy-all-88780.js --network coc
+```
+
+## Validation
+
+Live-verified on 88780 (RPC `http://209.74.64.88:38780`):
+
+- Every 13 contract `owner()` == MultiSigWallet `0x3c055D83…`.
+- PoSeManagerV2: `initialized()==true`, `DOMAIN_SEPARATOR != 0`, `challengeBondMin == 0.1 ETH`.
+- RollupStateManager: `submitOutputRoot` from a non-proposer EOA reverts.
+- `eth_getCode` non-empty at every new address.
+- Network still producing blocks (the redeploy is deployer-only txs — no consensus impact).
+- `cd contracts && npm test`: **494 passing** on `main`.
+- `@chainofclaw/soul` package: 117/117 tests pass after the manifest swap (claw-mem PR #48 `86ff3a3`).
+
+Manifest sync PRs: COC #701 (`e5e6022`) + claw-mem #48 (`86ff3a3`) — both merged.
+
+## Operational impact
+
+- **No node restart.** Core validators/observers do not reference contract addresses.
+- **All `onlyOwner` actions on 88780 now require a 3-of-5 multisig transaction.** The deployer key holds zero residual privilege after the ownership handoff.
+- Consumers (PoSe agent/relayer, `@chainofclaw/soul`, explorer) take addresses from the manifest. Any service that hard-coded a prior generation's address must switch to the manifest; per the audit, the off-chain PoSe services were not wired against the prior addresses on 88780.
+- Auto-closed on PR merge: #684, #687, #689, #691, #694.
+- Closed after the redeploy was verified live: #683, #685, #686.
+- Remaining OPEN: #650 and #667 — these are protocol-economics / witness-model design decisions that have structured-recommendation comments on the issues; both are out of scope for code change without a maintainer direction.
+
+## 88780 deployment history
+
+| Date | Generation | Trigger | Scope |
+|---|---|---|---|
+| 2026-05-11 | gen-0 | initial bring-up | superseded |
+| 2026-05-18 | gen-1 | PR #675 — `[codex] harden COC security surfaces` (full #645–#670 batch) | full 13 |
+| 2026-05-18 | gen-2 | PR #678 — `#676` pull-payment (PoSeManagerV2 only) | PoSeManagerV2 only |
+| 2026-05-19 | gen-3 | PR #698 — `#677/#680` settle CEI + finalize pagination (PoSeManagerV2 only) | PoSeManagerV2 only |
+| **2026-05-19** | **gen-4 (current)** | **this doc — #697 + #688/#690/#692/#695/#696 + multisig handoff** | **full 13 + MultiSigWallet** |

--- a/docs/operations-manual.en.md
+++ b/docs/operations-manual.en.md
@@ -114,6 +114,12 @@ COC_DATA_DIR=/tmp/coc-single \
 | Private Key | `0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80` |
 | Balance | 10 000 ETH |
 
+> **Warning (#686):** this is the public Hardhat test account #0 — its private key
+> is known to anyone with Hardhat installed. It may **only** be used to fund a
+> fresh non-public deployer; it must never own a contract on a shared testnet
+> or production network. `contracts/scripts/preflight.js`'s `assertSafeDeployer`
+> rejects this address and the other 19 public Hardhat keys as deployer.
+
 ### Verify
 
 ```bash
@@ -441,11 +447,37 @@ npm run deploy:governance:coc
 - `l2-arbitrum`
 - `l2-optimism`
 
-### Governance Contract
+### Governance Contracts
+
+On a shared testnet, ownership of every COC contract must sit with a
+multisig — not with the deployer EOA (#686). The recommended sequence is:
 
 ```bash
+# 0. Use a fresh, non-public deployer key. preflight.js rejects the 20
+#    default Hardhat test keys. Fund it from any pre-funded EOA.
+export DEPLOYER_PRIVATE_KEY=<fresh-non-public-key>
+export COC_RPC_URL=... COC_CHAIN_ID=...
+
+# 1. Deploy the MultiSigWallet that will own the contracts.
+export MULTISIG_OWNERS=<addr1,addr2,addr3,addr4,addr5>
+export MULTISIG_THRESHOLD=3
+npx hardhat run scripts/deploy-multisig-88780.js --network coc
+# -> MULTISIG_ADDRESS=0x...
+
+# 2. Deploy FactionRegistry / GovernanceDAO / Treasury — ownership goes
+#    straight to the multisig.
+export MULTISIG_ADDRESS=<from step 1>
 npx hardhat run scripts/deploy-governance.js --network coc
+
+# 3. Deploy the remaining 10 contracts; the script also calls
+#    PoSeManagerV2.initialize() (#685) and transferOwnership(multisig)
+#    on every contract (#686).
+export FACTION_REGISTRY=... GOVERNANCE_DAO=... TREASURY=...
+npx hardhat run scripts/deploy-all-88780.js --network coc
 ```
+
+On 88780 the canonical addresses live in `configs/deployed-contracts-88780.json`.
+The most recent deploy is logged in `docs/88780-redeploy-2026-05-19.md`.
 
 ### Verify PoSe Contract
 

--- a/docs/r3-2-prod-candidate-testnet-88780.md
+++ b/docs/r3-2-prod-candidate-testnet-88780.md
@@ -34,11 +34,19 @@ All 7 keys must be **distinct** (no shared anvil keys like in current 18780).
 - [ ] Update `scripts/gcloud/config.env` to add `COC_PROD_CANDIDATE_CHAIN_ID=88780`
 - [ ] Provision 5 GCP VMs reusing R1 fixture template
 - [ ] Bring up validators 6+7 on lab hardware
-- [x] Deploy contracts via `contracts/scripts/deploy-governance.js` then
-  `contracts/scripts/deploy-all-88780.js` (`COC_RPC_URL` / `COC_CHAIN_ID=88780`).
+- [x] Deploy contracts via `contracts/scripts/deploy-multisig-88780.js`,
+  `deploy-governance.js`, then `deploy-all-88780.js` (`COC_RPC_URL` /
+  `COC_CHAIN_ID=88780`, `DEPLOYER_PRIVATE_KEY` must be **non-public** —
+  `preflight.js:assertSafeDeployer` rejects the 20 default Hardhat test keys).
   All 13 deployed addresses are recorded in `configs/deployed-contracts-88780.json`
-  — the canonical manifest. Last redeploy 2026-05-18 carried the #645–#670
-  security-audit contract fixes.
+  — the canonical manifest; the `@chainofclaw/soul` 88780 manifest is kept in
+  sync.
+  Current generation: gen-4 (2026-05-19) — full redeploy with ownership of all
+  13 contracts handed to a 3-of-5 MultiSigWallet
+  (`0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E`). Carries the #683 rollup
+  proposer allowlist, #685 PoSeManagerV2 initialize-on-deploy, #686 ownership
+  re-key, and the #687/#689/#691/#694 pull-payment / epoch-hardening batch.
+  Full per-redeploy log: `docs/88780-redeploy-2026-05-19.md`.
 - [ ] All 7 validators stake 32 ETH into ValidatorRegistry
 - [ ] All 7 register in PoSeManagerV2 with serviceFlags=7
 - [ ] enableEmission with COC token (real ERC20, not deployer-as-stub)
@@ -61,7 +69,7 @@ All 7 keys must be **distinct** (no shared anvil keys like in current 18780).
 |---|---|
 | Chain stalls due to validator outage | H15 fallback proposer (R1.4 verified) |
 | Equivocation by colluding validators | EquivocationDetector + slash automation (R3.1) |
-| Governance proposal exploitation | Treasury 3-of-5 multisig + DAO timelock |
+| Governance proposal exploitation | Treasury 3-of-5 multisig + DAO timelock; since gen-4 (2026-05-19) every contract `owner()` is the 3-of-5 MultiSigWallet (no single-key admin override) |
 | GCP resource exhaustion | Reserved capacity + lab fallback validators |
 
 ## Roll-out Plan


### PR DESCRIPTION
## Summary

Records the contract + deployment changes from the 2026-05-19 gen-4 redeploy. No code change.

| File | Change |
|---|---|
| `docs/88780-redeploy-2026-05-19.md` | **new** — dated log of the gen-4 redeploy: 6 PRs in the security batch with squash hashes, all 13 new addresses + MultiSigWallet, deploy procedure, live-validation results, full 88780 deployment-generation history (gen-0 … gen-4) |
| `docs/r3-2-prod-candidate-testnet-88780.md` | "Deploy contracts" checklist line now references the `deploy-multisig-88780.js` + preflight flow and points at the dated log; Risk Register row clarified — since gen-4 every contract `owner()` is the 3-of-5 multisig |
| `docs/operations-manual.en.md` | "Pre-funded Account (Dev)" gets an explicit warning (it's the public Hardhat key #0; `preflight.js` rejects it as deployer); "Governance Contracts" deploy section rewritten to cover MultiSigWallet deploy + `initialize()` + ownership handoff |

## Validation

- `git diff --check` clean.
- `configs/deployed-contracts-88780.json` remains the canonical address source of truth — these docs link to it rather than duplicate it.