### PR TITLE
fix(security): re-enforce DHT Sybil per-IP caps on address-update path (#729)

### DIFF
--- a/node/src/dht.test.ts
+++ b/node/src/dht.test.ts
@@ -181,6 +181,50 @@ describe("RoutingTable", () => {
     assert.equal(add3, false, "third alias of same IP should hit per-IP bucket limit")
   })
 
+  it("rejects address-update to a host that would exceed the per-IP global cap (#729)", async () => {
+    // Pre-fix: addPeer's existing-id branch updated the address in-place and
+    // re-balanced globalIpCount with no cap check. An attacker who'd
+    // established N peers from N distinct IPs could reconnect each from a
+    // single funnel IP, every update succeeding and globalIpCount[funnel]
+    // piling up far past MAX_PEERS_PER_IP_GLOBAL = 10.
+    const rt = new RoutingTable("0x" + "00".repeat(32))
+
+    // Use bucket indices 255 down to 245 — distinct buckets, distinct
+    // starting IPs, so the initial inserts all succeed.
+    const N = 11
+    const ids: string[] = []
+    for (let i = 1; i <= N; i++) {
+      // High byte 0x80 >> (i-1) keeps each ID in a unique high bucket.
+      const bucket = i - 1
+      const hi = (0x80 >> bucket).toString(16).padStart(2, "0")
+      const id = "0x" + hi + i.toString(16).padStart(62, "0")
+      ids.push(id)
+      const ok = await rt.addPeer(makePeer(id, `192.0.2.${10 + i}:9000`))
+      assert.equal(ok, true, `initial add for peer ${i} should succeed (distinct IPs)`)
+    }
+    assert.equal(rt.size(), N)
+
+    // Funnel: update each peer's address to a single target IP. The first
+    // 10 updates fill globalIpCount[target] up to the cap; the 11th must be
+    // rejected so the funnel cannot eclipse the routing table.
+    const target = "203.0.113.7:9100"
+    let accepted = 0
+    let rejected = 0
+    for (let i = 0; i < N; i++) {
+      const ok = await rt.addPeer({ id: ids[i], address: target, lastSeenMs: Date.now() })
+      if (ok) accepted++
+      else rejected++
+    }
+    assert.equal(accepted, 10, "first 10 updates fit under the per-IP global cap")
+    assert.equal(rejected, 1, "11th update must be rejected to stop the eclipse funnel")
+
+    // The 11th peer must still be in the table with its original address —
+    // the rejected update only denies the address swap, not the entry.
+    const eleventh = rt.getPeer(ids[N - 1])
+    assert.ok(eleventh, "rejected peer must still exist in the table")
+    assert.equal(eleventh.address, "192.0.2.21:9000", "rejected peer keeps original address")
+  })
+
   it("evicts unreachable oldest peer via ping-evict", async () => {
     const rt = new RoutingTable("0x" + "00".repeat(32), {
       pingPeer: async () => false, // oldest peer always unreachable

--- a/node/src/dht.ts
+++ b/node/src/dht.ts
@@ -118,6 +118,41 @@ export class RoutingTable {
       // Move to tail (most recently seen); update global IP count if address changed
       const oldPeer = bucket.peers[existing]
       const oldHost = normalizeHostForBucket(extractHost(oldPeer.address))
+      // #729: when the address normalises to a different host, re-validate
+      // the per-IP Sybil caps against the new host BEFORE swapping. Without
+      // this gate, an attacker who established N peers across N distinct
+      // IPs could reconnect each from a single funnel address, every
+      // update succeeding and globalIpCount[target] piling up past the
+      // MAX_PEERS_PER_IP_GLOBAL cap (and same for the per-bucket cap) —
+      // a standard precursor to eclipse attacks.
+      if (oldHost !== peerHost && !isLoopbackHost(peerHost)) {
+        let sameHostInBucket = 0
+        for (let i = 0; i < bucket.peers.length; i++) {
+          if (i === existing) continue // exclude the entry we'd be updating
+          const h = normalizeHostForBucket(extractHost(bucket.peers[i].address))
+          if (h === peerHost) sameHostInBucket++
+        }
+        if (sameHostInBucket >= MAX_PEERS_PER_IP_PER_BUCKET) {
+          log.debug("update rejected: per-IP bucket limit at target host", {
+            ip: peerHost, bucket: idx, peerId: peer.id,
+          })
+          // Still bump lastSeenMs for the existing entry — only the address
+          // swap is denied. Move to tail with the OLD address so refresh
+          // ordering remains accurate.
+          bucket.peers.splice(existing, 1)
+          bucket.peers.push({ ...oldPeer, lastSeenMs: Date.now() })
+          return false
+        }
+        const targetGlobalCount = this.globalIpCount.get(peerHost) ?? 0
+        if (targetGlobalCount >= MAX_PEERS_PER_IP_GLOBAL) {
+          log.debug("update rejected: global per-IP limit at target host", {
+            ip: peerHost, peerId: peer.id,
+          })
+          bucket.peers.splice(existing, 1)
+          bucket.peers.push({ ...oldPeer, lastSeenMs: Date.now() })
+          return false
+        }
+      }
       bucket.peers.splice(existing, 1)
       bucket.peers.push({ ...peer, lastSeenMs: Date.now() })
       if (oldHost !== peerHost) {


### PR DESCRIPTION
## Summary

Closes #729.

`node/src/dht.ts::RoutingTable.addPeer` only enforced
`MAX_PEERS_PER_IP_PER_BUCKET` / `MAX_PEERS_PER_IP_GLOBAL` on the
**insert** path. When the peer's id already existed, the function
updated the entry's address in-place and just re-balanced
`globalIpCount` — never re-validating either cap against the new host.

An attacker who established N peers from N distinct IPs (initial-add
Sybil check satisfied) could then reconnect each peer from a single
funnel address; every `addPeer({id, address: funnel})` call hit the
existing-id branch and was committed. After N reconnects
`globalIpCount[funnel] = N`, far past the 10-peer cap, with the
per-bucket cap likewise bypassed. Standard eclipse-attack precursor.

## Changes

- `node/src/dht.ts::RoutingTable.addPeer` — in the existing-id branch,
  when the new normalised host differs from the old and isn't
  loopback, re-validate `MAX_PEERS_PER_IP_PER_BUCKET` (excluding the
  entry being updated) and `MAX_PEERS_PER_IP_GLOBAL` against the new
  host. Reject the swap on either breach; still bump `lastSeenMs` for
  the existing entry with its original address so refresh ordering
  stays accurate.
- `node/src/dht.test.ts` — `#729` regression: 11 peers from distinct
  IPs into distinct buckets, funnel them all to one target IP, assert
  the 11th update is rejected and that peer keeps its original
  address.

## Test plan

- [x] `node --experimental-strip-types --test node/src/dht.test.ts` —
      26 passing (25 existing + 1 new)
- [x] `node --experimental-strip-types --test node/src/dht*.test.ts` —
      68 passing, no regressions in DHT or DHT-network