### PR TITLE
fix(ipfs): full UnixFS directory DAG support incl. HAMT (#468)

### DIFF
--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -86,6 +86,7 @@ Status legend:
 - **IPFS MFS** — Implemented (Phase 26) — `COC/node/src/ipfs-mfs.ts`
 - **IPFS Pubsub** — Implemented (Phase 26) — `COC/node/src/ipfs-pubsub.ts`
 - **IPFS tar archive** — Implemented (Phase 28) — `COC/node/src/ipfs-tar.ts`
+- **IPFS UnixFS directory DAG (write + read, incl. HAMT)** — Implemented (#468) — `COC/node/src/ipfs-unixfs-dir.ts`, `ipfs-path-resolve.ts`, `ipfs-blockstore-adapter.ts` (directory uploads via `wrap-with-directory`, `<cid>/<path>` navigation on cat/ls/object-stat/gateway)
 - **EVM state snapshot** — Implemented (Phase 28 + Audit: full trie traversal) — `COC/node/src/state-snapshot.ts`
 - **Snap sync provider** — Implemented (Phase 29) — `COC/node/src/consensus.ts`
 - **Log indexing** — Implemented (Phase 13.2) — `COC/node/src/storage/block-index.ts`

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -197,6 +197,13 @@ Implemented:
 - **Phase 26**: Pubsub HTTP routes (`/api/v0/pubsub/*`) with ndjson streaming
 - **Phase 28**: IPFS tar archive for `/api/v0/get` (POSIX USTAR format)
 - **Phase 28**: EVM state snapshot export/import for fast sync
+- **#468**: IPFS UnixFS directory DAG — write path (`/api/v0/add?wrap-with-directory=true`,
+  multi-file / nested-directory uploads, automatic HAMT sharding) and read path
+  (`<cid>/<path>` navigation by Link name across `cat` / `ls` / `object/stat` / gateway,
+  transparent HAMT shard descent). Built on `ipfs-unixfs-importer` / `ipfs-unixfs-exporter`.
+  Note: files uploaded *inside* a directory are chunked by the importer and do not carry
+  the COC PoSe `merkleRoot`/`merkleLeaves` side-tree, so they are not currently subjects of
+  PoSe storage challenges (single-file `/api/v0/add` uploads are unaffected) — follow-up.
 
 - **M7**: Tx-level pruning by age (`StoragePruner.pruneTxByAge()` with configurable `txRetentionMs`)
 
@@ -214,6 +221,9 @@ Code:
 - `COC/node/src/ipfs-mfs.ts` (NEW - Phase 26)
 - `COC/node/src/ipfs-pubsub.ts` (NEW - Phase 26)
 - `COC/node/src/ipfs-tar.ts` (NEW - Phase 28)
+- `COC/node/src/ipfs-blockstore-adapter.ts` (NEW - #468)
+- `COC/node/src/ipfs-unixfs-dir.ts` (NEW - #468)
+- `COC/node/src/ipfs-path-resolve.ts` (NEW - #468)
 - `COC/node/src/state-snapshot.ts` (NEW - Phase 28)
 
 ## 5) Mempool & Fee Market

--- a/node/package.json
+++ b/node/package.json
@@ -17,10 +17,12 @@
     "@ethereumjs/util": "^9.0.1",
     "@ethereumjs/vm": "^10.0.0",
     "@ipld/dag-cbor": "^9.2.1",
-    "@ipld/dag-pb": "^4.1.0",
+    "@ipld/dag-pb": "^4.1.5",
     "@ronomon/reed-solomon": "^6.0.0",
     "ethers": "^6.13.5",
     "ipfs-unixfs": "^9.0.0",
+    "ipfs-unixfs-exporter": "13.6.6",
+    "ipfs-unixfs-importer": "16.0.1",
     "level": "^8.0.1",
     "multiformats": "^13.3.2",
     "ws": "^8.19.0"

--- a/node/src/ipfs-blockstore-adapter.test.ts
+++ b/node/src/ipfs-blockstore-adapter.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os"
 import { CID } from "multiformats/cid"
 import { sha256 } from "multiformats/hashes/sha2"
 import { IpfsBlockstore } from "./ipfs-blockstore.ts"
-import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { InterfaceBlockstoreAdapter, BlockstoreReadBudgetError } from "./ipfs-blockstore-adapter.ts"
 
 let tmpDir: string
 let store: IpfsBlockstore
@@ -68,7 +68,12 @@ describe("InterfaceBlockstoreAdapter", () => {
 
     await adapter.get(cid)
     await adapter.get(cid)
-    await assert.rejects(() => adapter.get(cid), /read budget exceeded/)
+    // The budget overrun throws a distinct typed error so callers can tell
+    // a resource-limit abort apart from an ordinary block miss.
+    await assert.rejects(
+      () => adapter.get(cid),
+      (err: unknown) => err instanceof BlockstoreReadBudgetError && /read budget exceeded/.test(err.message),
+    )
     assert.equal(adapter.reads, 3)
   })
 

--- a/node/src/ipfs-blockstore-adapter.test.ts
+++ b/node/src/ipfs-blockstore-adapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, beforeEach, afterEach } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { CID } from "multiformats/cid"
+import { sha256 } from "multiformats/hashes/sha2"
+import { IpfsBlockstore } from "./ipfs-blockstore.ts"
+import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+
+let tmpDir: string
+let store: IpfsBlockstore
+
+async function rawCid(bytes: Uint8Array): Promise<CID> {
+  const digest = await sha256.digest(bytes)
+  return CID.createV1(0x55, digest)
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "bs-adapter-"))
+  store = new IpfsBlockstore(tmpDir)
+  await store.init()
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe("InterfaceBlockstoreAdapter", () => {
+  it("put/get/has round-trip with CID <-> string translation", async () => {
+    const adapter = new InterfaceBlockstoreAdapter(store)
+    const bytes = new TextEncoder().encode("hello adapter")
+    const cid = await rawCid(bytes)
+
+    const returned = await adapter.put(cid, bytes)
+    assert.equal(returned.toString(), cid.toString())
+    assert.equal(await adapter.has(cid), true)
+    // `get` returns a Buffer (COC's blockstore reads via fs.readFile);
+    // Buffer is a Uint8Array subtype — compare on byte content.
+    assert.deepEqual(Buffer.from(await adapter.get(cid)), Buffer.from(bytes))
+
+    // The bytes are visible through COC's native string-keyed API too.
+    const native = await store.get(cid.toString())
+    assert.deepEqual(Buffer.from(native.bytes), Buffer.from(bytes))
+  })
+
+  it("get falls through COC's fetchRemote hook (C1.3)", async () => {
+    const bytes = new TextEncoder().encode("remote block")
+    const cid = await rawCid(bytes)
+    let fetchCalled = false
+    store.setHooks({
+      fetchRemote: async (wanted) => {
+        fetchCalled = true
+        assert.equal(wanted, cid.toString())
+        return bytes
+      },
+    })
+    const adapter = new InterfaceBlockstoreAdapter(store)
+    assert.deepEqual(await adapter.get(cid), bytes)
+    assert.equal(fetchCalled, true)
+  })
+
+  it("enforces the per-adapter block-read budget", async () => {
+    const adapter = new InterfaceBlockstoreAdapter(store, { maxBlockReads: 2 })
+    const bytes = new TextEncoder().encode("budget")
+    const cid = await rawCid(bytes)
+    await adapter.put(cid, bytes)
+
+    await adapter.get(cid)
+    await adapter.get(cid)
+    await assert.rejects(() => adapter.get(cid), /read budget exceeded/)
+    assert.equal(adapter.reads, 3)
+  })
+
+  it("delete is a no-op — the adapter must not drop COC blocks", async () => {
+    const adapter = new InterfaceBlockstoreAdapter(store)
+    const bytes = new TextEncoder().encode("keep me")
+    const cid = await rawCid(bytes)
+    await adapter.put(cid, bytes)
+    await adapter.delete(cid)
+    assert.equal(await store.has(cid.toString()), true)
+  })
+})

--- a/node/src/ipfs-blockstore-adapter.ts
+++ b/node/src/ipfs-blockstore-adapter.ts
@@ -28,6 +28,19 @@ export interface BlockstoreAdapterLimits {
   maxBlockReads?: number
 }
 
+/**
+ * Thrown by {@link InterfaceBlockstoreAdapter.get} when the per-adapter
+ * `maxBlockReads` budget is exhausted. A distinct type so callers can tell
+ * a resource-limit abort apart from an ordinary "not a UnixFS node" miss
+ * and surface it as a real error instead of silently degrading.
+ */
+export class BlockstoreReadBudgetError extends Error {
+  constructor(budget: number) {
+    super(`blockstore read budget exceeded (${budget})`)
+    this.name = "BlockstoreReadBudgetError"
+  }
+}
+
 export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put" | "has"> {
   private readonly inner: IpfsBlockstore
   private readonly maxBlockReads: number
@@ -45,7 +58,7 @@ export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put
 
   async get(cid: CID): Promise<Uint8Array> {
     if (++this.blockReads > this.maxBlockReads) {
-      throw new Error(`blockstore read budget exceeded (${this.maxBlockReads})`)
+      throw new BlockstoreReadBudgetError(this.maxBlockReads)
     }
     const block = await this.inner.get(cid.toString())
     return block.bytes

--- a/node/src/ipfs-blockstore-adapter.ts
+++ b/node/src/ipfs-blockstore-adapter.ts
@@ -1,0 +1,96 @@
+import { CID } from "multiformats/cid"
+import type { Blockstore } from "interface-blockstore"
+import type { IpfsBlockstore } from "./ipfs-blockstore.ts"
+
+/**
+ * Bridges COC's string-keyed {@link IpfsBlockstore} to the
+ * `interface-blockstore` `Blockstore` that `ipfs-unixfs-importer` and
+ * `ipfs-unixfs-exporter` expect.
+ *
+ * Only `get` / `put` / `has` are used by the importer/exporter path
+ * (`ReadableStorage = Pick<Blockstore,'get'>`, `WritableStorage =
+ * Pick<Blockstore,'put'>`); the remaining `Store` members are provided as
+ * thin shims so the adapter is a structural superset and can be passed
+ * wherever a `Blockstore` is wanted.
+ *
+ * The CID <-> string conversion is the only translation — block bytes pass
+ * through verbatim. `get` routes through COC's `store.get`, which
+ * transparently peer-fetches absent blocks (C1.3) and content-verifies
+ * them, so directory-DAG navigation works even over a partially-local DAG.
+ *
+ * DoS guard: a per-adapter `get` budget. A single HTTP request constructs
+ * one adapter, so capping `get` calls bounds the block fan-out a malicious
+ * (deep / wide / diamond) DAG can trigger. Construct a fresh adapter per
+ * request to reset the budget.
+ */
+export interface BlockstoreAdapterLimits {
+  /** Max number of `get` calls over this adapter's lifetime. */
+  maxBlockReads?: number
+}
+
+export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put" | "has"> {
+  private readonly inner: IpfsBlockstore
+  private readonly maxBlockReads: number
+  private blockReads = 0
+
+  constructor(inner: IpfsBlockstore, limits?: BlockstoreAdapterLimits) {
+    this.inner = inner
+    this.maxBlockReads = limits?.maxBlockReads ?? Number.POSITIVE_INFINITY
+  }
+
+  /** Number of `get` calls served so far — exposed for tests / metrics. */
+  get reads(): number {
+    return this.blockReads
+  }
+
+  async get(cid: CID): Promise<Uint8Array> {
+    if (++this.blockReads > this.maxBlockReads) {
+      throw new Error(`blockstore read budget exceeded (${this.maxBlockReads})`)
+    }
+    const block = await this.inner.get(cid.toString())
+    return block.bytes
+  }
+
+  async put(cid: CID, bytes: Uint8Array): Promise<CID> {
+    await this.inner.put({ cid: cid.toString(), bytes })
+    return cid
+  }
+
+  async has(cid: CID): Promise<boolean> {
+    return this.inner.has(cid.toString())
+  }
+
+  async *putMany(
+    source: AsyncIterable<{ cid: CID; block: Uint8Array }> | Iterable<{ cid: CID; block: Uint8Array }>,
+  ): AsyncGenerator<CID> {
+    for await (const { cid, block } of source) {
+      yield await this.put(cid, block)
+    }
+  }
+
+  async *getMany(
+    source: AsyncIterable<CID> | Iterable<CID>,
+  ): AsyncGenerator<{ cid: CID; block: Uint8Array }> {
+    for await (const cid of source) {
+      yield { cid, block: await this.get(cid) }
+    }
+  }
+
+  // GC is owned by COC's IpfsBlockstore (pins.json + gc()); deletion through
+  // the adapter is a no-op so the importer/exporter can never drop blocks.
+  async delete(_cid: CID): Promise<void> {
+    /* no-op — COC GC owns deletion */
+  }
+
+  async *deleteMany(source: AsyncIterable<CID> | Iterable<CID>): AsyncGenerator<CID> {
+    for await (const cid of source) {
+      yield cid
+    }
+  }
+
+  // The exporter never enumerates the whole store during a path walk; only
+  // implemented so the adapter satisfies the full Blockstore shape.
+  async *getAll(): AsyncGenerator<{ cid: CID; block: Uint8Array }> {
+    throw new Error("getAll is not supported by InterfaceBlockstoreAdapter")
+  }
+}

--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -8,6 +8,8 @@ import http from "node:http"
 import { IpfsBlockstore } from "./ipfs-blockstore.ts"
 import { UnixFsBuilder } from "./ipfs-unixfs.ts"
 import { IpfsHttpServer, isIpfsAdminAuthorized } from "./ipfs-http.ts"
+import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { buildDirectoryDag } from "./ipfs-unixfs-dir.ts"
 import type { CidString } from "./ipfs-types.ts"
 
 // The IPFS HTTP server uses a module-level rate limiter (100 req/min/IP).
@@ -2966,5 +2968,40 @@ describe("#468 UnixFS directory DAG", () => {
     const { status, raw } = await addDir([{ filename: "../escape.txt", content: "x" }])
     assert.equal(status, 400)
     assert.match(raw, /traversal|invalid_path/)
+  })
+
+  it("get of a directory CID returns a tar of the whole tree", async () => {
+    const { lines } = await addDir([
+      { filename: "readme.txt", content: "top-level" },
+      { filename: "docs/a.txt", content: "alpha-content" },
+    ])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/api/v0/get?arg=${root}`)
+    assert.equal(res.status, 200)
+    assert.match(String(res.headers["content-type"]), /application\/x-tar/)
+    // tar stores file names + (small) contents verbatim — smoke-check both.
+    const tar = (await res.buffer()).toString("binary")
+    assert.match(tar, /readme\.txt/)
+    assert.match(tar, /top-level/)
+    assert.match(tar, /a\.txt/)
+    assert.match(tar, /alpha-content/)
+  })
+
+  it("get of a pathologically deep directory tree is rejected (DoS guard)", async () => {
+    // Build a directory nested deeper than MAX_DIRECTORY_GET_DEPTH (64)
+    // straight into the blockstore — the HTTP upload path caps relative
+    // paths at 64 segments, so this depth is only reachable for a CID
+    // whose blocks were fetched from a peer.
+    const deepPath = Array.from({ length: 70 }, (_, i) => `d${i}`).join("/") + "/f.txt"
+    const adapter = new InterfaceBlockstoreAdapter(store)
+    const built = await buildDirectoryDag(
+      [{ path: deepPath, content: new TextEncoder().encode("deep") }],
+      adapter,
+    )
+    for (const node of built.all) await store.pin(node.cid)
+
+    const res = await fetch(`/api/v0/get?arg=${built.root.cid}`)
+    assert.equal(res.status, 400, `deep directory get must be rejected, got ${res.status}`)
+    assert.match(await res.text(), /too deep/)
   })
 })

--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -2892,16 +2892,19 @@ describe("#468 UnixFS directory DAG", () => {
     assert.equal(res.status, 400)
   })
 
-  it("object/stat of a directory reports its child count", async () => {
+  it("object/stat of a directory reports child count and a byte-unit CumulativeSize", async () => {
     const { lines } = await addDir([
-      { filename: "a", content: "1" },
-      { filename: "b", content: "2" },
+      { filename: "a", content: "hello" }, // 5 bytes
+      { filename: "b", content: "world!" }, // 6 bytes
     ])
     const root = lines[lines.length - 1].Hash
     const res = await fetch(`/api/v0/object/stat?arg=${root}`)
     assert.equal(res.status, 200)
-    const stat = (await res.json()) as { NumLinks: number }
+    const stat = (await res.json()) as { NumLinks: number; BlockSize: number; CumulativeSize: number }
     assert.equal(stat.NumLinks, 2)
+    // CumulativeSize must be in bytes — directory block + immediate file
+    // byte sizes (5 + 6) — not a mix of bytes and directory entry counts.
+    assert.equal(stat.CumulativeSize, stat.BlockSize + 11)
   })
 
   it("gateway resolves <dir>/<subpath> (issue #468 repro)", async () => {

--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -293,11 +293,11 @@ describe("IpfsHttpServer", () => {
       `error message must mention "no part found", got: ${errBody.message}`)
   })
 
-  it("#356: /api/v0/add rejects multi-part body (2+ parts) with 400 unsupported_multipart (no silent drop)", async () => {
-    // Pre-fix: the readMultipartFile loop returned on the FIRST part. A
-    // 2-file multipart upload returned the CID for file #1 and silently
-    // dropped file #2 — the client saw 200 OK and believed BOTH files
-    // were stored. /api/v0/add is single-file; reject multi-part.
+  it("#468: /api/v0/add with a multi-part body builds a directory DAG (no silent drop)", async () => {
+    // #356 pre-fix the readMultipartFile loop dropped parts 2..N. #468:
+    // a multi-part upload is now a directory upload — every part is
+    // stored under a wrapping UnixFS directory and the response streams
+    // one NDJSON line per file plus the wrapping directory.
     const boundary = "----MultiMpBoundary356"
     const body = [
       `--${boundary}`,
@@ -316,13 +316,20 @@ describe("IpfsHttpServer", () => {
       headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
       body,
     })
-    assert.equal(res.status, 400,
-      `multi-part body must be 400, got ${res.status}`)
-    const errBody = await res.json() as Record<string, string>
-    assert.equal(errBody.error, "unsupported_multipart",
-      `error code must be unsupported_multipart, got ${JSON.stringify(errBody)}`)
-    assert.match(errBody.message ?? "", /has 2 parts/i,
-      `error must surface part count, got: ${errBody.message}`)
+    assert.equal(res.status, 200, `multi-part directory upload must be 200, got ${res.status}`)
+    const lines = (await res.text()).trim().split("\n").map((l) => JSON.parse(l) as Record<string, string>)
+    // 2 files + 1 wrapping directory.
+    assert.equal(lines.length, 3, `expected 3 NDJSON lines, got ${lines.length}`)
+    const names = lines.map((l) => l.Name)
+    assert.ok(names.includes("a") && names.includes("b"), `files must be listed, got ${names}`)
+    const root = lines[lines.length - 1] // wrapping directory yielded last
+    // Both files must be retrievable through the directory CID.
+    const catA = await fetch(`/api/v0/cat?arg=${root.Hash}/a`)
+    assert.equal(catA.status, 200)
+    assert.equal(await catA.text(), "alpha")
+    const catB = await fetch(`/api/v0/cat?arg=${root.Hash}/b`)
+    assert.equal(catB.status, 200)
+    assert.equal(await catB.text(), "beta")
   })
 
   it("#356: /api/v0/add rejects multipart/* Content-Type without boundary param", async () => {
@@ -733,8 +740,9 @@ describe("IpfsHttpServer", () => {
       assert.equal(body.error, "unsupported_param", qs)
     }
 
-    // Boolean opt-ins we don't honor.
-    for (const key of ["raw-leaves", "wrap-with-directory", "nocopy", "inline", "trickle"]) {
+    // Boolean opt-ins we don't honor. (#468: wrap-with-directory left
+    // this list — it IS honored now; covered separately below.)
+    for (const key of ["raw-leaves", "nocopy", "inline", "trickle"]) {
       const r = await post(`${key}=true`)
       assert.equal(r.status, 400, `${key}=true: expected 400 (got ${r.status})`)
       // Case-insensitive `1` form also rejects.
@@ -745,6 +753,12 @@ describe("IpfsHttpServer", () => {
     // Garbage boolean value must reject too (kubo flag parser does).
     const rg = await post("raw-leaves=maybe")
     assert.equal(rg.status, 400, "raw-leaves=maybe: expected 400")
+    // #468: wrap-with-directory is a supported flag — a valid boolean is
+    // accepted (200), only a non-boolean value 400s.
+    const rwd = await post("wrap-with-directory=true")
+    assert.equal(rwd.status, 200, "wrap-with-directory=true: expected 200 (supported)")
+    const rwdGarbage = await post("wrap-with-directory=maybe")
+    assert.equal(rwdGarbage.status, 400, "wrap-with-directory=maybe: expected 400")
 
     // Defaults must still work (no params + matching values).
     const ok = await post("cid-version=1&hash=sha2-256&chunker=size-262144&raw-leaves=false&trickle=false")
@@ -2782,5 +2796,175 @@ describe("#312 pubsub topic rejects control characters", () => {
     } finally {
       pubsub.stop()
     }
+  })
+})
+
+// #468 — UnixFS directory DAG support (write + read, incl. HAMT).
+describe("#468 UnixFS directory DAG", () => {
+  // Build a multipart/form-data body from a list of {filename, content}
+  // parts. A part with `content === undefined` is an explicit directory.
+  function multipart(
+    parts: Array<{ filename: string; content?: string; directory?: boolean }>,
+  ): { body: Buffer; contentType: string } {
+    const boundary = "----COC468Boundary"
+    const segments: Buffer[] = []
+    for (const p of parts) {
+      let head = `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="${p.filename}"\r\n`
+      head += p.directory
+        ? "Content-Type: application/x-directory\r\n\r\n"
+        : "Content-Type: application/octet-stream\r\n\r\n"
+      segments.push(Buffer.from(head, "utf-8"))
+      segments.push(Buffer.from(p.content ?? "", "utf-8"))
+      segments.push(Buffer.from("\r\n", "utf-8"))
+    }
+    segments.push(Buffer.from(`--${boundary}--\r\n`, "utf-8"))
+    return {
+      body: Buffer.concat(segments),
+      contentType: `multipart/form-data; boundary=${boundary}`,
+    }
+  }
+
+  async function addDir(
+    parts: Array<{ filename: string; content?: string; directory?: boolean }>,
+    query = "",
+  ): Promise<{ status: number; lines: Array<Record<string, string>>; raw: string }> {
+    const { body, contentType } = multipart(parts)
+    const res = await fetch(`/api/v0/add${query}`, {
+      method: "POST",
+      headers: { "content-type": contentType },
+      body,
+    })
+    const raw = await res.text()
+    const lines = res.status === 200
+      ? raw.trim().split("\n").filter(Boolean).map((l) => JSON.parse(l) as Record<string, string>)
+      : []
+    return { status: res.status, lines, raw }
+  }
+
+  it("wrap-with-directory wraps a single file in a directory", async () => {
+    const { status, lines } = await addDir(
+      [{ filename: "hello.txt", content: "hi there" }],
+      "?wrap-with-directory=true",
+    )
+    assert.equal(status, 200)
+    // file line + wrapping directory line
+    assert.equal(lines.length, 2)
+    const root = lines[lines.length - 1]
+    const cat = await fetch(`/api/v0/cat?arg=${root.Hash}/hello.txt`)
+    assert.equal(cat.status, 200)
+    assert.equal(await cat.text(), "hi there")
+  })
+
+  it("builds a nested directory tree and lists it", async () => {
+    const { status, lines } = await addDir([
+      { filename: "index.html", content: "<h1>home</h1>" },
+      { filename: "docs/a.txt", content: "alpha" },
+      { filename: "docs/img/b.bin", content: "BINARY" },
+    ])
+    assert.equal(status, 200)
+    const root = lines[lines.length - 1].Hash
+
+    const lsRoot = await fetch(`/api/v0/ls?arg=${root}`)
+    assert.equal(lsRoot.status, 200)
+    const rootObjs = (await lsRoot.json()) as { Objects: Array<{ Links: Array<{ Name: string; Type: number }> }> }
+    const rootNames = rootObjs.Objects[0].Links.map((l) => l.Name).sort()
+    assert.deepEqual(rootNames, ["docs", "index.html"])
+
+    const lsDocs = await fetch(`/api/v0/ls?arg=${root}/docs`)
+    const docsObjs = (await lsDocs.json()) as { Objects: Array<{ Links: Array<{ Name: string; Type: number }> }> }
+    const docsLinks = docsObjs.Objects[0].Links
+    assert.deepEqual(docsLinks.map((l) => l.Name).sort(), ["a.txt", "img"])
+    assert.equal(docsLinks.find((l) => l.Name === "img")?.Type, 1) // directory
+    assert.equal(docsLinks.find((l) => l.Name === "a.txt")?.Type, 2) // file
+
+    const catNested = await fetch(`/api/v0/cat?arg=${root}/docs/img/b.bin`)
+    assert.equal(catNested.status, 200)
+    assert.equal(await catNested.text(), "BINARY")
+  })
+
+  it("cat of a directory CID is a 400", async () => {
+    const { lines } = await addDir([{ filename: "x", content: "y" }], "?wrap-with-directory=true")
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/api/v0/cat?arg=${root}`)
+    assert.equal(res.status, 400)
+  })
+
+  it("object/stat of a directory reports its child count", async () => {
+    const { lines } = await addDir([
+      { filename: "a", content: "1" },
+      { filename: "b", content: "2" },
+    ])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/api/v0/object/stat?arg=${root}`)
+    assert.equal(res.status, 200)
+    const stat = (await res.json()) as { NumLinks: number }
+    assert.equal(stat.NumLinks, 2)
+  })
+
+  it("gateway resolves <dir>/<subpath> (issue #468 repro)", async () => {
+    const { lines } = await addDir([{ filename: "docs/a.txt", content: "gateway-alpha" }])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/ipfs/${root}/docs/a.txt`)
+    assert.equal(res.status, 200, "subpath under a directory CID must resolve, not 400")
+    assert.equal(await res.text(), "gateway-alpha")
+  })
+
+  it("gateway serves index.html for a directory CID", async () => {
+    const { lines } = await addDir([
+      { filename: "index.html", content: "<title>COC</title>" },
+      { filename: "other.txt", content: "x" },
+    ])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/ipfs/${root}`)
+    assert.equal(res.status, 200)
+    assert.match(String(res.headers["content-type"]), /text\/html/)
+    assert.equal(await res.text(), "<title>COC</title>")
+  })
+
+  it("gateway returns 404 for a missing path component", async () => {
+    const { lines } = await addDir([{ filename: "docs/a.txt", content: "x" }])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/ipfs/${root}/docs/missing.txt`)
+    assert.equal(res.status, 404)
+  })
+
+  it("returns 400 not-a-directory when descending into a file mid-path", async () => {
+    const { lines } = await addDir([{ filename: "docs/a.txt", content: "x" }])
+    const root = lines[lines.length - 1].Hash
+    const res = await fetch(`/api/v0/cat?arg=${root}/docs/a.txt/deeper`)
+    assert.equal(res.status, 400)
+  })
+
+  it("HAMT-sized directory still lists every logical entry", async () => {
+    const parts = Array.from({ length: 4000 }, (_, i) => ({
+      filename: `entry-with-a-long-name-${i}.dat`,
+      content: `v${i}`,
+    }))
+    const { status, lines } = await addDir(parts)
+    assert.equal(status, 200)
+    const root = lines[lines.length - 1].Hash
+    const ls = await fetch(`/api/v0/ls?arg=${root}`)
+    const objs = (await ls.json()) as { Objects: Array<{ Links: unknown[] }> }
+    assert.equal(objs.Objects[0].Links.length, 4000)
+    // A specific deep entry resolves through the HAMT shards.
+    const cat = await fetch(`/api/v0/cat?arg=${root}/entry-with-a-long-name-1234.dat`)
+    assert.equal(cat.status, 200)
+    assert.equal(await cat.text(), "v1234")
+  })
+
+  it("rejects erasure + wrap-with-directory as mutually exclusive", async () => {
+    const { status, raw } = await addDir(
+      [{ filename: "a", content: "1" }, { filename: "b", content: "2" }],
+      "?erasure=2%2B1",
+    )
+    assert.equal(status, 400)
+    assert.match(raw, /mutually exclusive/)
+  })
+
+  it("rejects a directory upload with a path traversal segment", async () => {
+    const { status, raw } = await addDir([{ filename: "../escape.txt", content: "x" }])
+    assert.equal(status, 400)
+    assert.match(raw, /traversal|invalid_path/)
   })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -23,10 +23,28 @@ import {
   readErasureFile,
   erasureStatus,
 } from "./ipfs-erasure-reader.ts"
