### PR TITLE
fix(security): forceInclude must ignore sequencer's unverified markIncluded (#723)

### DIFF
--- a/contracts/contracts-src/rollup/DelayedInbox.sol
+++ b/contracts/contracts-src/rollup/DelayedInbox.sol
@@ -68,14 +68,18 @@ contract DelayedInbox is IDelayedInbox, Initializable, UUPSUpgradeable {
     /// @notice Force-include a transaction after the inclusion delay has elapsed.
     ///         Emits TransactionForceIncluded; the L2 sequencer must honor this.
     /// @param queueIndex Index in the queue
+    ///
+    /// #723: NOT gated on `entry.included` — that flag is set by an
+    /// unverified sequencer claim via `markIncluded`, and a malicious
+    /// sequencer would otherwise be able to suppress the censorship-
+    /// resistance signal by pre-emptively marking enqueued txs as
+    /// included without actually including them on L2. `_forceIncluded`
+    /// is the contract-owned one-shot guard against double-emit.
     function forceInclude(uint256 queueIndex) external override {
         if (queueIndex >= _queue.length) {
             revert QueueIndexOutOfRange(queueIndex, _queue.length);
         }
         RollupTypes.ForcedTx storage entry = _queue[queueIndex];
-        if (entry.included) {
-            revert AlreadyIncluded(queueIndex);
-        }
         if (_forceIncluded[queueIndex]) {
             revert AlreadyForceIncluded(queueIndex);
         }

--- a/contracts/test/delayed-inbox.test.cjs
+++ b/contracts/test/delayed-inbox.test.cjs
@@ -96,16 +96,18 @@ describe("DelayedInbox", function () {
       ).to.be.revertedWithCustomError(inbox, "QueueIndexOutOfRange")
     })
 
-    it("rejects force-include for already included tx", async function () {
-      // Mark as included first
+    it("still emits TransactionForceIncluded after a sequencer's unverified markIncluded (#723)", async function () {
+      // A malicious sequencer can pre-emptively `markIncluded` to set
+      // `entry.included = true` without actually including the tx on L2.
+      // `forceInclude` must NOT depend on that unverified flag — otherwise
+      // the censorship-resistance signal can be suppressed.
       await inbox.connect(sequencer).markIncluded(0)
 
       await ethers.provider.send("evm_increaseTime", [INCLUSION_DELAY + 1])
       await ethers.provider.send("evm_mine", [])
 
-      await expect(
-        inbox.connect(user1).forceInclude(0),
-      ).to.be.revertedWithCustomError(inbox, "AlreadyIncluded")
+      const tx = await inbox.connect(user1).forceInclude(0)
+      await expect(tx).to.emit(inbox, "TransactionForceIncluded").withArgs(0)
     })
 
     it("allows anyone to call forceInclude (not just sender)", async function () {


### PR DESCRIPTION
## Summary

Closes #723.

`DelayedInbox.forceInclude` gated on `entry.included` — a flag set only by
the sequencer's unverified `markIncluded` claim. A malicious sequencer
watching `TransactionEnqueued` events could call `markIncluded(queueIndex)`
immediately, without including the tx on L2; once the `INCLUSION_DELAY`
elapsed, the user's `forceInclude` would revert `AlreadyIncluded`,
silencing the on-chain censorship-resistance signal that watchdogs rely on.

The fix drops the `entry.included` revert in `forceInclude`.
`_forceIncluded[queueIndex]` is the contract-owned one-shot guard against
double-emit; `entry.included` stays as a sequencer-attested marker
visible via `getQueueItem` but no longer gates the resistance signal.
The deep rollup-state-root challenge path still catches sequencers that
mark-and-don't-execute, but the fast censorship signal is no longer
suppressible.

## Changes

- `DelayedInbox.sol::forceInclude` — remove the `entry.included` revert
  and document why the sequencer-attested flag must not gate the signal.
- `test/delayed-inbox.test.cjs` — flip the prior negative test (which
  asserted `AlreadyIncluded` on `markIncluded → forceInclude`) into a
  positive assertion that the censorship signal still fires.

## Deployment note

Shipping on 88780 requires a multisig `upgradeProxy` of the gen-5
`DelayedInbox` proxy (`0xac820809…`). No storage layout changes.

## Test plan

- [x] `npm run compile` clean
- [x] `npx hardhat test` — 531 passing, 1 pending (no regressions)
- [x] flipped `#723` test now passes on the fix and would fail on the pre-fix contract