### PR TITLE
fix(security): reward manifest signature must verify against an authoritative address (#727)

### DIFF
--- a/runtime/coc-relayer.ts
+++ b/runtime/coc-relayer.ts
@@ -143,6 +143,15 @@ const contractReader = useV2 ? new ContractReader({
 }) : null;
 
 const rewardManifestDir = config.rewardManifestDir ?? join(config.dataDir, "reward-manifests");
+// #727: trusted reward-manifest signer. When set, verifyManifestSignature
+// requires the recovered EIP-712 signer to match this address (overrides
+// the manifest's self-claimed generatorAddress).
+const rewardManifestSigner = process.env.COC_REWARD_MANIFEST_SIGNER
+  || config.rewardManifestSigner
+  || undefined;
+if (rewardManifestSigner) {
+  log.info("reward manifest signer pinned via config", { signer: rewardManifestSigner });
+}
 const pendingChallengesPath = process.env.COC_PENDING_CHALLENGES_PATH
   || config.pendingChallengesPath
   || join(config.dataDir, "pending-challenges-v2.json");
@@ -282,7 +291,7 @@ async function tryDistributeRewards(epochId: number, _batchIds: string[]): Promi
 
   // Signature verification (V1: warn only, non-blocking)
   if (v2Domain && manifest.generatorSignature) {
-    const sigResult = verifyManifestSignature(manifest, v2Domain);
+    const sigResult = verifyManifestSignature(manifest, v2Domain, { expectedSigner: rewardManifestSigner });
     if (sigResult.valid) {
       log.info("v1 manifest signature valid", { epochId, signer: sigResult.recoveredAddress });
     } else {
@@ -525,7 +534,7 @@ async function tryFinalizeV2(): Promise<void> {
 
       // Signature verification (V2: reject on invalid signature)
       if (v2Domain && manifest.generatorSignature) {
-        const sigResult = verifyManifestSignature(manifest, v2Domain);
+        const sigResult = verifyManifestSignature(manifest, v2Domain, { expectedSigner: rewardManifestSigner });
         if (sigResult.valid) {
           log.info("v2 manifest signature valid", { epochId: candidate, signer: sigResult.recoveredAddress });
         } else {

--- a/runtime/lib/config.ts
+++ b/runtime/lib/config.ts
@@ -60,6 +60,10 @@ export interface CocRuntimeConfig {
   insuranceFundAddress?: string;
   poseManagerV2Address?: string;
   rewardManifestDir?: string;
+  /** #727: trusted signer address for reward manifest verification. When set,
+   *  verifyManifestSignature requires the recovered EIP-712 signer to match
+   *  this value (overrides the manifest's self-claimed generatorAddress). */
+  rewardManifestSigner?: string;
   epochNonceStrict?: boolean;
   pendingChallengesPath?: string;
   /**

--- a/runtime/lib/reward-manifest.test.ts
+++ b/runtime/lib/reward-manifest.test.ts
@@ -155,6 +155,101 @@ describe("reward-manifest", () => {
     assert.equal(result.error, "address_mismatch");
   });
 
+  it("verifyManifestSignature rejects when neither generatorAddress nor expectedSigner is set (#727)", async () => {
+    // Pre-fix: any well-formed 65-byte signature passed verification when
+    // generatorAddress was omitted from the manifest. The relayer's V2
+    // finalize path would then trust the manifest's rewardRoot and commit
+    // an attacker-chosen value on chain.
+    const wallet = Wallet.createRandom();
+    const domain = buildDomain(1n, "0x0000000000000000000000000000000000000001");
+    const manifest: RewardManifest = {
+      epochId: 7,
+      rewardRoot: `0x${"ab".repeat(32)}`,
+      totalReward: "500",
+      slashTotal: "0",
+      treasuryDelta: "0",
+      leaves: [],
+      proofs: {},
+      scoringInputsHash: `0x${"cd".repeat(32)}`,
+      generatedAtMs: Date.now(),
+    };
+
+    const payload = manifestSigningPayload(manifest);
+    const signature = await wallet.signTypedData(
+      toEthersDomain(domain),
+      REWARD_MANIFEST_TYPES,
+      payload,
+    );
+    manifest.generatorSignature = signature;
+    // Intentionally omit manifest.generatorAddress.
+
+    const result = verifyManifestSignature(manifest, domain);
+    assert.equal(result.valid, false);
+    assert.equal(result.error, "no_signer_to_verify_against");
+  });
+
+  it("verifyManifestSignature accepts when expectedSigner matches recovered (#727)", async () => {
+    const wallet = Wallet.createRandom();
+    const domain = buildDomain(1n, "0x0000000000000000000000000000000000000001");
+    const manifest: RewardManifest = {
+      epochId: 8,
+      rewardRoot: `0x${"ab".repeat(32)}`,
+      totalReward: "500",
+      slashTotal: "0",
+      treasuryDelta: "0",
+      leaves: [],
+      proofs: {},
+      scoringInputsHash: `0x${"cd".repeat(32)}`,
+      generatedAtMs: Date.now(),
+    };
+
+    const payload = manifestSigningPayload(manifest);
+    manifest.generatorSignature = await wallet.signTypedData(
+      toEthersDomain(domain),
+      REWARD_MANIFEST_TYPES,
+      payload,
+    );
+    // Omit generatorAddress on purpose; trust comes from the offline-pinned
+    // expectedSigner.
+
+    const result = verifyManifestSignature(manifest, domain, { expectedSigner: wallet.address });
+    assert.equal(result.valid, true);
+    assert.equal(result.recoveredAddress, wallet.address.toLowerCase());
+  });
+
+  it("verifyManifestSignature rejects when expectedSigner overrides a matching self-claim (#727)", async () => {
+    const realSigner = Wallet.createRandom();
+    const trustedSigner = Wallet.createRandom();
+    const domain = buildDomain(1n, "0x0000000000000000000000000000000000000001");
+    const manifest: RewardManifest = {
+      epochId: 9,
+      rewardRoot: `0x${"ab".repeat(32)}`,
+      totalReward: "500",
+      slashTotal: "0",
+      treasuryDelta: "0",
+      leaves: [],
+      proofs: {},
+      scoringInputsHash: `0x${"cd".repeat(32)}`,
+      generatedAtMs: Date.now(),
+    };
+
+    const payload = manifestSigningPayload(manifest);
+    // Attacker signs with a random key and sets the self-claimed
+    // generatorAddress to that key — the self-claim alone would pass.
+    manifest.generatorSignature = await realSigner.signTypedData(
+      toEthersDomain(domain),
+      REWARD_MANIFEST_TYPES,
+      payload,
+    );
+    manifest.generatorAddress = realSigner.address.toLowerCase();
+
+    // Operator pinned a different trusted signer offline — must reject.
+    const result = verifyManifestSignature(manifest, domain, { expectedSigner: trustedSigner.address });
+    assert.equal(result.valid, false);
+    assert.equal(result.error, "address_mismatch");
+    assert.equal(result.recoveredAddress, realSigner.address.toLowerCase());
+  });
+
   it("verifyManifestSignature handles corrupted signature gracefully", () => {
     const domain = buildDomain(1n, "0x0000000000000000000000000000000000000001");
     const manifest: RewardManifest = {
@@ -168,6 +263,9 @@ describe("reward-manifest", () => {
       scoringInputsHash: `0x${"22".repeat(32)}`,
       generatedAtMs: 1,
       generatorSignature: "0xdeadbeef",
+      // #727: include a self-claim so the corrupt-signature path is reached
+      // (else the new fail-closed guard short-circuits before verifyTypedData).
+      generatorAddress: "0x0000000000000000000000000000000000000099",
     };
     const result = verifyManifestSignature(manifest, domain);
     assert.equal(result.valid, false);

--- a/runtime/lib/reward-manifest.ts
+++ b/runtime/lib/reward-manifest.ts
@@ -185,12 +185,39 @@ export interface ManifestVerifyResult {
   error?: string
 }
 
+export interface ManifestVerifyOptions {
+  /**
+   * #727: a trusted signer address configured offline (e.g. via
+   * COC_REWARD_MANIFEST_SIGNER). When set, takes priority over the
+   * manifest's self-claimed `generatorAddress` — the recovered signer
+   * must match this value. When unset the function falls back to
+   * `manifest.generatorAddress`; if THAT is also missing the signature
+   * is rejected, because a sig without any authoritative address to
+   * cross-check against silently accepted any random-key forgery.
+   */
+  expectedSigner?: string
+}
+
 export function verifyManifestSignature(
   manifest: RewardManifest,
   domain: { name: string; version: string; chainId: bigint | number; verifyingContract: string },
+  opts: ManifestVerifyOptions = {},
 ): ManifestVerifyResult {
   if (!manifest.generatorSignature) {
     return { valid: false, error: "missing" }
+  }
+
+  // #727: fail-closed when no authoritative address is available. Before this
+  // guard, a manifest with `generatorSignature` set but `generatorAddress`
+  // omitted would let any well-formed 65-byte signature pass verification,
+  // since the only cross-check (recoveredLower vs generatorAddress) was
+  // skipped entirely. A relayer wired to gate finalizeEpochV2 on the result
+  // would therefore commit an attacker-chosen rewardRoot from a forged
+  // manifest signed with a throwaway random key.
+  const expectedFromOpts = opts.expectedSigner ? opts.expectedSigner.toLowerCase() : undefined
+  const expectedFromManifest = manifest.generatorAddress ? manifest.generatorAddress.toLowerCase() : undefined
+  if (!expectedFromOpts && !expectedFromManifest) {
+    return { valid: false, error: "no_signer_to_verify_against" }
   }
 
   try {
@@ -198,7 +225,12 @@ export function verifyManifestSignature(
     const recovered = verifyTypedData(domain, REWARD_MANIFEST_TYPES, payload, manifest.generatorSignature)
     const recoveredLower = recovered.toLowerCase()
 
-    if (manifest.generatorAddress && recoveredLower !== manifest.generatorAddress.toLowerCase()) {
+    // Trusted-signer override (configured offline) takes priority over the
+    // self-claimed `generatorAddress`. The self-claim is otherwise just a
+    // hint that the forger could match — pinning the address out-of-band is
+    // the actual defence.
+    const required = expectedFromOpts ?? expectedFromManifest!
+    if (recoveredLower !== required) {
       return { valid: false, recoveredAddress: recoveredLower, error: "address_mismatch" }
     }
 


### PR DESCRIPTION
## Summary

Closes #727.

`runtime/lib/reward-manifest.ts::verifyManifestSignature` recovered the
EIP-712 signer but only cross-checked it against
`manifest.generatorAddress` when that field was set. Omitting the
self-claim let any well-formed 65-byte signature pass verification —
including one minted with a random throwaway key. The V2 relayer path
(`coc-relayer.ts:528`) gates `finalizeEpochV2` on a NON-`valid` result
and otherwise commits the manifest's `rewardRoot` straight to chain,
so a forger with write access to `rewardManifestDir` could dictate
`epochRewardRoots[epochId]` and then `claim()` arbitrary amounts.

## Changes

- `runtime/lib/reward-manifest.ts` — `verifyManifestSignature` now
  fail-closes when **neither** `manifest.generatorAddress` **nor** an
  `opts.expectedSigner` override is provided. Adds the
  `expectedSigner` option that takes priority over the self-claim —
  operators pin the trusted signer offline; the self-claim becomes
  just a hint.
- `runtime/lib/config.ts` — new optional `rewardManifestSigner` field.
- `runtime/coc-relayer.ts` — reads `COC_REWARD_MANIFEST_SIGNER` /
  `config.rewardManifestSigner` and threads it through both V1 and V2
  `verifyManifestSignature` call sites.
- `runtime/lib/reward-manifest.test.ts` — three #727 regressions:
  missing-address-and-no-override is rejected, `expectedSigner` alone
  accepts a matching sig, and `expectedSigner` defeats a colluding
  self-claim mismatch.

## Backward compatibility

Manifests that already include `generatorAddress` keep working
unchanged. Operators that haven't set `COC_REWARD_MANIFEST_SIGNER`
get the same behaviour as before for any manifest that does declare
its signer; they only lose the silent pass-through that previously
let `generatorAddress`-less manifests sail through verification.

## Test plan

- [x] `node --experimental-strip-types --test runtime/lib/reward-manifest.test.ts` — passing
- [x] runtime/lib + runtime/coc-relayer.test.ts — 196 passing, no regressions