### PR TITLE
fix(security): reject per-operator duplicates in PoSeManagerV2 witness quorum (#7)

### DIFF
--- a/contracts/contracts-src/settlement/IPoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/IPoSeManagerV2.sol
@@ -59,6 +59,11 @@ interface IPoSeManagerV2 {
     error MerkleRootMismatch();
     error MetadataLengthMismatch();
     error BadReceiptIndex();
+    /// @notice #7 — two witnessSet slots resolved to the same operator address
+    ///         within a single quorum vote. A single real-world entity running
+    ///         multiple nodeIds (up to MAX_NODES_PER_OPERATOR) would otherwise
+    ///         be able to deliver the K-of-N quorum singlehandedly.
+    error WitnessOperatorDuplicate();
 
     // Functions
     function initEpochNonce(uint64 epochId) external;

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -957,6 +957,18 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
 
         uint256 numReceipts = metadata.leafHashes.length;
         uint256 sigIdx = 0;
+        // #7 (audit follow-up): per-operator dedup. A single real-world
+        // entity may register up to MAX_NODES_PER_OPERATOR distinct
+        // nodeIds; when the PRNG-selected witnessSet contains multiple
+        // nodeIds owned by the same operator, naïve bit-counting lets
+        // that one entity deliver the K-of-N quorum singlehandedly,
+        // collapsing the security threshold to 1-of-1. `seenOperators`
+        // collects the verified operator address for every counted slot
+        // and rejects on second appearance. `m ≤ 32` (witnessBitmap is
+        // uint32) so the O(n²) seen-scan is bounded by 32×32=1024
+        // address comparisons, well within the EVM gas envelope.
+        address[] memory seenOperators = new address[](m);
+        uint256 seenCount = 0;
         for (uint256 i = 0; i < m && i < 32; i++) {
             if (witnessBitmap & (1 << i) != 0) {
                 if (sigIdx >= witnessSignatures.length) revert InvalidWitnessQuorum();
@@ -997,6 +1009,16 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
                 if (recovered == address(0) || recovered != operator) {
                     revert InvalidWitnessQuorum();
                 }
+
+                // (c-bis) #7: reject a second contribution from the same
+                //     operator. Without this, two nodeIds owned by the
+                //     same EOA both bit-set in witnessBitmap would each
+                //     pass (a)–(c) and contribute to the K-of-N count.
+                for (uint256 j = 0; j < seenCount; j++) {
+                    if (seenOperators[j] == operator) revert WitnessOperatorDuplicate();
+                }
+                seenOperators[seenCount] = operator;
+                seenCount += 1;
 
                 // (d) Anti-replay keyed on the verified EIP-712 digest, NOT the
                 //     raw signature bytes (#715). ECDSA signatures are malleable

--- a/contracts/test/pose-v2-witness-quorum-667.test.cjs
+++ b/contracts/test/pose-v2-witness-quorum-667.test.cjs
@@ -421,4 +421,128 @@ describe("PoSeManagerV2 — #667 witness-quorum independent verification", funct
       metadata,
     })).to.be.revertedWithCustomError(manager, "MetadataLengthMismatch")
   })
