### PR TITLE
fix(security): key witness anti-replay guard on EIP-712 digest (#715)

### DIFF
--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -972,34 +972,44 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
 
                 // (c) Try v2 typehash first (binds epochId). Fall back to v1
                 //     during the rollout window. PR-E will drop the v1 path.
+                //     `verifiedDigest` holds whichever digest actually
+                //     recovered the operator — it is the canonical identity of
+                //     this attestation and is reused for the anti-replay key.
                 address operator = nodeOperator[witnessSet[i]];
                 bytes calldata sig = witnessSignatures[sigIdx];
-                bytes32 digestV2 = _buildWitnessDigestV2(
+                bytes32 verifiedDigest = _buildWitnessDigestV2(
                     metadata.challengeIds[receiptIdx],
                     witnessSet[i],
                     metadata.responseBodyHashes[receiptIdx],
                     uint8(i),
                     epochId
                 );
-                address recovered = _recoverSigner(digestV2, sig);
+                address recovered = _recoverSigner(verifiedDigest, sig);
                 if (recovered != operator) {
-                    bytes32 digestV1 = _buildWitnessDigestV1(
+                    verifiedDigest = _buildWitnessDigestV1(
                         metadata.challengeIds[receiptIdx],
                         witnessSet[i],
                         metadata.responseBodyHashes[receiptIdx],
                         uint8(i)
                     );
-                    recovered = _recoverSigner(digestV1, sig);
+                    recovered = _recoverSigner(verifiedDigest, sig);
                 }
                 if (recovered == address(0) || recovered != operator) {
                     revert InvalidWitnessQuorum();
                 }
 
-                // (d) Anti-replay. (epochId, witnessNodeId, sigHash) uniquely
-                //     identifies a witness attestation usage; same sig cannot
-                //     be reused in two batches within an epoch nor (under v1
-                //     fallback) across epochs.
-                bytes32 replayKey = keccak256(abi.encodePacked(epochId, witnessSet[i], keccak256(sig)));
+                // (d) Anti-replay keyed on the verified EIP-712 digest, NOT the
+                //     raw signature bytes (#715). ECDSA signatures are malleable
+                //     in the `v` byte: `_recoverSigner` accepts sig[64] ∈
+                //     {0,1,27,28} and normalises {0,27}/{1,28} to the same `v`,
+                //     so every signature has two encodings that recover the same
+                //     signer — keccak256(sig) is therefore not a stable
+                //     attestation identity and a v-flip would mint a fresh key.
+                //     The digest is canonical: it fixes (challengeId,
+                //     witnessNodeId, responseBodyHash, witnessIndex[, epochId]).
+                //     `epochId` is mixed in explicitly so the v1-fallback digest
+                //     (which omits it) still stays epoch-scoped.
+                bytes32 replayKey = keccak256(abi.encodePacked(epochId, witnessSet[i], verifiedDigest));
                 if (_witnessSigUsed[replayKey]) revert WitnessSigReplay();
                 _witnessSigUsed[replayKey] = true;
 

--- a/contracts/test/pose-v2-witness-quorum-667.test.cjs
+++ b/contracts/test/pose-v2-witness-quorum-667.test.cjs
@@ -107,6 +107,19 @@ function buildMetadata(receipts, witnessReceiptIndex) {
   }
 }
 
+// #715: re-encode an ECDSA signature's recovery byte to its equivalent
+// non-EIP-155 form (0x1b<->0x00, 0x1c<->0x01). `_recoverSigner` normalises
+// both encodings to the same `v`, so the re-encoded signature recovers the
+// SAME signer while having different raw bytes — the malleability an
+// anti-replay guard keyed on keccak256(sig) would have been fooled by.
+function flipVByteEncoding(sig) {
+  const body = sig.slice(0, -2)
+  const v = sig.slice(-2).toLowerCase()
+  const flipped = { "1b": "00", "1c": "01", "00": "1b", "01": "1c" }[v]
+  if (flipped === undefined) throw new Error(`unexpected v byte: 0x${v}`)
+  return body + flipped
+}
+
 function makeReceipt(label) {
   return {
     challengeId: ethers.keccak256(ethers.toUtf8Bytes(`challenge-${label}`)),
@@ -269,6 +282,59 @@ describe("PoSeManagerV2 — #667 witness-quorum independent verification", funct
       sampleProofs2,
       1 << witnessIndex,
       [sig1], // <-- replayed
+      buildMetadata([r1, r2], [[witnessIndex, 0]]),
+    )).to.be.revertedWithCustomError(manager, "WitnessSigReplay")
+  })
+
+  it("reverts WitnessSigReplay when a v-byte-malleated copy of a used signature is reused (#715)", async function () {
+    const witness = await registerWitness(manager, deployer, "vmalleate")
+    const r1 = makeReceipt("vmalleate-1")
+    const r2 = makeReceipt("vmalleate-2")
+
+    const epochId = Math.floor((await ethers.provider.getBlock("latest")).timestamp / 3600)
+    const witnessIndex = 0
+
+    const sig1 = await signWitnessV2(manager, witness, {
+      challengeId: r1.challengeId,
+      responseBodyHash: r1.responseBodyHash,
+      witnessIndex,
+      epochId,
+    })
+
+    // Batch 1 — references r1 with the genuine signature, succeeds.
+    await submitV2Metadata(manager, {
+      epochId,
+      merkleRoot: buildMerkleRoot([r1.leafHash]),
+      sampleLeaf: r1.leafHash,
+      witnessBitmap: 1 << witnessIndex,
+      witnessSignatures: [sig1],
+      metadata: buildMetadata([r1], [[witnessIndex, 0]]),
+    })
+
+    // Batch 2 — distinct merkleRoot (r1+r2) so `epochMerkleRootUsed` does not
+    // block it. Reuses sig1 but with its recovery byte re-encoded: the bytes
+    // (and thus keccak256(sig)) differ, yet `_recoverSigner` recovers the same
+    // witness. A guard keyed on keccak256(sig) would NOT fire here; keyed on
+    // the verified EIP-712 digest it must still revert WitnessSigReplay.
+    const malleated = flipVByteEncoding(sig1)
+    expect(malleated).to.not.equal(sig1)
+
+    const merkleRoot2 = buildMerkleRoot([r1.leafHash, r2.leafHash])
+    const sampleProofs2 = [{ leaf: r1.leafHash, merkleProof: [r2.leafHash], leafIndex: 0 }]
+    const sampleCommitment2 = ethers.keccak256(
+      ethers.solidityPacked(["bytes32", "uint32", "bytes32"], [ethers.ZeroHash, 0, r1.leafHash])
+    )
+    const summaryHash2 = ethers.keccak256(
+      ethers.solidityPacked(["uint64", "bytes32", "bytes32", "uint32"], [epochId, merkleRoot2, sampleCommitment2, 1])
+    )
+
+    await expect(manager.submitBatchV2WithMetadata(
+      epochId,
+      merkleRoot2,
+      summaryHash2,
+      sampleProofs2,
+      1 << witnessIndex,
+      [malleated], // <-- v-malleated copy of sig1
       buildMetadata([r1, r2], [[witnessIndex, 0]]),
     )).to.be.revertedWithCustomError(manager, "WitnessSigReplay")
   })


### PR DESCRIPTION
## Summary

Closes #715.

`PoSeManagerV2._validateWitnessQuorumV2` (the #667 PR-B independent
witness-quorum verifier) keyed its `_witnessSigUsed` anti-replay guard on
`keccak256(sig)`. ECDSA signatures are malleable in the recovery byte:
`_recoverSigner` accepts `sig[64] ∈ {0,1,27,28}` and normalises
`{0,27}/{1,28}` to the same `v`, so every valid signature has **two** byte
encodings that recover the same signer. Re-encoding the `v` byte
(`0x1b → 0x00`) produced a *different* `keccak256(sig)` → a *different*
`replayKey` → the guard did not fire, letting an aggregator reuse a witness
signature across batches in an epoch and slip un-attested receipts past
witness quorum.

The guard now keys on the **verified EIP-712 digest** — the `digestV2` /
`digestV1` value that actually recovered the witness operator. The digest
is canonical (it fixes `challengeId, witnessNodeId, responseBodyHash,
witnessIndex[, epochId]`) and identical for both `v`-encodings, so the
malleable byte no longer matters. `epochId` stays mixed into the key
explicitly so the v1-fallback digest (which omits it) remains epoch-scoped.
The fix is also strictly stronger: two independently generated signatures
of the same attestation now collide on the key too.

A deeper fix — binding the batch `merkleRoot` into the witness typehash so
an attestation cannot be reused for a different batch at all — remains
#667 PR-E scope.

## Changes

- `contracts/contracts-src/settlement/PoSeManagerV2.sol` — replace the
  `keccak256(sig)` replay key with `keccak256(epochId, witnessNodeId,
  verifiedDigest)`; merge `digestV2`/`digestV1` locals into a single
  `verifiedDigest` that records which digest verified.
- `contracts/test/pose-v2-witness-quorum-667.test.cjs` — new regression:
  re-encode a used signature's `v` byte and assert the second submission
  still reverts `WitnessSigReplay`.

## Test plan

- [x] `npm run compile` clean
- [x] `npx hardhat test` — 532 passing, 1 pending (no regressions)
- [x] new `#715` regression fails on the pre-fix contract, passes on the fix