+import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { buildDirectoryDag, type DirEntryInput } from "./ipfs-unixfs-dir.ts"
+import {
+  resolveUnixfsPath,
+  listDirectory,
+  readEntryBytes,
+  PathResolveError,
+  MAX_BLOCK_READS,
+  type ResolvedEntry,
+  type DirectoryLink,
+} from "./ipfs-path-resolve.ts"
 
 const log = createLogger("ipfs")
 const ipfsRateLimiter = new RateLimiter(60_000, 100)
 setInterval(() => ipfsRateLimiter.cleanup(), 300_000).unref()
+
+/**
+ * #468: hard deadline for a single UnixFS DAG resolve / directory listing.
+ * A pathological (deep / wide / heavily-sharded) DAG cannot pin a request
+ * handler past this — the exporter's async iterators abort on the signal.
+ */
+const IPFS_RESOLVE_TIMEOUT_MS = 20_000
 
 class HttpError extends Error {
   readonly status: number
@@ -124,6 +142,14 @@ interface ResolvedCidPath {
   path: string[]
   leafIndex?: number
   leafSize?: number
+  /**
+   * Present when the CID/path resolved through the UnixFS DAG walker
+   * (issue #468 directory support). Carries the exporter entry so
+   * read handlers can stream file content or list directory children
+   * without a second blockstore round-trip. Absent for bare non-UnixFS
+   * CIDs and the #704 numeric chunk-link fallback.
+   */
+  entry?: ResolvedEntry
 }
 
 function isNotFoundError(err: unknown): boolean {
@@ -168,9 +194,12 @@ function validateAddParams(query: Record<string, string | string[] | undefined>)
 
   // Booleans we don't honor — accept "false" / absent, reject "true".
   // Case-insensitive to match kubo's go-flag parser.
+  //
+  // #468: `wrap-with-directory` left this list — it IS honored now (the
+  // directory-DAG write path). It is still validated as a boolean below
+  // so `wrap-with-directory=maybe` gets the same 400 kubo emits.
   const booleanRejectsTrue = [
     "raw-leaves",
-    "wrap-with-directory",
     "nocopy",
     "inline",
     "trickle",
@@ -188,6 +217,17 @@ function validateAddParams(query: Record<string, string | string[] | undefined>)
     if (norm !== "false" && norm !== "0") {
       throw new HttpError(400, "unsupported_param",
         `${key}: expected boolean (true/false/0/1), got '${raw}'`)
+    }
+  }
+
+  // #468: `wrap-with-directory` is a supported flag — only reject a
+  // non-boolean value, matching kubo's strconv.ParseBool behaviour.
+  const wrapRaw = firstQueryValue(query["wrap-with-directory"])
+  if (wrapRaw !== undefined) {
+    const norm = wrapRaw.toLowerCase()
+    if (norm !== "true" && norm !== "1" && norm !== "false" && norm !== "0") {
+      throw new HttpError(400, "unsupported_param",
+        `wrap-with-directory: expected boolean (true/false/0/1), got '${wrapRaw}'`)
     }
   }
 
@@ -445,18 +485,25 @@ export class IpfsHttpServer {
           res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: "invalid CID" }))
           return
         }
