### PR TITLE
fix(governance): require active bicameral approval

### DIFF
--- a/contracts/contracts-src/governance/GovernanceDAO.sol
+++ b/contracts/contracts-src/governance/GovernanceDAO.sol
@@ -15,6 +15,8 @@ contract GovernanceDAO {
         // judged against this snapshot so the denominator cannot be inflated
         // by permissionless registrations after voting closes.
         uint256 registeredSnapshot;
+        uint256 humanSnapshot;
+        uint256 clawSnapshot;
         ProposalType proposalType;
         address proposer;
         string title;
@@ -104,9 +106,14 @@ contract GovernanceDAO {
         uint256 proposalId = proposalCount;
         uint64 deadline = uint64(block.timestamp) + votingPeriod;
 
+        uint256 humanSnapshot = factionRegistry.humanCount();
+        uint256 clawSnapshot = factionRegistry.clawCount();
+
         proposals[proposalId] = Proposal({
             id: proposalId,
-            registeredSnapshot: factionRegistry.humanCount() + factionRegistry.clawCount(),
+            registeredSnapshot: humanSnapshot + clawSnapshot,
+            humanSnapshot: humanSnapshot,
+            clawSnapshot: clawSnapshot,
             proposalType: proposalType,
             proposer: msg.sender,
             title: title,
@@ -265,11 +272,14 @@ contract GovernanceDAO {
         }
 
         if (bicameralEnabled) {
-            // Both factions must independently reach approval threshold
+            // Both factions present at proposal creation must independently
+            // cast a non-abstain vote set and reach the approval threshold.
             uint256 humanTotal = p.forVotesHuman + p.againstVotesHuman;
             uint256 clawTotal = p.forVotesClaw + p.againstVotesClaw;
-            bool humanApproved = humanTotal == 0 || (p.forVotesHuman * 100) / humanTotal >= approvalPercent;
-            bool clawApproved = clawTotal == 0 || (p.forVotesClaw * 100) / clawTotal >= approvalPercent;
+            bool humanApproved = p.humanSnapshot == 0
+                || (humanTotal > 0 && (p.forVotesHuman * 100) / humanTotal >= approvalPercent);
+            bool clawApproved = p.clawSnapshot == 0
+                || (clawTotal > 0 && (p.forVotesClaw * 100) / clawTotal >= approvalPercent);
             return humanApproved && clawApproved;
         }
 

--- a/contracts/test/security-audit.test.cjs
+++ b/contracts/test/security-audit.test.cjs
@@ -375,6 +375,28 @@ describe("Security: GovernanceDAO", function () {
     expect(proposal.state).to.equal(2) // Rejected (claws rejected)
   })
 
+  it("bicameral: registered but silent faction does not auto-approve", async function () {
+    await dao.setBicameralEnabled(true)
+
+    const descHash = ethers.keccak256(ethers.toUtf8Bytes("silent-claws"))
+    await dao.connect(human1).createProposal(5, "Silent Claws", descHash, ethers.ZeroAddress, "0x", 0)
+
+    const created = await dao.getProposal(1)
+    expect(created.humanSnapshot).to.equal(2)
+    expect(created.clawSnapshot).to.equal(2)
+
+    // Humans reach approval and quorum, but the registered Claw chamber casts
+    // no non-abstain votes. Bicameral mode must not treat that as approval.
+    await dao.connect(human1).vote(1, 1)
+    await dao.connect(human2).vote(1, 1)
+
+    await advanceTime(7 * 86400 + 1)
+    await dao.queue(1)
+
+    const proposal = await dao.getProposal(1)
+    expect(proposal.state).to.equal(2) // Rejected (registered claw chamber was silent)
+  })
+
   it("bicameral: empty faction auto-approves (design note)", async function () {
     // Only register humans, no claws in this separate setup
     const FR2 = await ethers.getContractFactory("FactionRegistry")
@@ -394,6 +416,10 @@ describe("Security: GovernanceDAO", function () {
 
     await dao2.connect(human1).vote(1, 1)
     await dao2.connect(human2).vote(1, 1)
+
+    const created = await dao2.getProposal(1)
+    expect(created.humanSnapshot).to.equal(2)
+    expect(created.clawSnapshot).to.equal(0)
 
     await advanceTime(7 * 86400 + 1)
     await dao2.queue(1)


### PR DESCRIPTION
## Summary
- snapshot Human and Claw counts when a GovernanceDAO proposal is created
- require each faction that existed at creation to cast a non-abstain vote set and meet `approvalPercent` in bicameral mode
- preserve the existing compatibility behavior where a faction with zero registered voters at proposal creation does not block governance

## Root Cause
`_isApproved()` treated `humanTotal == 0` or `clawTotal == 0` as approved. That was intended for truly empty chambers, but it also let a registered chamber stay silent while the other chamber passed a proposal alone.

Closes #705

## Tests
- `cd contracts && npx hardhat test "test/security-audit.test.cjs" "test/governance-quorum-snapshot.test.cjs" "test/governance.test.cjs"`
- `git diff --check -- "contracts/contracts-src/governance/GovernanceDAO.sol" "contracts/test/security-audit.test.cjs"`