### PR TITLE
fix(security): wire BFT signatures end-to-end so on-chain EquivocationDetector path runs (#725)

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -533,6 +533,13 @@ if (bftEnabled) {
       blockHash1: evidence.blockHash1,
       blockHash2: evidence.blockHash2,
       detectedAtMs: evidence.detectedAtMs,
+      // #725: carry the two BFT signatures through to the evidence store /
+      // coc_getEquivocations RPC / relayer. Without them the relayer's
+      // on-chain EquivocationDetector submission path always trips its
+      // missing-signatures guard and the permissionless slashing layer
+      // never runs.
+      ...(evidence.signature1 ? { signature1: evidence.signature1 } : {}),
+      ...(evidence.signature2 ? { signature2: evidence.signature2 } : {}),
     }
     bftEvidenceStore.push({
       nodeId: nodeIdHex as `0x${string}`,

--- a/node/src/rpc.ts
+++ b/node/src/rpc.ts
@@ -3253,6 +3253,13 @@ async function handleRpc(
       return evidence.map((e) => {
         const raw = (e.rawEvidence ?? {}) as Record<string, unknown>
         const round = raw.round
+        // #725: surface the two BFT signatures alongside the hashes so the
+        // relayer's on-chain EquivocationDetector submission path actually
+        // has signatures to submit. Pre-fix this method stripped them and
+        // the relayer's pre-submit guard always tripped, leaving on-chain
+        // permissionless slashing as silent dead code.
+        const sig1 = typeof raw.signature1 === "string" ? raw.signature1 : undefined
+        const sig2 = typeof raw.signature2 === "string" ? raw.signature2 : undefined
         return {
           validatorId: raw.validatorId ?? raw.nodeId ?? "",
           height: raw.height ?? "0",
@@ -3262,6 +3269,8 @@ async function handleRpc(
           timestamp: raw.detectedAtMs ?? 0,
           phase: raw.phase ?? "",
           type: raw.type ?? "bft-equivocation",
+          ...(sig1 ? { signature1: sig1 } : {}),
+          ...(sig2 ? { signature2: sig2 } : {}),
         }
       })
     }

--- a/runtime/coc-relayer.test.ts
+++ b/runtime/coc-relayer.test.ts
@@ -69,4 +69,38 @@ describe("BFT -> PoSe slash bridge", () => {
 
     assert.equal(evidence, null)
   })
+
+  it("threads BFT signatures from the RPC response into the normalized evidence (#725)", () => {
+    const sig1 = "0x" + "ee".repeat(65)
+    const sig2 = "0x" + "ff".repeat(65)
+    const evidence = normalizeEquivocationRpcEntry({
+      validatorId: "node-signed",
+      height: "500",
+      phase: "commit",
+      vote1Hash: "0x" + "33".repeat(32),
+      vote2Hash: "0x" + "44".repeat(32),
+      timestamp: 1700000003000,
+      signature1: sig1,
+      signature2: sig2,
+    })
+
+    assert.ok(evidence)
+    assert.equal(evidence?.signature1, sig1)
+    assert.equal(evidence?.signature2, sig2)
+  })
+
+  it("omits signature fields entirely when the RPC response lacks them (legacy compatibility)", () => {
+    const evidence = normalizeEquivocationRpcEntry({
+      validatorId: "node-nosig",
+      height: "600",
+      phase: "prepare",
+      vote1Hash: "0x" + "55".repeat(32),
+      vote2Hash: "0x" + "66".repeat(32),
+      timestamp: 1700000004000,
+    })
+
+    assert.ok(evidence)
+    assert.equal(evidence?.signature1, undefined)
+    assert.equal(evidence?.signature2, undefined)
+  })
 })

--- a/runtime/coc-relayer.ts
+++ b/runtime/coc-relayer.ts
@@ -734,8 +734,32 @@ export function bridgeBftSlash(evidence: EquivocationEvidence): void {
       });
       return;
     }
+    if (evidence.phase !== "prepare" && evidence.phase !== "commit") {
+      log.warn("skipping EquivocationDetector submission — unsupported BFT phase", {
+        validator: evidence.validatorId,
+        height: evidence.height.toString(),
+        phase: evidence.phase,
+      });
+      return;
+    }
+    // #725: translate the runtime-side shape (vote*Hash / timestamp) into
+    // the node-side `EquivocationEvidence` shape (blockHash* / detectedAtMs
+    // / phase: "prepare"|"commit") that `EquivocationDetectorClient` and
+    // `buildSubmitEvidenceCall` consume. Two same-named interfaces live in
+    // `node/src/bft.ts` and `runtime/lib/bft-equivocation.ts`; this
+    // translation avoids a wider rename across both call graphs.
+    const onChainEvidence = {
+      validatorId: evidence.validatorId,
+      height: evidence.height,
+      phase: evidence.phase,
+      blockHash1: evidence.vote1Hash as `0x${string}`,
+      blockHash2: evidence.vote2Hash as `0x${string}`,
+      detectedAtMs: evidence.timestamp,
+      signature1: evidence.signature1 as `0x${string}`,
+      signature2: evidence.signature2 as `0x${string}`,
+    };
     void equivocationDetectorClient