+
+  // #7 (audit follow-up): per-operator dedup in _validateWitnessQuorumV2.
+  // A single real-world entity can register up to MAX_NODES_PER_OPERATOR (5)
+  // distinct nodeIds. When the PRNG-selected witnessSet contains two slots
+  // whose nodeOperator[] resolves to the same EOA, naïve bit-counting let
+  // that one entity deliver the K-of-N quorum singlehandedly — collapsing
+  // the security threshold to 1-of-1. The fix rejects on second appearance
+  // of the same operator within a single quorum vote.
+  describe("#7 per-operator quorum dedup", function () {
+    // Register an "alias" nodeId under an existing operator EOA. The alias
+    // is a fresh signing key whose public key derives the nodeId; the
+    // ownership proof is signed by the alias (proving alias controls the
+    // pubkey), while msg.sender = operator (proving operator pays bond).
+    // This is the legitimate multi-node-per-operator flow that #7 closes.
+    async function registerAliasForOperator(manager, funder, operator, label) {
+      const alias = ethers.Wallet.createRandom()
+      const pubkey = alias.signingKey.publicKey
+      const nodeId = ethers.keccak256(pubkey)
+      // Operator bond cost: MIN_BOND << existingNodeCount; with 2 nodes it's
+      // 0.1 + 0.2 = 0.3 ETH. registerWitness funded operator with 5 ETH.
+      const serviceCommitment = ethers.keccak256(ethers.toUtf8Bytes(`svc-${label}`))
+      const endpointCommitment = ethers.keccak256(ethers.toUtf8Bytes(`ep-${label}-${Date.now()}-${Math.random()}`))
+      const metadataHash = ethers.keccak256(ethers.toUtf8Bytes(`meta-${label}`))
+      const messageHash = ethers.keccak256(
+        ethers.solidityPacked(["string", "bytes32", "address"], ["coc-register:", nodeId, operator.address])
+      )
+      const ownershipSig = await alias.signMessage(ethers.getBytes(messageHash))
+      // Bond for the second node is MIN_BOND << 1 = 0.2 ETH. Pay 0.5 ETH
+      // to keep tests cheap.
+      await manager.connect(operator).registerNode(
+        nodeId, pubkey, 7, serviceCommitment, endpointCommitment, metadataHash, ownershipSig, "0x",
+        { value: ethers.parseEther("0.5") }
+      )
+      return { operator, nodeId, pubkey }
+    }
+
+    // Locate witnessSet[i] for the given nodeId — needed because the PRNG
+    // determines slot order, so callers must dynamically construct the
+    // witnessBitmap + signatures keyed off the actual slot of each node.
+    function slotOf(witnessSet, nodeId) {
+      const target = nodeId.toLowerCase()
+      for (let i = 0; i < witnessSet.length; i++) {
+        if (witnessSet[i].toLowerCase() === target) return i
+      }
+      throw new Error(`nodeId ${nodeId} not found in witnessSet`)
+    }
+
+    it("reverts WitnessOperatorDuplicate when both witnessSet slots resolve to the same operator", async function () {
+      // Operator EOA registers two distinct nodeIds. Both are in the
+      // witnessSet (m=2 since activeCount=2 → ceil(sqrt(2))=2).
+      const first = await registerWitness(manager, deployer, "dup-primary")
+      const second = await registerAliasForOperator(manager, deployer, first.operator, "dup-alias")
+      const receipt = makeReceipt("dup")
+      const epochId = Math.floor((await ethers.provider.getBlock("latest")).timestamp / 3600)
+
+      const witnessSet = await manager.getWitnessSet(epochId)
+      expect(witnessSet.length).to.equal(2)
+      const slotA = slotOf(witnessSet, first.nodeId)
+      const slotB = slotOf(witnessSet, second.nodeId)
+      // required = ceil(2*m/3) = ceil(4/3) = 2 — both bits must be set.
+      // Both sigs recover to first.operator — pre-fix this passed; post-fix
+      // it must revert.
+      const sigArgs = (witnessIndex) => ({
+        challengeId: receipt.challengeId,
+        responseBodyHash: receipt.responseBodyHash,
+        witnessIndex,
+        epochId,
+      })
+      const sigA = await signWitnessV2(manager, { operator: first.operator, nodeId: witnessSet[slotA] }, sigArgs(slotA))
+      const sigB = await signWitnessV2(manager, { operator: first.operator, nodeId: witnessSet[slotB] }, sigArgs(slotB))
+      const witnessBitmap = (1 << slotA) | (1 << slotB)
+      // witnessSignatures must be ordered low-bit-first — matches the
+      // contract's iteration order.
+      const sigs = slotA < slotB ? [sigA, sigB] : [sigB, sigA]
+      const witnessReceiptIndex = slotA < slotB ? [[slotA, 0], [slotB, 0]] : [[slotB, 0], [slotA, 0]]
+      const metadata = buildMetadata([receipt], witnessReceiptIndex)
+
+      await expect(submitV2Metadata(manager, {
+        epochId,
+        merkleRoot: buildMerkleRoot([receipt.leafHash]),
+        sampleLeaf: receipt.leafHash,
+        witnessBitmap,
+        witnessSignatures: sigs,
+        metadata,
+      })).to.be.revertedWithCustomError(manager, "WitnessOperatorDuplicate")
+    })
+
+    it("admits a quorum from two distinct operators (no false-positive on legitimate K-of-N)", async function () {
+      // Same shape as the duplicate test but each nodeId has its OWN
+      // operator EOA. The dedup must not fire.
+      const a = await registerWitness(manager, deployer, "dist-a")
+      const b = await registerWitness(manager, deployer, "dist-b")
+      const receipt = makeReceipt("dist")
+      const epochId = Math.floor((await ethers.provider.getBlock("latest")).timestamp / 3600)
+
+      const witnessSet = await manager.getWitnessSet(epochId)
+      expect(witnessSet.length).to.equal(2)
+      const slotA = slotOf(witnessSet, a.nodeId)
+      const slotB = slotOf(witnessSet, b.nodeId)
+      const sigA = await signWitnessV2(
+        manager,
+        { operator: a.operator, nodeId: witnessSet[slotA] },
+        { challengeId: receipt.challengeId, responseBodyHash: receipt.responseBodyHash, witnessIndex: slotA, epochId },
+      )
+      const sigB = await signWitnessV2(
+        manager,
+        { operator: b.operator, nodeId: witnessSet[slotB] },
+        { challengeId: receipt.challengeId, responseBodyHash: receipt.responseBodyHash, witnessIndex: slotB, epochId },
+      )
+      const witnessBitmap = (1 << slotA) | (1 << slotB)
+      const sigs = slotA < slotB ? [sigA, sigB] : [sigB, sigA]
+      const witnessReceiptIndex = slotA < slotB ? [[slotA, 0], [slotB, 0]] : [[slotB, 0], [slotA, 0]]
+      const metadata = buildMetadata([receipt], witnessReceiptIndex)
+
+      await expect(submitV2Metadata(manager, {
+        epochId,
+        merkleRoot: buildMerkleRoot([receipt.leafHash]),
+        sampleLeaf: receipt.leafHash,
+        witnessBitmap,
+        witnessSignatures: sigs,
+        metadata,
+      })).to.emit(manager, "ReceiptBatchMetadataSubmitted")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

The witness quorum check in `_validateWitnessQuorumV2` counted set bits in `witnessBitmap` and verified each was signed by the operator that owns the nodeId at the corresponding `witnessSet[i]` slot. It did NOT check that the operator addresses were distinct.

A single real-world entity can register up to `MAX_NODES_PER_OPERATOR=5` distinct nodeIds. When the PRNG-selected `witnessSet` contains multiple slots whose `nodeOperator[]` resolves to the same EOA, that one entity can sign all of those slots with its own key and deliver the K-of-N quorum singlehandedly — collapsing the security threshold to 1-of-1. Mitigation against this case existed only as a probabilistic limit (PRNG distribution + MAX_NODES_PER_OPERATOR=5), not a hard on-chain check.

## Fix

- New error `WitnessOperatorDuplicate()` in `IPoSeManagerV2`.
- `_validateWitnessQuorumV2` now maintains a memory `address[m]` `seenOperators` scratch buffer (m ≤ 32, bounded by uint32 bitmap → worst-case 32² = 1024 address comparisons, well within EVM gas budget), appends each verified operator after step (c), and reverts `WitnessOperatorDuplicate` on a repeat appearance.
- **No storage writes, no layout change** — fully UUPS-upgrade-safe.

## Test plan

- [x] New `#7 per-operator quorum dedup` describe block in `pose-v2-witness-quorum-667.test.cjs`:
  - **`reverts WitnessOperatorDuplicate when both witnessSet slots resolve to the same operator`** — registers two distinct nodeIds under one operator (via a fresh alias key + ownershipSig), constructs a full-quorum submission, asserts revert with the new custom error.
  - **`admits a quorum from two distinct operators`** — false-positive regression check that legitimate K-of-N quorums still pass.
- [x] Full `contracts/` suite: **543/543 pass** (525 baseline + 9 in #667 suite + 9 in other PR-related suites; no regressions).
- [x] UUPS upgrade-safety regressions for `PoSeManagerV2` still pass — no storage layout change.

## Deployment

Deployment is via `upgradeProxy()` signed by the multisig (`contracts/scripts/upgrade-pose-manager-v2-667.js` + the existing safe-propose flow from PR-D #714). The on-chain proxy address (`0x256eb949…`) stays the same; only the implementation behind it rolls forward.

**Operator note**: After upgrade, any batch where a single operator's nodeIds occupy multiple `witnessSet` slots will revert. The PRNG should rarely produce this, and `MAX_NODES_PER_OPERATOR=5` bounds it, but witness fleets that previously relied on a single operator carrying multiple slots in the same batch will start to fail. Recommend running the upgrade during a coordinated quiet window and monitoring `submitBatchV2WithMetadata` revert rate post-deploy.

## Background

Part of the 2026-05-24 audit batch on the post-gen-5 commit range (`14d5ccc..0dc653e`). Audit flagged **4 true HIGH** items; this PR closes the only contract-side finding:

- #9 — `/api/v0/add` anonymous DoS — fixed in PR #731 (node-side)
- #8 — gateway/cat/ls SSRF reflection — fixed in PR #731 (node-side)
- #10 — `wrap-with-directory` single-file PoSe-merkle bypass — fixed in PR #731 (node-side)
- **#7 (this PR)** — PoSeManagerV2 quorum operator dedup (contract-side)

The audit's CRITICAL #6 (v1 `submitBatchV2` deprecation) was self-verified as a false positive: v1 signatures already bind `(epochId, merkleRoot, nodeId, witnessIndex)` plus the `epochMerkleRootUsed` guard from #680 — no replay vector exists. v1 selector stays as transitional fallback until the agent fleet finishes migrating to v2 (PR-E).