### PR TITLE
feat(security): off-chain metadata + v2 typehash signing (#667 PR-B)

### DIFF
--- a/node/src/crypto/eip712-types.ts
+++ b/node/src/crypto/eip712-types.ts
@@ -68,6 +68,23 @@ export const WITNESS_TYPES = {
   ],
 } as const
 
+/**
+ * #667 v2 witness attestation typehash — adds `epochId`. Bound to the
+ * epoch in which the signature was collected so it cannot be replayed
+ * across epochs. Witnesses produce both v1 (`WITNESS_TYPES`) and v2
+ * (`WITNESS_TYPES_V2`) signatures during the rollout window; the
+ * contract accepts either.
+ */
+export const WITNESS_TYPES_V2 = {
+  WitnessAttestationV2: [
+    { name: "challengeId", type: "bytes32" },
+    { name: "nodeId", type: "bytes32" },
+    { name: "responseBodyHash", type: "bytes32" },
+    { name: "witnessIndex", type: "uint8" },
+    { name: "epochId", type: "uint64" },
+  ],
+} as const
+
 export const EVIDENCE_LEAF_TYPES = {
   EvidenceLeaf: [
     { name: "epoch", type: "uint64" },

--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -237,6 +237,9 @@ const poseV2Abi = [
   "event NodeRegistered(bytes32 indexed nodeId, address indexed operator, uint8 serviceFlags, uint256 bondAmount)",
   "function initEpochNonce(uint64 epochId)",
   "function submitBatchV2(uint64 epochId, bytes32 merkleRoot, bytes32 summaryHash, tuple(bytes32 leaf, bytes32[] merkleProof, uint32 leafIndex)[] sampleProofs, uint32 witnessBitmap, bytes[] witnessSignatures) returns (bytes32 batchId)",
+  // #667 — `submitBatchV2WithMetadata`. ReceiptBatchMetadata struct fields:
+  //   challengeIds[]; nodeIds[]; responseBodyHashes[]; leafHashes[]; witnessReceiptIndex[32]
+  "function submitBatchV2WithMetadata(uint64 epochId, bytes32 merkleRoot, bytes32 summaryHash, tuple(bytes32 leaf, bytes32[] merkleProof, uint32 leafIndex)[] sampleProofs, uint32 witnessBitmap, bytes[] witnessSignatures, tuple(bytes32[] challengeIds, bytes32[] nodeIds, bytes32[] responseBodyHashes, bytes32[] leafHashes, uint16[32] witnessReceiptIndex) metadata) returns (bytes32 batchId)",
   "function getActiveNodeCount() view returns (uint256)",
   "function getActiveNodeIds(uint256 offset, uint256 limit) view returns (bytes32[])",
   "function getWitnessSet(uint64 epochId) view returns (bytes32[])",
@@ -1225,6 +1228,34 @@ function stableStringifyAgent(value: unknown): string {
   return `{${props.join(",")}}`;
 }
 
+function popcount(n: number): number {
+  let count = 0;
+  let v = n;
+  while (v) {
+    count += v & 1;
+    v >>>= 1;
+  }
+  return count;
+}
+
+/**
+ * #667 — read the on-chain witness quorum threshold for an epoch. Returns
+ * `ceil(2m/3)` where `m = getWitnessSet(epochId).length`. When no witness
+ * set exists (early-network, isolated single-node devnet) returns 0, which
+ * lets `flushBatchV2` skip the quorum-fallback path entirely.
+ */
+async function computeWitnessQuorumThreshold(epochId: number): Promise<number> {
+  if (!poseV2Contract) return 0;
+  try {
+    const witnessSet = (await poseV2Contract.getWitnessSet(BigInt(epochId))) as string[];
+    const m = witnessSet.length;
+    if (m === 0) return 0;
+    return Math.floor((2 * m + 2) / 3); // ceil(2m/3)
+  } catch {
+    return 0;
+  }
+}
+
 async function collectBatchWitnessQuorum(epochId: number, merkleRoot: `0x${string}`): Promise<{
   bitmap: number;
   signatures: string[];
@@ -1269,58 +1300,76 @@ async function flushBatchV2(epochId: number, receipts: VerifiedReceiptV2[]): Pro
       return false;
     }
 
-    let witnessBitmap = 0;
-    let witnessSignatures: string[] = [];
-    try {
-      const witnessResult = await collectBatchWitnessQuorum(epochId, batch.merkleRoot as `0x${string}`);
-      if (witnessResult.quorumMet) {
-        witnessBitmap = witnessResult.bitmap;
-        witnessSignatures = witnessResult.signatures;
-      } else if (!allowEmptyBatchWitnessSubmission && witnessResult.requiredCount > 0) {
-        log.error("batchV2 skipped: witness quorum not met and empty fallback disabled", {
-          epochId,
-          merkleRoot: batch.merkleRoot,
-          signed: witnessResult.signedCount,
-          required: witnessResult.requiredCount,
-        });
-        return false;
-      } else {
-        runtimeStats.witnessFallbackCount += 1;
-        log.warn("batchV2 witness quorum not met, fallback to empty witness submission", {
-          epochId,
-          merkleRoot: batch.merkleRoot,
-          signed: witnessResult.signedCount,
-          required: witnessResult.requiredCount,
-          totalFallbacks: runtimeStats.witnessFallbackCount,
-        });
-      }
-    } catch (witnessError) {
+    // #667 — witness signatures now come from the per-receipt path collected
+    // by verifier-v2 at the receipt level (each receipt carries the witness
+    // attestations it actually received). The aggregator-built `batch`
+    // exposes them as `witnessSignatures` aligned with `witnessBitmap` set
+    // bits, plus a `metadata` payload the contract uses to rebuild EIP-712
+    // digests from ORIGINAL (challengeId, nodeId, responseBodyHash) instead
+    // of the batch merkleRoot.
+    //
+    // Fallback: when the per-receipt witnesses don't meet the on-chain
+    // quorum threshold and `allowEmptyBatchWitnessSubmission` is set, the
+    // owner-only empty-witness path lets the batch still settle (matches
+    // pre-#667 behaviour). The legacy `collectBatchWitnessQuorum` is no
+    // longer called — its "witness signs batch root" model is the #667
+    // root cause and lives in deprecated form for backwards reads only.
+    let witnessBitmap = batch.witnessBitmap;
+    let witnessSignatures: string[] = batch.witnessSignatures;
+    let usingEmptyFallback = false;
+
+    const requiredCount = await computeWitnessQuorumThreshold(epochId);
+    const signedCount = popcount(witnessBitmap);
+    if (requiredCount > 0 && signedCount < requiredCount) {
       if (!allowEmptyBatchWitnessSubmission) {
-        log.error("batchV2 skipped: witness collection failed and empty fallback disabled", {
+        log.error("batchV2 skipped: per-receipt witness quorum not met and empty fallback disabled", {
           epochId,
           merkleRoot: batch.merkleRoot,
-          error: String(witnessError),
+          signed: signedCount,
+          required: requiredCount,
         });
         return false;
       }
       runtimeStats.witnessFallbackCount += 1;
-      log.warn("batchV2 witness collection failed, fallback to empty witness submission", {
+      log.warn("batchV2 witness quorum not met, fallback to empty witness submission", {
         epochId,
         merkleRoot: batch.merkleRoot,
-        error: String(witnessError),
+        signed: signedCount,
+        required: requiredCount,
         totalFallbacks: runtimeStats.witnessFallbackCount,
       });
+      witnessBitmap = 0;
+      witnessSignatures = [];
+      usingEmptyFallback = true;
     }
 
     const tx = await retryAsync(
-      () => poseV2Contract.submitBatchV2(
-        BigInt(epochId),
-        batch.merkleRoot,
-        batch.summaryHash,
-        batch.sampleProofs,
-        witnessBitmap,
-        witnessSignatures,
-      ),
+      () => usingEmptyFallback
+        // Empty-witness path stays on the legacy ABI — bypasses metadata
+        // verification altogether (owner-only on-chain guard handles it).
+        ? poseV2Contract.submitBatchV2(
+            BigInt(epochId),
+            batch.merkleRoot,
+            batch.summaryHash,
+            batch.sampleProofs,
+            witnessBitmap,
+            witnessSignatures,
+          )
+        : poseV2Contract.submitBatchV2WithMetadata(
+            BigInt(epochId),
+            batch.merkleRoot,
+            batch.summaryHash,
+            batch.sampleProofs,
+            witnessBitmap,
+            witnessSignatures,
+            {
+              challengeIds: batch.metadata.challengeIds,
+              nodeIds: batch.metadata.nodeIds,
+              responseBodyHashes: batch.metadata.responseBodyHashes,
+              leafHashes: batch.metadata.leafHashes,
+              witnessReceiptIndex: batch.metadata.witnessReceiptIndex,
+            },
+          ),
       txRetryOptions,
     );
     const txReceipt = await retryAsync(() => tx.wait(), txRetryOptions);

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -12,7 +12,7 @@ import { readBoundedBody } from "./lib/pose-body-reader.ts";
 import { createNodeSigner, createNodeSignerV2, buildReceiptSignMessage } from "../node/src/crypto/signer.ts";
 import { keccak256Hex } from "../services/relayer/keccak256.ts";
 import { createLogger } from "../node/src/logger.ts";
-import { buildDomain, RECEIPT_TYPES, WITNESS_TYPES } from "../node/src/crypto/eip712-types.ts";
+import { buildDomain, RECEIPT_TYPES, WITNESS_TYPES, WITNESS_TYPES_V2 } from "../node/src/crypto/eip712-types.ts";
 
 const log = createLogger("coc-node");
 
@@ -97,6 +97,29 @@ async function signWitnessAttestation(
     nodeId,
     responseBodyHash,
     witnessIndex,
+  });
+}
+
+/**
+ * #667 — sign the v2 (`WitnessAttestationV2`) typehash that binds the
+ * attestation to `epochId`. Returned alongside the v1 signature so the
+ * on-chain `_validateWitnessQuorumV2` can pick either during the
+ * versioned-typehash rollout window.
+ */
+async function signWitnessAttestationV2(
+  challengeId: string,
+  nodeId: string,
+  responseBodyHash: string,
+  witnessIndex: number,
+  epochId: bigint,
+): Promise<string> {
+  if (!nodeSignerV2) throw new Error("v2 signer not available");
+  return nodeSignerV2.eip712.signTypedData(WITNESS_TYPES_V2, {
+    challengeId,
+    nodeId,
+    responseBodyHash,
+    witnessIndex,
+    epochId,
   });
 }
 
@@ -392,13 +415,28 @@ const server = http.createServer((req, res) => {
         return json(res, result.status, { error: result.error });
       }
       const fields = result.fields;
-      signWitnessAttestation(
+      const signV1 = signWitnessAttestation(
         fields.challengeId,
         fields.nodeId,
         fields.responseBodyHash,
         fields.witnessIndex,
-      )
-        .then((witnessSig) => {
+      );
+      // #667 — produce v2 signature too when caller passed `epochId`. The
+      // contract's `_validateWitnessQuorumV2` prefers v2 (which binds the
+      // signature to `epochId`) and falls back to v1 during rollout. We
+      // sign both so a single witness endpoint can serve mixed-version
+      // clients during the migration window.
+      const signV2 = fields.epochId !== undefined
+        ? signWitnessAttestationV2(
+            fields.challengeId,
+            fields.nodeId,
+            fields.responseBodyHash,
+            fields.witnessIndex,
+            fields.epochId,
+          )
+        : Promise.resolve<string | null>(null);
+      Promise.all([signV1, signV2])
+        .then(([witnessSig, witnessSigV2]) => {
           return json(res, 200, {
             challengeId: fields.challengeId,
             nodeId: fields.nodeId,
@@ -406,6 +444,7 @@ const server = http.createServer((req, res) => {
             witnessIndex: fields.witnessIndex,
             attestedAtMs: BigInt(Date.now()).toString(),
             witnessSig,
+            ...(witnessSigV2 ? { witnessSigV2 } : {}),
           });
         })
         .catch((error) => {

--- a/runtime/lib/pose-witness-validator.ts
+++ b/runtime/lib/pose-witness-validator.ts
@@ -20,10 +20,17 @@ export interface PoseWitnessFields {
   nodeId: string;
   responseBodyHash: string;
   witnessIndex: number;
+  /**
+   * #667 — optional epochId for v2 typehash binding. When provided the
+   * server returns both v1 and v2 signatures; when absent only v1 is
+   * produced (backwards-compatible with pre-#667 callers).
+   */
+  epochId?: bigint;
 }
 
 const HEX32_RE = /^0[xX][0-9a-fA-F]{64}$/;
 const HEX_ADDR_RE = /^0[xX][0-9a-fA-F]{40}$/;
+const MAX_UINT64 = (1n << 64n) - 1n;
 
 export type ValidateResult =
   | { ok: true; fields: PoseWitnessFields }
@@ -49,6 +56,29 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
     return { ok: false, status: 400, error: "witnessIndex must be a non-negative integer" };
   }
 
+  // #667: epochId is optional during the rollout window. Accept number or
+  // decimal-string (JSON has no bigint native form); reject anything else.
+  let epochId: bigint | undefined;
+  if (p.epochId !== undefined && p.epochId !== null) {
+    let parsed: bigint;
+    if (typeof p.epochId === "number") {
+      if (!Number.isFinite(p.epochId) || !Number.isInteger(p.epochId) || p.epochId < 0) {
+        return { ok: false, status: 400, error: "epochId must be a non-negative integer" };
+      }
+      parsed = BigInt(p.epochId);
+    } else if (typeof p.epochId === "string" && /^[0-9]+$/.test(p.epochId)) {
+      parsed = BigInt(p.epochId);
+    } else if (typeof p.epochId === "bigint") {
+      parsed = p.epochId;
+    } else {
+      return { ok: false, status: 400, error: "epochId must be a non-negative integer" };
+    }
+    if (parsed < 0n || parsed > MAX_UINT64) {
+      return { ok: false, status: 400, error: "epochId out of uint64 range" };
+    }
+    epochId = parsed;
+  }
+
   return {
     ok: true,
     fields: {
@@ -56,6 +86,7 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
       nodeId: p.nodeId.toLowerCase(),
       responseBodyHash: p.responseBodyHash.toLowerCase(),
       witnessIndex: p.witnessIndex,
+      epochId,
     },
   };
 }

--- a/runtime/lib/witness-collector.ts
+++ b/runtime/lib/witness-collector.ts
@@ -50,18 +50,24 @@ export async function collectWitnesses(
   nodeId: Hex32,
   responseBodyHash: Hex32,
   requestFn: WitnessRequestFn = requestJson,
+  epochId?: bigint,
 ): Promise<CollectResult> {
   const requests = config.witnessNodes.map(async (w) => {
     try {
+      const body: Record<string, unknown> = {
+        challengeId,
+        nodeId,
+        responseBodyHash,
+        witnessIndex: w.witnessIndex,
+      }
+      // #667 — when `epochId` is provided, opt in to the v2 typehash so
+      // the witness server returns a `witnessSigV2` alongside the v1
+      // signature. The aggregator prefers v2 when building the batch.
+      if (epochId !== undefined) body.epochId = epochId.toString()
       const response = await requestFn(
         `${w.url}/pose/witness`,
         "POST",
-        {
-          challengeId,
-          nodeId,
-          responseBodyHash,
-          witnessIndex: w.witnessIndex,
-        },
+        body,
         buildWitnessAuthHeaders(w.authToken),
       )
       const attest = response.json as WitnessAttestation | undefined
@@ -111,6 +117,16 @@ export async function collectWitnesses(
   }
 }
 
+/**
+ * @deprecated #667 — pairs with the legacy `submitBatchV2` path that has a
+ *             witness "rubber-stamp" hole (witnesses sign the batch root
+ *             rather than the receipts they actually attested to). Kept
+ *             only for backwards compatibility with the v1 typehash
+ *             rollout window; new code should rely on per-receipt
+ *             `collectWitnesses` + `BatchAggregatorV2.buildBatch` which
+ *             produces the `ReceiptBatchMetadata` for
+ *             `submitBatchV2WithMetadata`. PR-E removes this entry point.
+ */
 export async function collectBatchWitnessSignatures(
   merkleRoot: Hex32,
   witnessSet: Hex32[],

--- a/services/aggregator/batch-aggregator-v2-metadata.test.ts
+++ b/services/aggregator/batch-aggregator-v2-metadata.test.ts
@@ -1,0 +1,176 @@
+// #667 — BatchAggregatorV2 metadata + signature output tests.
+//
+// Covers the new pieces buildBatch emits for `submitBatchV2WithMetadata`:
+//   - challengeIds/nodeIds/responseBodyHashes/leafHashes are aligned and
+//     length-equal across all receipts in the batch.
+//   - witnessReceiptIndex[i] points at the first receipt whose
+//     per-receipt bitmap has bit i set (primary attribution).
+//   - witnessReceiptIndex unused slots default to 0xffff sentinel.
+//   - witnessSignatures are ordered by bitmap bit position (ascending)
+//     and prefer the v2 (witnessSigV2) signature when available.
+//   - Throws when a per-receipt witness attestation is missing for a
+//     set bit — fail loud rather than ship a quorum-failing batch.
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { BatchAggregatorV2, type ReceiptBatchV2 } from "./batch-aggregator-v2.ts"
+import { WITNESS_INDEX_UNUSED } from "../common/pose-types-v2.ts"
+import type { VerifiedReceiptV2, WitnessAttestation } from "../common/pose-types-v2.ts"
+import type { Hex32 } from "../common/pose-types.ts"
+
+function hex32(label: string): Hex32 {
+  const padded = label.padStart(64, "0")
+  return `0x${padded}` as Hex32
+}
+
+function nonce16(label: string): `0x${string}` {
+  return `0x${label.padStart(32, "0")}` as `0x${string}`
+}
+
+function makeWitness(
+  bit: number,
+  challengeId: Hex32,
+  nodeId: Hex32,
+  responseBodyHash: Hex32,
+  withV2 = true,
+): WitnessAttestation {
+  return {
+    challengeId,
+    nodeId,
+    responseBodyHash,
+    witnessIndex: bit,
+    attestedAtMs: 1n,
+    witnessSig: `0x${"aa".repeat(64)}${bit.toString(16).padStart(2, "0")}` as `0x${string}`,
+    ...(withV2
+      ? { witnessSigV2: `0x${"bb".repeat(64)}${bit.toString(16).padStart(2, "0")}` as `0x${string}` }
+      : {}),
+  }
+}
+
+function makeReceipt(label: string, witnessBits: number[], v2Sig = true): VerifiedReceiptV2 {
+  const challengeId = hex32(label + "ch")
+  const nodeId = hex32(label + "nd")
+  const responseBodyHash = hex32(label + "rb")
+  let bitmap = 0
+  const witnesses: WitnessAttestation[] = []
+  for (const bit of witnessBits) {
+    bitmap |= 1 << bit
+    witnesses.push(makeWitness(bit, challengeId, nodeId, responseBodyHash, v2Sig))
+  }
+  return {
+    challenge: {
+      version: 2,
+      challengeId,
+      epochId: 100n,
+      nodeId,
+      challengeType: "compute" as any,
+      nonce: nonce16(label + "no"),
+      challengeNonce: 1n,
+      querySpec: {},
+      querySpecHash: hex32(label + "qs"),
+      issuedAtMs: 0n,
+      deadlineMs: 9999,
+      challengerId: hex32(label + "cr"),
+      challengerSig: "0x" as `0x${string}`,
+    },
+    receipt: {
+      challengeId,
+      nodeId,
+      responseAtMs: 1n,
+      responseBody: {},
+      responseBodyHash,
+      tipHash: hex32(label + "tp"),
+      tipHeight: 1n,
+      nodeSig: "0x" as `0x${string}`,
+    },
+    witnesses,
+    witnessBitmap: bitmap,
+    evidenceLeaf: {
+      epoch: 100n,
+      nodeId,
+      nonce: nonce16(label + "no"),
+      tipHash: hex32(label + "tp"),
+      tipHeight: 1n,
+      latencyMs: 1,
+      resultCode: 0,
+      witnessBitmap: bitmap,
+    },
+    verifiedAtMs: 0n,
+  }
+}
+
+describe("BatchAggregatorV2 — #667 metadata + signatures", () => {
+  const agg = new BatchAggregatorV2({ sampleSize: 1 })
+
+  it("emits aligned per-receipt arrays", () => {
+    const receipts = [
+      makeReceipt("a", [0, 1]),
+      makeReceipt("b", [1, 2]),
+      makeReceipt("c", [3]),
+    ]
+    const batch = agg.buildBatch(100n, receipts)
+    const m = batch.metadata
+    assert.equal(m.challengeIds.length, 3)
+    assert.equal(m.nodeIds.length, 3)
+    assert.equal(m.responseBodyHashes.length, 3)
+    assert.equal(m.leafHashes.length, 3)
+    assert.equal(m.witnessReceiptIndex.length, 32)
+    assert.equal(m.leafHashes[0], batch.leafHashes[0])
+  })
+
+  it("witnessReceiptIndex points to first receipt whose bitmap has the bit set", () => {
+    // bit 0 only on receipt 0; bit 1 on both 0 and 1 (primary=0); bit 2 on receipt 1; bit 3 on receipt 2
+    const receipts = [
+      makeReceipt("a", [0, 1]),
+      makeReceipt("b", [1, 2]),
+      makeReceipt("c", [3]),
+    ]
+    const m = agg.buildBatch(100n, receipts).metadata
+    assert.equal(m.witnessReceiptIndex[0], 0, "bit 0 → receipt 0")
+    assert.equal(m.witnessReceiptIndex[1], 0, "bit 1 primary should be receipt 0 (first match)")
+    assert.equal(m.witnessReceiptIndex[2], 1, "bit 2 → receipt 1")
+    assert.equal(m.witnessReceiptIndex[3], 2, "bit 3 → receipt 2")
+  })
+
+  it("unused witnessReceiptIndex slots are 0xffff sentinel", () => {
+    const receipts = [makeReceipt("only", [0, 5])]
+    const m = agg.buildBatch(100n, receipts).metadata
+    for (const bit of [1, 2, 3, 4, 6, 7, 31]) {
+      assert.equal(
+        m.witnessReceiptIndex[bit],
+        WITNESS_INDEX_UNUSED,
+        `bit ${bit} should be ${WITNESS_INDEX_UNUSED}`,
+      )
+    }
+    assert.equal(m.witnessReceiptIndex[0], 0)
+    assert.equal(m.witnessReceiptIndex[5], 0)
+  })
+
+  it("witnessSignatures are emitted in ascending bit order and prefer v2", () => {
+    // bit 0 + bit 3 set; receipt index 0 has both, with v2 sigs.
+    const r = makeReceipt("z", [0, 3])
+    const batch = agg.buildBatch(100n, [r])
+    assert.equal(batch.witnessSignatures.length, 2, "popcount(0b1001) = 2 → 2 sigs")
+    // Must be the v2 signatures (witnessSigV2 prefix bb...)
+    for (const sig of batch.witnessSignatures) {
+      assert.ok(sig.toLowerCase().startsWith("0xbb"), `expected v2 prefix, got ${sig.slice(0, 6)}`)
+    }
+    // Trailing byte encodes the witness bit — ascending order.
+    assert.equal(batch.witnessSignatures[0].slice(-2), "00", "first sig is bit 0")
+    assert.equal(batch.witnessSignatures[1].slice(-2), "03", "second sig is bit 3")
+  })
+
+  it("falls back to v1 signature when v2 is not available", () => {
+    const r = makeReceipt("v1only", [0], /* v2Sig */ false)
+    const batch = agg.buildBatch(100n, [r])
+    assert.equal(batch.witnessSignatures.length, 1)
+    assert.ok(batch.witnessSignatures[0].toLowerCase().startsWith("0xaa"), "v1 prefix")
+  })
+
+  it("throws when a witness attestation is missing for a set bit", () => {
+    // bit 0 is set in r.witnessBitmap but receipt has no attestation for it.
+    const r = makeReceipt("z", [])
+    r.witnessBitmap = 1 // claim bit 0 without the matching attestation
+    assert.throws(() => agg.buildBatch(100n, [r]), /witness attestation missing for bit 0/)
+  })
+})

--- a/services/aggregator/batch-aggregator-v2.ts
+++ b/services/aggregator/batch-aggregator-v2.ts
@@ -5,7 +5,12 @@
 import { keccak256Hex } from "../relayer/keccak256.ts"
 import { buildMerkleRoot, buildMerkleProof } from "../common/merkle.ts"
 import type { Hex32 } from "../common/pose-types.ts"
-import type { VerifiedReceiptV2, EvidenceLeafV2 } from "../common/pose-types-v2.ts"
+import type {
+  VerifiedReceiptV2,
+  EvidenceLeafV2,
+  ReceiptBatchMetadata,
+} from "../common/pose-types-v2.ts"
+import { WITNESS_INDEX_UNUSED } from "../common/pose-types-v2.ts"
 import type { SampleProof } from "./batch-aggregator.ts"
 
 export interface ReceiptBatchV2 {
@@ -15,6 +20,21 @@ export interface ReceiptBatchV2 {
   leafHashes: Hex32[]
   sampleProofs: SampleProof[]
   witnessBitmap: number
+  /**
+   * Per-receipt metadata for the on-chain independent witness verification
+   * path (#667). Pass to `submitBatchV2WithMetadata` together with
+   * `witnessSignatures`.
+   */
+  metadata: ReceiptBatchMetadata
+  /**
+   * Witness signatures aligned with `witnessBitmap` set bits in ascending
+   * order. Each entry is the signature from the witness whose
+   * `metadata.witnessReceiptIndex[i]` points at the receipt this signature
+   * actually attests to. Prefers v2-typehash signatures (`witnessSigV2`)
+   * when available; falls back to the v1 `witnessSig` during the rollout
+   * window.
+   */
+  witnessSignatures: `0x${string}`[]
 }
 
 export interface BatchAggregatorV2Config {
@@ -72,11 +92,15 @@ export class BatchAggregatorV2 {
 
     const summaryHash = this.buildSummaryHash(epochId, merkleRoot, sampleProofs)
 
-    // OR-combine all witness bitmaps
+    // OR-combine all witness bitmaps (batch-level bitmap).
     let combinedBitmap = 0
     for (const r of receipts) {
       combinedBitmap |= r.witnessBitmap
     }
+
+    // #667 — build per-receipt metadata + per-bit witness signature array.
+    const metadata = this.buildMetadata(receipts, leafHashes, combinedBitmap)
+    const witnessSignatures = this.collectWitnessSignatures(receipts, combinedBitmap, metadata)
 
     return {
       epochId,
@@ -85,7 +109,74 @@ export class BatchAggregatorV2 {
       leafHashes,
       sampleProofs,
       witnessBitmap: combinedBitmap,
+      metadata,
+      witnessSignatures,
     }
+  }
+
+  /**
+   * Build the per-receipt metadata payload that `submitBatchV2WithMetadata`
+   * consumes. `witnessReceiptIndex[i]` (i in 0..31) maps bit `i` of the
+   * batch-level bitmap to the index of the "primary" receipt for that bit —
+   * i.e. the first receipt in `receipts` whose per-receipt `witnessBitmap`
+   * also has bit `i` set. Unused bits hold `WITNESS_INDEX_UNUSED`.
+   */
+  private buildMetadata(
+    receipts: VerifiedReceiptV2[],
+    leafHashes: Hex32[],
+    combinedBitmap: number,
+  ): ReceiptBatchMetadata {
+    const witnessReceiptIndex: number[] = new Array(32).fill(WITNESS_INDEX_UNUSED)
+    for (let bit = 0; bit < 32; bit++) {
+      if ((combinedBitmap & (1 << bit)) === 0) continue
+      // Find the first receipt whose per-receipt bitmap also has this bit.
+      for (let i = 0; i < receipts.length; i++) {
+        if ((receipts[i].witnessBitmap & (1 << bit)) !== 0) {
+          witnessReceiptIndex[bit] = i
+          break
+        }
+      }
+    }
+
+    return {
+      challengeIds: receipts.map((r) => r.challenge.challengeId),
+      nodeIds: receipts.map((r) => r.receipt.nodeId),
+      responseBodyHashes: receipts.map((r) => r.receipt.responseBodyHash),
+      leafHashes,
+      witnessReceiptIndex,
+    }
+  }
+
+  /**
+   * Collect witness signatures aligned with set bits in `combinedBitmap`
+   * (ascending bit order). Prefers v2-typehash signatures (`witnessSigV2`)
+   * when present; falls back to v1 (`witnessSig`) for backwards compatibility
+   * during the rollout window. Throws if a required signature is missing —
+   * the contract would `revert InvalidWitnessQuorum` and the relayer would
+   * waste gas, so fail loudly here instead.
+   */
+  private collectWitnessSignatures(
+    receipts: VerifiedReceiptV2[],
+    combinedBitmap: number,
+    metadata: ReceiptBatchMetadata,
+  ): `0x${string}`[] {
+    const signatures: `0x${string}`[] = []
+    for (let bit = 0; bit < 32; bit++) {
+      if ((combinedBitmap & (1 << bit)) === 0) continue
+      const receiptIdx = metadata.witnessReceiptIndex[bit]
+      if (receiptIdx === WITNESS_INDEX_UNUSED) {
+        throw new Error(`witnessReceiptIndex[${bit}] missing despite bit set`)
+      }
+      const receipt = receipts[receiptIdx]
+      const attestation = receipt.witnesses.find((w) => w.witnessIndex === bit)
+      if (!attestation) {
+        throw new Error(
+          `witness attestation missing for bit ${bit} on receipt ${receiptIdx} (challengeId=${receipt.challenge.challengeId})`,
+        )
+      }
+      signatures.push(attestation.witnessSigV2 ?? attestation.witnessSig)
+    }
+    return signatures
   }
 
   private buildSummaryHash(epochId: bigint, merkleRoot: Hex32, sampleProofs: SampleProof[]): Hex32 {

--- a/services/common/pose-types-v2.ts
+++ b/services/common/pose-types-v2.ts
@@ -80,7 +80,38 @@ export interface WitnessAttestation {
   witnessIndex: number
   attestedAtMs: bigint
   witnessSig: `0x${string}`
+  /**
+   * Optional v2 typehash signature (#667). Includes `epochId` so the
+   * signature is permanently bound to the epoch in which it was collected.
+   * Witnesses produce both v1 (`witnessSig`) and v2 (`witnessSigV2`) during
+   * the versioned-typehash rollout window; the contract accepts either.
+   */
+  witnessSigV2?: `0x${string}`
 }
+
+/**
+ * Per-receipt metadata sent alongside a v2 batch (#667). Lets the contract
+ * verify each witness signature against the ORIGINAL (challengeId, responseBodyHash)
+ * the witness actually attested to — not the batch merkleRoot. The contract
+ * independently rebuilds the Merkle root from `leafHashes` to assert it
+ * matches the submitted root.
+ *
+ * `witnessReceiptIndex[i]` is the index in {challengeIds, nodeIds,
+ * responseBodyHashes, leafHashes} that the witness at bit `i` (0..31) of
+ * the batch-level bitmap attested to. Unused bit positions hold the sentinel
+ * value `0xffff` (which the contract rejects when accessed via `BadReceiptIndex`).
+ */
+export interface ReceiptBatchMetadata {
+  challengeIds: Hex32[]
+  nodeIds: Hex32[]
+  responseBodyHashes: Hex32[]
+  leafHashes: Hex32[]
+  /** Fixed length 32 — matches Solidity `uint16[32]`. */
+  witnessReceiptIndex: number[]
+}
+
+/** Sentinel for `witnessReceiptIndex` slots that don't have an assigned receipt. */
+export const WITNESS_INDEX_UNUSED = 0xffff
 
 // Evidence leaf for Merkle batch (mirrors Solidity EvidenceLeafV2 struct)
 export interface EvidenceLeafV2 {


### PR DESCRIPTION
## Summary

PR-B in the #667 series. Stacked on top of #710 (PR-A, now merged); this PR has been rebased onto ``main`` so the diff below is the off-chain wiring only — the PR-A commit (``538e9ae``) is in main already.

> Note: the previous attempt at this PR (#712) was auto-closed when PR-A's base branch was deleted on squash-merge. This is a re-open with the same contents.

## Headline changes

- **``BatchAggregatorV2.buildBatch``** now emits a ``ReceiptBatchMetadata`` (``challengeIds`` / ``nodeIds`` / ``responseBodyHashes`` / ``leafHashes`` / ``witnessReceiptIndex[32]``) plus a ``witnessSignatures[]`` array aligned with the batch-level bitmap. Signatures come from per-receipt attestations already collected by ``ReceiptVerifierV2`` (which verifies against ORIGINAL receipt fields, not the batch root). Prefers v2 typehash signatures, falls back to v1.
- **``coc-node`` ``/pose/witness``** accepts an optional ``epochId`` parameter and returns both ``witnessSig`` (v1) and ``witnessSigV2`` (with ``epochId``) when ``epochId`` is provided. Backwards compatible with pre-#667 callers.
- **``coc-agent.flushBatchV2``** calls ``submitBatchV2WithMetadata`` on the happy path with metadata + per-receipt signatures. Reads the on-chain quorum threshold (``computeWitnessQuorumThreshold``); only falls back to the legacy empty-witness path (owner-only on-chain guard) when the per-receipt quorum is not met. ``collectBatchWitnessQuorum`` is no longer called for fresh submissions.
- **``collectBatchWitnessSignatures``** marked ``@deprecated`` — the "witness signs batch root" path that PR #700 left unauthenticated and #667 now closes structurally.
- **``WITNESS_TYPES_V2``** EIP-712 typehash added (binds ``epochId``).

## Rollout discipline

- Witnesses produce both v1 and v2 signatures during the rollout window. The contract's ``_validateWitnessQuorumV2`` accepts either.
- ``ReceiptBatchMetadata.witnessReceiptIndex`` unused slots hold the sentinel ``0xffff`` — matches the contract's ``BadReceiptIndex`` error path.
- Aggregator fails loud when a per-receipt witness attestation is missing for a set bit, rather than shipping a doomed-to-revert batch.

## Test plan

- [x] ``cd contracts && npx hardhat test test/pose-v2.test.cjs test/pose-v2-e2e.test.cjs test/pose-v2-witness-quorum-667.test.cjs`` — 64 passing + 1 pending (carried over from PR-A)
- [x] ``node --experimental-strip-types --test services/**/*.test.ts`` — **148 passing** (incl. 6 new in ``batch-aggregator-v2-metadata.test.ts``)
- [x] ``node --experimental-strip-types --test runtime/**/*.test.ts`` — **195 passing**
- [ ] CI re-run on this PR (was suppressed previously because base was the PR-A branch, not main)
- [ ] PR-B follow-up integration test for ``WitnessNotActive`` (the ``it.skip`` from PR-A)
- [ ] PR-C — claw-mem ``@chainofclaw/soul@2.1.0`` ABI sync
- [ ] PR-D — 88780 UUPS upgrade via Gnosis Safe Tx Service

Closes: previously #712 (auto-closed by base-branch deletion).

🤖 Generated with Claude Code