-      .submitEvidence(evidence)
+      .submitEvidence(onChainEvidence)
       .then((result) => {
         log.info("EquivocationDetector submitEvidence succeeded", {
           validator: evidence.validatorId,

--- a/runtime/lib/bft-equivocation.ts
+++ b/runtime/lib/bft-equivocation.ts
@@ -8,6 +8,14 @@ export interface EquivocationEvidence {
   vote1Hash: string
   vote2Hash: string
   timestamp: number
+  /**
+   * #725: the two BFT signatures over the conflicting vote hashes.
+   * When present, the relayer can submit them to the on-chain
+   * EquivocationDetector for permissionless slashing. Optional
+   * because legacy / round-only evidence may omit them.
+   */
+  signature1?: string
+  signature2?: string
 }
 
 export function normalizeEquivocationRpcEntry(entry: Record<string, unknown>): EquivocationEvidence | null {
@@ -42,6 +50,13 @@ export function normalizeEquivocationRpcEntry(entry: Record<string, unknown>): E
         ? Number(timestampValue)
       : Date.now()
 
+  // #725: extract the BFT signatures so downstream callers can submit the
+  // evidence to the on-chain EquivocationDetector.
+  const sig1 = typeof entry.signature1 === "string" && entry.signature1.length > 0
+    ? entry.signature1 : undefined
+  const sig2 = typeof entry.signature2 === "string" && entry.signature2.length > 0
+    ? entry.signature2 : undefined
+
   return {
     validatorId,
     height,
@@ -50,6 +65,8 @@ export function normalizeEquivocationRpcEntry(entry: Record<string, unknown>): E
     vote1Hash,
     vote2Hash,
     timestamp,
+    ...(sig1 ? { signature1: sig1 } : {}),
+    ...(sig2 ? { signature2: sig2 } : {}),
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #725.

The Phase I3c on-chain `EquivocationDetector.submitEvidence` enforcement
chain was silently dead code. Every link looked wired in isolation but
the shapes never composed end-to-end, so the relayer's only data source
(`coc_getEquivocations` RPC) produced records the on-chain submission
path systematically rejected.

The chain (and where each link failed):

1. `node/src/index.ts:527` persisted equivocation `rawEvidence`
   **without** `signature1`/`signature2`.
2. `node/src/rpc.ts::coc_getEquivocations` projected the response
   **without** signatures (even if they had been in `rawEvidence`).
3. `runtime/lib/bft-equivocation.ts::EquivocationEvidence` carried no
   signature fields, and `normalizeEquivocationRpcEntry` never read any.
4. `runtime/coc-relayer.ts::bridgeBftSlash` then triggered
   `if (!evidence.signature1 || !evidence.signature2) return` on
   **every** record, never calling
   `EquivocationDetectorClient.submitEvidence`.

Compounding shape problem: the runtime-side `EquivocationEvidence` uses
`vote1Hash` / `vote2Hash` / `timestamp`, while
`bft-slash-bridge.ts::buildSubmitEvidenceCall` (the calldata encoder)
reads `blockHash1` / `blockHash2` / `detectedAtMs`. Two same-named
interfaces in `node/src/bft.ts` and `runtime/lib/bft-equivocation.ts`.
Even if signatures had been carried, the encoder would have received
`undefined` hash fields.

## Changes

- `node/src/index.ts` — include `signature1` / `signature2` in the
  persisted `rawEvidence` when the in-process record carries them.
- `node/src/rpc.ts::coc_getEquivocations` — surface
  `signature1` / `signature2` from `rawEvidence` in the JSON-RPC
  response.
- `runtime/lib/bft-equivocation.ts` — add optional `signature1?` /
  `signature2?` to `EquivocationEvidence` and extract them in
  `normalizeEquivocationRpcEntry`.
- `runtime/coc-relayer.ts::bridgeBftSlash` — translate the runtime-side
  shape (`vote*Hash` / `timestamp`) into the node-side shape
  (`blockHash*` / `detectedAtMs`) before calling `submitEvidence`. Also
  add an explicit phase guard so an unsupported phase is logged loudly
  instead of silently producing bad calldata.
- `runtime/coc-relayer.test.ts` — two normalize regressions covering
  signature pass-through and the legacy no-signature case.

A longer-term cleanup would collapse the two `EquivocationEvidence`
types into one canonical record — touches many call sites and is out
of scope here.

## Test plan

- [x] `runtime/coc-relayer.test.ts` — 6 passing (4 existing + 2 new)
- [x] `node/src/{rpc-extended,bft,p2p-bft-evidence}.test.ts` — 209
      passing, no regressions