-        let resolvedCid = cid
-        if (parsed.path.length > 0) {
-          try {
-            resolvedCid = (await this.resolveCidPath(cid, parsed.path)).cid
-          } catch (err) {
-            if (err instanceof HttpError && err.status === 404) {
-              res.writeHead(404, { "content-type": "application/json", "access-control-allow-origin": "*" })
-              res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: err.code, message: err.message }))
-              return
-            }
-            throw err
+        // #468: resolve the full `<cid>/<subpath>` through the UnixFS DAG
+        // walker. Maps both 404 (missing component) and 400 (mid-path
+        // non-directory) to a structured JSON error with CORS preserved.
+        let resolved: ResolvedCidPath
+        try {
+          resolved = await this.resolveCidPath(cid, parsed.path)
+        } catch (err) {
+          if (err instanceof HttpError && (err.status === 404 || err.status === 400)) {
+            res.writeHead(err.status, { "content-type": "application/json", "access-control-allow-origin": "*" })
+            res.end(req.method === "HEAD" ? undefined : JSON.stringify({ error: err.code, message: err.message }))
+            return
           }
+          throw err
+        }
+        // #468: a directory CID — serve `index.html` if the directory has
+        // one (the canonical static-site pattern), else a JSON listing.
+        if (resolved.entry?.type === "directory") {
+          await this.serveGatewayDirectory(req, res, resolved.entry)
+          return
         }
         // #168: pre-fix ENOENT for valid-shape-missing CIDs propagated
         // to the outer 500 handler, logging a stacktrace for every probe.
