### PR TITLE
fix(security): snapshot proposer bond in OutputProposal (#717)

### DIFF
--- a/contracts/contracts-src/rollup/RollupStateManager.sol
+++ b/contracts/contracts-src/rollup/RollupStateManager.sol
@@ -114,7 +114,10 @@ contract RollupStateManager is IRollupStateManager, Initializable, UUPSUpgradeab
             l1Timestamp: uint64(block.timestamp),
             proposer: msg.sender,
             challenged: false,
-            finalized: false
+            finalized: false,
+            // Snapshot the escrowed bond so refund/slash use the amount
+            // actually posted, not the (now mutable) live PROPOSER_BOND (#717).
+            bond: msg.value
         });
 
         lastSubmittedBlock = l2BlockNumber;
@@ -190,8 +193,10 @@ contract RollupStateManager is IRollupStateManager, Initializable, UUPSUpgradeab
         challenge.proposerFault = proposerAtFault;
 
         if (proposerAtFault) {
-            // Slash proposer bond: 50% burn, 30% challenger, 20% insurance
-            uint256 totalSlash = PROPOSER_BOND;
+            // Slash proposer bond: 50% burn, 30% challenger, 20% insurance.
+            // Use the bond escrowed by this proposal (#717), not the live
+            // PROPOSER_BOND — the latter can change across a UUPS upgrade.
+            uint256 totalSlash = proposal.bond;
             uint256 burnAmount = (totalSlash * SLASH_BURN_BPS) / 10000;
             uint256 challengerReward = (totalSlash * SLASH_CHALLENGER_BPS) / 10000;
             uint256 insuranceAmount = totalSlash - burnAmount - challengerReward;
@@ -282,8 +287,10 @@ contract RollupStateManager is IRollupStateManager, Initializable, UUPSUpgradeab
 
         proposal.finalized = true;
 
-        // Refund proposer bond. Rejected ETH must not block finalization.
-        _payOrCredit(proposal.proposer, PROPOSER_BOND);
+        // Refund the bond this proposal actually escrowed (#717), not the
+        // live PROPOSER_BOND — the latter can change across a UUPS upgrade.
+        // Rejected ETH must not block finalization.
+        _payOrCredit(proposal.proposer, proposal.bond);
 
         // Update latest finalized block
         if (l2BlockNumber > _latestFinalizedBlock) {

--- a/contracts/contracts-src/rollup/RollupTypes.sol
+++ b/contracts/contracts-src/rollup/RollupTypes.sol
@@ -11,6 +11,7 @@ library RollupTypes {
         address proposer;         // who submitted the output
         bool    challenged;       // currently under active challenge
         bool    finalized;        // past challenge window, immutable
+        uint256 bond;             // proposer bond actually escrowed at submission
     }
 
     struct OutputChallenge {

--- a/contracts/contracts-src/test-contracts/RollupStateManagerBondConfigurable.sol
+++ b/contracts/contracts-src/test-contracts/RollupStateManagerBondConfigurable.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {RollupStateManager} from "../rollup/RollupStateManager.sol";
+
+/// @dev Test-only subclass exposing post-deploy mutation of `PROPOSER_BOND`.
+///      On the production contract the bond parameters are storage variables
+///      documented as "mutable across upgrades" but have no setter — they can
+///      only change via a UUPS upgrade. This subclass simulates such a change
+///      so #717 (refund/slash must use the bond actually escrowed, not the
+///      live global) can be regression-tested without performing a full
+///      proxy upgrade in the test harness.
+contract RollupStateManagerBondConfigurable is RollupStateManager {
+    function setProposerBondForTest(uint256 newBond) external {
+        PROPOSER_BOND = newBond;
+    }
+}

--- a/contracts/test/rollup-bond-snapshot-717.test.cjs
+++ b/contracts/test/rollup-bond-snapshot-717.test.cjs
@@ -1,0 +1,106 @@
+// RollupStateManager — #717 proposer-bond snapshot regression.
+//
+// The 88780 gen-5 UUPS conversion turned PROPOSER_BOND from `immutable` into
+// a mutable storage variable ("mutable across upgrades"). OutputProposal did
+// not record the bond a proposer actually escrowed, so finalizeOutput and
+// resolveChallenge read the live global PROPOSER_BOND — mis-accounting every
+// in-flight proposal once that global changes.
+//
+// These tests use a test-only subclass (RollupStateManagerBondConfigurable)
+// that exposes setProposerBondForTest to simulate the post-deploy retune
+// that on production would happen via a UUPS upgrade.
+
+const { expect } = require("chai")
+const { ethers, upgrades } = require("hardhat")
+
+const CHALLENGE_WINDOW = 60
+const PROPOSER_BOND = ethers.parseEther("1")
+const CHALLENGER_BOND = ethers.parseEther("0.5")
+const RAISED_BOND = ethers.parseEther("3")
+
+describe("RollupStateManager — #717 proposer bond snapshot", function () {
+  let manager
+  let deployer, proposer, challenger, insuranceFund
+  let outputRoot, stateRoot
+
+  beforeEach(async function () {
+    ;[deployer, proposer, challenger, insuranceFund] = await ethers.getSigners()
+
+    const Factory = await ethers.getContractFactory("RollupStateManagerBondConfigurable")
+    manager = await upgrades.deployProxy(
+      Factory,
+      [
+        CHALLENGE_WINDOW,
+        PROPOSER_BOND,
+        CHALLENGER_BOND,
+        insuranceFund.address,
+        proposer.address,
+        deployer.address,
+      ],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await manager.waitForDeployment()
+
+    // Pre-fund the contract so a buggy over-refund (live bond > escrowed
+    // bond) would actually succeed and be observable, instead of failing on
+    // insufficient balance and masking the bug as a pull-payment credit.
+    await deployer.sendTransaction({ to: await manager.getAddress(), value: ethers.parseEther("10") })
+
+    stateRoot = ethers.keccak256(ethers.toUtf8Bytes("state-root-1"))
+    const blockHash = ethers.keccak256(ethers.toUtf8Bytes("block-hash-1"))
+    outputRoot = ethers.solidityPackedKeccak256(
+      ["uint64", "bytes32", "bytes32"],
+      [100, stateRoot, blockHash],
+    )
+  })
+
+  it("submitOutputRoot records the escrowed bond on the proposal", async function () {
+    await manager.connect(proposer).submitOutputRoot(100, outputRoot, stateRoot, { value: PROPOSER_BOND })
+    const proposal = await manager.getOutputProposal(100)
+    expect(proposal.bond).to.equal(PROPOSER_BOND)
+  })
+
+  it("finalizeOutput refunds the escrowed bond even after PROPOSER_BOND is raised", async function () {
+    await manager.connect(proposer).submitOutputRoot(100, outputRoot, stateRoot, { value: PROPOSER_BOND })
+
+    // Simulate a post-deploy parameter retune (on prod: a UUPS upgrade):
+    // the live global is now 3x the bond this proposal escrowed.
+    await manager.setProposerBondForTest(RAISED_BOND)
+    expect(await manager.PROPOSER_BOND()).to.equal(RAISED_BOND)
+
+    await ethers.provider.send("evm_increaseTime", [CHALLENGE_WINDOW + 1])
+    await ethers.provider.send("evm_mine", [])
+
+    const before = await ethers.provider.getBalance(proposer.address)
+    // Finalize from deployer so proposer's balance reflects only the refund.
+    await manager.connect(deployer).finalizeOutput(100)
+    const after = await ethers.provider.getBalance(proposer.address)
+
+    // Must refund exactly what was posted (1 ETH), not the live 3 ETH.
+    expect(after - before).to.equal(PROPOSER_BOND)
+  })
+
+  it("resolveChallenge slashes the escrowed bond even after PROPOSER_BOND is raised", async function () {
+    await manager.connect(proposer).submitOutputRoot(100, outputRoot, stateRoot, { value: PROPOSER_BOND })
+    await manager.connect(challenger).challengeOutputRoot(100, { value: CHALLENGER_BOND })
+
+    await manager.setProposerBondForTest(RAISED_BOND)
+
+    const challengerBefore = await ethers.provider.getBalance(challenger.address)
+    const insuranceBefore = await ethers.provider.getBalance(insuranceFund.address)
+
+    // Wrong state root => proposer at fault => slash the escrowed bond.
+    const correctRoot = ethers.keccak256(ethers.toUtf8Bytes("correct-root"))
+    await manager.connect(deployer).resolveChallenge(100, correctRoot)
+
+    // Slash distribution is 30% challenger / 20% insurance of the ESCROWED
+    // 1 ETH bond (challenger also gets its own 0.5 ETH bond back) — not of
+    // the live 3 ETH global.
+    const challengerAfter = await ethers.provider.getBalance(challenger.address)
+    const insuranceAfter = await ethers.provider.getBalance(insuranceFund.address)
+    expect(challengerAfter - challengerBefore).to.equal(
+      CHALLENGER_BOND + (PROPOSER_BOND * 3000n) / 10000n,
+    )
+    expect(insuranceAfter - insuranceBefore).to.equal((PROPOSER_BOND * 2000n) / 10000n)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #717.

The 88780 gen-5 UUPS conversion turned `RollupStateManager`'s
`PROPOSER_BOND` from `immutable` into a mutable storage variable (the
contract header documents the bond params as *"mutable across upgrades"*).
But `RollupTypes.OutputProposal` never recorded the bond a proposer
actually escrowed, so both payout paths read the **live global**:

- `finalizeOutput` refunded `PROPOSER_BOND`
- `resolveChallenge` (proposer-fault) slashed `totalSlash = PROPOSER_BOND`

While the value was `immutable` this was safe. Post-conversion, any change
to `PROPOSER_BOND` mis-accounts every in-flight proposal: a raised bond
over-refunds / over-distributes and drains the contract (from the locked
burn pool, other proposers' bonds, insurance) until `_payOrCredit` calls
start failing; a lowered bond strands funds.

`OutputChallenge` already stores `bond` and the challenger-side payouts use
it correctly — the proposer side was the asymmetric oversight.

## Changes

- `RollupTypes.OutputProposal` — add `uint256 bond`, appended at the end of
  the struct so the layout stays upgrade-safe (struct used only as a
  mapping value).
- `RollupStateManager.submitOutputRoot` — store `bond: msg.value`.
- `RollupStateManager.finalizeOutput` — refund `proposal.bond`.
- `RollupStateManager.resolveChallenge` — `totalSlash = proposal.bond`.
- `test-contracts/RollupStateManagerBondConfigurable.sol` — test-only
  subclass exposing `setProposerBondForTest`, simulating the post-deploy
  retune that on production happens via a UUPS upgrade.
- `test/rollup-bond-snapshot-717.test.cjs` — regression: an in-flight
  proposal refunds / slashes the bond it escrowed even after the live
  `PROPOSER_BOND` is changed.

## Deployment note

Shipping this on 88780 needs a multisig `upgradeProxy` of the gen-5
`RollupStateManager` proxy (`0xA2Bf9FA3…`). The appended struct field keeps
the OZ storage-layout check green.

## Test plan

- [x] `npm run compile` clean
- [x] `npx hardhat test` — 534 passing, 1 pending (no regressions)
- [x] new `#717` regressions fail on the pre-fix contract, pass on the fix