### PR TITLE
refactor(contracts): convert 13 production contracts to UUPS upgradeable (WIP)

### DIFF
--- a/contracts/contracts-src/governance/CidRegistry.sol
+++ b/contracts/contracts-src/governance/CidRegistry.sol
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
  * @title CidRegistry
@@ -12,22 +15,59 @@ pragma solidity ^0.8.20;
  *         register the mapping (the hash preimage proves knowledge).
  *         Once written, entries are immutable — CIDs are content-addressed,
  *         so a given hash always maps to the same string.
+ *
+ *         UUPS upgradeable since 88780 gen-5; upgrade is gated on `owner`
+ *         (the 3-of-5 MultiSigWallet after the gen-5 ownership handoff).
  */
-contract CidRegistry {
+contract CidRegistry is Initializable, UUPSUpgradeable {
     // ── Storage ──────────────────────────────────────────────────────────
 
     /// @dev cidHash → original CID string (empty string means not registered)
     mapping(bytes32 => string) private _cidMap;
 
+    /// @notice Upgrade authority. Set to the deployer in `initialize`, then
+    /// `transferOwnership`'d to the 88780 multisig.
+    address public owner;
+
     // ── Events ───────────────────────────────────────────────────────────
 
     event CidRegistered(bytes32 indexed cidHash, string cid, address indexed registrant);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     // ── Errors ───────────────────────────────────────────────────────────
 
     error HashMismatch(bytes32 expected, bytes32 actual);
     error AlreadyRegistered(bytes32 cidHash);
     error EmptyCid();
+    error OnlyOwner();
+    error ZeroAddress();
+
+    // ── Initializer ──────────────────────────────────────────────────────
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialOwner) external initializer {
+        if (initialOwner == address(0)) revert ZeroAddress();
+        owner = initialOwner;
+    }
+
+    // ── Ownership / upgrade auth ─────────────────────────────────────────
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert OnlyOwner();
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     // ── External functions ───────────────────────────────────────────────
 
@@ -89,4 +129,10 @@ contract CidRegistry {
     function isRegistered(bytes32 cidHash) external view returns (bool) {
         return bytes(_cidMap[cidHash]).length != 0;
     }
+
+    // ── Storage gap (UUPS) ───────────────────────────────────────────────
+    // Reserve space for future state. Every new storage field must shrink
+    // this gap and be appended before it — reordering / inserting before
+    // `_cidMap`/`owner` is forbidden across upgrades.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/DIDRegistry.sol
+++ b/contracts/contracts-src/governance/DIDRegistry.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /// @title DIDRegistry - DID management for AI agents on COC blockchain
 /// @notice Extends SoulRegistry with key rotation, delegation, credentials,
 ///         ephemeral identities, and agent lineage tracking.
 ///         References SoulRegistry for identity verification (does not modify it).
+///         UUPS upgradeable since 88780 gen-5; upgrade gated on `owner` (multisig).
 interface ISoulRegistry {
     struct SoulIdentity {
         bytes32 agentId;
@@ -23,7 +27,7 @@ interface ISoulRegistry {
     function getSoul(bytes32 agentId) external view returns (SoulIdentity memory);
 }
 
-contract DIDRegistry {
+contract DIDRegistry is Initializable, UUPSUpgradeable {
     // -----------------------------------------------------------------------
     //  Types
     // -----------------------------------------------------------------------
@@ -117,8 +121,10 @@ contract DIDRegistry {
         "AnchorCredential(bytes32 credentialHash,bytes32 issuerAgentId,bytes32 subjectAgentId,bytes32 credentialCid,uint64 expiresAt,uint64 nonce)"
     );
 
-    bytes32 public immutable DOMAIN_SEPARATOR;
-    ISoulRegistry public immutable soulRegistry;
+    bytes32 public DOMAIN_SEPARATOR;
+    ISoulRegistry public soulRegistry;
+    /// @notice Upgrade authority (the 88780 multisig after gen-5 handoff).
+    address public owner;
 
     // -----------------------------------------------------------------------
     //  Storage
@@ -195,14 +201,28 @@ contract DIDRegistry {
     error CredentialAlreadyRevoked();
     error InvalidCredentialHash();
     error ZeroAddress();
+    error OnlyOwner();
+
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert OnlyOwner();
+        _;
+    }
 
     // -----------------------------------------------------------------------
     //  Constructor
     // -----------------------------------------------------------------------
 
-    constructor(address _soulRegistry) {
-        if (_soulRegistry == address(0)) revert ZeroAddress();
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _soulRegistry, address initialOwner) external initializer {
+        if (_soulRegistry == address(0) || initialOwner == address(0)) revert ZeroAddress();
         soulRegistry = ISoulRegistry(_soulRegistry);
+        owner = initialOwner;
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 DOMAIN_TYPEHASH,
@@ -212,6 +232,14 @@ contract DIDRegistry {
                 address(this)
             )
         );
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     // -----------------------------------------------------------------------
@@ -628,4 +656,7 @@ contract DIDRegistry {
         if (recovered == address(0)) revert InvalidSignature();
         return recovered;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/EquivocationDetector.sol
+++ b/contracts/contracts-src/governance/EquivocationDetector.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 interface IValidatorRegistry {
     function slashValidator(bytes32 nodeId, bytes32 reason) external;
 }
@@ -44,14 +47,14 @@ interface IValidatorRegistry {
  *           3. Off-chain bridge (runtime/coc-relayer.ts) submits evidence
  *              when the BFT coordinator detects equivocation.
  */
-contract EquivocationDetector {
+contract EquivocationDetector is Initializable, UUPSUpgradeable {
     // ── Constants ────────────────────────────────────────────────────────
 
     uint256 public constant DEFAULT_SLASH_COOLDOWN_BLOCKS = 1000;
 
     // ── Storage ──────────────────────────────────────────────────────────
 
-    IValidatorRegistry public immutable validatorRegistry;
+    IValidatorRegistry public validatorRegistry;
     address public owner;
     uint256 public slashCooldownBlocks;
 
@@ -93,12 +96,19 @@ contract EquivocationDetector {
         _;
     }
 
-    constructor(address registry) {
-        if (registry == address(0)) revert ZeroAddress();
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address registry, address initialOwner) external initializer {
+        if (registry == address(0) || initialOwner == address(0)) revert ZeroAddress();
         validatorRegistry = IValidatorRegistry(registry);
-        owner = msg.sender;
+        owner = initialOwner;
         slashCooldownBlocks = DEFAULT_SLASH_COOLDOWN_BLOCKS;
     }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     // ── Public ───────────────────────────────────────────────────────────
 
@@ -264,4 +274,7 @@ contract EquivocationDetector {
         }
         return string(buf);
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/FactionRegistry.sol
+++ b/contracts/contracts-src/governance/FactionRegistry.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /// @title FactionRegistry - Maps addresses to Human or Claw factions
-/// @notice Faction is immutable once registered to prevent speculative switching
-contract FactionRegistry {
+/// @notice Faction is immutable once registered to prevent speculative switching.
+///         UUPS upgradeable since 88780 gen-5; upgrade is gated on `owner`.
+contract FactionRegistry is Initializable, UUPSUpgradeable {
     uint256 internal constant SECP256K1N_HALF =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
@@ -51,10 +55,18 @@ contract FactionRegistry {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        owner = msg.sender;
-        verifier = msg.sender;
+        _disableInitializers();
     }
+
+    function initialize(address initialOwner, address initialVerifier) external initializer {
+        if (initialOwner == address(0) || initialVerifier == address(0)) revert ZeroAddress();
+        owner = initialOwner;
+        verifier = initialVerifier;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /// @notice Register as Human (called via MetaMask)
     function registerHuman() external {
@@ -156,4 +168,7 @@ contract FactionRegistry {
 
         return ecrecover(hash, v, r, s);
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/GovernanceDAO.sol
+++ b/contracts/contracts-src/governance/GovernanceDAO.sol
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {FactionRegistry} from "./FactionRegistry.sol";
 
 /// @title GovernanceDAO - Multi-type proposals with stake-weighted voting
-/// @notice Supports bicameral mode where both factions must independently approve
-contract GovernanceDAO {
+/// @notice Supports bicameral mode where both factions must independently approve.
+///         UUPS upgradeable since 88780 gen-5; upgrade gated on `owner` (the
+///         88780 multisig). Bicameral check fixed for silent-faction (#705).
+contract GovernanceDAO is Initializable, UUPSUpgradeable {
     enum ProposalType { ValidatorAdd, ValidatorRemove, ParameterChange, TreasurySpend, ContractUpgrade, FreeText }
     enum ProposalState { Pending, Approved, Rejected, Queued, Executed, Cancelled, Expired }
 
@@ -15,6 +19,11 @@ contract GovernanceDAO {
         // judged against this snapshot so the denominator cannot be inflated
         // by permissionless registrations after voting closes.
         uint256 registeredSnapshot;
+        // #705: per-faction count snapshots at creation so the bicameral
+        // approval check can distinguish "faction did not exist at creation"
+        // (auto-pass) from "faction exists but stayed silent" (must NOT pass).
+        uint256 humanSnapshot;
+        uint256 clawSnapshot;
         ProposalType proposalType;
         address proposer;
         string title;
@@ -39,12 +48,12 @@ contract GovernanceDAO {
     mapping(uint256 => Proposal) public proposals;
     mapping(uint256 => mapping(address => bool)) public hasVoted;
 
-    // Governance parameters (can be changed via governance proposals)
-    uint64 public votingPeriod = 7 days;
-    uint64 public timelockDelay = 2 days;
-    uint256 public quorumPercent = 40;
-    uint256 public approvalPercent = 60;
-    bool public bicameralEnabled = false;
+    // Governance parameters (set in `initialize`; mutable via owner setters).
+    uint64 public votingPeriod;
+    uint64 public timelockDelay;
+    uint256 public quorumPercent;
+    uint256 public approvalPercent;
+    bool public bicameralEnabled;
 
     address public owner;
     address public treasury;
@@ -81,10 +90,23 @@ contract GovernanceDAO {
         _;
     }
 
-    constructor(address _factionRegistry) {
-        factionRegistry = FactionRegistry(_factionRegistry);
-        owner = msg.sender;
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
     }
+
+    function initialize(address _factionRegistry, address initialOwner) external initializer {
+        require(_factionRegistry != address(0) && initialOwner != address(0), "zero address");
+        factionRegistry = FactionRegistry(_factionRegistry);
+        owner = initialOwner;
+        votingPeriod = 7 days;
+        timelockDelay = 2 days;
+        quorumPercent = 40;
+        approvalPercent = 60;
+        bicameralEnabled = false;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
@@ -104,9 +126,13 @@ contract GovernanceDAO {
         uint256 proposalId = proposalCount;
         uint64 deadline = uint64(block.timestamp) + votingPeriod;
 
+        uint256 humanSnap = factionRegistry.humanCount();
+        uint256 clawSnap = factionRegistry.clawCount();
         proposals[proposalId] = Proposal({
             id: proposalId,
-            registeredSnapshot: factionRegistry.humanCount() + factionRegistry.clawCount(),
+            registeredSnapshot: humanSnap + clawSnap,
+            humanSnapshot: humanSnap,
+            clawSnapshot: clawSnap,
             proposalType: proposalType,
             proposer: msg.sender,
             title: title,
@@ -265,11 +291,17 @@ contract GovernanceDAO {
         }
 
         if (bicameralEnabled) {
-            // Both factions must independently reach approval threshold
+            // #705: a faction that existed at proposal creation must cast at
+            // least one non-abstain vote AND meet the approval threshold;
+            // only a faction that did not exist at creation (snapshot==0) is
+            // treated as auto-approved (preserves the empty-chamber
+            // compatibility behaviour without auto-passing silent factions).
             uint256 humanTotal = p.forVotesHuman + p.againstVotesHuman;
             uint256 clawTotal = p.forVotesClaw + p.againstVotesClaw;
-            bool humanApproved = humanTotal == 0 || (p.forVotesHuman * 100) / humanTotal >= approvalPercent;
-            bool clawApproved = clawTotal == 0 || (p.forVotesClaw * 100) / clawTotal >= approvalPercent;
+            bool humanApproved = p.humanSnapshot == 0
+                || (humanTotal > 0 && (p.forVotesHuman * 100) / humanTotal >= approvalPercent);
+            bool clawApproved = p.clawSnapshot == 0
+                || (clawTotal > 0 && (p.forVotesClaw * 100) / clawTotal >= approvalPercent);
             return humanApproved && clawApproved;
         }
 
@@ -280,4 +312,7 @@ contract GovernanceDAO {
         if (totalCast == 0) return false;
         return (totalFor * 100) / totalCast >= approvalPercent;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/InsuranceFund.sol
+++ b/contracts/contracts-src/governance/InsuranceFund.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /**
  * @title InsuranceFund
  * @notice Phase I5 — accumulates the 20% insurance share of each
@@ -12,21 +15,29 @@ pragma solidity ^0.8.24;
  *         Minimal by design: deposit via plain ETH transfer, withdraw
  *         only by governance, transferable governance role. Holds no
  *         off-chain state; auditable purely via events.
+ *
+ *         UUPS upgradeable since 88780 gen-5; upgrade is gated on `owner`
+ *         (separate from `governance` so day-to-day withdrawal authority
+ *         and upgrade authority can be split if needed).
  */
-contract InsuranceFund {
+contract InsuranceFund is Initializable, UUPSUpgradeable {
     address public governance;
     uint256 public totalDeposited;
     uint256 public totalWithdrawn;
     mapping(address => uint256) public pendingWithdrawals;
     uint256 public pendingWithdrawalTotal;
+    /// @notice Upgrade authority (the 88780 multisig after gen-5 handoff).
+    address public owner;
 
     event Deposited(address indexed from, uint256 amount, uint256 totalDepositedAfter);
     event Withdrawn(address indexed to, uint256 amount, uint256 totalWithdrawnAfter);
     event WithdrawalCredited(address indexed payee, uint256 amount);
     event WithdrawalClaimed(address indexed payee, uint256 amount);
     event GovernanceUpdated(address indexed oldGovernance, address indexed newGovernance);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error OnlyGovernance();
+    error OnlyOwner();
     error ZeroAmount();
     error TransferFailed();
     error InsufficientBalance(uint256 requested, uint256 available);
@@ -38,10 +49,29 @@ contract InsuranceFund {
         _;
     }
 
-    constructor(address initialGovernance) {
-        if (initialGovernance == address(0)) revert ZeroAddress();
-        governance = initialGovernance;
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert OnlyOwner();
+        _;
     }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialGovernance, address initialOwner) external initializer {
+        if (initialGovernance == address(0) || initialOwner == address(0)) revert ZeroAddress();
+        governance = initialGovernance;
+        owner = initialOwner;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /// @notice Anyone can deposit ETH; the slash router does this implicitly.
     receive() external payable {
@@ -110,4 +140,7 @@ contract InsuranceFund {
             emit WithdrawalCredited(to, amount);
         }
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/SoulRegistry.sol
+++ b/contracts/contracts-src/governance/SoulRegistry.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {MerkleProofLite} from "../settlement/MerkleProofLite.sol";
 
 /// @title SoulRegistry - On-chain soul identity and backup anchoring for OpenClaw agents
 /// @notice Enables AI agents to persist their identity, memory, and chat history to IPFS
 ///         with on-chain CID anchoring and social recovery via guardians.
-contract SoulRegistry {
+///         UUPS upgradeable since 88780 gen-5; upgrade gated on `owner` (the multisig).
+contract SoulRegistry is Initializable, UUPSUpgradeable {
     // -----------------------------------------------------------------------
     //  Types
     // -----------------------------------------------------------------------
@@ -116,7 +119,9 @@ contract SoulRegistry {
         "Heartbeat(bytes32 agentId,uint64 timestamp,uint64 nonce)"
     );
 
-    bytes32 public immutable DOMAIN_SEPARATOR;
+    bytes32 public DOMAIN_SEPARATOR;
+    /// @notice Upgrade authority (the 88780 multisig after gen-5 handoff).
+    address public owner;
 
     // -----------------------------------------------------------------------
     //  Storage
@@ -202,12 +207,28 @@ contract SoulRegistry {
     error ResurrectionNotReady();
     error CarrierNotConfirmed();
     error InvalidKeyHash();
+    error OnlyOwner();
+    error ZeroAddress();
+
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert OnlyOwner();
+        _;
+    }
 
     // -----------------------------------------------------------------------
     //  Constructor
     // -----------------------------------------------------------------------
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialOwner) external initializer {
+        if (initialOwner == address(0)) revert ZeroAddress();
+        owner = initialOwner;
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 DOMAIN_TYPEHASH,
@@ -217,6 +238,14 @@ contract SoulRegistry {
                 address(this)
             )
         );
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     // -----------------------------------------------------------------------
@@ -931,4 +960,7 @@ contract SoulRegistry {
         }
         return false;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/Treasury.sol
+++ b/contracts/contracts-src/governance/Treasury.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /**
  * @title Treasury
  * @notice DAO treasury with 3/5 multisig and governance-enforced spending limits.
@@ -10,7 +13,7 @@ pragma solidity ^0.8.24;
  * - Withdrawals exceeding 5% require DAO proposal (external governance contract)
  * - Receives slash proceeds (20% of PoSe penalties) and other deposits
  */
-contract Treasury {
+contract Treasury is Initializable, UUPSUpgradeable {
     uint8 public constant REQUIRED_CONFIRMATIONS = 3;
     uint8 public constant MAX_SIGNERS = 5;
     uint16 public constant SPENDING_CAP_BPS = 500; // 5% of balance
@@ -69,9 +72,18 @@ contract Treasury {
         _;
     }
 
-    constructor(address[5] memory _signers, address _governance) {
-        if (_governance == address(0)) revert ZeroAddress();
-        owner = msg.sender;
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address[5] memory _signers,
+        address _governance,
+        address initialOwner
+    ) external initializer {
+        if (_governance == address(0) || initialOwner == address(0)) revert ZeroAddress();
+        owner = initialOwner;
         governance = _governance;
         for (uint8 i = 0; i < MAX_SIGNERS; i++) {
             if (_signers[i] == address(0)) revert ZeroAddress();
@@ -80,6 +92,8 @@ contract Treasury {
             isSigner[_signers[i]] = true;
         }
     }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /**
      * @notice Propose a withdrawal. Any signer can propose.
@@ -213,4 +227,7 @@ contract Treasury {
     receive() external payable {
         emit Deposit(msg.sender, msg.value);
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/governance/ValidatorRegistry.sol
+++ b/contracts/contracts-src/governance/ValidatorRegistry.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /**
  * @title ValidatorRegistry
  * @notice On-chain BFT validator set with stake, lockup-protected unstake,
@@ -35,7 +38,7 @@ pragma solidity ^0.8.24;
  *           MAX_VALIDATORS    21
  *           SLASH_BPS         1000  (10% of remaining stake per slash)
  */
-contract ValidatorRegistry {
+contract ValidatorRegistry is Initializable, UUPSUpgradeable {
     // ── Constants ────────────────────────────────────────────────────────
 
     uint256 public constant MIN_STAKE = 32 ether;
@@ -154,11 +157,27 @@ contract ValidatorRegistry {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        owner = msg.sender;
-        slasher = msg.sender;
-        slashRecipient = msg.sender;
+        _disableInitializers();
     }
+
+    function initialize(
+        address initialOwner,
+        address initialSlasher,
+        address initialSlashRecipient
+    ) external initializer {
+        if (
+            initialOwner == address(0) ||
+            initialSlasher == address(0) ||
+            initialSlashRecipient == address(0)
+        ) revert ZeroAddress();
+        owner = initialOwner;
+        slasher = initialSlasher;
+        slashRecipient = initialSlashRecipient;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     // ── Stake / activate ─────────────────────────────────────────────────
 
@@ -408,4 +427,7 @@ contract ValidatorRegistry {
         // Validator record gets created. Anything else is a misuse.
         revert();
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/rollup/DelayedInbox.sol
+++ b/contracts/contracts-src/rollup/DelayedInbox.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {RollupTypes} from "./RollupTypes.sol";
 import {IDelayedInbox} from "./IDelayedInbox.sol";
 
@@ -8,8 +10,9 @@ import {IDelayedInbox} from "./IDelayedInbox.sol";
 /// @notice Users can enqueue transactions that the L2 sequencer must eventually include.
 ///         After INCLUSION_DELAY elapses, anyone can call forceInclude() to emit an event
 ///         that the sequencer is obligated to process.
-contract DelayedInbox is IDelayedInbox {
-    uint256 public immutable override INCLUSION_DELAY;
+///         UUPS upgradeable since 88780 gen-5; upgrade gated on `owner`.
+contract DelayedInbox is IDelayedInbox, Initializable, UUPSUpgradeable {
+    uint256 public override INCLUSION_DELAY;
     address public sequencer;
     address public owner;
 
@@ -23,12 +26,26 @@ contract DelayedInbox is IDelayedInbox {
         _;
     }
 
-    constructor(uint256 inclusionDelaySeconds, address sequencerAddress) {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        uint256 inclusionDelaySeconds,
+        address sequencerAddress,
+        address initialOwner
+    ) external initializer {
         require(inclusionDelaySeconds > 0, "inclusion delay must be > 0");
         require(sequencerAddress != address(0), "sequencer cannot be zero");
+        require(initialOwner != address(0), "owner cannot be zero");
         INCLUSION_DELAY = inclusionDelaySeconds;
         sequencer = sequencerAddress;
-        owner = msg.sender;
+        owner = initialOwner;
+    }
+
+    function _authorizeUpgrade(address) internal override {
+        require(msg.sender == owner, "only owner");
     }
 
     /// @notice Enqueue an L2 transaction for eventual forced inclusion
@@ -109,4 +126,7 @@ contract DelayedInbox is IDelayedInbox {
         emit OwnerUpdated(owner, newOwner);
         owner = newOwner;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/rollup/RollupStateManager.sol
+++ b/contracts/contracts-src/rollup/RollupStateManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {RollupTypes} from "./RollupTypes.sol";
 import {IRollupStateManager} from "./IRollupStateManager.sol";
 
@@ -9,11 +11,12 @@ import {IRollupStateManager} from "./IRollupStateManager.sol";
 ///         Proposers submit output roots for L2 block ranges; challengers can dispute
 ///         within the challenge window. After the window elapses without challenge (or
 ///         after challenge resolution in proposer's favor), outputs are finalized.
-contract RollupStateManager is IRollupStateManager {
-    // ── Configuration (immutable after deploy) ──────────────────────────
-    uint256 public immutable override CHALLENGE_WINDOW;
-    uint256 public immutable override PROPOSER_BOND;
-    uint256 public immutable override CHALLENGER_BOND;
+///         UUPS upgradeable since 88780 gen-5; upgrade gated on `owner` (the multisig).
+contract RollupStateManager is IRollupStateManager, Initializable, UUPSUpgradeable {
+    // ── Configuration (set in `initialize`; mutable across upgrades) ─────
+    uint256 public override CHALLENGE_WINDOW;
+    uint256 public override PROPOSER_BOND;
+    uint256 public override CHALLENGER_BOND;
 
     // ── Slash distribution (basis points, must sum to 10000) ────────────
     uint256 public constant SLASH_BURN_BPS       = 5000; // 50% burned
@@ -49,27 +52,36 @@ contract RollupStateManager is IRollupStateManager {
         _;
     }
 
-    constructor(
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
         uint256 challengeWindowSeconds,
         uint256 proposerBondWei,
         uint256 challengerBondWei,
         address insuranceFundAddress,
-        address initialProposer
-    ) {
+        address initialProposer,
+        address initialOwner
+    ) external initializer {
         require(challengeWindowSeconds > 0, "challenge window must be > 0");
         require(proposerBondWei > 0, "proposer bond must be > 0");
         require(challengerBondWei > 0, "challenger bond must be > 0");
+        require(initialOwner != address(0), "owner cannot be zero");
         CHALLENGE_WINDOW = challengeWindowSeconds;
         PROPOSER_BOND = proposerBondWei;
         CHALLENGER_BOND = challengerBondWei;
         insuranceFund = insuranceFundAddress;
-        owner = msg.sender;
-        challengeResolver = msg.sender;
+        owner = initialOwner;
+        challengeResolver = initialOwner;
         if (initialProposer != address(0)) {
             allowedProposers[initialProposer] = true;
             emit ProposerUpdated(initialProposer, true);
         }
     }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     // ── Submit Output Root ──────────────────────────────────────────────
 
@@ -330,4 +342,7 @@ contract RollupStateManager is IRollupStateManager {
 
     /// @notice Accept ETH deposits (for bond top-ups)
     receive() external payable {}
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/settlement/PoSeManager.sol
+++ b/contracts/contracts-src/settlement/PoSeManager.sol
@@ -1,16 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IPoSeManager} from "./IPoSeManager.sol";
 import {PoSeTypes} from "./PoSeTypes.sol";
 import {PoSeManagerStorage} from "./PoSeManagerStorage.sol";
 import {MerkleProofLite} from "./MerkleProofLite.sol";
 
-contract PoSeManager is IPoSeManager, PoSeManagerStorage {
+contract PoSeManager is IPoSeManager, PoSeManagerStorage, UUPSUpgradeable {
     uint256 internal constant SECP256K1N_HALF =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
     uint16 internal constant BPS_DENOMINATOR = 10_000;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialOwner) external initializer {
+        __PoSeManagerStorage_init(initialOwner);
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 
     error InvalidNodeId();
     error NodeAlreadyRegistered();
@@ -440,4 +452,7 @@ contract PoSeManager is IPoSeManager, PoSeManagerStorage {
         if (reasonCode >= 5) return 1000; // generic provable fault
         return 1000;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/settlement/PoSeManagerStorage.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerStorage.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {PoSeTypes} from "./PoSeTypes.sol";
 
-abstract contract PoSeManagerStorage {
+abstract contract PoSeManagerStorage is Initializable {
     uint64 public constant EPOCH_SECONDS = 3600;
     uint64 public constant DISPUTE_WINDOW_EPOCHS = 2;
     uint64 public constant UNBOND_DELAY_EPOCHS = 7 * 24; // 7 days in hours
@@ -54,9 +55,13 @@ abstract contract PoSeManagerStorage {
         _;
     }
 
-    constructor() {
-        owner = msg.sender;
-        roles[SLASHER_ROLE][msg.sender] = true;
+    /// @dev Chained initializer for upgradeable derived contracts (PoSeManager
+    ///      v1 and PoSeManagerV2). Each derived contract calls this from its
+    ///      own `initialize(...)` function under the `initializer` modifier.
+    function __PoSeManagerStorage_init(address initialOwner) internal onlyInitializing {
+        require(initialOwner != address(0), "zero owner");
+        owner = initialOwner;
+        roles[SLASHER_ROLE][initialOwner] = true;
     }
 
     /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
@@ -81,4 +86,7 @@ abstract contract PoSeManagerStorage {
     function _setRole(bytes32 role, address account, bool enabled) internal {
         roles[role][account] = enabled;
     }
+
+    // UUPS storage gap (base class) — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IPoSeManagerV2} from "./IPoSeManagerV2.sol";
 import {PoSeTypes} from "./PoSeTypes.sol";
 import {PoSeTypesV2} from "./PoSeTypesV2.sol";
@@ -14,7 +15,7 @@ interface ICOCToken {
     function burn(uint256 amount) external;
 }
 
-contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
+contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
     using EmissionSchedule for uint64;
     uint16 internal constant BPS_DENOMINATOR = 10_000;
     uint16 public constant SLASH_EPOCH_CAP_BPS = 500;      // 5% per epoch
@@ -58,7 +59,9 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     uint256 public challengeBondMin;
     uint256 public insuranceBalance;
     bytes32 public DOMAIN_SEPARATOR;
-    bool public allowEmptyWitnessSubmission = false;
+    bool public allowEmptyWitnessSubmission;
+    /// @dev Kept for storage-layout compatibility with the pre-UUPS deployment.
+    /// The OZ `initializer` modifier now provides the single-shot guard.
     bool public initialized;
     uint256 private _challengeCounter;
 
@@ -101,10 +104,20 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
     error AlreadyInitialized();
     error ZeroAddress();
 
-    function initialize(uint256 chainId, address verifyingContract, uint256 _challengeBondMin) external onlyOwner {
-        if (initialized) revert AlreadyInitialized();
-        if (verifyingContract == address(0)) revert ZeroAddress();
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Proxy initializer. `chainId` and `verifyingContract` are no
+    ///         longer parameters — they are taken from `block.chainid` and
+    ///         `address(this)` (the proxy address) so the EIP-712 domain
+    ///         always reflects the live deployment.
+    function initialize(uint256 _challengeBondMin, address initialOwner) external initializer {
         if (_challengeBondMin == 0) revert BondTooLow();
+        if (initialOwner == address(0)) revert ZeroAddress();
+
+        __PoSeManagerStorage_init(initialOwner);
 
         initialized = true;
         DOMAIN_SEPARATOR = keccak256(
@@ -112,12 +125,12 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256("COCPoSe"),
                 keccak256("2"),
-                chainId,
-                verifyingContract
+                block.chainid,
+                address(this)
             )
         );
         challengeBondMin = _challengeBondMin;
-        emit Initialized(chainId, verifyingContract, _challengeBondMin);
+        emit Initialized(block.chainid, address(this), _challengeBondMin);
     }
 
     /**
@@ -909,4 +922,9 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage {
 
     // Allow receiving ETH for burns
     receive() external payable {}
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/test-contracts/TestERC1967Proxy.sol
+++ b/contracts/contracts-src/test-contracts/TestERC1967Proxy.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @dev Concrete OZ ERC1967Proxy that the integration-test harness can deploy
+/// from raw artifact + bytecode. The standalone tests live outside hardhat's
+/// upgrades plugin (they start a real Hardhat node and talk to it via
+/// JsonRpcProvider), so they need a concrete proxy contract to compile into
+/// `artifacts/`.
+contract TestERC1967Proxy is ERC1967Proxy {
+    constructor(address implementation, bytes memory data)
+        ERC1967Proxy(implementation, data)
+    {}
+}

--- a/contracts/contracts-src/token/COCToken.sol
+++ b/contracts/contracts-src/token/COCToken.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /**
  * @title COCToken
  * @notice Supply tracking and emission control for the COC native token.
@@ -18,7 +21,7 @@ pragma solidity ^0.8.24;
  * Note: In Solidity, `ether` keyword means 10^18 (the smallest unit), NOT Ethereum.
  * On this chain, 1 ether = 1 COC = 10^18 wei (COC's smallest unit).
  */
-contract COCToken {
+contract COCToken is Initializable, UUPSUpgradeable {
     string public constant name = "ChainOfClaw";
     string public constant symbol = "COC";
     uint8 public constant decimals = 18;
@@ -42,6 +45,7 @@ contract COCToken {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event MinterUpdated(address indexed oldMinter, address indexed newMinter);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
     event Mint(address indexed to, uint256 amount);
     event Burn(address indexed from, uint256 amount);
     event BaseFeeBurnRecorded(uint64 indexed blockNumber, uint256 amount);
@@ -69,9 +73,19 @@ contract COCToken {
      * @param genesisRecipients  Addresses receiving genesis allocation
      * @param genesisAmounts     Amounts for each recipient (must sum to GENESIS_SUPPLY)
      */
-    constructor(address[] memory genesisRecipients, uint256[] memory genesisAmounts) {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address[] memory genesisRecipients,
+        uint256[] memory genesisAmounts,
+        address initialOwner
+    ) external initializer {
         require(genesisRecipients.length == genesisAmounts.length, "length mismatch");
-        owner = msg.sender;
+        if (initialOwner == address(0)) revert ZeroAddress();
+        owner = initialOwner;
 
         uint256 genesisTotal = 0;
         for (uint256 i = 0; i < genesisRecipients.length; i++) {
@@ -82,6 +96,14 @@ contract COCToken {
         }
         require(genesisTotal == GENESIS_SUPPLY, "genesis total must equal GENESIS_SUPPLY");
         totalSupply = GENESIS_SUPPLY;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     // ── Minter Management ──────────────────────────────────────────
@@ -220,4 +242,7 @@ contract COCToken {
             ? totalBurned - totalBurnedFromBaseFee - totalBurnedFromSlash
             : 0;
     }
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/contracts-src/token/FoundationVesting.sol
+++ b/contracts/contracts-src/token/FoundationVesting.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
 /**
  * @title FoundationVesting
  * @notice Tiered release schedule for Foundation's 6% genesis allocation (60M COC).
@@ -8,8 +11,9 @@ pragma solidity ^0.8.24;
  * - Year 1: 1.5% (15M COC) available immediately for startup operations
  * - Remaining 4.5% (45M COC): 48-month linear vesting starting at deployment
  * - Quarterly spending cap: max 15% of current balance per quarter
+ * - UUPS upgradeable since 88780 gen-5; upgrade gated on `owner`.
  */
-contract FoundationVesting {
+contract FoundationVesting is Initializable, UUPSUpgradeable {
     address public beneficiary;        // Foundation multisig or EOA
     address public owner;              // Deployer (can update beneficiary)
 
@@ -30,6 +34,7 @@ contract FoundationVesting {
     event WithdrawalCredited(address indexed payee, uint256 amount);
     event WithdrawalClaimed(address indexed payee, uint256 amount);
     event BeneficiaryUpdated(address indexed oldBeneficiary, address indexed newBeneficiary);
+    event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error NotOwner();
     error NotBeneficiary();
@@ -49,12 +54,25 @@ contract FoundationVesting {
         _;
     }
 
-    constructor(address _beneficiary) {
-        if (_beneficiary == address(0)) revert ZeroAddress();
-        owner = msg.sender;
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _beneficiary, address initialOwner) external initializer {
+        if (_beneficiary == address(0) || initialOwner == address(0)) revert ZeroAddress();
+        owner = initialOwner;
         beneficiary = _beneficiary;
         vestingStart = block.timestamp;
         quarterStart = block.timestamp;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        emit OwnerUpdated(owner, newOwner);
+        owner = newOwner;
     }
 
     /**
@@ -155,4 +173,7 @@ contract FoundationVesting {
 
     // Accept ETH deposits (for initial funding)
     receive() external payable {}
+
+    // UUPS storage gap — append-only state from now on.
+    uint256[50] private __gap;
 }

--- a/contracts/hardhat.config.cjs
+++ b/contracts/hardhat.config.cjs
@@ -1,5 +1,6 @@
 require("@nomicfoundation/hardhat-ethers")
 require("@nomicfoundation/hardhat-chai-matchers")
+require("@openzeppelin/hardhat-upgrades")
 require("hardhat-gas-reporter")
 require("solidity-coverage")
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -17,6 +17,8 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@openzeppelin/contracts-upgradeable": "^5.1.0",
+    "@openzeppelin/hardhat-upgrades": "^3.6.0",
     "chai": "^4.5.0",
     "ethers": "^6.13.5",
     "hardhat": "^2.22.18",

--- a/contracts/scripts/deploy-all-88780.js
+++ b/contracts/scripts/deploy-all-88780.js
@@ -1,21 +1,37 @@
 /**
- * Deploy ALL COC contracts to 88780 R3.2 testnet
+ * Deploy ALL COC contracts to 88780 R3.2 testnet (UUPS proxies — gen-5)
  *
- * Run AFTER scripts/deploy-governance.js (which deploys FactionRegistry/DAO/Treasury).
- * Picks up existing governance addresses from env if provided.
+ * Run AFTER scripts/deploy-governance.js (which deploys FactionRegistry/DAO/
+ * Treasury proxies). Picks up existing governance addresses from env if
+ * provided.
+ *
+ * Every contract goes up behind a UUPS proxy via @openzeppelin/hardhat-upgrades.
+ * Implementations are constructor-locked; the proxy runs `initialize(...)`
+ * once at deploy.
  *
  * Usage:
- *   DEPLOYER_PRIVATE_KEY=0x... \
- *   COC_RPC_URL=http://209.74.64.88:38780 \
- *   COC_CHAIN_ID=88780 \
- *   FACTION_REGISTRY=0x... GOVERNANCE_DAO=0x... TREASURY=0x... \
+ *   DEPLOYER_PRIVATE_KEY=0x...  (non-public — preflight enforces)
+ *   COC_RPC_URL=http://209.74.64.88:38780
+ *   COC_CHAIN_ID=88780
+ *   MULTISIG_ADDRESS=0x...
+ *   FACTION_REGISTRY=0x... GOVERNANCE_DAO=0x... TREASURY=0x...
  *     npx hardhat run scripts/deploy-all-88780.js --network coc
  */
 
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const fs = require("fs")
 const path = require("path")
 const { assertSafeDeployer, transferOwnershipChecked } = require("./preflight.js")
+
+async function deployProxy(factoryName, args) {
+  const Factory = await ethers.getContractFactory(factoryName)
+  const proxy = await upgrades.deployProxy(Factory, args, {
+    initializer: "initialize",
+    kind: "uups",
+  })
+  await proxy.waitForDeployment()
+  return proxy
+}
 
 async function main() {
   const [deployer] = await ethers.getSigners()
@@ -26,7 +42,7 @@ async function main() {
   // #683: address seeded into the RollupStateManager proposer allowlist.
   const outputProposer = process.env.OUTPUT_PROPOSER_ADDRESS || ethers.ZeroAddress
 
-  console.log("=== COC R3.2 88780 Full Contract Deploy ===")
+  console.log("=== COC R3.2 88780 Full Contract Deploy (UUPS gen-5) ===")
   console.log(`Network:  ${network.name} (chainId: ${network.chainId})`)
   console.log(`Deployer: ${deployer.address}`)
   const bal = await ethers.provider.getBalance(deployer.address)
@@ -41,152 +57,99 @@ async function main() {
     contracts: {},
   }
 
-  // Pre-existing governance from deploy-governance.js (if env set)
+  // Pre-existing governance proxies from deploy-governance.js (if env set)
   if (process.env.FACTION_REGISTRY) deployed.contracts.FactionRegistry = process.env.FACTION_REGISTRY
   if (process.env.GOVERNANCE_DAO) deployed.contracts.GovernanceDAO = process.env.GOVERNANCE_DAO
   if (process.env.TREASURY) deployed.contracts.Treasury = process.env.TREASURY
 
-  // Skip already-deployed contracts (if env addresses set, no need to redeploy)
-  const skipExisting = process.env.SKIP_EXISTING === "1"
-  if (skipExisting) {
-    console.log("(SKIP_EXISTING=1: only deploying contracts missing from env)")
-  }
-
-  // 1. SoulRegistry (no constructor args)
-  console.log("Deploying SoulRegistry...")
-  const SoulRegistry = await ethers.getContractFactory("SoulRegistry")
-  const soulRegistry = await SoulRegistry.deploy()
-  await soulRegistry.waitForDeployment()
+  // 1. SoulRegistry — initialize(initialOwner)
+  console.log("Deploying SoulRegistry proxy...")
+  const soulRegistry = await deployProxy("SoulRegistry", [deployer.address])
   deployed.contracts.SoulRegistry = await soulRegistry.getAddress()
   console.log(`  SoulRegistry: ${deployed.contracts.SoulRegistry}`)
 
-  // 2. DIDRegistry (depends on SoulRegistry)
-  console.log("Deploying DIDRegistry...")
-  const DIDRegistry = await ethers.getContractFactory("DIDRegistry")
-  const didRegistry = await DIDRegistry.deploy(deployed.contracts.SoulRegistry)
-  await didRegistry.waitForDeployment()
+  // 2. DIDRegistry — initialize(_soulRegistry, initialOwner)
+  console.log("Deploying DIDRegistry proxy...")
+  const didRegistry = await deployProxy("DIDRegistry", [
+    deployed.contracts.SoulRegistry,
+    deployer.address,
+  ])
   deployed.contracts.DIDRegistry = await didRegistry.getAddress()
   console.log(`  DIDRegistry:  ${deployed.contracts.DIDRegistry}`)
 
-  // 3. CidRegistry (no constructor args)
-  console.log("Deploying CidRegistry...")
-  const CidRegistry = await ethers.getContractFactory("CidRegistry")
-  const cidRegistry = await CidRegistry.deploy()
-  await cidRegistry.waitForDeployment()
+  // 3. CidRegistry — initialize(initialOwner)
+  console.log("Deploying CidRegistry proxy...")
+  const cidRegistry = await deployProxy("CidRegistry", [deployer.address])
   deployed.contracts.CidRegistry = await cidRegistry.getAddress()
   console.log(`  CidRegistry:  ${deployed.contracts.CidRegistry}`)
 
-  // 4. PoSeManager v1
-  console.log("Deploying PoSeManager (v1)...")
-  try {
-    const PoSeManager = await ethers.getContractFactory("PoSeManager")
-    const poseV1 = await PoSeManager.deploy()
-    await poseV1.waitForDeployment()
-    deployed.contracts.PoSeManager = await poseV1.getAddress()
-    console.log(`  PoSeManager:  ${deployed.contracts.PoSeManager}`)
-  } catch (e) {
-    console.log(`  SKIPPED (constructor args mismatch): ${e.message.slice(0, 100)}`)
-    deployed.contracts.PoSeManager = null
-  }
+  // 4. PoSeManager v1 — initialize(initialOwner)
+  console.log("Deploying PoSeManager (v1) proxy...")
+  const poseV1 = await deployProxy("PoSeManager", [deployer.address])
+  deployed.contracts.PoSeManager = await poseV1.getAddress()
+  console.log(`  PoSeManager:  ${deployed.contracts.PoSeManager}`)
 
-  // 5. PoSeManager v2
-  console.log("Deploying PoSeManagerV2...")
-  try {
-    const PoSeManagerV2 = await ethers.getContractFactory("PoSeManagerV2")
-    const poseV2 = await PoSeManagerV2.deploy()
-    await poseV2.waitForDeployment()
-    deployed.contracts.PoSeManagerV2 = await poseV2.getAddress()
-    console.log(`  PoSeManagerV2: ${deployed.contracts.PoSeManagerV2}`)
-    // #685: initialize so DOMAIN_SEPARATOR / challengeBondMin are non-zero.
-    // verifyingContract is the contract's own address — the off-chain witness
-    // signers (runtime/coc-node.ts) build the EIP-712 domain from it too.
-    const challengeBondMin = process.env.POSE_CHALLENGE_BOND_MIN
-      ? BigInt(process.env.POSE_CHALLENGE_BOND_MIN)
-      : ethers.parseEther("0.1")
-    const initTx = await poseV2.initialize(
-      network.chainId,
-      deployed.contracts.PoSeManagerV2,
-      challengeBondMin,
-    )
-    await initTx.wait()
-    console.log(`  PoSeManagerV2.initialize() done (challengeBondMin=${challengeBondMin})`)
-  } catch (e) {
-    console.log(`  SKIPPED (constructor args mismatch): ${e.message.slice(0, 100)}`)
-    deployed.contracts.PoSeManagerV2 = null
-  }
+  // 5. PoSeManagerV2 — initialize(challengeBondMin, initialOwner)
+  //    Proxy address auto-fills DOMAIN_SEPARATOR via address(this) inside
+  //    the initializer; no separate post-deploy initialize step needed (#685).
+  console.log("Deploying PoSeManagerV2 proxy...")
+  const challengeBondMin = process.env.POSE_CHALLENGE_BOND_MIN
+    ? BigInt(process.env.POSE_CHALLENGE_BOND_MIN)
+    : ethers.parseEther("0.1")
+  const poseV2 = await deployProxy("PoSeManagerV2", [challengeBondMin, deployer.address])
+  deployed.contracts.PoSeManagerV2 = await poseV2.getAddress()
+  console.log(`  PoSeManagerV2: ${deployed.contracts.PoSeManagerV2} (initialized; bondMin=${challengeBondMin})`)
 
-  // 6. ValidatorRegistry (no args expected, on-chain validator stake registry)
-  console.log("Deploying ValidatorRegistry...")
-  try {
-    const ValidatorRegistry = await ethers.getContractFactory("ValidatorRegistry")
-    const vr = await ValidatorRegistry.deploy()
-    await vr.waitForDeployment()
-    deployed.contracts.ValidatorRegistry = await vr.getAddress()
-    console.log(`  ValidatorRegistry: ${deployed.contracts.ValidatorRegistry}`)
-  } catch (e) {
-    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
-    deployed.contracts.ValidatorRegistry = null
-  }
+  // 6. ValidatorRegistry — initialize(initialOwner, initialSlasher, initialSlashRecipient)
+  console.log("Deploying ValidatorRegistry proxy...")
+  const vr = await deployProxy("ValidatorRegistry", [
+    deployer.address,
+    deployer.address,
+    deployer.address,
+  ])
+  deployed.contracts.ValidatorRegistry = await vr.getAddress()
+  console.log(`  ValidatorRegistry: ${deployed.contracts.ValidatorRegistry}`)
 
-  // 7. EquivocationDetector (depends on ValidatorRegistry)
-  console.log("Deploying EquivocationDetector...")
-  try {
-    const ED = await ethers.getContractFactory("EquivocationDetector")
-    const ed = await ED.deploy(deployed.contracts.ValidatorRegistry)
-    await ed.waitForDeployment()
-    deployed.contracts.EquivocationDetector = await ed.getAddress()
-    console.log(`  EquivocationDetector: ${deployed.contracts.EquivocationDetector}`)
-  } catch (e) {
-    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
-    deployed.contracts.EquivocationDetector = null
-  }
+  // 7. EquivocationDetector — initialize(validatorRegistry, initialOwner)
+  console.log("Deploying EquivocationDetector proxy...")
+  const ed = await deployProxy("EquivocationDetector", [
+    deployed.contracts.ValidatorRegistry,
+    deployer.address,
+  ])
+  deployed.contracts.EquivocationDetector = await ed.getAddress()
+  console.log(`  EquivocationDetector: ${deployed.contracts.EquivocationDetector}`)
 
-  // 8. InsuranceFund (initial governance = GovernanceDAO)
-  console.log("Deploying InsuranceFund...")
-  try {
-    const IF = await ethers.getContractFactory("InsuranceFund")
-    const insurance = await IF.deploy(deployed.contracts.GovernanceDAO)
-    await insurance.waitForDeployment()
-    deployed.contracts.InsuranceFund = await insurance.getAddress()
-    console.log(`  InsuranceFund: ${deployed.contracts.InsuranceFund}`)
-  } catch (e) {
-    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
-    deployed.contracts.InsuranceFund = null
-  }
+  // 8. InsuranceFund — initialize(governance, initialOwner)
+  console.log("Deploying InsuranceFund proxy...")
+  const insurance = await deployProxy("InsuranceFund", [
+    deployed.contracts.GovernanceDAO,
+    deployer.address,
+  ])
+  deployed.contracts.InsuranceFund = await insurance.getAddress()
+  console.log(`  InsuranceFund: ${deployed.contracts.InsuranceFund}`)
 
-  // 9. DelayedInbox (rollup): (inclusionDelaySeconds, sequencerAddress)
-  console.log("Deploying DelayedInbox...")
-  try {
-    const DI = await ethers.getContractFactory("DelayedInbox")
-    // 24-hour inclusion delay, deployer as initial sequencer (testnet)
-    const di = await DI.deploy(86400, deployer.address)
-    await di.waitForDeployment()
-    deployed.contracts.DelayedInbox = await di.getAddress()
-    console.log(`  DelayedInbox: ${deployed.contracts.DelayedInbox}`)
-  } catch (e) {
-    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
-    deployed.contracts.DelayedInbox = null
-  }
+  // 9. DelayedInbox — initialize(inclusionDelaySeconds, sequencer, initialOwner)
+  console.log("Deploying DelayedInbox proxy...")
+  const di = await deployProxy("DelayedInbox", [
+    86400, // 24h inclusion delay
+    deployer.address, // initial sequencer (testnet)
+    deployer.address,
+  ])
+  deployed.contracts.DelayedInbox = await di.getAddress()
+  console.log(`  DelayedInbox: ${deployed.contracts.DelayedInbox}`)
 
-  // 10. RollupStateManager: (challengeWindowSeconds, proposerBondWei, challengerBondWei, insuranceFundAddress)
-  console.log("Deploying RollupStateManager...")
-  try {
-    const RSM = await ethers.getContractFactory("RollupStateManager")
-    // 24h challenge window, 1 ETH bonds (testnet), InsuranceFund as recipient
-    const rsm = await RSM.deploy(
-      86400,
-      ethers.parseEther("1"),
-      ethers.parseEther("1"),
-      deployed.contracts.InsuranceFund || ethers.ZeroAddress,
-      outputProposer,
-    )
-    await rsm.waitForDeployment()
-    deployed.contracts.RollupStateManager = await rsm.getAddress()
-    console.log(`  RollupStateManager: ${deployed.contracts.RollupStateManager}`)
-  } catch (e) {
-    console.log(`  SKIPPED: ${e.message.slice(0, 100)}`)
-    deployed.contracts.RollupStateManager = null
-  }
+  // 10. RollupStateManager — initialize(challengeWindow, proposerBond, challengerBond, insuranceFund, initialProposer, initialOwner)
+  console.log("Deploying RollupStateManager proxy...")
+  const rsm = await deployProxy("RollupStateManager", [
+    86400, // 24h challenge window
+    ethers.parseEther("1"), // proposer bond
+    ethers.parseEther("1"), // challenger bond
+    deployed.contracts.InsuranceFund || ethers.ZeroAddress,
+    outputProposer,
+    deployer.address,
+  ])
+  deployed.contracts.RollupStateManager = await rsm.getAddress()
+  console.log(`  RollupStateManager: ${deployed.contracts.RollupStateManager}`)
 
   // --- #686: hand contract ownership to the multisig ---
   const multisig = process.env.MULTISIG_ADDRESS
@@ -197,10 +160,14 @@ async function main() {
       "FactionRegistry",
       "GovernanceDAO",
       "Treasury",
+      "SoulRegistry",
+      "DIDRegistry",
+      "CidRegistry",
       "PoSeManager",
       "PoSeManagerV2",
       "ValidatorRegistry",
       "EquivocationDetector",
+      "InsuranceFund",
       "DelayedInbox",
       "RollupStateManager",
     ]
@@ -214,22 +181,28 @@ async function main() {
       await transferOwnershipChecked(c, name, multisig)
     }
     deployed.owner = multisig
-    console.log("Ownership handoff complete — all owners verified == multisig.")
+    console.log("Ownership handoff complete — all 13 proxies' owner == multisig.")
+    console.log("Upgrade authority for every proxy is now the 3-of-5 multisig (#686 resolved).")
   } else {
     deployed.owner = deployer.address
     console.log("")
-    console.log("WARNING: MULTISIG_ADDRESS not set — contracts remain owned by the")
+    console.log("WARNING: MULTISIG_ADDRESS not set — proxies remain owned by the")
     console.log("         deployer. #686 is NOT resolved until ownership is moved")
     console.log("         to a multisig.")
   }
 
-  // Write deployment manifest
+  // Write deployment manifest (records proxy addresses; the OZ upgrades plugin
+  // stores implementation addresses + storage-layout hashes in
+  // contracts/.openzeppelin/<network>.json — commit that file too).
   const outPath = path.join(__dirname, "..", "..", "configs", "deployed-contracts-88780.json")
   fs.writeFileSync(outPath, JSON.stringify(deployed, null, 2))
   console.log("")
   console.log("=== Deployment Summary ===")
   console.log(JSON.stringify(deployed, null, 2))
   console.log(`\nManifest: ${outPath}`)
+  console.log("\nDon't forget to commit `contracts/.openzeppelin/coc-88780.json` —")
+  console.log("the OZ upgrades plugin needs it to validate storage layout on future")
+  console.log("upgradeProxy() calls. Losing it loses the safety check.")
 }
 
 main().catch((err) => {

--- a/contracts/scripts/deploy-governance.js
+++ b/contracts/scripts/deploy-governance.js
@@ -1,10 +1,14 @@
 /**
- * Deploy Governance Contracts
+ * Deploy Governance Contracts (UUPS proxies — gen-5)
  *
- * Deploys FactionRegistry, GovernanceDAO, and Treasury to the target network.
- * Wires contracts together and outputs deployed addresses.
+ * Deploys FactionRegistry, GovernanceDAO, and Treasury as OpenZeppelin UUPS
+ * proxies. Each implementation is locked via _disableInitializers and the
+ * proxy runs the contract's `initialize(...)` exactly once.
  *
  * Usage:
+ *   MULTISIG_ADDRESS=0x...   # optional; if set, ownership of every proxy is
+ *                              transferred to it as the final step of the
+ *                              cross-script flow (see deploy-all-88780.js).
  *   npx hardhat run scripts/deploy-governance.js --network <network>
  *
  * Environment:
@@ -12,9 +16,10 @@
  *   INITIAL_TIMELOCK_DELAY - Timelock delay in seconds (default: 86400 = 1 day)
  *   INITIAL_QUORUM_PERCENT - Quorum percentage (default: 40)
  *   INITIAL_APPROVAL_PERCENT - Approval threshold (default: 60)
+ *   TREASURY_SIGNERS       - Comma-separated; exactly 5 addresses (default: 88780 validators)
  */
 
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const { assertSafeDeployer } = require("./preflight.js")
 
 async function main() {
@@ -24,33 +29,44 @@ async function main() {
   // #686: refuse to deploy from a public Hardhat test account.
   assertSafeDeployer(deployer.address)
 
-  console.log("=== COC Governance Deployment ===")
+  console.log("=== COC Governance Deployment (UUPS) ===")
   console.log(`Network:  ${network.name} (chainId: ${network.chainId})`)
   console.log(`Deployer: ${deployer.address}`)
   console.log(`Balance:  ${ethers.formatEther(await ethers.provider.getBalance(deployer.address))} ETH`)
   console.log("")
 
-  // 1. Deploy FactionRegistry
-  console.log("Deploying FactionRegistry...")
+  // 1. Deploy FactionRegistry behind a UUPS proxy.
+  //    initialize(initialOwner, initialVerifier) — owner stays deployer until
+  //    deploy-all-88780.js does the final transferOwnership(multisig).
+  console.log("Deploying FactionRegistry proxy...")
   const FactionRegistry = await ethers.getContractFactory("FactionRegistry")
-  const factionRegistry = await FactionRegistry.deploy()
+  const factionRegistry = await upgrades.deployProxy(
+    FactionRegistry,
+    [deployer.address, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await factionRegistry.waitForDeployment()
   const factionAddr = await factionRegistry.getAddress()
   console.log(`  FactionRegistry: ${factionAddr}`)
 
-  // 2. Deploy GovernanceDAO
-  console.log("Deploying GovernanceDAO...")
+  // 2. Deploy GovernanceDAO behind a UUPS proxy.
+  //    initialize(_factionRegistry, initialOwner). Default governance params
+  //    (votingPeriod=7d, timelockDelay=2d, quorum=40%, approval=60%) are set
+  //    inside the initializer; we override them below via owner setters.
+  console.log("Deploying GovernanceDAO proxy...")
   const GovernanceDAO = await ethers.getContractFactory("GovernanceDAO")
-  const governanceDAO = await GovernanceDAO.deploy(factionAddr)
+  const governanceDAO = await upgrades.deployProxy(
+    GovernanceDAO,
+    [factionAddr, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await governanceDAO.waitForDeployment()
   const daoAddr = await governanceDAO.getAddress()
   console.log(`  GovernanceDAO:   ${daoAddr}`)
 
-  // 3. Deploy Treasury
-  // Treasury constructor is (address[5] _signers, address _governance).
-  // Signers default to the five chainId-88780 validators; override with
-  // TREASURY_SIGNERS (comma-separated, exactly 5 addresses).
-  console.log("Deploying Treasury...")
+  // 3. Deploy Treasury behind a UUPS proxy.
+  //    initialize(address[5] _signers, address _governance, address initialOwner).
+  console.log("Deploying Treasury proxy...")
   const DEFAULT_TREASURY_SIGNERS = [
     "0xde4e7889aa9007318ff261b1ee675f1305153590",
     "0xb939e5a68abd2e000e78876bd86edd1cbba49eb9",
@@ -65,7 +81,11 @@ async function main() {
     throw new Error(`Treasury requires exactly 5 signers, got ${treasurySigners.length}`)
   }
   const Treasury = await ethers.getContractFactory("Treasury")
-  const treasury = await Treasury.deploy(treasurySigners, daoAddr)
+  const treasury = await upgrades.deployProxy(
+    Treasury,
+    [treasurySigners, daoAddr, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await treasury.waitForDeployment()
   const treasuryAddr = await treasury.getAddress()
   console.log(`  Treasury:        ${treasuryAddr}`)
@@ -77,7 +97,7 @@ async function main() {
   await tx.wait()
   console.log("  GovernanceDAO.setTreasury() done")
 
-  // 5. Set initial governance parameters
+  // 5. Set initial governance parameters (only the deployer can while still owner).
   const votingPeriod = parseInt(process.env.INITIAL_VOTING_PERIOD || "259200") // 3 days
   const timelockDelay = parseInt(process.env.INITIAL_TIMELOCK_DELAY || "86400") // 1 day
   const quorumPercent = parseInt(process.env.INITIAL_QUORUM_PERCENT || "40")

--- a/contracts/scripts/deploy-posev2-88780.js
+++ b/contracts/scripts/deploy-posev2-88780.js
@@ -1,80 +1,77 @@
 /**
- * Standalone redeploy of PoSeManagerV2 to 88780.
+ * In-place upgrade of the PoSeManagerV2 UUPS proxy on 88780.
  *
- * PoSeManagerV2 has no constructor args and zero on-chain dependents, so a
- * standalone redeploy does not cascade stale cross-references.
+ * Since gen-5 (UUPS conversion), PoSeManagerV2 lives behind a proxy. To ship
+ * a code change, this script compiles the new implementation, validates it
+ * against the storage layout the OpenZeppelin upgrades plugin recorded in
+ * `contracts/.openzeppelin/coc-88780.json`, and calls `upgradeToAndCall` on
+ * the existing proxy.
  *
- * Unlike earlier revisions this script also:
- *   - refuses public Hardhat test accounts as deployer (#686)
- *   - calls initialize() right after deploy so DOMAIN_SEPARATOR /
- *     challengeBondMin are non-zero (#685)
- *   - hands ownership to MULTISIG_ADDRESS when set (#686)
+ * The upgrade tx must be sent by the proxy's `owner` — which after the gen-5
+ * handoff is the 3-of-5 multisig. That means in production this script is
+ * really used to *prepare* the new implementation and the encoded
+ * `upgradeToAndCall` calldata for multisig signing; the deployer key alone
+ * cannot push the upgrade through. For testnet ad-hoc upgrades, the multisig
+ * signs via its normal flow.
  *
  * Environment:
- *   DEPLOYER_PRIVATE_KEY    — securely-held deployer key
- *   POSE_CHALLENGE_BOND_MIN — challenge bond minimum in wei (default 0.1 ETH)
- *   MULTISIG_ADDRESS        — multisig that should own the contract
+ *   DEPLOYER_PRIVATE_KEY  — must be non-public (preflight enforces). For the
+ *                           actual on-chain upgrade tx the proxy's `owner`
+ *                           (the multisig) must sign; this script will revert
+ *                           if the deployer is not the owner. Use multisig
+ *                           tooling to construct the tx if needed.
+ *   POSEV2_PROXY_ADDR     — required; the existing PoSeManagerV2 proxy.
+ *   COC_RPC_URL / COC_CHAIN_ID
  */
-const { ethers } = require("hardhat")
-const { assertSafeDeployer, transferOwnershipChecked } = require("./preflight.js")
+const { ethers, upgrades } = require("hardhat")
+const { assertSafeDeployer } = require("./preflight.js")
 
 async function main() {
   const [deployer] = await ethers.getSigners()
   const network = await ethers.provider.getNetwork()
 
-  // #686: refuse to deploy from a public Hardhat test account.
   assertSafeDeployer(deployer.address)
 
+  const proxyAddr = process.env.POSEV2_PROXY_ADDR
+  if (!proxyAddr) {
+    throw new Error("POSEV2_PROXY_ADDR is required (the existing PoSeManagerV2 proxy)")
+  }
+
   console.log(`Network:  chainId ${network.chainId}`)
-  console.log(`Deployer: ${deployer.address}`)
+  console.log(`Caller:   ${deployer.address}`)
   console.log(`Balance:  ${ethers.formatEther(await ethers.provider.getBalance(deployer.address))} ETH`)
-  console.log(`Nonce:    ${await ethers.provider.getTransactionCount(deployer.address)}`)
+  console.log(`Proxy:    ${proxyAddr}`)
   console.log("")
 
-  console.log("Deploying PoSeManagerV2 (no constructor args)...")
-  const PoSeManagerV2 = await ethers.getContractFactory("PoSeManagerV2")
-  const poseV2 = await PoSeManagerV2.deploy()
-  await poseV2.waitForDeployment()
-  const addr = await poseV2.getAddress()
-  console.log(`  PoSeManagerV2: ${addr}`)
+  console.log("Compiling and validating new PoSeManagerV2 implementation against stored layout...")
+  const NewFactory = await ethers.getContractFactory("PoSeManagerV2")
 
-  // #685: initialize immediately so DOMAIN_SEPARATOR / challengeBondMin are
-  // non-zero. verifyingContract is the contract's own address — the off-chain
-  // witness signers (runtime/coc-node.ts) build the EIP-712 domain from it too.
-  const challengeBondMin = process.env.POSE_CHALLENGE_BOND_MIN
-    ? BigInt(process.env.POSE_CHALLENGE_BOND_MIN)
-    : ethers.parseEther("0.1")
-  const initTx = await poseV2.initialize(network.chainId, addr, challengeBondMin)
-  await initTx.wait()
-  console.log(`  PoSeManagerV2.initialize() done (challengeBondMin=${challengeBondMin})`)
+  // upgradeProxy will:
+  //   1. validate storage layout against contracts/.openzeppelin/coc-88780.json
+  //   2. deploy the new implementation if its bytecode hash differs
+  //   3. call proxy.upgradeToAndCall(newImpl, "") — this requires the caller
+  //      to be the proxy's `owner` (multisig in gen-5). If the deployer is
+  //      not the owner the tx reverts with OnlyOwner.
+  const upgraded = await upgrades.upgradeProxy(proxyAddr, NewFactory, { kind: "uups" })
+  await upgraded.waitForDeployment()
 
-  // Post-deploy verification
-  const code = await ethers.provider.getCode(addr)
-  const initialized = await poseV2.initialized()
-  const domainSeparator = await poseV2.DOMAIN_SEPARATOR()
+  const code = await ethers.provider.getCode(proxyAddr)
+  const initialized = await upgraded.initialized()
+  const challengeBondMin = await upgraded.challengeBondMin()
   console.log("")
-  console.log("Verification:")
-  console.log(`  code size:        ${(code.length - 2) / 2} bytes`)
-  console.log(`  initialized:      ${initialized}`)
-  console.log(`  DOMAIN_SEPARATOR: ${domainSeparator}`)
-  if (code === "0x" || !initialized || domainSeparator === ethers.ZeroHash) {
-    console.error("FAIL: post-deploy verification failed")
+  console.log("Upgrade verification:")
+  console.log(`  proxy code size:  ${(code.length - 2) / 2} bytes`)
+  console.log(`  initialized:      ${initialized}  (should remain true post-upgrade)`)
+  console.log(`  challengeBondMin: ${challengeBondMin}`)
+
+  if (code === "0x" || !initialized) {
+    console.error("FAIL: post-upgrade verification failed")
     process.exit(1)
   }
 
-  // #686: hand ownership to the multisig if configured.
-  const multisig = process.env.MULTISIG_ADDRESS
-  if (multisig) {
-    console.log("")
-    await transferOwnershipChecked(poseV2, "PoSeManagerV2", multisig)
-  } else {
-    console.log("")
-    console.log("WARNING: MULTISIG_ADDRESS not set — PoSeManagerV2 remains owned")
-    console.log("         by the deployer (#686 not resolved).")
-  }
-
   console.log("")
-  console.log(`NEW_POSEMANAGERV2=${addr}`)
+  console.log("PoSeManagerV2 upgraded in-place; proxy address unchanged.")
+  console.log(`POSEV2_PROXY=${proxyAddr}`)
 }
 
 main().catch((err) => {

--- a/contracts/test/DIDRegistry.test.cjs
+++ b/contracts/test/DIDRegistry.test.cjs
@@ -6,7 +6,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const { malleateSignature } = require("./signature-utils.cjs")
 
 // ---------------------------------------------------------------------------
@@ -126,13 +126,22 @@ async function mineSeconds(seconds) {
 // ---------------------------------------------------------------------------
 
 async function deployContracts() {
+  const [deployer] = await ethers.getSigners()
   const SoulFactory = await ethers.getContractFactory("SoulRegistry")
-  const soulRegistry = await SoulFactory.deploy()
+  const soulRegistry = await upgrades.deployProxy(
+    SoulFactory,
+    [deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await soulRegistry.waitForDeployment()
   const soulAddress = await soulRegistry.getAddress()
 
   const DIDFactory = await ethers.getContractFactory("DIDRegistry")
-  const didRegistry = await DIDFactory.deploy(soulAddress)
+  const didRegistry = await upgrades.deployProxy(
+    DIDFactory,
+    [soulAddress, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await didRegistry.waitForDeployment()
   const didAddress = await didRegistry.getAddress()
 
@@ -180,7 +189,11 @@ describe("DIDRegistry", function () {
     it("should reject zero SoulRegistry address", async function () {
       const DIDFactory = await ethers.getContractFactory("DIDRegistry")
       await expect(
-        DIDFactory.deploy(ethers.ZeroAddress)
+        upgrades.deployProxy(
+          DIDFactory,
+          [ethers.ZeroAddress, owner.address],
+          { initializer: "initialize", kind: "uups" },
+        ),
       ).to.be.revertedWithCustomError(didRegistry, "ZeroAddress")
     })
   })

--- a/contracts/test/EquivocationDetector.test.cjs
+++ b/contracts/test/EquivocationDetector.test.cjs
@@ -17,7 +17,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 const MIN_STAKE = ethers.parseEther("32")
 const SLASH_BPS = 1000n
@@ -41,11 +41,19 @@ async function deployStack() {
   const signers = await ethers.getSigners()
   const owner = signers[0]
   const RegistryFactory = await ethers.getContractFactory("ValidatorRegistry")
-  const registry = await RegistryFactory.deploy()
+  const registry = await upgrades.deployProxy(
+    RegistryFactory,
+    [owner.address, owner.address, owner.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await registry.waitForDeployment()
 
   const DetectorFactory = await ethers.getContractFactory("EquivocationDetector")
-  const detector = await DetectorFactory.deploy(await registry.getAddress())
+  const detector = await upgrades.deployProxy(
+    DetectorFactory,
+    [await registry.getAddress(), owner.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await detector.waitForDeployment()
 
   // Wire detector as the registry's slasher so it can call slashValidator.
@@ -67,12 +75,16 @@ describe("EquivocationDetector: deployment", () => {
     expect(await detector.slashCooldownBlocks()).to.equal(1000n)
   })
 
-  it("rejects zero-address registry in constructor", async () => {
+  it("rejects zero-address registry in initialize", async () => {
+    const [deployer] = await ethers.getSigners()
     const Factory = await ethers.getContractFactory("EquivocationDetector")
-    await expect(Factory.deploy(ethers.ZeroAddress)).to.be.revertedWithCustomError(
-      Factory,
-      "ZeroAddress",
-    )
+    await expect(
+      upgrades.deployProxy(
+        Factory,
+        [ethers.ZeroAddress, deployer.address],
+        { initializer: "initialize", kind: "uups" },
+      ),
+    ).to.be.revertedWithCustomError(Factory, "ZeroAddress")
   })
 })
 

--- a/contracts/test/InsuranceFund.test.cjs
+++ b/contracts/test/InsuranceFund.test.cjs
@@ -9,11 +9,16 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 async function deployFund(initialGovernance) {
+  const [deployer] = await ethers.getSigners()
   const Factory = await ethers.getContractFactory("InsuranceFund")
-  const fund = await Factory.deploy(initialGovernance)
+  const fund = await upgrades.deployProxy(
+    Factory,
+    [initialGovernance, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await fund.waitForDeployment()
   return fund
 }
@@ -28,8 +33,15 @@ async function installRejectingReceiverCode(address) {
 
 describe("InsuranceFund: deployment", () => {
   it("rejects zero-address governance", async () => {
+    const [deployer] = await ethers.getSigners()
     const Factory = await ethers.getContractFactory("InsuranceFund")
-    await expect(Factory.deploy(ethers.ZeroAddress)).to.be.revertedWithCustomError(Factory, "ZeroAddress")
+    await expect(
+      upgrades.deployProxy(
+        Factory,
+        [ethers.ZeroAddress, deployer.address],
+        { initializer: "initialize", kind: "uups" },
+      ),
+    ).to.be.revertedWithCustomError(Factory, "ZeroAddress")
   })
 
   it("constructor sets governance", async () => {

--- a/contracts/test/SoulRegistry.test.cjs
+++ b/contracts/test/SoulRegistry.test.cjs
@@ -6,7 +6,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 // ---------------------------------------------------------------------------
 //  EIP-712 Helpers
@@ -73,8 +73,13 @@ function extractEventArg(receipt, eventName, index = 0) {
 }
 
 async function deploySoulRegistry() {
+  const [deployer] = await ethers.getSigners()
   const Factory = await ethers.getContractFactory("SoulRegistry")
-  const registry = await Factory.deploy()
+  const registry = await upgrades.deployProxy(
+    Factory,
+    [deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await registry.waitForDeployment()
   const address = await registry.getAddress()
   const network = await ethers.provider.getNetwork()

--- a/contracts/test/ValidatorRegistry.test.cjs
+++ b/contracts/test/ValidatorRegistry.test.cjs
@@ -15,7 +15,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 // ---------------------------------------------------------------------------
 //  Helpers
@@ -50,7 +50,11 @@ async function deployRegistry() {
   const signers = await ethers.getSigners()
   const owner = signers[0]
   const Factory = await ethers.getContractFactory("ValidatorRegistry")
-  const registry = await Factory.deploy()
+  const registry = await upgrades.deployProxy(
+    Factory,
+    [owner.address, owner.address, owner.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await registry.waitForDeployment()
   // `signers` doubles as funder pool; tests that need named extras (e.g.
   // a stranger to assert revert) take from the tail.
@@ -452,7 +456,11 @@ describe("ValidatorRegistry: Phase I5 — slash split when insuranceFund set", (
     const { registry, owner, signers } = await deployRegistry()
     const reporter = signers[1]
     const InsuranceFundFactory = await ethers.getContractFactory("InsuranceFund")
-    const insuranceFund = await InsuranceFundFactory.deploy(owner.address)
+    const insuranceFund = await upgrades.deployProxy(
+      InsuranceFundFactory,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await insuranceFund.waitForDeployment()
 
     // Wire: slashRecipient = reporter; insuranceFund = the new contract.

--- a/contracts/test/coc-token.test.cjs
+++ b/contracts/test/coc-token.test.cjs
@@ -1,5 +1,5 @@
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 describe("COCToken", function () {
   let token
@@ -10,7 +10,11 @@ describe("COCToken", function () {
     ;[owner, minter] = await ethers.getSigners()
 
     const Factory = await ethers.getContractFactory("COCToken")
-    token = await Factory.deploy([owner.address], [ethers.parseEther("250000000")])
+    token = await upgrades.deployProxy(
+      Factory,
+      [[owner.address], [ethers.parseEther("250000000")], owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await token.waitForDeployment()
   })
 

--- a/contracts/test/contract-ownership.test.cjs
+++ b/contracts/test/contract-ownership.test.cjs
@@ -4,13 +4,26 @@
  * Every governance / settlement contract that has an onlyOwner-gated admin
  * surface must be able to hand ownership to a multisig — otherwise the owner
  * is permanently stuck on the deploy key (which on 88780 was a public Hardhat
- * test account). This verifies transferOwnership on each contract that had it
- * added: owner can transfer, non-owner is rejected, the zero address is
- * rejected, and admin power follows the new owner.
+ * test account). Verifies transferOwnership on each contract: owner can
+ * transfer, non-owner rejected, zero address rejected, admin power follows
+ * the new owner.
+ *
+ * Updated for gen-5 UUPS: every contract is deployed through
+ * upgrades.deployProxy with the new `initialize(...)` signature.
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
+
+async function deploy(factoryName, args) {
+  const Factory = await ethers.getContractFactory(factoryName)
+  const proxy = await upgrades.deployProxy(Factory, args, {
+    initializer: "initialize",
+    kind: "uups",
+  })
+  await proxy.waitForDeployment()
+  return proxy
+}
 
 describe("Contract ownership transfer (#686)", function () {
   let deployer, newOwner, outsider
@@ -22,8 +35,7 @@ describe("Contract ownership transfer (#686)", function () {
   describe("FactionRegistry", function () {
     let c
     beforeEach(async function () {
-      c = await (await ethers.getContractFactory("FactionRegistry")).deploy()
-      await c.waitForDeployment()
+      c = await deploy("FactionRegistry", [deployer.address, deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {
@@ -56,12 +68,8 @@ describe("Contract ownership transfer (#686)", function () {
   describe("GovernanceDAO", function () {
     let c
     beforeEach(async function () {
-      const fr = await (await ethers.getContractFactory("FactionRegistry")).deploy()
-      await fr.waitForDeployment()
-      c = await (await ethers.getContractFactory("GovernanceDAO")).deploy(
-        await fr.getAddress(),
-      )
-      await c.waitForDeployment()
+      const fr = await deploy("FactionRegistry", [deployer.address, deployer.address])
+      c = await deploy("GovernanceDAO", [await fr.getAddress(), deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {
@@ -86,11 +94,7 @@ describe("Contract ownership transfer (#686)", function () {
     beforeEach(async function () {
       const accounts = await ethers.getSigners()
       const signers = accounts.slice(3, 8).map((s) => s.address)
-      c = await (await ethers.getContractFactory("Treasury")).deploy(
-        signers,
-        deployer.address,
-      )
-      await c.waitForDeployment()
+      c = await deploy("Treasury", [signers, deployer.address, deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {
@@ -113,11 +117,7 @@ describe("Contract ownership transfer (#686)", function () {
   describe("DelayedInbox", function () {
     let c
     beforeEach(async function () {
-      c = await (await ethers.getContractFactory("DelayedInbox")).deploy(
-        3600,
-        deployer.address,
-      )
-      await c.waitForDeployment()
+      c = await deploy("DelayedInbox", [3600, deployer.address, deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {
@@ -140,8 +140,7 @@ describe("Contract ownership transfer (#686)", function () {
   describe("PoSeManager (v1)", function () {
     let c
     beforeEach(async function () {
-      c = await (await ethers.getContractFactory("PoSeManager")).deploy()
-      await c.waitForDeployment()
+      c = await deploy("PoSeManager", [deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {
@@ -164,8 +163,7 @@ describe("Contract ownership transfer (#686)", function () {
   describe("PoSeManagerV2", function () {
     let c
     beforeEach(async function () {
-      c = await (await ethers.getContractFactory("PoSeManagerV2")).deploy()
-      await c.waitForDeployment()
+      c = await deploy("PoSeManagerV2", [ethers.parseEther("0.1"), deployer.address])
     })
 
     it("transfers ownership and emits OwnerUpdated", async function () {

--- a/contracts/test/delayed-inbox.test.cjs
+++ b/contracts/test/delayed-inbox.test.cjs
@@ -9,7 +9,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 // Short inclusion delay for testing (120 seconds)
 const INCLUSION_DELAY = 120
@@ -22,7 +22,11 @@ describe("DelayedInbox", function () {
     ;[deployer, sequencer, user1, user2] = await ethers.getSigners()
 
     const Factory = await ethers.getContractFactory("DelayedInbox")
-    inbox = await Factory.deploy(INCLUSION_DELAY, sequencer.address)
+    inbox = await upgrades.deployProxy(
+      Factory,
+      [INCLUSION_DELAY, sequencer.address, deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await inbox.waitForDeployment()
   })
 

--- a/contracts/test/did-delegation-chain-revocation.test.cjs
+++ b/contracts/test/did-delegation-chain-revocation.test.cjs
@@ -12,7 +12,7 @@
  * MAX_DELEGATION_DEPTH); `grantDelegation()` rejects a globally-revoked parent.
  */
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 const SOUL_DOMAIN = { name: "COCSoulRegistry", version: "1" }
 const DID_DOMAIN = { name: "COCDIDRegistry", version: "1" }
@@ -85,10 +85,18 @@ describe("Security: DIDRegistry delegation chain revocation", function () {
   beforeEach(async function () {
     ;[ownerA, ownerB] = await ethers.getSigners()
     const Soul = await ethers.getContractFactory("SoulRegistry")
-    soul = await Soul.deploy()
+    soul = await upgrades.deployProxy(
+      Soul,
+      [ownerA.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await soul.waitForDeployment()
     const Did = await ethers.getContractFactory("DIDRegistry")
-    did = await Did.deploy(await soul.getAddress())
+    did = await upgrades.deployProxy(
+      Did,
+      [await soul.getAddress(), ownerA.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await did.waitForDeployment()
     const net = await ethers.provider.getNetwork()
     soulDomain = { ...SOUL_DOMAIN, chainId: net.chainId, verifyingContract: await soul.getAddress() }

--- a/contracts/test/equivocation-evidence-replay.test.cjs
+++ b/contracts/test/equivocation-evidence-replay.test.cjs
@@ -14,7 +14,7 @@
  * slash, forever.
  */
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 const MIN_STAKE = ethers.parseEther("32")
 
@@ -30,10 +30,16 @@ async function makeOperator(funder) {
 
 async function deployStack() {
   const [owner] = await ethers.getSigners()
-  const registry = await (await ethers.getContractFactory("ValidatorRegistry")).deploy()
+  const registry = await upgrades.deployProxy(
+    await ethers.getContractFactory("ValidatorRegistry"),
+    [owner.address, owner.address, owner.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await registry.waitForDeployment()
-  const detector = await (await ethers.getContractFactory("EquivocationDetector")).deploy(
-    await registry.getAddress(),
+  const detector = await upgrades.deployProxy(
+    await ethers.getContractFactory("EquivocationDetector"),
+    [await registry.getAddress(), owner.address],
+    { initializer: "initialize", kind: "uups" },
   )
   await detector.waitForDeployment()
   await registry.connect(owner).setSlasher(await detector.getAddress())

--- a/contracts/test/foundation-vesting.test.cjs
+++ b/contracts/test/foundation-vesting.test.cjs
@@ -3,11 +3,16 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 async function deployVesting(beneficiary) {
+  const [deployer] = await ethers.getSigners()
   const Factory = await ethers.getContractFactory("FoundationVesting")
-  const vesting = await Factory.deploy(beneficiary)
+  const vesting = await upgrades.deployProxy(
+    Factory,
+    [beneficiary, deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
   await vesting.waitForDeployment()
   return vesting
 }

--- a/contracts/test/gas-benchmarks.test.cjs
+++ b/contracts/test/gas-benchmarks.test.cjs
@@ -6,14 +6,19 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 describe("Gas Benchmarks: FactionRegistry", function () {
   let registry
 
   beforeEach(async function () {
+    const [owner] = await ethers.getSigners()
     const FactionRegistry = await ethers.getContractFactory("FactionRegistry")
-    registry = await FactionRegistry.deploy()
+    registry = await upgrades.deployProxy(
+      FactionRegistry,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await registry.waitForDeployment()
   })
 
@@ -49,19 +54,30 @@ describe("Gas Benchmarks: GovernanceDAO", function () {
   let dao, registry
 
   beforeEach(async function () {
+    const [owner] = await ethers.getSigners()
     const FactionRegistry = await ethers.getContractFactory("FactionRegistry")
-    registry = await FactionRegistry.deploy()
+    registry = await upgrades.deployProxy(
+      FactionRegistry,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await registry.waitForDeployment()
 
     const GovernanceDAO = await ethers.getContractFactory("GovernanceDAO")
-    dao = await GovernanceDAO.deploy(await registry.getAddress())
+    dao = await upgrades.deployProxy(
+      GovernanceDAO,
+      [await registry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await dao.waitForDeployment()
 
-    const [owner] = await ethers.getSigners()
     await registry.connect(owner).registerHuman()
   })
 
-  it("createProposal gas < 250k", async function () {
+  it("createProposal gas < 270k", async function () {
+    // Budget bumped from 250k → 270k in gen-5: GovernanceDAO.createProposal
+    // now writes humanSnapshot + clawSnapshot per proposal (#706 / #705) for
+    // the silent-faction bicameral check, adding ~2 SSTOREs per call.
     const tx = await dao.createProposal(
       0, // ValidatorAdd
       "Benchmark proposal",
@@ -71,7 +87,7 @@ describe("Gas Benchmarks: GovernanceDAO", function () {
       0
     )
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.be.lessThan(250000n)
+    expect(receipt.gasUsed).to.be.lessThan(270000n)
   })
 
   it("vote gas < 120k", async function () {
@@ -93,12 +109,16 @@ describe("Gas Benchmarks: PoSeManager", function () {
   let manager, owner, operator
 
   beforeEach(async function () {
-    const PoSeManager = await ethers.getContractFactory("PoSeManager")
-    manager = await PoSeManager.deploy()
-    await manager.waitForDeployment()
-
     const [signer] = await ethers.getSigners()
     owner = signer
+    const PoSeManager = await ethers.getContractFactory("PoSeManager")
+    manager = await upgrades.deployProxy(
+      PoSeManager,
+      [owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await manager.waitForDeployment()
+
     operator = ethers.Wallet.createRandom().connect(ethers.provider)
     await owner.sendTransaction({ to: operator.address, value: ethers.parseEther("5") })
   })
@@ -161,7 +181,11 @@ describe("Gas Benchmarks: Treasury", function () {
     const signers = await ethers.getSigners()
     const signerAddrs = signers.slice(0, 5).map(s => s.address)
     const Treasury = await ethers.getContractFactory("Treasury")
-    treasury = await Treasury.deploy(signerAddrs, signers[0].address)
+    treasury = await upgrades.deployProxy(
+      Treasury,
+      [signerAddrs, signers[0].address, signers[0].address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await treasury.waitForDeployment()
   })
 

--- a/contracts/test/governance-lifecycle.test.cjs
+++ b/contracts/test/governance-lifecycle.test.cjs
@@ -14,7 +14,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 describe("Governance Lifecycle: Prowl Testnet Proposals", function () {
   let dao, registry, treasury
@@ -24,17 +24,29 @@ describe("Governance Lifecycle: Prowl Testnet Proposals", function () {
     ;[owner, human1, human2, human3, human4, human5] = await ethers.getSigners()
 
     const FactionRegistry = await ethers.getContractFactory("FactionRegistry")
-    registry = await FactionRegistry.deploy()
+    registry = await upgrades.deployProxy(
+      FactionRegistry,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await registry.waitForDeployment()
 
     const GovernanceDAO = await ethers.getContractFactory("GovernanceDAO")
-    dao = await GovernanceDAO.deploy(await registry.getAddress())
+    dao = await upgrades.deployProxy(
+      GovernanceDAO,
+      [await registry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await dao.waitForDeployment()
 
     const Treasury = await ethers.getContractFactory("Treasury")
     const signers5 = await ethers.getSigners()
     const signerAddrs = signers5.slice(0, 5).map(s => s.address)
-    treasury = await Treasury.deploy(signerAddrs, await dao.getAddress())
+    treasury = await upgrades.deployProxy(
+      Treasury,
+      [signerAddrs, await dao.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await treasury.waitForDeployment()
     await dao.setTreasury(await treasury.getAddress())
 

--- a/contracts/test/governance-quorum-snapshot.test.cjs
+++ b/contracts/test/governance-quorum-snapshot.test.cjs
@@ -10,7 +10,7 @@
  * Fix: snapshot the registered count into the Proposal at createProposal().
  */
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 async function advanceTime(seconds) {
   await ethers.provider.send("evm_increaseTime", [seconds])
@@ -27,12 +27,21 @@ describe("Security: GovernanceDAO quorum snapshot", function () {
     attacker = all[4]
     sybils = all.slice(5, 25) // 20 sybil accounts the attacker controls
 
+    const owner = all[0]
     const FR = await ethers.getContractFactory("FactionRegistry")
-    factionRegistry = await FR.deploy()
+    factionRegistry = await upgrades.deployProxy(
+      FR,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await factionRegistry.waitForDeployment()
 
     const DAO = await ethers.getContractFactory("GovernanceDAO")
-    dao = await DAO.deploy(await factionRegistry.getAddress())
+    dao = await upgrades.deployProxy(
+      DAO,
+      [await factionRegistry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await dao.waitForDeployment()
 
     for (const m of members) {

--- a/contracts/test/governance.test.cjs
+++ b/contracts/test/governance.test.cjs
@@ -1,5 +1,5 @@
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 describe("Governance Contracts", function () {
   let factionRegistry, governanceDAO, treasury
@@ -8,24 +8,32 @@ describe("Governance Contracts", function () {
   beforeEach(async function () {
     ;[owner, human1, human2, claw1, claw2] = await ethers.getSigners()
 
-    // Deploy FactionRegistry
     const FactionRegistry = await ethers.getContractFactory("FactionRegistry")
-    factionRegistry = await FactionRegistry.deploy()
+    factionRegistry = await upgrades.deployProxy(
+      FactionRegistry,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await factionRegistry.waitForDeployment()
 
-    // Deploy GovernanceDAO
     const GovernanceDAO = await ethers.getContractFactory("GovernanceDAO")
-    governanceDAO = await GovernanceDAO.deploy(await factionRegistry.getAddress())
+    governanceDAO = await upgrades.deployProxy(
+      GovernanceDAO,
+      [await factionRegistry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await governanceDAO.waitForDeployment()
 
-    // Deploy Treasury (3/5 multisig)
     const Treasury = await ethers.getContractFactory("Treasury")
     const signers5 = await ethers.getSigners()
     const signerAddrs = signers5.slice(0, 5).map(s => s.address)
-    treasury = await Treasury.deploy(signerAddrs, await governanceDAO.getAddress())
+    treasury = await upgrades.deployProxy(
+      Treasury,
+      [signerAddrs, await governanceDAO.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await treasury.waitForDeployment()
 
-    // Set treasury in governance
     await governanceDAO.setTreasury(await treasury.getAddress())
   })
 

--- a/contracts/test/pose-coverage.test.cjs
+++ b/contracts/test/pose-coverage.test.cjs
@@ -15,7 +15,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const { malleateSignature } = require("./signature-utils.cjs")
 
 // Helper: register a node from a random wallet with proper ownership sig
@@ -93,7 +93,11 @@ describe("PoSeManager: Extended Coverage", function () {
   beforeEach(async function () {
     ;[owner] = await ethers.getSigners()
     const PoSeManager = await ethers.getContractFactory("PoSeManager")
-    manager = await PoSeManager.deploy()
+    manager = await upgrades.deployProxy(
+      PoSeManager,
+      [owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await manager.waitForDeployment()
   })
 

--- a/contracts/test/pose-v2-e2e.test.cjs
+++ b/contracts/test/pose-v2-e2e.test.cjs
@@ -10,7 +10,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 // ---------------------------------------------------------------------------
 //  Helpers (mirror TypeScript off-chain libraries)
@@ -177,11 +177,12 @@ describe("PoSe v2 E2E: Full Protocol Lifecycle", function () {
     deployer = signers[0]
 
     const Factory = await ethers.getContractFactory("PoSeManagerV2")
-    manager = await Factory.deploy()
+    manager = await upgrades.deployProxy(
+      Factory,
+      [ethers.parseEther("0.01"), deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await manager.waitForDeployment()
-
-    const chainId = (await ethers.provider.getNetwork()).chainId
-    await manager.initialize(chainId, await manager.getAddress(), ethers.parseEther("0.01"))
     await manager.setAllowEmptyWitnessSubmission(true)
   })
 

--- a/contracts/test/pose-v2.test.cjs
+++ b/contracts/test/pose-v2.test.cjs
@@ -14,7 +14,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const { malleateSignature } = require("./signature-utils.cjs")
 
 // Register a node on PoSeManagerV2
@@ -217,12 +217,12 @@ describe("PoSeManagerV2", function () {
     deployer = signers[0]
 
     const Factory = await ethers.getContractFactory("PoSeManagerV2")
-    manager = await Factory.deploy()
+    manager = await upgrades.deployProxy(
+      Factory,
+      [ethers.parseEther("0.01"), deployer.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await manager.waitForDeployment()
-
-    // Initialize with EIP-712 domain
-    const chainId = (await ethers.provider.getNetwork()).chainId
-    await manager.initialize(chainId, await manager.getAddress(), ethers.parseEther("0.01"))
 
     // Enable empty witness for most tests (strict mode tested separately)
     await manager.setAllowEmptyWitnessSubmission(true)
@@ -230,33 +230,32 @@ describe("PoSeManagerV2", function () {
 
   describe("initialize", function () {
     it("rejects repeated initialization", async function () {
-      const chainId = (await ethers.provider.getNetwork()).chainId
-
+      // OZ Initializable surfaces re-init attempts as InvalidInitialization().
       await expect(
-        manager.initialize(chainId, await manager.getAddress(), ethers.parseEther("0.01"))
-      ).to.be.revertedWithCustomError(manager, "AlreadyInitialized")
+        manager.initialize(ethers.parseEther("0.01"), deployer.address)
+      ).to.be.revertedWithCustomError(manager, "InvalidInitialization")
     })
 
-    it("rejects a zero verifying contract", async function () {
+    it("rejects a zero initial owner", async function () {
       const Factory = await ethers.getContractFactory("PoSeManagerV2")
-      const fresh = await Factory.deploy()
-      await fresh.waitForDeployment()
-      const chainId = (await ethers.provider.getNetwork()).chainId
-
       await expect(
-        fresh.initialize(chainId, ethers.ZeroAddress, ethers.parseEther("0.01"))
-      ).to.be.revertedWithCustomError(fresh, "ZeroAddress")
+        upgrades.deployProxy(
+          Factory,
+          [ethers.parseEther("0.01"), ethers.ZeroAddress],
+          { initializer: "initialize", kind: "uups" },
+        ),
+      ).to.be.revertedWithCustomError(Factory, "ZeroAddress")
     })
 
     it("rejects a zero challenge bond minimum", async function () {
       const Factory = await ethers.getContractFactory("PoSeManagerV2")
-      const fresh = await Factory.deploy()
-      await fresh.waitForDeployment()
-      const chainId = (await ethers.provider.getNetwork()).chainId
-
       await expect(
-        fresh.initialize(chainId, await fresh.getAddress(), 0)
-      ).to.be.revertedWithCustomError(fresh, "BondTooLow")
+        upgrades.deployProxy(
+          Factory,
+          [0, deployer.address],
+          { initializer: "initialize", kind: "uups" },
+        ),
+      ).to.be.revertedWithCustomError(Factory, "BondTooLow")
     })
 
     it("rejects lowering challenge bond minimum to zero", async function () {
@@ -1042,7 +1041,11 @@ describe("PoSeManagerV2", function () {
       await registerNode(manager, deployer)
 
       const Token = await ethers.getContractFactory("COCToken")
-      const token = await Token.deploy([deployer.address], [ethers.parseEther("250000000")])
+      const token = await upgrades.deployProxy(
+        Token,
+        [[deployer.address], [ethers.parseEther("250000000")], deployer.address],
+        { initializer: "initialize", kind: "uups" },
+      )
       await token.waitForDeployment()
       await token.setMinter(await manager.getAddress())
       await manager.enableEmission(await token.getAddress(), 0)

--- a/contracts/test/rollup-resolve-reentrancy.test.cjs
+++ b/contracts/test/rollup-resolve-reentrancy.test.cjs
@@ -14,7 +14,7 @@
  * Fix: CEI — delete the output (and reset lastSubmittedBlock) before transfers.
  */
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 const CHALLENGE_WINDOW = 1000
 const PROPOSER_BOND = ethers.parseEther("1")
@@ -28,12 +28,17 @@ describe("Security: RollupStateManager resolveChallenge reentrancy", function ()
   beforeEach(async function () {
     ;[deployer, proposer, insuranceFund] = await ethers.getSigners()
 
-    manager = await (await ethers.getContractFactory("RollupStateManager")).deploy(
-      CHALLENGE_WINDOW,
-      PROPOSER_BOND,
-      CHALLENGER_BOND,
-      insuranceFund.address,
-      proposer.address,
+    manager = await upgrades.deployProxy(
+      await ethers.getContractFactory("RollupStateManager"),
+      [
+        CHALLENGE_WINDOW,
+        PROPOSER_BOND,
+        CHALLENGER_BOND,
+        insuranceFund.address,
+        proposer.address,
+        deployer.address,
+      ],
+      { initializer: "initialize", kind: "uups" },
     )
     await manager.waitForDeployment()
 

--- a/contracts/test/rollup-state-manager.test.cjs
+++ b/contracts/test/rollup-state-manager.test.cjs
@@ -11,7 +11,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 // Short challenge window for testing (60 seconds)
 const CHALLENGE_WINDOW = 60
@@ -28,12 +28,17 @@ describe("RollupStateManager", function () {
     ;[deployer, proposer, challenger, insuranceFund] = await ethers.getSigners()
 
     const Factory = await ethers.getContractFactory("RollupStateManager")
-    manager = await Factory.deploy(
-      CHALLENGE_WINDOW,
-      PROPOSER_BOND,
-      CHALLENGER_BOND,
-      insuranceFund.address,
-      proposer.address,
+    manager = await upgrades.deployProxy(
+      Factory,
+      [
+        CHALLENGE_WINDOW,
+        PROPOSER_BOND,
+        CHALLENGER_BOND,
+        insuranceFund.address,
+        proposer.address,
+        deployer.address,
+      ],
+      { initializer: "initialize", kind: "uups" },
     )
     await manager.waitForDeployment()
 

--- a/contracts/test/security-audit.test.cjs
+++ b/contracts/test/security-audit.test.cjs
@@ -8,7 +8,7 @@
  */
 
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 const { malleateSignature } = require("./signature-utils.cjs")
 
 // Helper: register a PoSe node for an operator wallet
@@ -72,7 +72,11 @@ describe("Security: FactionRegistry", function () {
   beforeEach(async function () {
     ;[owner, user1, user2] = await ethers.getSigners()
     const F = await ethers.getContractFactory("FactionRegistry")
-    registry = await F.deploy()
+    registry = await upgrades.deployProxy(
+      F,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await registry.waitForDeployment()
   })
 
@@ -176,17 +180,29 @@ describe("Security: GovernanceDAO", function () {
     ;[owner, human1, human2, claw1, claw2, outsider] = await ethers.getSigners()
 
     const FR = await ethers.getContractFactory("FactionRegistry")
-    factionRegistry = await FR.deploy()
+    factionRegistry = await upgrades.deployProxy(
+      FR,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await factionRegistry.waitForDeployment()
 
     const DAO = await ethers.getContractFactory("GovernanceDAO")
-    dao = await DAO.deploy(await factionRegistry.getAddress())
+    dao = await upgrades.deployProxy(
+      DAO,
+      [await factionRegistry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await dao.waitForDeployment()
 
     const T = await ethers.getContractFactory("Treasury")
     const signers5 = await ethers.getSigners()
     const signerAddrs = [signers5[0].address, signers5[1].address, signers5[2].address, signers5[3].address, signers5[4].address]
-    treasury = await T.deploy(signerAddrs, await dao.getAddress())
+    treasury = await upgrades.deployProxy(
+      T,
+      [signerAddrs, await dao.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await treasury.waitForDeployment()
 
     await dao.setTreasury(await treasury.getAddress())
@@ -378,11 +394,19 @@ describe("Security: GovernanceDAO", function () {
   it("bicameral: empty faction auto-approves (design note)", async function () {
     // Only register humans, no claws in this separate setup
     const FR2 = await ethers.getContractFactory("FactionRegistry")
-    const reg2 = await FR2.deploy()
+    const reg2 = await upgrades.deployProxy(
+      FR2,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await reg2.waitForDeployment()
 
     const DAO2 = await ethers.getContractFactory("GovernanceDAO")
-    const dao2 = await DAO2.deploy(await reg2.getAddress())
+    const dao2 = await upgrades.deployProxy(
+      DAO2,
+      [await reg2.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await dao2.waitForDeployment()
 
     await dao2.setBicameralEnabled(true)
@@ -439,21 +463,33 @@ describe("Security: Treasury", function () {
     ;[owner, user1, signer2, signer3, signer4, signer5] = await ethers.getSigners()
     T = await ethers.getContractFactory("Treasury")
     const signerAddrs = [owner.address, user1.address, signer2.address, signer3.address, signer4.address]
-    treasury = await T.deploy(signerAddrs, owner.address) // owner as governance
+    treasury = await upgrades.deployProxy(
+      T,
+      [signerAddrs, owner.address, owner.address], // owner as governance + initialOwner
+      { initializer: "initialize", kind: "uups" },
+    )
     await treasury.waitForDeployment()
   })
 
   it("rejects duplicate multisig signers at deployment", async function () {
     const signerAddrs = [owner.address, user1.address, signer2.address, signer3.address, owner.address]
     await expect(
-      T.deploy(signerAddrs, owner.address)
+      upgrades.deployProxy(
+        T,
+        [signerAddrs, owner.address, owner.address],
+        { initializer: "initialize", kind: "uups" },
+      ),
     ).to.be.revertedWithCustomError(treasury, "DuplicateSigner")
   })
 
   it("rejects zero governance at deployment and update time", async function () {
     const signerAddrs = [owner.address, user1.address, signer2.address, signer3.address, signer4.address]
     await expect(
-      T.deploy(signerAddrs, ethers.ZeroAddress)
+      upgrades.deployProxy(
+        T,
+        [signerAddrs, ethers.ZeroAddress, owner.address],
+        { initializer: "initialize", kind: "uups" },
+      ),
     ).to.be.revertedWithCustomError(treasury, "ZeroAddress")
 
     await expect(
@@ -565,7 +601,11 @@ describe("Security: PoSeManager", function () {
     ;[owner] = await ethers.getSigners()
 
     const PoSeManager = await ethers.getContractFactory("PoSeManager")
-    pose = await PoSeManager.deploy()
+    pose = await upgrades.deployProxy(
+      PoSeManager,
+      [owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await pose.waitForDeployment()
 
     operator1 = ethers.Wallet.createRandom().connect(ethers.provider)

--- a/contracts/test/soul-registry-stale-recovery.test.cjs
+++ b/contracts/test/soul-registry-stale-recovery.test.cjs
@@ -14,7 +14,7 @@
  * registration and refuses inactive souls.
  */
 const { expect } = require("chai")
-const { ethers } = require("hardhat")
+const { ethers, upgrades } = require("hardhat")
 
 const DOMAIN_NAME = "COCSoulRegistry"
 const DOMAIN_VERSION = "1"
@@ -49,7 +49,11 @@ describe("Security: SoulRegistry stale recovery state", function () {
   beforeEach(async function () {
     ;[alice, bob, guardian, guardian2, attacker] = await ethers.getSigners()
     const Factory = await ethers.getContractFactory("SoulRegistry")
-    registry = await Factory.deploy()
+    registry = await upgrades.deployProxy(
+      Factory,
+      [alice.address],
+      { initializer: "initialize", kind: "uups" },
+    )
     await registry.waitForDeployment()
     const net = await ethers.provider.getNetwork()
     domain = { name: DOMAIN_NAME, version: DOMAIN_VERSION, chainId: net.chainId, verifyingContract: await registry.getAddress() }

--- a/contracts/test/uups-upgrade-safety.test.cjs
+++ b/contracts/test/uups-upgrade-safety.test.cjs
@@ -1,0 +1,192 @@
+/**
+ * UUPS upgrade-safety regressions (gen-5).
+ *
+ * Two guarantees this test set locks in:
+ *
+ * 1) Storage layout: every UUPS contract can be re-deployed and then
+ *    upgradeProxy'd back onto the same implementation without the OZ
+ *    upgrades plugin flagging an incompatible layout. Because the plugin's
+ *    validator runs on every deployProxy/upgradeProxy call, just exercising
+ *    the path on each contract proves the implementation's storage shape
+ *    is well-formed (no `__gap` errors, no unsafe-allow markers needed
+ *    beyond the locked-constructor one already declared in source).
+ *
+ * 2) Upgrade authorisation: every UUPS contract's _authorizeUpgrade reverts
+ *    when called by a non-owner. This is the on-chain guarantee that the
+ *    88780 multisig is the sole upgrade authority once ownership is
+ *    transferred.
+ */
+
+const { expect } = require("chai")
+const { ethers, upgrades } = require("hardhat")
+
+// Each row: [factoryName, args-builder(deployer) → init args].
+// initialOwner is always the last arg; non-owner upgrade tests
+// connect a different signer.
+function describeContract(factoryName, argsBuilder, postDeploy) {
+  describe(`UUPS upgrade safety — ${factoryName}`, function () {
+    let deployer, outsider
+    let proxy
+
+    beforeEach(async function () {
+      ;[deployer, outsider] = await ethers.getSigners()
+      const Factory = await ethers.getContractFactory(factoryName)
+      const args = await argsBuilder(deployer)
+      proxy = await upgrades.deployProxy(Factory, args, {
+        initializer: "initialize",
+        kind: "uups",
+      })
+      await proxy.waitForDeployment()
+      if (postDeploy) await postDeploy(proxy, deployer)
+    })
+
+    it("upgradeProxy onto the same implementation succeeds (layout valid)", async function () {
+      const Factory = await ethers.getContractFactory(factoryName)
+      const upgraded = await upgrades.upgradeProxy(await proxy.getAddress(), Factory, {
+        kind: "uups",
+      })
+      // The proxy address must not change after upgrade.
+      expect(await upgraded.getAddress()).to.equal(await proxy.getAddress())
+      // owner() must survive the upgrade
+      expect((await upgraded.owner()).toLowerCase()).to.equal(deployer.address.toLowerCase())
+    })
+
+    it("non-owner cannot upgrade (reverts via _authorizeUpgrade)", async function () {
+      // Deploy a fresh implementation off-proxy and try to call
+      // upgradeToAndCall directly from a non-owner. The proxy delegates to
+      // the implementation's _authorizeUpgrade, which must revert.
+      const Factory = await ethers.getContractFactory(factoryName)
+      const freshImpl = await Factory.deploy()
+      await freshImpl.waitForDeployment()
+      const proxyAsUUPS = await ethers.getContractAt(
+        ["function upgradeToAndCall(address,bytes) payable"],
+        await proxy.getAddress(),
+        outsider,
+      )
+      await expect(
+        proxyAsUUPS.upgradeToAndCall(await freshImpl.getAddress(), "0x"),
+      ).to.be.reverted // any of OnlyOwner / "only owner" / "not owner"
+    })
+  })
+}
+
+describeContract(
+  "FactionRegistry",
+  async (d) => [d.address, d.address],
+)
+
+describeContract(
+  "CidRegistry",
+  async (d) => [d.address],
+)
+
+describeContract(
+  "InsuranceFund",
+  async (d) => [d.address, d.address],
+)
+
+describeContract(
+  "FoundationVesting",
+  async (d) => [d.address, d.address],
+)
+
+describeContract(
+  "ValidatorRegistry",
+  async (d) => [d.address, d.address, d.address],
+)
+
+describeContract(
+  "DelayedInbox",
+  async (d) => [86400, d.address, d.address],
+)
+
+describeContract(
+  "RollupStateManager",
+  async (d) => [
+    86400,
+    ethers.parseEther("1"),
+    ethers.parseEther("1"),
+    d.address,
+    d.address,
+    d.address,
+  ],
+)
+
+describeContract(
+  "SoulRegistry",
+  async (d) => [d.address],
+)
+
+describeContract(
+  "PoSeManager",
+  async (d) => [d.address],
+)
+
+describeContract(
+  "PoSeManagerV2",
+  async (d) => [ethers.parseEther("0.1"), d.address],
+  async (proxy) => {
+    // Verify DOMAIN_SEPARATOR was computed from the proxy address inside
+    // initialize, not the (locked) implementation. address(this) inside
+    // initialize === the proxy address under delegatecall.
+    const ds = await proxy.DOMAIN_SEPARATOR()
+    expect(ds).to.not.equal(ethers.ZeroHash)
+  },
+)
+
+// GovernanceDAO and Treasury depend on FactionRegistry being already
+// deployed (Treasury also needs a 5-signer array). Hand them custom
+// argsBuilders that deploy the dependency proxy first.
+
+describeContract(
+  "GovernanceDAO",
+  async (d) => {
+    const FR = await ethers.getContractFactory("FactionRegistry")
+    const fr = await upgrades.deployProxy(FR, [d.address, d.address], {
+      initializer: "initialize",
+      kind: "uups",
+    })
+    await fr.waitForDeployment()
+    return [await fr.getAddress(), d.address]
+  },
+)
+
+describeContract(
+  "Treasury",
+  async (d) => {
+    const signers = await ethers.getSigners()
+    const signerAddrs = signers.slice(0, 5).map((s) => s.address)
+    return [signerAddrs, d.address, d.address]
+  },
+)
+
+describeContract(
+  "DIDRegistry",
+  async (d) => {
+    const Soul = await ethers.getContractFactory("SoulRegistry")
+    const soul = await upgrades.deployProxy(Soul, [d.address], {
+      initializer: "initialize",
+      kind: "uups",
+    })
+    await soul.waitForDeployment()
+    return [await soul.getAddress(), d.address]
+  },
+)
+
+describeContract(
+  "EquivocationDetector",
+  async (d) => {
+    const VR = await ethers.getContractFactory("ValidatorRegistry")
+    const vr = await upgrades.deployProxy(VR, [d.address, d.address, d.address], {
+      initializer: "initialize",
+      kind: "uups",
+    })
+    await vr.waitForDeployment()
+    return [await vr.getAddress(), d.address]
+  },
+)
+
+describeContract(
+  "COCToken",
+  async (d) => [[d.address], [ethers.parseEther("250000000")], d.address],
+)

--- a/tests/integration/governance-dao-lifecycle.integration.test.ts
+++ b/tests/integration/governance-dao-lifecycle.integration.test.ts
@@ -27,7 +27,9 @@ import { dirname, join } from "node:path"
 import test from "node:test"
 import { fileURLToPath } from "node:url"
 import {
+  Contract,
   ContractFactory,
+  Interface,
   JsonRpcProvider,
   Wallet,
   ZeroAddress,
@@ -40,6 +42,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, "..", "..")
 const contractsDir = join(repoRoot, "contracts")
 const artifactsDir = join(contractsDir, "artifacts", "contracts-src", "governance")
+const testArtifactsDir = join(contractsDir, "artifacts", "contracts-src", "test-contracts")
 
 const hardhatCliRoot = join(repoRoot, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
 const hardhatCliContracts = join(contractsDir, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
@@ -56,6 +59,35 @@ const HUMAN_KEYS = [
 function loadArtifact(name: string): { abi: unknown[]; bytecode: string } {
   const path = join(artifactsDir, `${name}.sol`, `${name}.json`)
   return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function loadTestProxyArtifact(): { abi: unknown[]; bytecode: string } {
+  const path = join(testArtifactsDir, "TestERC1967Proxy.sol", "TestERC1967Proxy.json")
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+// gen-5 helper: deploy implementation, then ERC1967Proxy initialized with
+// the contract's initialize(...) calldata. Returns a Contract bound to the
+// proxy address.
+async function deployUUPS(
+  contractName: string,
+  initArgs: unknown[],
+  deployer: Wallet,
+  txOpts: () => { nonce: number },
+): Promise<Contract> {
+  const artifact = loadArtifact(contractName)
+  const impl = await new ContractFactory(artifact.abi, artifact.bytecode, deployer).deploy(txOpts())
+  await impl.waitForDeployment()
+  const iface = new Interface(artifact.abi)
+  const initCalldata = iface.encodeFunctionData("initialize", initArgs)
+  const proxyArt = loadTestProxyArtifact()
+  const proxy = await new ContractFactory(proxyArt.abi, proxyArt.bytecode, deployer).deploy(
+    await impl.getAddress(),
+    initCalldata,
+    txOpts(),
+  )
+  await proxy.waitForDeployment()
+  return new Contract(await proxy.getAddress(), artifact.abi, deployer)
 }
 
 async function getFreePort(): Promise<number> {
@@ -144,10 +176,8 @@ test("R2.2 governance DAO lifecycle: propose → vote → queue → execute end-
     const txOpts = (): { nonce: number } => ({ nonce: nonce++ })
 
     // ── Step 1: Deploy FactionRegistry, GovernanceDAO, Treasury ─────────
-    const fr = await new ContractFactory(loadArtifact("FactionRegistry").abi, loadArtifact("FactionRegistry").bytecode, deployerWallet).deploy(txOpts())
-    await fr.waitForDeployment()
-    const dao = await new ContractFactory(loadArtifact("GovernanceDAO").abi, loadArtifact("GovernanceDAO").bytecode, deployerWallet).deploy(await fr.getAddress(), txOpts())
-    await dao.waitForDeployment()
+    const fr = await deployUUPS("FactionRegistry", [deployerWallet.address, deployerWallet.address], deployerWallet, txOpts)
+    const dao = await deployUUPS("GovernanceDAO", [await fr.getAddress(), deployerWallet.address], deployerWallet, txOpts)
 
     // Treasury needs 5 signers + governance address. Use deployer + 4 anvil
     // wallets for signers (the multisig path isn't exercised by this test —
@@ -161,12 +191,12 @@ test("R2.2 governance DAO lifecycle: propose → vote → queue → execute end-
       "0x0000000000000000000000000000000000000001",
       "0x0000000000000000000000000000000000000002",
     ].slice(0, 5) as [string, string, string, string, string]
-    const treasury = await new ContractFactory(
-      loadArtifact("Treasury").abi,
-      loadArtifact("Treasury").bytecode,
+    const treasury = await deployUUPS(
+      "Treasury",
+      [signerAddrs, await dao.getAddress(), deployerWallet.address],
       deployerWallet,
-    ).deploy(signerAddrs, await dao.getAddress(), txOpts())
-    await treasury.waitForDeployment()
+      txOpts,
+    )
     await (await dao.setTreasury(await treasury.getAddress(), txOpts()) as any).wait()
 
     // ── Step 2: Owner shrinks votingPeriod (1d minimum) + zero timelock ─

--- a/tests/integration/governance-treasury-spend.integration.test.ts
+++ b/tests/integration/governance-treasury-spend.integration.test.ts
@@ -46,6 +46,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, "..", "..")
 const contractsDir = join(repoRoot, "contracts")
 const artifactsDir = join(contractsDir, "artifacts", "contracts-src", "governance")
+const testArtifactsDir = join(contractsDir, "artifacts", "contracts-src", "test-contracts")
 
 const hardhatCliRoot = join(repoRoot, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
 const hardhatCliContracts = join(contractsDir, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
@@ -69,6 +70,32 @@ const ANVIL_KEYS = [
 function loadArtifact(name: string): { abi: unknown[]; bytecode: string } {
   const path = join(artifactsDir, `${name}.sol`, `${name}.json`)
   return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function loadTestProxyArtifact(): { abi: unknown[]; bytecode: string } {
+  const path = join(testArtifactsDir, "TestERC1967Proxy.sol", "TestERC1967Proxy.json")
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+async function deployUUPS(
+  contractName: string,
+  initArgs: unknown[],
+  deployer: Wallet,
+  txOpts: () => { nonce: number },
+): Promise<Contract> {
+  const artifact = loadArtifact(contractName)
+  const impl = await new ContractFactory(artifact.abi, artifact.bytecode, deployer).deploy(txOpts())
+  await impl.waitForDeployment()
+  const iface = new Interface(artifact.abi)
+  const initCalldata = iface.encodeFunctionData("initialize", initArgs)
+  const proxyArt = loadTestProxyArtifact()
+  const proxy = await new ContractFactory(proxyArt.abi, proxyArt.bytecode, deployer).deploy(
+    await impl.getAddress(),
+    initCalldata,
+    txOpts(),
+  )
+  await proxy.waitForDeployment()
+  return new Contract(await proxy.getAddress(), artifact.abi, deployer)
 }
 
 async function getFreePort(): Promise<number> {
@@ -155,29 +182,18 @@ async function deployGovernanceStack(provider: JsonRpcProvider) {
   let nonce = await provider.getTransactionCount(deployer.address)
   const txOpts = (): { nonce: number } => ({ nonce: nonce++ })
 
-  const fr = await new ContractFactory(
-    loadArtifact("FactionRegistry").abi,
-    loadArtifact("FactionRegistry").bytecode,
-    deployer,
-  ).deploy(txOpts())
-  await fr.waitForDeployment()
-
-  const dao = await new ContractFactory(
-    loadArtifact("GovernanceDAO").abi,
-    loadArtifact("GovernanceDAO").bytecode,
-    deployer,
-  ).deploy(await fr.getAddress(), txOpts())
-  await dao.waitForDeployment()
+  const fr = await deployUUPS("FactionRegistry", [deployer.address, deployer.address], deployer, txOpts)
+  const dao = await deployUUPS("GovernanceDAO", [await fr.getAddress(), deployer.address], deployer, txOpts)
 
   // 5 real multisig signers: deployer + anvil 1..4.
   const signerWallets = [deployer, ...ANVIL_KEYS.slice(0, 4).map((k) => new Wallet(k, provider))]
   const signerAddrs = signerWallets.map((w) => w.address) as [string, string, string, string, string]
-  const treasury = await new ContractFactory(
-    loadArtifact("Treasury").abi,
-    loadArtifact("Treasury").bytecode,
+  const treasury = await deployUUPS(
+    "Treasury",
+    [signerAddrs, await dao.getAddress(), deployer.address],
     deployer,
-  ).deploy(signerAddrs, await dao.getAddress(), txOpts())
-  await treasury.waitForDeployment()
+    txOpts,
+  )
 
   await (await (dao.setTreasury(await treasury.getAddress(), txOpts()) as any)).wait()
   await (await (dao.setVotingPeriod(86400, txOpts()) as any)).wait()

--- a/tests/integration/pose-v2-settlement.integration.test.ts
+++ b/tests/integration/pose-v2-settlement.integration.test.ts
@@ -34,7 +34,9 @@ import test from "node:test"
 import { fileURLToPath } from "node:url"
 import {
   AbiCoder,
+  Contract,
   ContractFactory,
+  Interface,
   JsonRpcProvider,
   Wallet,
   ZeroHash,
@@ -50,6 +52,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, "..", "..")
 const contractsDir = join(repoRoot, "contracts")
 const artifactsDir = join(contractsDir, "artifacts", "contracts-src", "settlement")
+const testArtifactsDir = join(contractsDir, "artifacts", "contracts-src", "test-contracts")
 
 const hardhatCliRoot = join(repoRoot, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
 const hardhatCliContracts = join(contractsDir, "node_modules", "hardhat", "internal", "cli", "bootstrap.js")
@@ -333,14 +336,27 @@ async function currentEpoch(provider: JsonRpcProvider): Promise<number> {
   return Math.floor(Number(block!.timestamp) / EPOCH_SECONDS)
 }
 
+function loadTestProxyArtifact(): { abi: unknown[]; bytecode: string } {
+  const path = join(testArtifactsDir, "TestERC1967Proxy.sol", "TestERC1967Proxy.json")
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
 async function deployManager(ctx: Omit<Ctx, "manager">): Promise<any> {
+  // gen-5: PoSeManagerV2 lives behind a UUPS proxy. Deploy implementation,
+  // ABI-encode initialize(challengeBondMin, initialOwner), deploy
+  // ERC1967Proxy with the init calldata, return a Contract bound to the
+  // proxy address using the implementation's ABI.
   const art = loadArtifact("PoSeManagerV2")
-  const factory = new ContractFactory(art.abi, art.bytecode, ctx.deployer)
-  const manager = await factory.deploy(ctx.nextNonce())
-  await manager.waitForDeployment()
-  const chainId = (await ctx.provider.getNetwork()).chainId
-  await (await manager.initialize(chainId, await manager.getAddress(), parseEther("0.01"), ctx.nextNonce())).wait()
-  return manager
+  const implFactory = new ContractFactory(art.abi, art.bytecode, ctx.deployer)
+  const impl = await implFactory.deploy(ctx.nextNonce())
+  await impl.waitForDeployment()
+  const iface = new Interface(art.abi)
+  const initCalldata = iface.encodeFunctionData("initialize", [parseEther("0.01"), ctx.deployer.address])
+  const proxyArt = loadTestProxyArtifact()
+  const proxyFactory = new ContractFactory(proxyArt.abi, proxyArt.bytecode, ctx.deployer)
+  const proxy = await proxyFactory.deploy(await impl.getAddress(), initCalldata, ctx.nextNonce())
+  await proxy.waitForDeployment()
+  return new Contract(await proxy.getAddress(), art.abi, ctx.deployer)
 }
 
 async function extractArg(manager: any, receipt: any, eventName: string, argIndex: number): Promise<any> {

--- a/tests/integration/relayer-v2-hardhat-recovery.integration.test.ts
+++ b/tests/integration/relayer-v2-hardhat-recovery.integration.test.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url"
 import {
   Contract,
   ContractFactory,
+  Interface,
   JsonRpcProvider,
   NonceManager,
   Wallet,
@@ -41,6 +42,23 @@ const poseArtifact = JSON.parse(
       "settlement",
       "PoSeManagerV2.sol",
       "PoSeManagerV2.json",
+    ),
+    "utf8",
+  ),
+) as { abi: unknown[]; bytecode: string }
+
+// gen-5: PoSeManagerV2 is UUPS-upgradeable. We need a concrete ERC1967Proxy
+// (vendored at contracts/contracts-src/test-contracts/TestERC1967Proxy.sol).
+const testProxyArtifact = JSON.parse(
+  readFileSync(
+    join(
+      repoRoot,
+      "contracts",
+      "artifacts",
+      "contracts-src",
+      "test-contracts",
+      "TestERC1967Proxy.sol",
+      "TestERC1967Proxy.json",
     ),
     "utf8",
   ),
@@ -291,12 +309,19 @@ test("relayer v2 recovery works against real Hardhat JSON-RPC + deployed PoSeMan
     provider = new JsonRpcProvider(node.url)
     const deployerWallet = new Wallet(DEPLOYER_KEY, provider)
     const txSigner = new NonceManager(deployerWallet)
-    const factory = new ContractFactory(poseArtifact.abi, poseArtifact.bytecode, txSigner)
-    const manager = await factory.deploy()
-    await manager.waitForDeployment()
-
-    const network = await provider.getNetwork()
-    await (await manager.initialize(network.chainId, await manager.getAddress(), parseEther("0.01"))).wait()
+    // gen-5: PoSeManagerV2 lives behind a UUPS proxy. Deploy the
+    // implementation, then ERC1967Proxy initialized with
+    // initialize(challengeBondMin, initialOwner). The resulting `manager`
+    // Contract is bound to the proxy address with the implementation ABI.
+    const implFactory = new ContractFactory(poseArtifact.abi, poseArtifact.bytecode, txSigner)
+    const impl = await implFactory.deploy()
+    await impl.waitForDeployment()
+    const iface = new Interface(poseArtifact.abi)
+    const initCalldata = iface.encodeFunctionData("initialize", [parseEther("0.01"), deployerWallet.address])
+    const proxyFactory = new ContractFactory(testProxyArtifact.abi, testProxyArtifact.bytecode, txSigner)
+    const proxy = await proxyFactory.deploy(await impl.getAddress(), initCalldata)
+    await proxy.waitForDeployment()
+    const manager = new Contract(await proxy.getAddress(), poseArtifact.abi, txSigner)
     await (await manager.setAllowEmptyWitnessSubmission(true)).wait()
 
     const registered = await registerNode(manager, txSigner, provider)


### PR DESCRIPTION
## Status: DRAFT — contracts only, tests/scripts/deploy to follow

User-approved gen-5 architectural pivot to UUPS upgradeable contracts (plan: `/home/bob/.claude/plans/applyblock-delightful-hennessy.md`).

## What's in this commit (`3c6622a`)

All **13 production contracts + PoSeManagerStorage base** converted to OpenZeppelin UUPS:

- `Initializable` + `UUPSUpgradeable` inheritance, locked-implementation constructor (`_disableInitializers()`), proxy `initialize(...)`.
- `_authorizeUpgrade(address)` gated on `onlyOwner` — the 88780 multisig (`0x3c055D83…`) becomes upgrade authority after the gen-5 handoff.
- Upgrade-blocking `immutable` state vars converted to mutable + initialised in `initialize` (SoulRegistry/DIDRegistry DOMAIN_SEPARATOR + DIDRegistry.soulRegistry + EquivocationDetector.validatorRegistry + DelayedInbox.INCLUSION_DELAY + RollupStateManager CHALLENGE_WINDOW/PROPOSER_BOND/CHALLENGER_BOND).
- `uint256[50] private __gap` reserved at every contract's end.
- PoSeManagerStorage refactored to a chained `__PoSeManagerStorage_init(initialOwner)`; PoSeManager v1 + v2 call it from their initialisers.
- PoSeManagerV2.initialize signature simplified to `(challengeBondMin, initialOwner)` — chainId/verifyingContract now derived from `block.chainid` + `address(this)` (the proxy).
- **#706 (GovernanceDAO bicameral silent-faction, #705) folded in** — Proposal stores humanSnapshot/clawSnapshot at creation; `_isApproved` bicameral branch requires non-zero snapshot before auto-passing an empty chamber.
- `MultiSigWallet.sol` left untouched (upgrade authority must stay immutable).
- Deps: `@openzeppelin/contracts-upgradeable@^5.1.0`, `@openzeppelin/hardhat-upgrades@^3.6.0`; plugin required in `hardhat.config.cjs`.

`cd contracts && npx hardhat compile` is clean (1 view-restrictable warning).

## TODO on this branch before ready-for-review

1. Refactor existing tests to use `upgrades.deployProxy(Factory, [args], { kind: 'uups' })` instead of `Factory.deploy(args)` (5 shared helpers + ~9 inline sites).
2. New `contracts/test/uups-upgrade-safety.test.cjs` — per-contract deploy → state-snapshot → upgrade → verify; non-owner upgrade revert.
3. Rewrite `scripts/deploy-governance.js` + `scripts/deploy-all-88780.js` to use `upgrades.deployProxy`; `scripts/deploy-posev2-88780.js` becomes `upgrades.upgradeProxy`.

## Follow-up (separate PRs after this merges)

- gen-5 on-chain redeploy on 88780 (every contract behind a UUPS proxy; multisig handoff via post-init `transferOwnership`).
- Manifest PRs: COC `configs/deployed-contracts-88780.json` + `contracts/.openzeppelin/coc-88780.json` + claw-mem `@chainofclaw/soul` manifest.
- Doc PR: new dated log + r3-2 SOP refresh + storage-gap discipline note.
- Close #706 (folded in here).
- `Refs #686` — full resolution after the gen-5 redeploy.

## Trade-off (re-stated)

Post-conversion, the multisig can replace any contract's logic. Users of the 88780 contracts must trust the multisig. `MultiSigWallet` itself stays immutable.