@@ -471,7 +518,7 @@ export class IpfsHttpServer {
         // outer catch's structured handler. Same family as #168/#232/
         // #268/#270/#543 — generic 500 leak for a well-defined case.
         try {
-          const data = await this.readByCid(resolvedCid)
+          const data = await this.readResolved(resolved)
           // #324: HTTP Range support per RFC 7233. Pre-fix the gateway
           // returned the full body for every request, even when the
           // client sent `Range: bytes=N-M` — making resumable downloads,
@@ -588,7 +635,9 @@ export class IpfsHttpServer {
         // upload + a v1 CID they can't reconcile against their v0
         // expectation.
         validateAddParams(url.query as Record<string, string | string[] | undefined>)
-        await this.handleAdd(req, res, firstQueryValue(url.query.erasure))
+        const wrapRaw = firstQueryValue(url.query["wrap-with-directory"])?.toLowerCase()
+        const wrapWithDirectory = wrapRaw === "true" || wrapRaw === "1"
+        await this.handleAdd(req, res, firstQueryValue(url.query.erasure), wrapWithDirectory)
         return
       }
       if (url.pathname === "/api/v0/version") {
@@ -850,8 +899,25 @@ export class IpfsHttpServer {
     req: http.IncomingMessage,
     res: http.ServerResponse,
     erasureSpec?: string,
+    wrapWithDirectory = false,
   ): Promise<void> {
-    const { filename, bytes } = await readMultipartFile(req)
+    // #468: read every multipart part. A request is a directory upload
+    // when the client asked to wrap, OR sent more than one part, OR any
+    // part carries a nested relative path / explicit-directory marker.
+    const parts = await readMultipartFiles(req)
+    const nested = parts.some((p) => p.path !== undefined && p.path.includes("/"))
+    const isDirectory =
+      wrapWithDirectory || nested || parts.length > 1 || parts.some((p) => p.isDir)
+
+    if (isDirectory) {
+      await this.handleAddDirectory(res, parts, erasureSpec)
+      return
+    }
+
+    // Single-file upload — the original code path, unchanged. It keeps
+    // producing the PoSe `merkleRoot`/`merkleLeaves` side-tree.
+    const filename = parts[0].path
+    const bytes = parts[0].bytes
 
     // Phase Q.4: opt-in Reed-Solomon erasure coding via ?erasure=N+M.
     // The UnixFS DAG is still produced (for back-compat retrieval via
@@ -955,6 +1021,55 @@ export class IpfsHttpServer {
   }
 
   /**
+   * #468: directory-DAG upload. Builds a UnixFS directory tree from the
+   * multipart parts via `ipfs-unixfs-importer` (which auto-shards large
+   * directories into HAMT nodes), pins every emitted block, and streams a
+   * kubo-style NDJSON response — one `{Name,Hash,Size}` line per file and
+   * sub-directory, the wrapping root directory last.
+   */
+  private async handleAddDirectory(
+    res: http.ServerResponse,
+    parts: MultipartPart[],
+    erasureSpec?: string,
+  ): Promise<void> {
+    // Erasure coding operates on a single file's bytes — it has no
+    // meaning for a directory tree. Reject the combination explicitly.
+    if (erasureSpec) {
+      throw new HttpError(400, "unsupported_param",
+        "erasure coding and wrap-with-directory are mutually exclusive")
+    }
+
+    const entries: DirEntryInput[] = parts.map((p) =>
+      p.isDir
+        ? { path: p.path ?? "" }
+        : { path: p.path ?? "file", content: p.bytes },
+    )
+
+    const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
+    const imported = await buildDirectoryDag(entries, adapter)
+
+    // Recursively pin every node the importer emitted. COC's blockstore
+    // GC is flat (it does not walk a pinned root's children), so each
+    // directory + file-root CID must be pinned explicitly to survive
+    // `repo/gc`.
+    for (const node of imported.all) {
+      await this.store.pin(node.cid)
+    }
+
+    // kubo NDJSON: one JSON object per line, children first, root last.
+    res.writeHead(200, { "content-type": "application/json" })
+    for (const node of imported.all) {
+      const line: IpfsAddResult = {
+        Name: node.path,
+        Hash: node.cid,
+        Size: String(node.size),
+      }
+      res.write(`${JSON.stringify(line)}\n`)
+    }
+    res.end()
+  }
+
+  /**
    * Collect per-chunk replication status for the just-PUT DAG. Returns
    * null when the wiring isn't attached (replication gating is a no-op)
    * or when no push promises landed in the awaiter's tracking map
@@ -1047,14 +1162,18 @@ export class IpfsHttpServer {
     return parsed
   }
 
-  private async resolveCidPathArg(res: http.ServerResponse, arg?: string): Promise<ResolvedCidPath | null> {
+  private async resolveCidPathArg(
+    res: http.ServerResponse,
+    arg?: string,
+    opts?: { probeDirectory?: boolean },
+  ): Promise<ResolvedCidPath | null> {
     const parsed = this.parseCidPathArg(res, arg)
     if (!parsed) return null
     try {
-      return await this.resolveCidPath(parsed.cid, parsed.path)
+      return await this.resolveCidPath(parsed.cid, parsed.path, opts)
     } catch (err) {
-      if (err instanceof HttpError && err.status === 404) {
-        res.writeHead(404, { "content-type": "application/json" })
+      if (err instanceof HttpError && (err.status === 404 || err.status === 400)) {
+        res.writeHead(err.status, { "content-type": "application/json" })
         res.end(JSON.stringify({ error: err.code, message: err.message }))
         return null
       }
@@ -1062,34 +1181,98 @@ export class IpfsHttpServer {
     }
   }
 
-  private async resolveCidPath(rootCid: string, path: string[]): Promise<ResolvedCidPath> {
+  /**
+   * #468: resolve `<rootCid>` plus optional path segments to a single DAG
+   * node. Walks UnixFS directory DAGs (plain + HAMT) by Link name. For a
+   * bare CID that resolves to a directory the entry is attached so
+   * `ls`/`object/stat`/gateway can navigate it; bare file / non-UnixFS
+   * CIDs return without an entry so the existing file-meta / `readByCid`
+   * path handles them unchanged.
+   *
+   * Retains PR #704's numeric chunk-link fallback: `<file-cid>/<n>`
+   * addresses chunk leaf `n` via the file-meta leaf table.
+   */
+  private async resolveCidPath(
+    rootCid: string,
+    path: string[],
+    opts?: { probeDirectory?: boolean },
+  ): Promise<ResolvedCidPath> {
+    // `probeDirectory: false` keeps block-level endpoints (block/stat,
+    // block/get) off the UnixFS DAG walker entirely — block/stat must
+    // stay a local-only metadata query (#310: no fetchRemote on miss).
+    const probeDirectory = opts?.probeDirectory !== false
+    const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
+    const signal = AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)
+
+    if (!probeDirectory) {
+      // Block endpoints: bare CID resolves to itself; a subpath only
+      // resolves via the fetch-free numeric chunk-link table (#704).
+      if (path.length === 0) return { rootCid, cid: rootCid, path: [] }
+      if (path.length === 1 && /^[0-9]+$/.test(path[0])) {
+        const numeric = await this.resolveNumericLeaf(rootCid, path)
+        if (numeric) return numeric
+      }
+      throw new HttpError(404, "no such file", `no link named '${path[0]}' under ${rootCid}`)
+    }
+
     if (path.length === 0) {
+      // Bare CID: probe for a UnixFS directory. Files / non-UnixFS CIDs
+      // (raw blocks, erasure manifests, missing blocks) fall through with
+      // no entry — the existing readByCid / file-meta path handles them.
+      try {
+        const entry = await resolveUnixfsPath(rootCid, [], adapter, signal)
+        if (entry.type === "directory") {
+          return { rootCid, cid: rootCid, path: [], entry }
+        }
+      } catch {
+        /* not navigable as UnixFS — fall through to the bare-CID path */
+      }
       return { rootCid, cid: rootCid, path: [] }
     }
 
-    const head = path[0]
-    if (path.length !== 1 || !/^[0-9]+$/.test(head)) {
-      throw new HttpError(404, "no such file", `no link named '${head}' under ${rootCid}`)
+    try {
+      const entry = await resolveUnixfsPath(rootCid, path, adapter, signal)
+      return { rootCid, cid: entry.cid, path, entry }
+    } catch (err) {
+      if (err instanceof PathResolveError) {
+        // A subpath directly under a file/raw root (depth 0): PR #704's
+        // numeric chunk-link fallback applies. A single numeric segment
+        // addresses chunk leaf `n`; anything else is a genuine miss.
+        if (err.kind === "not_a_directory" && err.depth === 0) {
+          if (path.length === 1 && /^[0-9]+$/.test(path[0])) {
+            const numeric = await this.resolveNumericLeaf(rootCid, path)
+            if (numeric) return numeric
+          }
+          throw new HttpError(404, "no such file", `no link named '${path[0]}' under ${rootCid}`)
+        }
+        // Mid-path non-directory → 400; missing component → 404.
+        if (err.kind === "not_a_directory") {
+          throw new HttpError(400, "not a directory", err.message)
+        }
+        throw new HttpError(404, "no such file", err.message)
+      }
+      throw err
     }
+  }
 
-    const index = Number(head)
+  /** PR #704 numeric chunk-link lookup — `<file-cid>/<n>` → leaf `n`. */
+  private async resolveNumericLeaf(rootCid: string, path: string[]): Promise<ResolvedCidPath | null> {
+    const index = Number(path[0])
     const meta = await this.readFileMeta()
     const file = meta[rootCid]
     if (!Number.isSafeInteger(index) || !file || index < 0 || index >= file.leaves.length) {
-      throw new HttpError(404, "no such file", `no link named '${head}' under ${rootCid}`)
+      return null
     }
-
     const leafSize = index === file.leaves.length - 1
       ? file.size - file.blockSize * (file.leaves.length - 1)
       : file.blockSize
+    return { rootCid, cid: file.leaves[index], path, leafIndex: index, leafSize }
+  }
 
-    return {
-      rootCid,
-      cid: file.leaves[index],
-      path,
-      leafIndex: index,
-      leafSize,
-    }
+  /** #468: enumerate a resolved directory entry's children, under a hard
+   * timeout so a maliciously huge / sharded directory can't hang. */
+  private async listResolvedDirectory(entry: ResolvedEntry): Promise<DirectoryLink[]> {
+    return listDirectory(entry, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
   }
 
   private async handleLs(res: http.ServerResponse, cid?: string): Promise<void> {
@@ -1107,6 +1290,31 @@ export class IpfsHttpServer {
           },
         ],
       }))
+      return
+    }
+    // #468: a CID/path that resolved through the UnixFS DAG walker.
+    if (resolved.entry) {
+      if (resolved.entry.type === "directory") {
+        const links = await this.listResolvedDirectory(resolved.entry)
+        res.writeHead(200, { "content-type": "application/json" })
+        res.end(JSON.stringify({
+          Objects: [{
+            Hash: resolved.cid,
+            // kubo UnixFS ls Type enum: 1 = directory, 2 = file.
+            Links: links.map((l) => ({
+              Name: l.name,
+              Hash: l.cid,
+              Size: l.size,
+              Type: l.type === "directory" ? 1 : 2,
+            })),
+          }],
+        }))
+        return
+      }
+      // A file resolved via a directory subpath has no file-meta entry.
+      // kubo `ls` of a plain file CID returns it with no links.
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ Objects: [{ Hash: resolved.cid, Links: [] }] }))
       return
     }
     const meta = await this.readFileMeta()
