### PR TITLE
fix(security): gate Treasury withdrawals on current-signer confirmations (#719)

### DIFF
--- a/contracts/contracts-src/governance/Treasury.sol
+++ b/contracts/contracts-src/governance/Treasury.sol
@@ -140,7 +140,11 @@ contract Treasury is Initializable, UUPSUpgradeable {
         if (proposalId >= proposalCount) revert InvalidProposal();
         Proposal storage p = proposals[proposalId];
         if (p.executed) revert AlreadyExecuted();
-        if (p.confirmations < REQUIRED_CONFIRMATIONS) revert NotEnoughConfirmations();
+        // Count confirmations over the CURRENT signer set (#719). The raw
+        // `p.confirmations` counter is not decremented by `replaceSigner`, so
+        // a removed signer's stale confirmation would otherwise still count
+        // toward the 3-of-5 threshold.
+        if (_currentConfirmations(p) < REQUIRED_CONFIRMATIONS) revert NotEnoughConfirmations();
         uint256 available = _availableBalance();
         if (available < p.amount) revert InsufficientBalance();
 
@@ -213,6 +217,24 @@ contract Treasury is Initializable, UUPSUpgradeable {
     function _availableBalance() internal view returns (uint256) {
         uint256 balance = address(this).balance;
         return balance > pendingWithdrawalTotal ? balance - pendingWithdrawalTotal : 0;
+    }
+
+    /// @notice Confirmations on a proposal from the CURRENT signer set (#719).
+    ///         `replaceSigner` does not revisit pending proposals, so the raw
+    ///         `p.confirmations` counter can include confirmations from
+    ///         signers that have since been removed. Recomputing over
+    ///         `signers` is the source of truth for the 3-of-5 threshold.
+    function _currentConfirmations(Proposal storage p) internal view returns (uint8 count) {
+        for (uint8 i = 0; i < MAX_SIGNERS; i++) {
+            if (p.confirmed[signers[i]]) count++;
+        }
+    }
+
+    /// @notice Confirmations on `proposalId` counted over the current signer
+    ///         set — what `executeWithdrawal` actually gates on.
+    function currentConfirmations(uint256 proposalId) external view returns (uint8) {
+        if (proposalId >= proposalCount) revert InvalidProposal();
+        return _currentConfirmations(proposals[proposalId]);
     }
 
     function _payOrCredit(address to, uint256 amount) internal {

--- a/contracts/test/treasury-signer-rotation-719.test.cjs
+++ b/contracts/test/treasury-signer-rotation-719.test.cjs
@@ -1,0 +1,78 @@
+// Treasury — #719 signer-rotation confirmation accounting.
+//
+// `replaceSigner` removes a signer but does not revisit pending proposals,
+// so the raw `p.confirmations` counter can include confirmations from
+// signers that have since been removed. `executeWithdrawal` must gate on
+// confirmations counted over the CURRENT signer set, not the raw counter.
+
+const { expect } = require("chai")
+const { ethers, upgrades } = require("hardhat")
+
+describe("Treasury — #719 signer rotation confirmation accounting", function () {
+  let treasury
+  let s0, s1, s2, s3, s4 // initial 3-of-5 multisig signers
+  let owner, newSigner, governance, recipient
+
+  beforeEach(async function () {
+    const all = await ethers.getSigners()
+    ;[s0, s1, s2, s3, s4, owner, newSigner, governance, recipient] = all
+
+    const Treasury = await ethers.getContractFactory("Treasury")
+    treasury = await upgrades.deployProxy(
+      Treasury,
+      [
+        [s0.address, s1.address, s2.address, s3.address, s4.address],
+        governance.address,
+        owner.address,
+      ],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await treasury.waitForDeployment()
+
+    // Fund the treasury so withdrawals can execute.
+    await owner.sendTransaction({ to: await treasury.getAddress(), value: ethers.parseEther("100") })
+  })
+
+  it("does not count a removed signer's stale confirmation toward the threshold", async function () {
+    // s0 proposes (auto-confirms), s1 confirms — 2 genuine confirmations.
+    await treasury.connect(s0).proposeWithdrawal(recipient.address, ethers.parseEther("1"))
+    await treasury.connect(s1).confirmWithdrawal(0)
+    expect(await treasury.currentConfirmations(0)).to.equal(2)
+
+    // Owner rotates s0 out of the multisig (routine rotation / key eviction).
+    await treasury.connect(owner).replaceSigner(0, newSigner.address)
+
+    // s2 confirms. The raw counter is now 3 (s0 ghost + s1 + s2), but only
+    // s1 and s2 are current signers who confirmed.
+    await treasury.connect(s2).confirmWithdrawal(0)
+    const raw = (await treasury.proposals(0)).confirmations
+    expect(raw).to.equal(3)
+    expect(await treasury.currentConfirmations(0)).to.equal(2)
+
+    // Execution must be blocked: only 2 current-signer confirmations.
+    await expect(
+      treasury.connect(s1).executeWithdrawal(0),
+    ).to.be.revertedWithCustomError(treasury, "NotEnoughConfirmations")
+
+    // The newly-added signer confirms → 3 current-signer confirmations.
+    await treasury.connect(newSigner).confirmWithdrawal(0)
+    expect(await treasury.currentConfirmations(0)).to.equal(3)
+
+    const before = await ethers.provider.getBalance(recipient.address)
+    await treasury.connect(s1).executeWithdrawal(0)
+    const after = await ethers.provider.getBalance(recipient.address)
+    expect(after - before).to.equal(ethers.parseEther("1"))
+  })
+
+  it("executes normally with three genuine current-signer confirmations", async function () {
+    await treasury.connect(s0).proposeWithdrawal(recipient.address, ethers.parseEther("1"))
+    await treasury.connect(s1).confirmWithdrawal(0)
+    await treasury.connect(s2).confirmWithdrawal(0)
+    expect(await treasury.currentConfirmations(0)).to.equal(3)
+
+    const before = await ethers.provider.getBalance(recipient.address)
+    await treasury.connect(s3).executeWithdrawal(0)
+    const after = await ethers.provider.getBalance(recipient.address)
+    expect(after - before).to.equal(ethers.parseEther("1"))
+  })
+})


### PR DESCRIPTION
## Summary

Closes #719.

`Treasury.executeWithdrawal` gated on the raw `p.confirmations` counter — a
monotonic count of *confirm actions ever taken*, not "current signers who
confirmed". `replaceSigner` removes a signer (`isSigner[old] = false`) but
never revisits pending proposals, so a removed signer's confirmation kept
counting toward the 3-of-5 threshold.

A proposal pending across a signer rotation could therefore execute with
fewer than 3 *current* signers' approval. When `replaceSigner` is used to
evict a *compromised* signer, the attacker's confirmations on in-flight
malicious proposals survive the eviction — exactly the case where the
threshold guarantee matters most.

## Changes

- `Treasury.sol` — add `_currentConfirmations(Proposal)`, an `O(5)` count of
  `confirmed[]` over the current `signers` set; gate `executeWithdrawal` on
  it instead of the raw counter. A removed signer (no longer in `signers[]`)
  is no longer counted; a newly-added signer who confirmed *is*. Also expose
  `currentConfirmations(proposalId)` as a view. `p.confirmations` is kept as
  an informational / event field.
- `test/treasury-signer-rotation-719.test.cjs` — regression: a proposal
  cannot execute on a removed signer's stale confirmation after
  `replaceSigner`, and executes normally once a current signer makes up the
  count.

## Test plan

- [x] `npm run compile` clean
- [x] `npx hardhat test` — 533 passing, 1 pending (no regressions)
- [x] new `#719` regression fails on the pre-fix contract, passes on the fix