### PR TITLE
docs(upgrades): PR-D — 88780 PoSeManagerV2 upgrade scripts + runbook (#667)

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,0 +1,3 @@
+# OZ upgrade prepareUpgrade output — pinned per-run, consumed by
+# scripts/safe-propose-pose-upgrade.ts.
+tmp/

--- a/contracts/scripts/safe-propose-pose-upgrade.ts
+++ b/contracts/scripts/safe-propose-pose-upgrade.ts
@@ -1,0 +1,160 @@
+/**
+ * Propose the PoSeManagerV2 #667 upgrade tx to the Gnosis Safe owning the
+ * proxy. Reads the prepared impl from `tmp/upgrade-667-prepared.json`
+ * (output of `upgrade-pose-manager-v2-667.js`) and submits a Safe Tx
+ * Service proposal that, when executed by N-of-M multisig signers,
+ * points the live proxy at the new implementation.
+ *
+ * USAGE
+ *   COC_RPC_URL=https://<88780-rpc> \
+ *   SAFE_TX_SERVICE_URL=https://<safe-tx-service-for-88780> \
+ *   PROPOSER_PRIVATE_KEY=0x<proposer-eoa> \
+ *   POSE_MULTISIG_ADDRESS=0x<safe-address> \
+ *   npx ts-node scripts/safe-propose-pose-upgrade.ts
+ *
+ * Required env
+ *   - COC_RPC_URL         JSON-RPC for 88780.
+ *   - SAFE_TX_SERVICE_URL Safe Tx Service base URL. If your network is not
+ *                         in Safe Global's hosted index, run your own
+ *                         instance (https://github.com/safe-global/safe-tx-service).
+ *   - POSE_MULTISIG_ADDRESS  The Safe holding ownership of the PoSeManagerV2
+ *                            proxy (must match the proxy's `owner()`).
+ *   - PROPOSER_PRIVATE_KEY EOA that signs the proposal (must be one of the
+ *                          Safe owners). DOES NOT execute; signers approve
+ *                          via Safe UI afterwards.
+ *
+ * Safety
+ * ------
+ * - Constructs an `upgradeToAndCall(newImpl, "")` call with empty init data.
+ *   No re-initialization runs on the proxy; pre-upgrade storage is fully
+ *   preserved (UUPS, OZ upgrade-safety validated already).
+ * - Calls `proxy.owner()` and asserts it equals POSE_MULTISIG_ADDRESS — if
+ *   the owner changed (e.g. ownership was transferred to GovernanceDAO),
+ *   ABORT and re-coordinate.
+ * - The proposal is created but NOT executed. Signers approve through the
+ *   Safe UI; quorum is the Safe's own threshold (not this script's choice).
+ *
+ * After execution
+ * ---------------
+ * - Verify the upgrade via `eth_call` on `proxy.implementation()` (ERC-1967
+ *   slot). The address should now match `prepared.newImpl`.
+ * - Submit a sentinel `submitBatchV2WithMetadata` batch from a privileged
+ *   aggregator with a tiny metadata payload to assert the new path works.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { ethers } from "ethers"
+import Safe from "@safe-global/protocol-kit"
+import SafeApiKit from "@safe-global/api-kit"
+import {
+  type SafeTransactionDataPartial,
+  type MetaTransactionData,
+  OperationType,
+} from "@safe-global/safe-core-sdk-types"
+
+const PREPARED_PATH = join(__dirname, "..", "tmp", "upgrade-667-prepared.json")
+
+const UUPS_ABI = [
+  "function upgradeToAndCall(address newImplementation, bytes data) external payable",
+  "function owner() external view returns (address)",
+] as const
+
+interface PreparedUpgrade {
+  proxy: string
+  newImpl: string
+  contractName: string
+  chainId: number
+  preparedAt: string
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name]
+  if (!v || v.length === 0) {
+    throw new Error(`required env ${name} is not set`)
+  }
+  return v
+}
+
+async function main(): Promise<void> {
+  const rpcUrl = requireEnv("COC_RPC_URL")
+  const safeTxServiceUrl = requireEnv("SAFE_TX_SERVICE_URL")
+  const safeAddress = ethers.getAddress(requireEnv("POSE_MULTISIG_ADDRESS"))
+  const proposerKey = requireEnv("PROPOSER_PRIVATE_KEY")
+
+  const prepared = JSON.parse(readFileSync(PREPARED_PATH, "utf8")) as PreparedUpgrade
+  if (prepared.chainId !== 88780) {
+    throw new Error(`prepared upgrade chainId=${prepared.chainId}, expected 88780`)
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl)
+  const network = await provider.getNetwork()
+  if (Number(network.chainId) !== 88780) {
+    throw new Error(`RPC chainId=${network.chainId}, expected 88780`)
+  }
+
+  // Owner sanity check before submitting anything.
+  const proxy = new ethers.Contract(prepared.proxy, UUPS_ABI, provider)
+  const liveOwner = ethers.getAddress(await proxy.owner())
+  if (liveOwner !== safeAddress) {
+    throw new Error(
+      `proxy ${prepared.proxy} owner=${liveOwner} does not match POSE_MULTISIG_ADDRESS=${safeAddress}. ` +
+      `Ownership may have been transferred — verify with the team before proceeding.`
+    )
+  }
+  console.log(`✓ proxy ${prepared.proxy} owned by Safe ${safeAddress}`)
+
+  // Encode the upgradeToAndCall calldata.
+  const iface = new ethers.Interface(UUPS_ABI)
+  const data = iface.encodeFunctionData("upgradeToAndCall", [prepared.newImpl, "0x"])
+  console.log(`  upgradeToAndCall(${prepared.newImpl}, 0x) — ${data.length / 2 - 1} bytes calldata`)
+
+  // Build Safe SDK transaction.
+  const proposer = new ethers.Wallet(proposerKey, provider)
+  const safeSdk = await Safe.init({
+    provider: rpcUrl,
+    signer: proposerKey,
+    safeAddress,
+  })
+
+  const safeTransactionData: MetaTransactionData = {
+    to: prepared.proxy,
+    value: "0",
+    data,
+    operation: OperationType.Call,
+  }
+  const safeTransaction = await safeSdk.createTransaction({
+    transactions: [safeTransactionData],
+  })
+  const safeTxHash = await safeSdk.getTransactionHash(safeTransaction)
+  const senderSignature = await safeSdk.signHash(safeTxHash)
+
+  // Push to Safe Tx Service for the other signers to approve.
+  const apiKit = new SafeApiKit({
+    chainId: BigInt(88780),
+    txServiceUrl: safeTxServiceUrl,
+  })
+  await apiKit.proposeTransaction({
+    safeAddress,
+    safeTransactionData: safeTransaction.data,
+    safeTxHash,
+    senderAddress: proposer.address,
+    senderSignature: senderSignature.data,
+    origin: "PoSeManagerV2 #667 upgrade",
+  })
+
+  console.log("")
+  console.log(`✓ Safe Tx proposed`)
+  console.log(`  safeTxHash:  ${safeTxHash}`)
+  console.log(`  txService:   ${safeTxServiceUrl}`)
+  console.log(`  proposer:    ${proposer.address}`)
+  console.log(`  to (proxy):  ${prepared.proxy}`)
+  console.log(`  new impl:    ${prepared.newImpl}`)
+  console.log("")
+  console.log(`Other signers should approve via the Safe UI; once the threshold is met any owner can execute.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/contracts/scripts/test-upgrade-dry-run-667.js
+++ b/contracts/scripts/test-upgrade-dry-run-667.js
@@ -1,0 +1,122 @@
+/**
+ * Local dry-run of the PoSeManagerV2 #667 upgrade.
+ *
+ * USAGE
+ *   npx hardhat run scripts/test-upgrade-dry-run-667.js
+ *
+ * Runs against the default Hardhat in-process EVM (no real chain touched).
+ * Simulates the full upgrade lifecycle:
+ *
+ *   1. Deploy a fresh `PoSeManagerV2` proxy (UUPS, owned by a test EOA).
+ *   2. Read pre-upgrade view state (`challengeBondMin`, `DOMAIN_SEPARATOR`,
+ *      `getActiveNodeCount`) — these MUST survive the upgrade unchanged.
+ *   3. Call `upgrades.upgradeProxy(proxy, NewImpl, { kind: 'uups' })` to
+ *      point the proxy at the same `PoSeManagerV2` source compiled from
+ *      head — this is the OZ-validated drop-in of the new logic.
+ *   4. Read the same view state post-upgrade and assert equality.
+ *   5. Submit a tiny `submitBatchV2WithMetadata` call to assert the new
+ *      method dispatches successfully on the upgraded proxy.
+ *
+ * Used as a CI smoke gate before triggering the live 88780 upgrade
+ * (`scripts/upgrade-pose-manager-v2-667.js` + multisig propose). Catches
+ * storage-layout / initializer / DOMAIN_SEPARATOR regressions that the
+ * OZ layout validator alone might miss.
+ */
+
+const { ethers, upgrades } = require("hardhat")
+
+async function main() {
+  const [deployer, witness] = await ethers.getSigners()
+
+  // ---- Phase 1: deploy a fresh proxy ----------------------------------
+  const Factory = await ethers.getContractFactory("PoSeManagerV2")
+  const proxy = await upgrades.deployProxy(
+    Factory,
+    [ethers.parseEther("0.01"), deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
+  await proxy.waitForDeployment()
+  const proxyAddr = await proxy.getAddress()
+  console.log(`[dry-run] proxy deployed: ${proxyAddr}`)
+
+  await proxy.setAllowEmptyWitnessSubmission(true) // bootstrap-mode
+
+  const preChallengeBondMin = await proxy.challengeBondMin()
+  const preDomain = await proxy.DOMAIN_SEPARATOR()
+  const preActiveCount = await proxy.getActiveNodeCount()
+  console.log(`[dry-run] pre-upgrade state captured:`)
+  console.log(`           challengeBondMin = ${preChallengeBondMin}`)
+  console.log(`           DOMAIN_SEPARATOR = ${preDomain}`)
+  console.log(`           activeNodeCount  = ${preActiveCount}`)
+
+  // ---- Phase 2: upgrade (same source — production upgrade is identical) -----
+  console.log(`[dry-run] running upgrades.validateUpgrade...`)
+  await upgrades.validateUpgrade(proxyAddr, Factory, { kind: "uups" })
+  console.log(`[dry-run]   ✓ layout compatible`)
+
+  console.log(`[dry-run] running upgrades.upgradeProxy...`)
+  const upgraded = await upgrades.upgradeProxy(proxyAddr, Factory, { kind: "uups" })
+  await upgraded.waitForDeployment()
+  console.log(`[dry-run]   ✓ proxy upgraded`)
+
+  // ---- Phase 3: post-upgrade state must match pre-upgrade -------------
+  const postChallengeBondMin = await upgraded.challengeBondMin()
+  const postDomain = await upgraded.DOMAIN_SEPARATOR()
+  const postActiveCount = await upgraded.getActiveNodeCount()
+
+  if (preChallengeBondMin !== postChallengeBondMin) {
+    throw new Error(`challengeBondMin drifted: pre=${preChallengeBondMin} post=${postChallengeBondMin}`)
+  }
+  if (preDomain !== postDomain) {
+    throw new Error(`DOMAIN_SEPARATOR drifted: pre=${preDomain} post=${postDomain}`)
+  }
+  if (preActiveCount !== postActiveCount) {
+    throw new Error(`activeNodeCount drifted: pre=${preActiveCount} post=${postActiveCount}`)
+  }
+  console.log(`[dry-run]   ✓ challengeBondMin / DOMAIN_SEPARATOR / activeNodeCount preserved`)
+
+  // ---- Phase 4: new method dispatches on the upgraded proxy -----------
+  // Owner-only empty-witness path; lightest possible call that exercises
+  // `submitBatchV2WithMetadata` glue without needing a registered witness set.
+  const latestBlock = await ethers.provider.getBlock("latest")
+  const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+  const leafHash = ethers.keccak256(ethers.toUtf8Bytes("dry-run-leaf"))
+  const pairRoot = ethers.keccak256(
+    ethers.solidityPacked(["bytes32", "bytes32"], leafHash <= leafHash ? [leafHash, leafHash] : [leafHash, leafHash])
+  )
+  const sampleProofs = [{ leaf: leafHash, merkleProof: [leafHash], leafIndex: 0 }]
+  const sampleCommitment = ethers.keccak256(
+    ethers.solidityPacked(["bytes32", "uint32", "bytes32"], [ethers.ZeroHash, 0, leafHash])
+  )
+  const summaryHash = ethers.keccak256(
+    ethers.solidityPacked(["uint64", "bytes32", "bytes32", "uint32"], [epochId, pairRoot, sampleCommitment, 1])
+  )
+  const metadata = {
+    challengeIds: [ethers.keccak256(ethers.toUtf8Bytes("ch"))],
+    nodeIds: [ethers.keccak256(ethers.toUtf8Bytes("nd"))],
+    responseBodyHashes: [ethers.keccak256(ethers.toUtf8Bytes("rb"))],
+    leafHashes: [leafHash],
+    witnessReceiptIndex: new Array(32).fill(0xffff),
+  }
+
+  // No witnesses registered ⇒ contract takes the empty-witness owner-only
+  // branch (allowEmptyWitnessSubmission=true was set above).
+  await upgraded.submitBatchV2WithMetadata(
+    BigInt(epochId),
+    pairRoot,
+    summaryHash,
+    sampleProofs,
+    0, // witnessBitmap
+    [], // witnessSignatures
+    metadata,
+  )
+  console.log(`[dry-run]   ✓ submitBatchV2WithMetadata dispatched on upgraded proxy`)
+
+  console.log(``)
+  console.log(`[dry-run] PASS — live upgrade should be safe.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/contracts/scripts/upgrade-pose-manager-v2-667.js
+++ b/contracts/scripts/upgrade-pose-manager-v2-667.js
@@ -1,0 +1,101 @@
+/**
+ * Upgrade preparation for PoSeManagerV2 #667 fix.
+ *
+ * USAGE
+ *   COC_RPC_URL=https://<88780-rpc> \
+ *   npx hardhat run scripts/upgrade-pose-manager-v2-667.js --network coc
+ *
+ * What this script does
+ * ---------------------
+ * 1. Runs `upgrades.validateUpgrade` against the live PoSeManagerV2 proxy to
+ *    assert the new implementation's storage layout is compatible (i.e. the
+ *    `__gap` reduction + `_witnessSigUsed` addition introduced in PR #710
+ *    are append-only and do NOT relocate any existing slot).
+ * 2. Runs `upgrades.prepareUpgrade` which:
+ *    - Deploys the new implementation bytecode to 88780.
+ *    - Writes the impl entry into `.openzeppelin/unknown-88780.json` so the
+ *      OZ plugin tracks it for future upgrades.
+ *    - Returns the new implementation address — DO NOT call `upgradeProxy`
+ *      from here; the proxy is owned by a Gnosis Safe multisig, and the
+ *      actual `upgradeToAndCall` tx must come from the multisig (see
+ *      scripts/safe-propose-pose-upgrade.ts).
+ *
+ * Outputs
+ * -------
+ * - `tmp/upgrade-667-prepared.json` — { proxy, newImpl, contractName,
+ *   chainId, preparedAt } — consumed by safe-propose-pose-upgrade.ts.
+ *
+ * Safety
+ * ------
+ * - No live proxy state is touched. The new impl ends up at a fresh address
+ *   and is wired to the proxy only when the multisig executes the proposal.
+ * - The script aborts if `validateUpgrade` reports any layout violation;
+ *   inspect the OZ output and fix the storage definition before retrying.
+ */
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { ethers, upgrades } = require("hardhat")
+
+const DEPLOYED_88780 = path.join(__dirname, "..", "..", "configs", "deployed-contracts-88780.json")
+
+async function main() {
+  const deployed = JSON.parse(fs.readFileSync(DEPLOYED_88780, "utf8"))
+  if (deployed.chainId !== 88780) {
+    throw new Error(`expected deployed-contracts manifest for chainId=88780, got ${deployed.chainId}`)
+  }
+  const proxy = deployed.contracts.PoSeManagerV2
+  if (!/^0x[0-9a-fA-F]{40}$/.test(proxy)) {
+    throw new Error(`PoSeManagerV2 address missing or malformed in ${DEPLOYED_88780}: ${proxy}`)
+  }
+
+  const provider = ethers.provider
+  const network = await provider.getNetwork()
+  if (Number(network.chainId) !== 88780) {
+    throw new Error(
+      `network mismatch: connected to chainId=${network.chainId}, expected 88780. ` +
+      `Set COC_RPC_URL / COC_CHAIN_ID for the 88780 testnet before running.`
+    )
+  }
+
+  console.log(`PoSeManagerV2 #667 upgrade — preparing new implementation`)
+  console.log(`  proxy:       ${proxy}`)
+  console.log(`  network:     ${network.name} (chainId ${network.chainId})`)
+
+  const Factory = await ethers.getContractFactory("PoSeManagerV2")
+
+  console.log(`  validating storage layout compatibility...`)
+  await upgrades.validateUpgrade(proxy, Factory, { kind: "uups" })
+  console.log(`    ✓ layout compatible`)
+
+  console.log(`  deploying new implementation (no proxy state changes)...`)
+  const newImplAddress = await upgrades.prepareUpgrade(proxy, Factory, { kind: "uups" })
+  if (typeof newImplAddress !== "string") {
+    throw new Error(`prepareUpgrade returned non-string: ${String(newImplAddress)}`)
+  }
+  console.log(`    ✓ new impl deployed: ${newImplAddress}`)
+
+  const out = {
+    proxy,
+    newImpl: newImplAddress,
+    contractName: "PoSeManagerV2",
+    chainId: 88780,
+    preparedAt: new Date().toISOString(),
+    refs: ["#667", "PR #710", "PR #713"],
+  }
+  const outDir = path.join(__dirname, "..", "tmp")
+  fs.mkdirSync(outDir, { recursive: true })
+  const outPath = path.join(outDir, "upgrade-667-prepared.json")
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n")
+  console.log(`  wrote ${outPath}`)
+
+  console.log("")
+  console.log(`Next step: propose the upgradeToAndCall tx to the Safe owning ${proxy}:`)
+  console.log(`  npx ts-node scripts/safe-propose-pose-upgrade.ts`)
+  console.log(`(Reads ${outPath}; multisig signers approve via the Safe UI.)`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/docs/upgrades/667-pose-manager-v2.md
+++ b/docs/upgrades/667-pose-manager-v2.md
@@ -1,0 +1,100 @@
+# PoSeManagerV2 #667 Upgrade Runbook
+
+Upgrade target: live 88780 `PoSeManagerV2` proxy →
+implementation containing the protocol fix for issue #667 (independent
+on-chain witness quorum verification, [PR #710](https://github.com/chainofclaw/COC/pull/710)).
+
+## Pre-flight
+
+| Check | Command |
+|---|---|
+| OZ storage layout compatibility | `npx hardhat run scripts/upgrade-pose-manager-v2-667.js --network coc` (step 1 internally — validates without writing) |
+| Local dry-run upgrade simulation | `npx hardhat run scripts/test-upgrade-dry-run-667.js` |
+| Proxy owner is the expected Safe | `cast call <PROXY> "owner()"` (or via `eth_call`); compare to `POSE_MULTISIG_ADDRESS` |
+| ABI in `@chainofclaw/soul@2.1.0` matches new impl | Already done (claw-mem PR #50, merged) |
+| Aggregator/agent fleet running PR #713 (off-chain v2 path) | Check `coc-agent --version` on each operator host |
+
+## Order of operations
+
+### 1. Prepare new implementation
+
+The Safe multisig owns the proxy; this step deploys the new impl bytecode but does NOT wire the proxy to it.
+
+```bash
+cd contracts
+COC_RPC_URL=https://prod-1.coc:28780 \
+npx hardhat run scripts/upgrade-pose-manager-v2-667.js --network coc
+```
+
+Outputs `tmp/upgrade-667-prepared.json` with the new impl address. Commit `.openzeppelin/unknown-88780.json` (the OZ plugin's manifest) so the upgrade history stays reproducible.
+
+### 2. Propose the Safe tx
+
+```bash
+COC_RPC_URL=https://prod-1.coc:28780 \
+SAFE_TX_SERVICE_URL=https://<safe-tx-service-for-88780> \
+POSE_MULTISIG_ADDRESS=0x<safe-address> \
+PROPOSER_PRIVATE_KEY=0x<one-of-the-safe-signers> \
+npx ts-node scripts/safe-propose-pose-upgrade.ts
+```
+
+The script:
+- Asserts `proxy.owner() == POSE_MULTISIG_ADDRESS` before submitting.
+- Encodes `upgradeToAndCall(newImpl, "")` — empty calldata, no re-initialize.
+- Pushes the proposal to Safe Tx Service. Returns the `safeTxHash`.
+
+Open the proposal in the Safe UI (Safe Wallet). The other owners review and sign.
+
+### 3. Coordinate the cut-over window
+
+Per the plan (`docs/plans/skills-https-github-com-ngplateform-cla-whimsical-stearns.md`):
+
+1. **Pause aggregator submissions** — configure `coc-agent` to skip `flushBatchV2` rounds (operational flag); existing receipts queue in mempool / agent state.
+2. **Wait for dispute window** — current epoch's batches must clear the 2-epoch dispute window (~2 hours on 88780). The new `_validateWitnessQuorumV2` does not touch existing storage; in-flight batches are unaffected, but easier to verify when there's no in-flight churn.
+3. **Multisig executes** the proposal via Safe UI. The tx is `proxy.upgradeToAndCall(newImpl, "0x")`; gas budget ~80k.
+4. **Verify on-chain**:
+   ```bash
+   # ERC-1967 implementation slot = keccak256("eip1967.proxy.implementation") - 1
+   cast storage <PROXY> 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+   ```
+   Should now decode to the address in `tmp/upgrade-667-prepared.json:newImpl`.
+5. **Resume aggregators** — un-pause `coc-agent`.
+6. **Smoke test the new path** — submit one v2-metadata batch from an aggregator and confirm `ReceiptBatchMetadataSubmitted` event emits.
+
+### 4. Roll forward and monitor
+
+For the next 48 hours, watch:
+- `BatchSubmittedV2` event volume — should remain steady (witnesses keep producing v1+v2 signatures during the rollout window, so neither path is "starved").
+- `WitnessSigReplay` reverts in tx receipts — should be zero in steady state; non-zero indicates an aggregator misconfiguration trying to reuse signatures across batches.
+- `_witnessSigUsed` storage growth — bounded by `(active validator count) × (batches per epoch) × (epochs)`. At current 88780 scale (~5 active validators, ~10 batches/epoch) this is ~50 slots/epoch ≈ ~1MB/year of growth, well within budget.
+
+## Rollback
+
+The old impl address is preserved by the OZ plugin and pinned in
+`.openzeppelin/unknown-88780.json` history (git log). To roll back:
+
+```bash
+# Find the previous impl entry in the OZ manifest history.
+git log -p contracts/.openzeppelin/unknown-88780.json | grep '"address"' | head -20
+
+# Propose a Safe tx pointing the proxy back at the old impl:
+SAFE_TX_SERVICE_URL=... POSE_MULTISIG_ADDRESS=... PROPOSER_PRIVATE_KEY=... \
+SAFE_TARGET_IMPL=0x<old-impl> \
+npx ts-node scripts/safe-propose-pose-upgrade-revert.ts  # (not in PR-D — add if needed)
+```
+
+Until PR-E (v1 typehash sunset, 30 days after this upgrade), the old impl
+is structurally compatible: every `submitBatchV2` call that worked before
+the upgrade also works after. Rollback is therefore equivalent in
+behaviour, just slower to settle (no metadata path available).
+
+## Open coordination items (deferred to live upgrade day)
+
+- [ ] **Confirm Safe Tx Service endpoint for chainId 88780** — if not in the
+      `safe-global` hosted index, stand up a self-hosted Safe Tx Service
+      first.
+- [ ] **Identify the Safe owner set + threshold** — required to estimate
+      signing-round duration; coordinate signer availability.
+- [ ] **Aggregator pause mechanism** — confirm `coc-agent` has a runtime
+      flag (or graceful stop) that holds new batches without losing
+      in-mempool receipts.


### PR DESCRIPTION
## Summary

PR-D in the #667 series. Adds the **preparation tooling and runbook** for upgrading the live 88780 ``PoSeManagerV2`` proxy to the new implementation containing the protocol fix landed in #710 + #713. This PR does **not** execute the upgrade — the proxy is owned by a Gnosis Safe multisig, and the actual ``upgradeToAndCall`` must come from the Safe via Safe Tx Service.

## What's in this PR

### Scripts (``contracts/scripts/``)

- **``upgrade-pose-manager-v2-667.js``** — reads ``configs/deployed-contracts-88780.json``, runs ``upgrades.validateUpgrade`` + ``upgrades.prepareUpgrade`` (deploys new impl, writes OZ manifest), emits ``contracts/tmp/upgrade-667-prepared.json``. **No proxy state touched.**
- **``safe-propose-pose-upgrade.ts``** — consumes the prepared output, asserts ``proxy.owner() == POSE_MULTISIG_ADDRESS``, encodes ``upgradeToAndCall(newImpl, "")`` with empty calldata (no re-initialize), signs with the proposer EOA, pushes to Safe Tx Service. Returns ``safeTxHash`` for the other Safe owners to approve via Safe UI.
- **``test-upgrade-dry-run-667.js``** — local Hardhat in-process dry-run that exercises the full upgrade lifecycle (validateUpgrade → upgradeProxy → assert state preservation → submitBatchV2WithMetadata dispatches on upgraded proxy). **PASS confirmed locally.**

### Runbook (``docs/upgrades/667-pose-manager-v2.md``)

Step-by-step: pre-flight checks → prepare impl → propose Safe tx → cut-over window (pause aggregator → wait dispute window → multisig executes → verify ERC-1967 slot → resume → smoke test) → 48h monitoring → rollback procedure.

## Open coordination items (deferred to live upgrade day)

The runbook documents three items that need live confirmation before triggering the upgrade. They do not block this PR's merge:

- [ ] Confirm Safe Tx Service endpoint for chainId 88780 (if not in the safe-global hosted index, stand up a self-hosted instance).
- [ ] Identify the Safe owner set + threshold to estimate signing-round duration.
- [ ] Confirm ``coc-agent`` has a runtime pause flag that holds new batches without losing in-mempool receipts.

## Test plan

- [x] ``cd contracts && npm install`` — clean
- [x] ``cd contracts && npm run compile`` — already compiled (no contract changes in this PR)
- [x] ``cd contracts && npx hardhat run scripts/test-upgrade-dry-run-667.js`` — **PASS**: layout compatible, state preserved across upgrade, new method dispatches
- [ ] Live upgrade day: run ``scripts/upgrade-pose-manager-v2-667.js --network coc`` against 88780; commit the updated ``.openzeppelin/unknown-88780.json``
- [ ] Live upgrade day: run ``scripts/safe-propose-pose-upgrade.ts`` and coordinate signers
- [ ] Live upgrade day: verify ERC-1967 impl slot matches the prepared impl; smoke test ``submitBatchV2WithMetadata`` from a privileged aggregator

## Implementation notes

- Force-added past the root ``.gitignore: *.js`` rule (the existing ``deploy-*.js`` scripts use the same exception).
- Added ``contracts/.gitignore`` to keep ``tmp/upgrade-667-prepared.json`` out of source control — it's a per-run artifact bridging ``upgrade-pose-manager-v2-667.js`` and ``safe-propose-pose-upgrade.ts``.
- ``upgradeToAndCall(newImpl, "")`` uses empty calldata: no re-initialize runs, all pre-upgrade storage (including ``challengeBondMin``, ``DOMAIN_SEPARATOR``, ``_activeNodeIds``, witness state) is preserved verbatim. UUPS layout safety has been verified by the OZ plugin already.

Refs #667 #710 #713