@@ -1147,6 +1355,22 @@ export class IpfsHttpServer {
   private async handleObjectStat(res: http.ServerResponse, cid?: string): Promise<void> {
     const resolved = await this.resolveCidPathArg(res, cid)
     if (!resolved) {
+      return
+    }
+    // #468: a resolved UnixFS directory — report NumLinks from the live
+    // child listing rather than the file-meta leaf table.
+    if (resolved.entry?.type === "directory") {
+      const links = await this.listResolvedDirectory(resolved.entry)
+      const block = await this.store.get(resolved.cid)
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({
+        Hash: resolved.cid,
+        NumLinks: links.length,
+        BlockSize: block.bytes.length,
+        LinksSize: Math.min(links.length * 36, block.bytes.length),
+        DataSize: resolved.entry.size,
+        CumulativeSize: links.reduce((sum, l) => sum + l.size, block.bytes.length),
+      }))
       return
     }
     // #230: pre-fix the bare `store.get(cid)` call let ENOENT bubble
@@ -1228,7 +1452,12 @@ export class IpfsHttpServer {
       }
       length = n
     }
-    const data = await this.readByCid(resolved.cid)
+    // #468: `cat` of a directory CID is an error in kubo too.
+    if (resolved.entry?.type === "directory") {
+      throw new HttpError(400, "this dag node is a directory",
+        `${resolved.cid} is a directory — use /api/v0/ls`)
+    }
+    const data = await this.readResolved(resolved)
     const buf = Buffer.from(data)
     const slice = length !== undefined ? buf.subarray(offset, offset + length) : buf.subarray(offset)
     res.writeHead(200)
@@ -1240,10 +1469,104 @@ export class IpfsHttpServer {
     if (!resolved) {
       return
     }
-    const data = await this.readByCid(resolved.cid)
+    // #468: `get` of a directory streams a tar of every file in the tree.
+    if (resolved.entry?.type === "directory") {
+      const files = await this.collectDirectoryFiles(resolved.entry)
+      const archive = createTarArchive(files)
+      res.writeHead(200, { "content-type": "application/x-tar" })
+      res.end(archive)
+      return
+    }
+    const data = await this.readResolved(resolved)
     const archive = createTarArchive([{ name: resolved.cid, data }])
     res.writeHead(200, { "content-type": "application/x-tar" })
     res.end(archive)
+  }
+
+  /**
+   * #468: read a resolved entry's bytes. A file resolved through the
+   * UnixFS DAG walker uses the exporter (handles arbitrary DAG depth);
+   * a bare CID / numeric chunk-link falls back to `readByCid` (codec
+   * dispatch: raw / erasure / single-level UnixFS).
+   */
+  private async readResolved(resolved: ResolvedCidPath): Promise<Uint8Array> {
+    if (resolved.entry && resolved.entry.type !== "directory") {
+      return readEntryBytes(resolved.entry, undefined, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
+    }
+    return this.readByCid(resolved.cid)
+  }
+
+  /**
+   * #468: recursively collect every file in a resolved directory tree as
+   * `{ name, data }` tar entries, the name being the file's path relative
+   * to the directory root. Bounded by the path-resolve module's directory
+   * / read-size caps.
+   */
+  private async collectDirectoryFiles(
+    dir: ResolvedEntry,
+    prefix = "",
+  ): Promise<Array<{ name: string; data: Uint8Array }>> {
+    const out: Array<{ name: string; data: Uint8Array }> = []
+    const links = await this.listResolvedDirectory(dir)
+    for (const link of links) {
+      const childPath = prefix ? `${prefix}/${link.name}` : link.name
+      const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
+      const child = await resolveUnixfsPath(link.cid, [], adapter,
+        AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
+      if (child.type === "directory") {
+        out.push(...await this.collectDirectoryFiles(child, childPath))
+      } else {
+        out.push({
+          name: childPath,
+          data: await readEntryBytes(child, undefined, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)),
+        })
+      }
+    }
+    return out
+  }
+
+  /**
+   * #468: gateway response for a directory CID. Serves `index.html` when
+   * present (the canonical browser-dApp / static-site pattern), otherwise
+   * returns a JSON directory listing.
+   */
+  private async serveGatewayDirectory(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    dir: ResolvedEntry,
+  ): Promise<void> {
+    const links = await this.listResolvedDirectory(dir)
+    const index = links.find((l) => l.name === "index.html" && l.type === "file")
+    if (index) {
+      const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
+      const child = await resolveUnixfsPath(index.cid, [], adapter,
+        AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
+      const data = await readEntryBytes(child, undefined, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
+      const headers: http.OutgoingHttpHeaders = {
+        "content-type": "text/html; charset=utf-8",
+        "content-length": String(data.length),
+        "access-control-allow-origin": "*",
+      }
+      res.writeHead(200, headers)
+      res.end(req.method === "HEAD" ? undefined : data)
+      return
+    }
+    const body = JSON.stringify({
+      Type: "directory",
+      Hash: dir.cid,
+      Links: links.map((l) => ({
+        Name: l.name,
+        Hash: l.cid,
+        Size: l.size,
+        Type: l.type === "directory" ? 1 : 2,
+      })),
+    })
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": String(Buffer.byteLength(body)),
+      "access-control-allow-origin": "*",
+    })
+    res.end(req.method === "HEAD" ? undefined : body)
   }
 
   /**
@@ -1331,7 +1654,9 @@ export class IpfsHttpServer {
   }
 
   private async handleBlockGet(_req: http.IncomingMessage, res: http.ServerResponse, cid?: string): Promise<void> {
-    const resolved = await this.resolveCidPathArg(res, cid)
+    // #468: block endpoints operate on blocks, not the UnixFS DAG — keep
+    // them off the directory walker (block/stat must not fetchRemote).
+    const resolved = await this.resolveCidPathArg(res, cid, { probeDirectory: false })
     if (!resolved) {
       return
     }
@@ -1352,7 +1677,9 @@ export class IpfsHttpServer {
   }
 
   private async handleBlockStat(res: http.ServerResponse, cid?: string): Promise<void> {
-    const resolved = await this.resolveCidPathArg(res, cid)
+    // #310/#468: block/stat is a local-only metadata query — never walk
+    // the UnixFS DAG (would call store.get → fetchRemote on a miss).
+    const resolved = await this.resolveCidPathArg(res, cid, { probeDirectory: false })
     if (!resolved) {
       return
     }
@@ -2396,4 +2723,111 @@ async function readMultipartFile(req: http.IncomingMessage): Promise<{ filename?
       `multipart body has ${validParts.length} parts, but this endpoint accepts at most 1`)
   }
   return validParts[0]
+}
+
+// #468 — directory-upload multipart parsing.
+
+/** Max parts in one directory upload. */
+const MAX_MULTIPART_PARTS = 10_000
+/** Max path components in a single uploaded file's relative path. */
+const MAX_PATH_SEGMENTS = 64
+/** Max total length of a relative path. */
+const MAX_PATH_LENGTH = 1024
+/** Max length of a single path segment. */
+const MAX_SEGMENT_LENGTH = 255
+
+interface MultipartPart {
+  /** Relative POSIX path. Undefined for a raw (non-multipart) body. */
+  path?: string
+  bytes: Uint8Array
+  /** True for an explicit empty-directory part (kubo `application/x-directory`). */
+  isDir?: boolean
+}
+
+/**
+ * #468: validate and normalise a multipart `filename` into a safe relative
+ * POSIX path. Unlike `readMultipartFile` (which strips to a basename), this
+ * preserves directory components so nested-directory uploads work — but
+ * rejects traversal (`..`), absolute paths, backslashes, NUL bytes, and
+ * over-long paths/segments.
+ */
+function sanitizeRelPath(raw: string): string {
+  if (raw.includes("\0")) {
+    throw new HttpError(400, "invalid_path", "path contains a NUL byte")
+  }
+  if (raw.includes("\\")) {
+    throw new HttpError(400, "invalid_path", `path contains a backslash: '${raw}'`)
+  }
+  if (raw.startsWith("/")) {
+    throw new HttpError(400, "invalid_path", `absolute paths are not allowed: '${raw}'`)
+  }
+  if (raw.length > MAX_PATH_LENGTH) {
+    throw new HttpError(400, "invalid_path", `path too long (max ${MAX_PATH_LENGTH})`)
+  }
+  const segments = raw.split("/").filter((s) => s.length > 0)
+  if (segments.length > MAX_PATH_SEGMENTS) {
+    throw new HttpError(400, "invalid_path", `path too deep (max ${MAX_PATH_SEGMENTS} segments)`)
+  }
+  for (const seg of segments) {
+    if (seg === "." || seg === "..") {
+      throw new HttpError(400, "invalid_path", `path traversal segment '${seg}' is not allowed`)
+    }
+    if (seg.length > MAX_SEGMENT_LENGTH) {
+      throw new HttpError(400, "invalid_path", `path segment too long (max ${MAX_SEGMENT_LENGTH})`)
+    }
+  }
+  if (segments.length === 0) {
+    throw new HttpError(400, "invalid_path", "empty path")
+  }
+  return segments.join("/")
+}
+
+/**
+ * #468: parse a multipart body into N parts, preserving each part's
+ * relative path so directory trees can be reconstructed. Falls back to a
+ * single pathless part for raw (non-multipart) bodies — keeping the
+ * single-file `curl --data-binary` upload path working.
+ */
+async function readMultipartFiles(req: http.IncomingMessage): Promise<MultipartPart[]> {
+  const contentType = req.headers["content-type"] ?? ""
+  const boundaryMatch = /boundary=([^;\s]{1,256})/.exec(contentType)
+  if (!boundaryMatch) {
+    // Same #356 guard as readMultipartFile: multipart/* without a boundary
+    // is a client error; anything else is a raw-body upload.
+    if (/^multipart\//i.test(contentType.trim())) {
+      throw new HttpError(400, "invalid_multipart",
+        "multipart/* Content-Type requires boundary param")
+    }
+    const raw = await readBody(req)
+    return [{ bytes: raw }]
+  }
+
+  const boundary = boundaryMatch[1]
+  const raw = Buffer.from(await readBody(req))
+  const rawParts = findMultipartParts(raw, boundary)
+  const parts: MultipartPart[] = []
+  for (const { start, end } of rawParts) {
+    const part = raw.subarray(start, end)
+    const sepIdx = part.indexOf("\r\n\r\n")
+    if (sepIdx === -1) continue
+    const headerRaw = part.subarray(0, sepIdx).toString("binary")
+    const body = part.subarray(sepIdx + 4)
+    const filenameMatch = /filename="([^"]+)"/.exec(headerRaw)
+    const rawFilename = filenameMatch ? filenameMatch[1] : undefined
+    // kubo marks directory entries with an `application/x-directory`
+    // (or legacy `x-directory`) Content-Type and an empty body.
+    const isDir = /content-type:\s*application\/x-directory/i.test(headerRaw) ||
+      /content-type:\s*x-directory/i.test(headerRaw)
+    const path = rawFilename !== undefined ? sanitizeRelPath(rawFilename) : undefined
+    parts.push({ path, bytes: new Uint8Array(body), isDir })
+    if (parts.length > MAX_MULTIPART_PARTS) {
+      throw new HttpError(400, "unsupported_multipart",
+        `multipart body has more than ${MAX_MULTIPART_PARTS} parts`)
+    }
+  }
+
+  if (parts.length === 0) {
+    throw new HttpError(400, "invalid_multipart", "no part found in multipart body")
+  }
+  return parts
 }

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -23,7 +23,7 @@ import {
   readErasureFile,
   erasureStatus,
 } from "./ipfs-erasure-reader.ts"
-import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { InterfaceBlockstoreAdapter, BlockstoreReadBudgetError } from "./ipfs-blockstore-adapter.ts"
 import { buildDirectoryDag, type DirEntryInput } from "./ipfs-unixfs-dir.ts"
 import {
   resolveUnixfsPath,
@@ -167,6 +167,25 @@ function isNotFoundError(err: unknown): boolean {
   if (err && typeof err === "object" && "code" in err && (err as { code: unknown }).code === "ENOENT") return true
   const msg = String(err instanceof Error ? err.message : err)
   return /not\s*found|no such|ENOENT/i.test(msg)
+}
+
+/**
+ * #468: classify a UnixFS-resolve failure. Returns an `HttpError` when the
+ * failure is a *resource limit* — the per-request block-read budget was
+ * exhausted, or the resolve `AbortSignal` timed out — so callers surface a
+ * clean 504 instead of letting it fall through as a misleading 500 (or, in
+ * the bare-CID probe, get swallowed entirely). Returns `null` for ordinary
+ * "not a navigable UnixFS node" errors, which callers handle themselves.
+ */
+function resolveLimitError(err: unknown, signal: AbortSignal): HttpError | null {
+  if (signal.aborted) {
+    return new HttpError(504, "resolve timeout",
+      `UnixFS path resolution exceeded ${IPFS_RESOLVE_TIMEOUT_MS}ms`)
+  }
+  if (err instanceof BlockstoreReadBudgetError) {
+    return new HttpError(504, "resolve aborted", err.message)
+  }
+  return null
 }
 
 /**
@@ -1235,8 +1254,13 @@ export class IpfsHttpServer {
         if (entry.type === "directory") {
           return { rootCid, cid: rootCid, path: [], entry }
         }
-      } catch {
-        /* not navigable as UnixFS — fall through to the bare-CID path */
+      } catch (err) {
+        // A resource limit (read-budget exhausted / resolve timeout) is a
+        // real failure — surface it instead of swallowing it and letting
+        // the bare-CID path turn it into a misleading 500. Ordinary
+        // "not navigable as UnixFS" errors fall through as before.
+        const limit = resolveLimitError(err, signal)
+        if (limit) throw limit
       }
       return { rootCid, cid: rootCid, path: [] }
     }
@@ -1262,6 +1286,9 @@ export class IpfsHttpServer {
         }
         throw new HttpError(404, "no such file", err.message)
       }
+      // Read-budget / timeout → 504, not an opaque 500.
+      const limit = resolveLimitError(err, signal)
+      if (limit) throw limit
       throw err
     }
   }
@@ -1373,6 +1400,15 @@ export class IpfsHttpServer {
     if (resolved.entry?.type === "directory") {
       const links = await this.listResolvedDirectory(resolved.entry)
       const block = await this.store.get(resolved.cid)
+      // kubo's CumulativeSize is the *recursive* byte size of the whole
+      // subtree. Computing that exactly needs a full subtree walk — too
+      // costly for a stat call — so report a lower-bound approximation:
+      // the directory block plus the byte sizes of immediate *file*
+      // children. A directory child's `size` is an entry count, not a
+      // byte count, so it is deliberately excluded rather than summed
+      // with the wrong unit.
+      const immediateFileBytes = links.reduce(
+        (sum, l) => sum + (l.type === "file" ? l.size : 0), 0)
       res.writeHead(200, { "content-type": "application/json" })
       res.end(JSON.stringify({
         Hash: resolved.cid,
@@ -1380,7 +1416,7 @@ export class IpfsHttpServer {
         BlockSize: block.bytes.length,
         LinksSize: Math.min(links.length * 36, block.bytes.length),
         DataSize: resolved.entry.size,
-        CumulativeSize: links.reduce((sum, l) => sum + l.size, block.bytes.length),
+        CumulativeSize: block.bytes.length + immediateFileBytes,
       }))
       return
     }

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -46,6 +46,17 @@ setInterval(() => ipfsRateLimiter.cleanup(), 300_000).unref()
  */
 const IPFS_RESOLVE_TIMEOUT_MS = 20_000
 
+/**
+ * #468: aggregate caps for `/api/v0/get` of a directory tree. The tar is
+ * assembled fully in memory, so the per-file `MAX_READ_SIZE` cap is not
+ * enough — the cumulative byte count, file count, and nesting depth must
+ * all be bounded so a malicious wide/deep directory CID cannot exhaust
+ * node memory (the endpoint is not auth-gated).
+ */
+const MAX_DIRECTORY_GET_BYTES = 64 * 1024 * 1024
+const MAX_DIRECTORY_GET_FILES = 10_000
+const MAX_DIRECTORY_GET_DEPTH = 64
+
 class HttpError extends Error {
   readonly status: number
   readonly code: string
@@ -1471,7 +1482,7 @@ export class IpfsHttpServer {
     }
     // #468: `get` of a directory streams a tar of every file in the tree.
     if (resolved.entry?.type === "directory") {
-      const files = await this.collectDirectoryFiles(resolved.entry)
+      const files = await this.collectDirectoryFiles(resolved.entry, "", { bytes: 0, files: 0 }, 0)
       const archive = createTarArchive(files)
       res.writeHead(200, { "content-type": "application/x-tar" })
       res.end(archive)
@@ -1499,13 +1510,25 @@ export class IpfsHttpServer {
   /**
    * #468: recursively collect every file in a resolved directory tree as
    * `{ name, data }` tar entries, the name being the file's path relative
-   * to the directory root. Bounded by the path-resolve module's directory
-   * / read-size caps.
+   * to the directory root.
+   *
+   * `acc` is a single object shared across the whole recursion so the
+   * cumulative byte count and file count are bounded globally (not just
+   * per-file); `depth` is per-branch. Exceeding any of
+   * {@link MAX_DIRECTORY_GET_BYTES} / {@link MAX_DIRECTORY_GET_FILES} /
+   * {@link MAX_DIRECTORY_GET_DEPTH} aborts the request — without this a
+   * malicious wide/deep directory CID could exhaust node memory.
    */
   private async collectDirectoryFiles(
     dir: ResolvedEntry,
-    prefix = "",
+    prefix: string,
+    acc: { bytes: number; files: number },
+    depth: number,
   ): Promise<Array<{ name: string; data: Uint8Array }>> {
+    if (depth > MAX_DIRECTORY_GET_DEPTH) {
+      throw new HttpError(400, "directory too deep",
+        `directory nesting exceeds ${MAX_DIRECTORY_GET_DEPTH} levels`)
+    }
     const out: Array<{ name: string; data: Uint8Array }> = []
     const links = await this.listResolvedDirectory(dir)
     for (const link of links) {
@@ -1514,12 +1537,20 @@ export class IpfsHttpServer {
       const child = await resolveUnixfsPath(link.cid, [], adapter,
         AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
       if (child.type === "directory") {
-        out.push(...await this.collectDirectoryFiles(child, childPath))
+        out.push(...await this.collectDirectoryFiles(child, childPath, acc, depth + 1))
       } else {
-        out.push({
-          name: childPath,
-          data: await readEntryBytes(child, undefined, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)),
-        })
+        const data = await readEntryBytes(child, undefined, AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS))
+        acc.files += 1
+        acc.bytes += data.length
+        if (acc.files > MAX_DIRECTORY_GET_FILES) {
+          throw new HttpError(413, "directory too large",
+            `directory tar exceeds ${MAX_DIRECTORY_GET_FILES} files`)
+        }
+        if (acc.bytes > MAX_DIRECTORY_GET_BYTES) {
+          throw new HttpError(413, "directory too large",
+            `directory tar exceeds ${MAX_DIRECTORY_GET_BYTES} bytes`)
+        }
+        out.push({ name: childPath, data })
       }
     }
     return out

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -56,6 +56,13 @@ const IPFS_RESOLVE_TIMEOUT_MS = 20_000
 const MAX_DIRECTORY_GET_BYTES = 64 * 1024 * 1024
 const MAX_DIRECTORY_GET_FILES = 10_000
 const MAX_DIRECTORY_GET_DEPTH = 64
+/**
+ * Cap on the total number of DAG nodes (files AND directories) visited
+ * while assembling a directory tar. The byte / file caps do not bound a
+ * tree built entirely of empty sub-directories — depth alone would still
+ * allow an enormous traversal — so every visited entry is counted here.
+ */
+const MAX_DIRECTORY_GET_NODES = 50_000
 
 class HttpError extends Error {
   readonly status: number
@@ -1518,7 +1525,7 @@ export class IpfsHttpServer {
     }
     // #468: `get` of a directory streams a tar of every file in the tree.
     if (resolved.entry?.type === "directory") {
-      const files = await this.collectDirectoryFiles(resolved.entry, "", { bytes: 0, files: 0 }, 0)
+      const files = await this.collectDirectoryFiles(resolved.entry, "", { bytes: 0, files: 0, nodes: 0 }, 0)
       const archive = createTarArchive(files)
       res.writeHead(200, { "content-type": "application/x-tar" })
       res.end(archive)
@@ -1549,16 +1556,17 @@ export class IpfsHttpServer {
    * to the directory root.
    *
    * `acc` is a single object shared across the whole recursion so the
-   * cumulative byte count and file count are bounded globally (not just
-   * per-file); `depth` is per-branch. Exceeding any of
+   * cumulative byte count, file count, and node count are bounded
+   * globally (not just per-file); `depth` is per-branch. Exceeding any of
    * {@link MAX_DIRECTORY_GET_BYTES} / {@link MAX_DIRECTORY_GET_FILES} /
-   * {@link MAX_DIRECTORY_GET_DEPTH} aborts the request — without this a
-   * malicious wide/deep directory CID could exhaust node memory.
+   * {@link MAX_DIRECTORY_GET_NODES} / {@link MAX_DIRECTORY_GET_DEPTH}
+   * aborts the request — without this a malicious wide/deep directory CID
+   * could exhaust node memory or pin the handler on an enormous traversal.
    */
   private async collectDirectoryFiles(
     dir: ResolvedEntry,
     prefix: string,
-    acc: { bytes: number; files: number },
+    acc: { bytes: number; files: number; nodes: number },
     depth: number,
   ): Promise<Array<{ name: string; data: Uint8Array }>> {
     if (depth > MAX_DIRECTORY_GET_DEPTH) {
@@ -1568,6 +1576,15 @@ export class IpfsHttpServer {
     const out: Array<{ name: string; data: Uint8Array }> = []
     const links = await this.listResolvedDirectory(dir)
     for (const link of links) {
+      // Count every entry — file or directory — so a tree made purely of
+      // empty sub-directories (which never touches the byte/file caps) is
+      // still bounded. Checked before the resolve so the (n+1)-th node's
+      // blocks are never fetched.
+      acc.nodes += 1
+      if (acc.nodes > MAX_DIRECTORY_GET_NODES) {
+        throw new HttpError(413, "directory too large",
+          `directory tree exceeds ${MAX_DIRECTORY_GET_NODES} nodes`)
+      }
       const childPath = prefix ? `${prefix}/${link.name}` : link.name
       const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
       const child = await resolveUnixfsPath(link.cid, [], adapter,

--- a/node/src/ipfs-path-resolve.test.ts
+++ b/node/src/ipfs-path-resolve.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, beforeEach, afterEach } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { IpfsBlockstore } from "./ipfs-blockstore.ts"
+import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { buildDirectoryDag } from "./ipfs-unixfs-dir.ts"
+import {
+  resolveUnixfsPath,
+  listDirectory,
+  readEntryBytes,
+  PathResolveError,
+  MAX_PATH_DEPTH,
+  isParsableCid,
+} from "./ipfs-path-resolve.ts"
+
+let tmpDir: string
+let store: IpfsBlockstore
+const enc = (s: string) => new TextEncoder().encode(s)
+const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+function adapter(): InterfaceBlockstoreAdapter {
+  return new InterfaceBlockstoreAdapter(store)
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "path-resolve-"))
+  store = new IpfsBlockstore(tmpDir)
+  await store.init()
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function sampleTree(): Promise<string> {
+  const res = await buildDirectoryDag([
+    { path: "index.html", content: enc("<h1>home</h1>") },
+    { path: "docs/a.txt", content: enc("alpha") },
+    { path: "docs/img/b.bin", content: enc("BINARY") },
+  ], adapter())
+  return res.root.cid
+}
+
+describe("resolveUnixfsPath", () => {
+  it("navigates a nested file by name", async () => {
+    const root = await sampleTree()
+    const entry = await resolveUnixfsPath(root, ["docs", "a.txt"], adapter())
+    assert.equal(entry.type, "file")
+    assert.equal(dec(await readEntryBytes(entry)), "alpha")
+  })
+
+  it("navigates two levels deep", async () => {
+    const root = await sampleTree()
+    const entry = await resolveUnixfsPath(root, ["docs", "img", "b.bin"], adapter())
+    assert.equal(dec(await readEntryBytes(entry)), "BINARY")
+  })
+
+  it("resolves the root itself with an empty path", async () => {
+    const root = await sampleTree()
+    const entry = await resolveUnixfsPath(root, [], adapter())
+    assert.equal(entry.type, "directory")
+    assert.equal(entry.cid, root)
+  })
+
+  it("lists directory children", async () => {
+    const root = await sampleTree()
+    const dir = await resolveUnixfsPath(root, ["docs"], adapter())
+    const links = await listDirectory(dir)
+    const names = links.map((l) => l.name).sort()
+    assert.deepEqual(names, ["a.txt", "img"])
+    assert.equal(links.find((l) => l.name === "img")?.type, "directory")
+    assert.equal(links.find((l) => l.name === "a.txt")?.type, "file")
+  })
+
+  it("throws not_found for a missing path component", async () => {
+    const root = await sampleTree()
+    await assert.rejects(
+      () => resolveUnixfsPath(root, ["nope.txt"], adapter()),
+      (err: unknown) => err instanceof PathResolveError && err.kind === "not_found",
+    )
+  })
+
+  it("throws not_a_directory when descending into a file", async () => {
+    const root = await sampleTree()
+    await assert.rejects(
+      () => resolveUnixfsPath(root, ["index.html", "x"], adapter()),
+      (err: unknown) => err instanceof PathResolveError && err.kind === "not_a_directory" && err.depth === 1,
+    )
+  })
+
+  it("rejects a path deeper than MAX_PATH_DEPTH", async () => {
+    const root = await sampleTree()
+    const deep = Array.from({ length: MAX_PATH_DEPTH + 1 }, (_, i) => `s${i}`)
+    await assert.rejects(
+      () => resolveUnixfsPath(root, deep, adapter()),
+      (err: unknown) => err instanceof PathResolveError && /too deep/.test(err.message),
+    )
+  })
+
+  it("navigates a HAMT-sharded directory by name", async () => {
+    const entries = Array.from({ length: 4000 }, (_, i) => ({
+      path: `entry-with-a-long-name-${i}.dat`,
+      content: enc(`v${i}`),
+    }))
+    const res = await buildDirectoryDag(entries, adapter())
+    assert.equal(res.root.type, "hamt-sharded-directory")
+    const target = await resolveUnixfsPath(res.root.cid, ["entry-with-a-long-name-2718.dat"], adapter())
+    assert.equal(dec(await readEntryBytes(target)), "v2718")
+  })
+})
+
+describe("readEntryBytes", () => {
+  it("rejects reading a directory as a file", async () => {
+    const root = await sampleTree()
+    const dir = await resolveUnixfsPath(root, [], adapter())
+    await assert.rejects(() => readEntryBytes(dir), /is a directory/)
+  })
+})
+
+describe("isParsableCid", () => {
+  it("accepts a valid CID and rejects garbage", async () => {
+    const root = await sampleTree()
+    assert.equal(isParsableCid(root), true)
+    assert.equal(isParsableCid("not-a-cid"), false)
+  })
+})

--- a/node/src/ipfs-path-resolve.ts
+++ b/node/src/ipfs-path-resolve.ts
@@ -1,0 +1,190 @@
+import { CID } from "multiformats/cid"
+import { exporter } from "ipfs-unixfs-exporter"
+import type { UnixFSEntry } from "ipfs-unixfs-exporter"
+import type { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+
+/**
+ * Read-path UnixFS directory DAG navigation (issue #468).
+ *
+ * Resolves `<rootCid>/<seg>/<seg>…` by walking the DAG one path component
+ * at a time. Each hop delegates to `ipfs-unixfs-exporter`, so plain
+ * `directory` nodes (name lookup) **and** `hamt-sharded-directory` nodes
+ * (transparent shard descent) both work without us re-implementing the
+ * murmur3/bucket math.
+ *
+ * Walking segment-by-segment (rather than handing the whole path to the
+ * exporter in one call) lets us distinguish the two failure modes the
+ * exporter conflates into `ERR_NOT_FOUND`: a missing path component
+ * (404 "no such file") vs. trying to descend into a file (400 "not a
+ * directory").
+ */
+
+/** Max number of path components after the root CID. Guards against a
+ * malicious arg with thousands of segments forcing thousands of hops. */
+export const MAX_PATH_DEPTH = 64
+/** Max directory entries enumerated by {@link listDirectory}. Aligned with
+ * `ipfs-unixfs.ts`'s `MAX_READ_LINKS`. */
+export const MAX_DIR_ENTRIES = 10_000
+/** Max cumulative bytes streamed by {@link readEntryBytes}. Aligned with
+ * `ipfs-unixfs.ts`'s `MAX_READ_SIZE`. */
+export const MAX_READ_SIZE = 50 * 1024 * 1024
+/** Max blocks a single resolve/read may pull through the blockstore. */
+export const MAX_BLOCK_READS = 50_000
+
+export type ResolvedType = "file" | "directory" | "raw"
+
+export class PathResolveError extends Error {
+  readonly kind: "not_found" | "not_a_directory"
+  /** 0-based index of the path segment that failed. 0 means the root
+   * node itself (e.g. a file CID given a subpath). */
+  readonly depth: number
+  constructor(kind: "not_found" | "not_a_directory", message: string, depth = 0) {
+    super(message)
+    this.name = "PathResolveError"
+    this.kind = kind
+    this.depth = depth
+  }
+}
+
+export interface ResolvedEntry {
+  /** CID of the resolved node (a leaf/sub-CID, not necessarily the root). */
+  cid: string
+  type: ResolvedType
+  /** UnixFS logical size: file byte count, or directory entry count. */
+  size: number
+  /** The underlying exporter entry — used for content()/listing. */
+  entry: UnixFSEntry
+}
+
+export interface DirectoryLink {
+  name: string
+  cid: string
+  size: number
+  type: "file" | "directory"
+}
+
+function isNotFound(err: unknown): boolean {
+  return Boolean(err) && typeof err === "object" && (err as { code?: string }).code === "ERR_NOT_FOUND"
+}
+
+function normalizeType(t: UnixFSEntry["type"]): ResolvedType {
+  if (t === "directory") return "directory"
+  if (t === "file") return "file"
+  // raw / identity / object — treat as opaque leaf bytes.
+  return "raw"
+}
+
+/**
+ * Resolve `rootCid` plus zero or more path `segments` to a single DAG node.
+ *
+ * @throws {PathResolveError} `not_found` for a missing component,
+ *   `not_a_directory` when a non-directory is encountered mid-path.
+ */
+export async function resolveUnixfsPath(
+  rootCid: string,
+  segments: string[],
+  blockstore: InterfaceBlockstoreAdapter,
+  signal?: AbortSignal,
+): Promise<ResolvedEntry> {
+  if (segments.length > MAX_PATH_DEPTH) {
+    throw new PathResolveError("not_found", `path too deep (max ${MAX_PATH_DEPTH} segments)`)
+  }
+
+  let currentCid = rootCid
+  let entry: UnixFSEntry
+  try {
+    entry = await exporter(rootCid, blockstore, { signal })
+  } catch (err) {
+    if (isNotFound(err)) throw new PathResolveError("not_found", `block not found: ${rootCid}`)
+    throw err
+  }
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    const type = normalizeType(entry.type)
+    if (type !== "directory") {
+      throw new PathResolveError(
+        "not_a_directory",
+        `cannot descend into '${seg}': ${currentCid} is not a directory`,
+        i,
+      )
+    }
+    try {
+      // One hop. The exporter does plain-name lookup or HAMT shard descent
+      // for `<dir-cid>/<seg>` depending on the directory node type.
+      entry = await exporter(`${currentCid}/${seg}`, blockstore, { signal })
+    } catch (err) {
+      if (isNotFound(err)) {
+        throw new PathResolveError("not_found", `no link named '${seg}' under ${currentCid}`, i)
+      }
+      throw err
+    }
+    currentCid = entry.cid.toString()
+  }
+
+  return { cid: currentCid, type: normalizeType(entry.type), size: Number(entry.size), entry }
+}
+
+/**
+ * List the children of a resolved directory entry. Throws if the entry is
+ * not a directory. Enumeration is capped at {@link MAX_DIR_ENTRIES}.
+ */
+export async function listDirectory(resolved: ResolvedEntry, signal?: AbortSignal): Promise<DirectoryLink[]> {
+  if (resolved.type !== "directory") {
+    throw new PathResolveError("not_a_directory", `${resolved.cid} is not a directory`)
+  }
+  const links: DirectoryLink[] = []
+  for await (const child of resolved.entry.content({ signal }) as AsyncIterable<UnixFSEntry>) {
+    links.push({
+      name: child.name,
+      cid: child.cid.toString(),
+      size: Number(child.size),
+      type: child.type === "directory" ? "directory" : "file",
+    })
+    if (links.length >= MAX_DIR_ENTRIES) {
+      throw new PathResolveError("not_found", `directory has too many entries (max ${MAX_DIR_ENTRIES})`)
+    }
+  }
+  return links
+}
+
+/**
+ * Read the full byte content of a resolved file/raw entry into one buffer.
+ * Enforces {@link MAX_READ_SIZE}. Optional `offset`/`length` slice the file.
+ */
+export async function readEntryBytes(
+  resolved: ResolvedEntry,
+  range?: { offset?: number; length?: number },
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  if (resolved.type === "directory") {
+    throw new PathResolveError("not_a_directory", `${resolved.cid} is a directory, not a file`)
+  }
+  const parts: Uint8Array[] = []
+  let total = 0
+  const opts = { signal, ...(range?.offset !== undefined ? { offset: range.offset } : {}), ...(range?.length !== undefined ? { length: range.length } : {}) }
+  for await (const chunk of resolved.entry.content(opts) as AsyncIterable<Uint8Array>) {
+    total += chunk.length
+    if (total > MAX_READ_SIZE) {
+      throw new PathResolveError("not_found", `file exceeds max read size (${MAX_READ_SIZE})`)
+    }
+    parts.push(chunk)
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const p of parts) {
+    out.set(p, offset)
+    offset += p.length
+  }
+  return out
+}
+
+/** True when `value` parses as a CID — used to validate the root component. */
+export function isParsableCid(value: string): boolean {
+  try {
+    CID.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/node/src/ipfs-unixfs-dir.test.ts
+++ b/node/src/ipfs-unixfs-dir.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, beforeEach, afterEach } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { IpfsBlockstore } from "./ipfs-blockstore.ts"
+import { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+import { buildDirectoryDag } from "./ipfs-unixfs-dir.ts"
+
+let tmpDir: string
+let store: IpfsBlockstore
+let adapter: InterfaceBlockstoreAdapter
+const enc = (s: string) => new TextEncoder().encode(s)
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "unixfs-dir-"))
+  store = new IpfsBlockstore(tmpDir)
+  await store.init()
+  adapter = new InterfaceBlockstoreAdapter(store)
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe("buildDirectoryDag", () => {
+  it("builds a flat directory with multiple files", async () => {
+    const res = await buildDirectoryDag([
+      { path: "a.txt", content: enc("alpha") },
+      { path: "b.txt", content: enc("beta") },
+    ], adapter)
+    assert.equal(res.root.type, "directory")
+    assert.ok(res.root.cid.startsWith("bafy"))
+    const fileNodes = res.all.filter((n) => n.type === "file")
+    assert.equal(fileNodes.length, 2)
+  })
+
+  it("creates intermediate directories for nested paths", async () => {
+    const res = await buildDirectoryDag([
+      { path: "docs/a.txt", content: enc("alpha") },
+      { path: "docs/img/b.bin", content: enc("BINARY") },
+    ], adapter)
+    const paths = res.all.map((n) => n.path)
+    // Implicit `docs` and `docs/img` directories must be materialised.
+    assert.ok(paths.includes("docs"), `expected 'docs' dir, got ${paths}`)
+    assert.ok(paths.includes("docs/img"), `expected 'docs/img' dir, got ${paths}`)
+    assert.equal(res.root.type, "directory")
+  })
+
+  it("is deterministic — same input yields the same root CID", async () => {
+    const input = [
+      { path: "x", content: enc("one") },
+      { path: "y", content: enc("two") },
+    ]
+    const a = await buildDirectoryDag(input, adapter)
+    const b = await buildDirectoryDag(input, new InterfaceBlockstoreAdapter(store))
+    assert.equal(a.root.cid, b.root.cid)
+  })
+
+  it("handles an empty (explicit) directory entry", async () => {
+    const res = await buildDirectoryDag([{ path: "emptydir" }], adapter)
+    assert.equal(res.root.type, "directory")
+    // The empty directory exists as a link inside the wrapping root even
+    // though the importer does not yield it as a separate node.
+    const { resolveUnixfsPath } = await import("./ipfs-path-resolve.ts")
+    const child = await resolveUnixfsPath(res.root.cid, ["emptydir"], adapter)
+    assert.equal(child.type, "directory")
+  })
+
+  it("auto-shards a large directory into a HAMT node", async () => {
+    // Enough entries with long names to push the directory node past the
+    // 256 KiB shard-split threshold → importer emits hamt-sharded-directory.
+    const entries = Array.from({ length: 5000 }, (_, i) => ({
+      path: `file-with-a-deliberately-long-name-${i}.txt`,
+      content: enc(`c${i}`),
+    }))
+    const res = await buildDirectoryDag(entries, adapter)
+    assert.equal(res.root.type, "hamt-sharded-directory",
+      `large directory must shard into HAMT, got ${res.root.type}`)
+  })
+})

--- a/node/src/ipfs-unixfs-dir.ts
+++ b/node/src/ipfs-unixfs-dir.ts
@@ -1,0 +1,93 @@
+import { importer } from "ipfs-unixfs-importer"
+import { fixedSize } from "ipfs-unixfs-importer/chunker"
+import { balanced } from "ipfs-unixfs-importer/layout"
+import type { InterfaceBlockstoreAdapter } from "./ipfs-blockstore-adapter.ts"
+
+/**
+ * Write-path directory DAG construction (issue #468).
+ *
+ * COC's bespoke `UnixFsBuilder.addFile` stays the single-file path (it
+ * carries the PoSe `merkleRoot`/`merkleLeaves` side-tree). For multi-file
+ * and nested-directory uploads we delegate to `ipfs-unixfs-importer`,
+ * which builds the dag-pb directory tree from a flat list of POSIX paths
+ * and — when a directory's serialized node exceeds the shard threshold —
+ * automatically emits `hamt-sharded-directory` nodes. The importer is the
+ * canonical IPFS implementation, so the produced DAGs are byte-identical
+ * to kubo/Helia and interoperable with every public gateway.
+ */
+
+/** Fixed chunk size — mirrors `UnixFsBuilder` and the value advertised by
+ * `validateAddParams` (`chunker=size-262144`). */
+const CHUNK_SIZE = 262144
+
+export interface DirEntryInput {
+  /** POSIX-style relative path, e.g. `docs/img/logo.png`. */
+  path: string
+  /** File bytes. Omit for an explicit (possibly empty) directory entry. */
+  content?: Uint8Array
+}
+
+export interface ImportedNode {
+  path: string
+  cid: string
+  size: number
+  type: "file" | "directory" | "hamt-sharded-directory" | "raw"
+}
+
+export interface DirectoryImportResult {
+  /** The wrapping root directory (last node yielded by the importer). */
+  root: ImportedNode
+  /** Every node emitted — children first, root last. */
+  all: ImportedNode[]
+}
+
+/**
+ * Build a UnixFS directory DAG from a flat list of path/content entries.
+ *
+ * Intermediate directories are created implicitly (`a/b/c.txt` materialises
+ * `a` and `a/b`). The result is always wrapped in a single root directory.
+ *
+ * The importer config is pinned for kubo parity and to match the leaf
+ * encoding `UnixFsBuilder.addFile` produces (UnixFS-wrapped file leaves, not
+ * raw leaves), so a file uploaded bare vs. inside a directory chunks the
+ * same way:
+ *   - `chunker: fixedSize(262144)`  — 256 KiB fixed chunks
+ *   - `layout: balanced()`          — balanced DAG
+ *   - `rawLeaves: false` + `leafType: 'file'` — UnixFS file leaves
+ *   - `cidVersion: 1`               — base32 `bafy…` CIDs
+ *   - `shardSplitThresholdBytes` / `shardFanoutBits` left at kubo defaults
+ *     (256 KiB / fanout 256) so HAMT sharding triggers identically.
+ */
+export async function buildDirectoryDag(
+  entries: DirEntryInput[],
+  blockstore: InterfaceBlockstoreAdapter,
+): Promise<DirectoryImportResult> {
+  const candidates = entries.map((e) =>
+    e.content !== undefined ? { path: e.path, content: e.content } : { path: e.path },
+  )
+
+  const all: ImportedNode[] = []
+  for await (const node of importer(candidates, blockstore, {
+    wrapWithDirectory: true,
+    chunker: fixedSize({ chunkSize: CHUNK_SIZE }),
+    layout: balanced(),
+    rawLeaves: false,
+    leafType: "file",
+    cidVersion: 1,
+  })) {
+    all.push({
+      path: node.path ?? "",
+      cid: node.cid.toString(),
+      size: Number(node.size),
+      type: (node.unixfs?.type as ImportedNode["type"]) ?? "raw",
+    })
+  }
+
+  if (all.length === 0) {
+    throw new Error("importer produced no nodes")
+  }
+  // With wrapWithDirectory the importer yields children first and the
+  // wrapping root directory last.
+  const root = all[all.length - 1]
+  return { root, all }
+}


### PR DESCRIPTION
## Summary

Closes the remaining scope of #468. PR #704 (`48329ba`) only resolved numeric chunk-link subpaths; this PR implements the full UnixFS **directory DAG** — both the write path (producing directory DAGs) and the read path (deserializing + navigating them by Link name), including **HAMT-sharded directories**.

`<CID>/<subpath>` requests — `/ipfs/<DIR>/index.html`, `/api/v0/cat?arg=<DIR>/<file>`, etc. — now resolve through the DAG instead of returning a misleading `invalid cid`.

## Approach

- **Write**: `ipfs-unixfs-importer@16.0.1` builds nested directory trees from flat paths and auto-shards large directories into `hamt-sharded-directory` nodes.
- **Read**: `ipfs-unixfs-exporter@13.6.6` resolves `<cid>/<path>` by Link name, descending HAMT shards transparently.
- Versions pinned to the `multiformats@^13`-compatible line (latest requires v14, which conflicts with COC's pin).
- Single-file uploads still use COC's bespoke `UnixFsBuilder.addFile` — the PoSe `merkleRoot`/`merkleLeaves` side-tree and existing CIDs are unchanged.

## Changes

New modules:
- `node/src/ipfs-blockstore-adapter.ts` — bridges COC's `IpfsBlockstore` to `interface-blockstore` (with a per-request block-read budget).
- `node/src/ipfs-unixfs-dir.ts` — `buildDirectoryDag()` wrapping the importer.
- `node/src/ipfs-path-resolve.ts` — `resolveUnixfsPath()` wrapping the exporter (depth / entry-count / read-size / timeout caps).

`node/src/ipfs-http.ts`:
- `/api/v0/add` honors `wrap-with-directory` + multi-file / nested-directory uploads (NDJSON response, recursive pin, path-traversal guards).
- `resolveCidPath` generalised from numeric-only to full DAG-by-name navigation; PR #704's numeric chunk-link fallback retained.
- `cat` / `ls` / `object/stat` / gateway resolve `<cid>/<path>`; gateway serves `index.html` or a JSON listing for directory CIDs.
- Error mapping: invalid CID → 400, missing component → 404, mid-path non-directory → 400.
- `block/stat` / `block/get` stay off the DAG walker (`block/stat` remains local-only — preserves #310).

## Known gap (deliberate)

Files uploaded *inside* a directory are chunked by the importer and do **not** carry COC's PoSe `merkleRoot`/`merkleLeaves`, so they are not currently subjects of PoSe storage challenges. Single-file `/api/v0/add` uploads are unaffected. Noted in `docs/implementation-status.md`; follow-up tracked separately.

## Test plan

- [x] 370 `ipfs-*` unit + integration tests pass (30 new: 19 unit across the 3 new modules, 11 HTTP integration).
- [x] 52 IPFS e2e + hardening tests pass (`tests/e2e/ipfs-e2e*.test.ts`, `tests/security/ipfs-hardening.test.ts`).
- [x] HAMT verified: a 4–6k-entry directory shards into `hamt-sharded-directory` and resolves entries by name.
- [x] #468 repro confirmed fixed: `GET /ipfs/<DIR>/docs/a.txt` returns the file (was 400).
- [x] Back-compat: all pre-existing single-file `add`/`cat`/`ls`/`object-stat`/gateway tests + PR #704 numeric-subpath tests pass unchanged.

Run: `node --experimental-strip-types --test $(find node/src -name 'ipfs-*.test.ts' | sort)`