### PR TITLE
fix(security): IPFS write-path & response-body hardening (#14 + #15 subset)

### DIFF
--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1416,7 +1416,14 @@ if (config.soulRegistryAddress && config.didRegistryAddress) {
   const resolver = createDIDResolver({ defaultChainId: config.chainId, provider: didProvider })
   didResolverInstance = resolver
   didDataProviderInstance = didProvider
-  console.log(`[DID] Resolver configured: SoulRegistry=${config.soulRegistryAddress}, DIDRegistry=${config.didRegistryAddress}`)
+  // #15 (audit follow-up): structured log instead of console.log so the
+  // line goes through the project logger (level / component / fields)
+  // and isn't a free-form line on stdout. Public-chain addresses, but
+  // routing through `log.info` keeps the stdout shape consistent.
+  log.info("DID resolver configured", {
+    soulRegistry: config.soulRegistryAddress,
+    didRegistry: config.didRegistryAddress,
+  })
 }
 
 startRpcServer(

--- a/node/src/ipfs-blockstore-adapter.ts
+++ b/node/src/ipfs-blockstore-adapter.ts
@@ -56,6 +56,17 @@ export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put
   private readonly maxBlockReads: number
   private readonly localOnly: boolean
   private blockReads = 0
+  /**
+   * #14 (audit follow-up): every CID we successfully `put` through the
+   * adapter is recorded here so the caller can roll back a partial
+   * import. The importer streams blocks to the blockstore as it builds
+   * the DAG; when it throws mid-way (oversized inputs, malformed
+   * candidates, etc.) the already-written blocks would otherwise sit
+   * unpinned on disk until the next `repo/gc` cycle. handleAddDirectory
+   * iterates this set inside its `catch` to issue best-effort
+   * `removeBlock` calls and reclaim the space immediately.
+   */
+  private readonly _putCids = new Set<string>()
 
   constructor(inner: IpfsBlockstore, limits?: BlockstoreAdapterLimits) {
     this.inner = inner
@@ -73,6 +84,11 @@ export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put
     return this.localOnly
   }
 
+  /** #14: CIDs successfully put through this adapter — for partial-import rollback. */
+  get putCids(): ReadonlySet<string> {
+    return this._putCids
+  }
+
   async get(cid: CID): Promise<Uint8Array> {
     if (++this.blockReads > this.maxBlockReads) {
       throw new BlockstoreReadBudgetError(this.maxBlockReads)
@@ -83,6 +99,9 @@ export class InterfaceBlockstoreAdapter implements Pick<Blockstore, "get" | "put
 
   async put(cid: CID, bytes: Uint8Array): Promise<CID> {
     await this.inner.put({ cid: cid.toString(), bytes })
+    // Record only after the inner put succeeded — a failed put didn't
+    // actually allocate disk, so the rollback set must not include it.
+    this._putCids.add(cid.toString())
     return cid
   }
 

--- a/node/src/ipfs-http.test.ts
+++ b/node/src/ipfs-http.test.ts
@@ -1485,15 +1485,28 @@ describe("IpfsHttpServer", () => {
       `must NOT say 'invalid CID' (the pre-fix bug shape), got ${JSON.stringify(subBody)}`)
     assert.match(`${subBody.error} ${subBody.message ?? ""}`, /no link|no such file/i,
       `error must reference 'no link' or 'no such file', got ${JSON.stringify(subBody)}`)
-    assert.match(subBody.message ?? "", new RegExp(`'extra'.*${cid.slice(0, 20)}`),
-      `message must name both subpath and CID for clarity, got: ${subBody.message}`)
+    // #15 (audit follow-up): the response body intentionally NO LONGER
+    // names the specific CID / subpath — that detail was an enumeration
+    // side channel ("'foo' under bafy…X" lets a probe distinguish
+    // "node has not heard of bafy…X" from "bafy…X exists but lacks
+    // link 'foo'"). The detail still lands in `log.warn` server-side
+    // for operator debugging; only the generic kind reaches the wire.
+    assert.equal(
+      (subBody.message ?? "").includes(cid), false,
+      "response body MUST NOT echo the CID — that's a #15 enumeration oracle")
 
     // (c) /ipfs/<cid>/a/b/c — multi-segment subpath
     const deep = await fetch(`/ipfs/${cid}/a/b/c`)
     assert.equal(deep.status, 404)
     const deepBody = await deep.json() as { error?: string; message?: string }
     assert.notEqual(deepBody.error, "invalid CID")
-    assert.match(deepBody.message ?? "", /'a'/, "message names the FIRST missing segment")
+    // #15 (audit follow-up): segment names also redacted — naming "'a'"
+    // here would let an attacker enumerate which directory layer the
+    // walk stopped at, narrowing the probe target.
+    assert.equal(
+      (deepBody.message ?? "").includes("a/b/c"), false,
+      "response must not echo the requested subpath — #15 enumeration oracle")
+    assert.match(deepBody.error ?? "", /no such file/i)
 
     // (d) Truly invalid CID still returns 400 "invalid CID" (regression sentinel)
     const invalid = await fetch("/ipfs/not-a-cid")
@@ -3343,6 +3356,60 @@ describe("#468 UnixFS directory DAG", () => {
       assert.equal(res.status, 200)
       assert.equal(res.headers["x-coc-pose-coverage"], "files=0,skipped=0",
         "zero-file directory → zero coverage required, zero skipped")
+    })
+  })
+
+  // #14 (audit follow-up): handleAddDirectory partial-import cleanup.
+  // The ipfs-unixfs-importer streams blocks into the blockstore as it
+  // walks the candidate list; if it throws mid-build (oversized input,
+  // bad path, abort signal) every block put-so-far would sit on disk,
+  // unpinned, until the next repo/gc — an attacker repeating the
+  // failing shape could slowly fill disk between GC cycles. Fix:
+  // adapter records each successful put, and handleAddDirectory's
+  // catch block iterates those CIDs to issue best-effort removeBlock.
+  describe("#14 handleAddDirectory partial-import cleanup", () => {
+    it("removeBlock-sweeps every CID the importer wrote when buildDirectoryDag throws", async () => {
+      // Monkey-patch store.put so the third put throws — a realistic
+      // mid-import failure shape. The importer will have written ≥2
+      // blocks by then; those CIDs must be reclaimed.
+      const realPut = store.put.bind(store)
+      let putCount = 0
+      const seenCids: string[] = []
+      const FAIL_AFTER = 2
+      ;(store as { put: typeof store.put }).put = async (block, opts) => {
+        putCount += 1
+        if (putCount > FAIL_AFTER) {
+          throw new Error("simulated mid-import failure")
+        }
+        seenCids.push(block.cid)
+        return realPut(block, opts)
+      }
+      try {
+        // Multi-file directory that forces at least 3 puts (3 files →
+        // ≥3 file CIDs + 1 wrapping directory CID after success).
+        const { body, contentType } = multipart([
+          { filename: "a.txt", content: "alpha-content" },
+          { filename: "b.txt", content: "bravo-content" },
+          { filename: "c.txt", content: "charlie-content" },
+        ])
+        const res = await fetch("/api/v0/add", {
+          method: "POST",
+          headers: { "content-type": contentType },
+          body,
+        })
+        // Failure surfaces as a 500 (the throw propagates through the
+        // outer try/catch's generic 500 mapper).
+        assert.equal(res.status, 500,
+          "mid-import failure must surface — must NOT silently swallow + return 200")
+        // Every block successfully written before the failure must have
+        // been removed by the catch path.
+        for (const cid of seenCids) {
+          assert.equal(await store.has(cid), false,
+            `CID ${cid} was written before the failure and MUST be removed by cleanup`)
+        }
+      } finally {
+        ;(store as { put: typeof store.put }).put = realPut
+      }
     })
   })
 })

--- a/node/src/ipfs-http.ts
+++ b/node/src/ipfs-http.ts
@@ -1265,7 +1265,31 @@ export class IpfsHttpServer {
     )
 
     const adapter = new InterfaceBlockstoreAdapter(this.store, { maxBlockReads: MAX_BLOCK_READS })
-    const imported = await buildDirectoryDag(entries, adapter)
+    // #15: bound the importer the same way `resolveUnixfsPath` is bounded
+    // on the read path — a stalled or maliciously-slow build must surface
+    // fast rather than wedge the handler.
+    const buildSignal = AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)
+    let imported
+    try {
+      imported = await buildDirectoryDag(entries, adapter, buildSignal)
+    } catch (err) {
+      // #14 (audit follow-up): the importer streams blocks into the
+      // blockstore as it builds the DAG; a mid-import failure (oversized
+      // input, validator rejection, abort signal, etc.) leaves every
+      // block put-so-far on disk, unpinned, occupying space until the
+      // next `repo/gc` cycle. Best-effort cleanup here closes that gap:
+      // iterate the adapter's tracked CIDs and removeBlock each one.
+      // Errors during cleanup are swallowed so the operator still sees
+      // the original importer failure, not a cascading delete error.
+      for (const cid of adapter.putCids) {
+        try {
+          await this.store.removeBlock(cid)
+        } catch {
+          /* best-effort — partial cleanup is still better than none */
+        }
+      }
+      throw err
+    }
 
     // Recursively pin every node the importer emitted. COC's blockstore
     // GC is flat (it does not walk a pinned root's children), so each
@@ -1506,7 +1530,11 @@ export class IpfsHttpServer {
         const numeric = await this.resolveNumericLeaf(rootCid, path)
         if (numeric) return numeric
       }
-      throw new HttpError(404, "no such file", `no link named '${path[0]}' under ${rootCid}`)
+      // #15: detail (CID + segment) goes to log only — embedding it in
+      // the HTTP response is a side channel an enumerator can use to
+      // probe local cache state and directory layouts.
+      log.warn("path resolve miss", { rootCid, segment: path[0], reason: "block-mode-numeric-fallback-failed" })
+      throw new HttpError(404, "no such file", "no link found at requested path")
     }
 
     if (path.length === 0) {
@@ -1542,13 +1570,18 @@ export class IpfsHttpServer {
             const numeric = await this.resolveNumericLeaf(rootCid, path)
             if (numeric) return numeric
           }
-          throw new HttpError(404, "no such file", `no link named '${path[0]}' under ${rootCid}`)
+          // #15: detail to log only — see numeric-fallback miss above.
+          log.warn("path resolve miss", { rootCid, segment: path[0], reason: "not-a-directory-at-root" })
+          throw new HttpError(404, "no such file", "no link found at requested path")
         }
         // Mid-path non-directory → 400; missing component → 404.
+        // #15: route detailed err.message to log; response carries the
+        // PathResolveError.publicMessage (kind-only, no CID/segment).
+        log.warn("path resolve miss", { rootCid, segments: path, kind: err.kind, depth: err.depth, detail: err.message })
         if (err.kind === "not_a_directory") {
-          throw new HttpError(400, "not a directory", err.message)
+          throw new HttpError(400, "not a directory", err.publicMessage)
         }
-        throw new HttpError(404, "no such file", err.message)
+        throw new HttpError(404, "no such file", err.publicMessage)
       }
       // Read-budget / timeout → 504, not an opaque 500.
       const limit = resolveLimitError(err, signal)

--- a/node/src/ipfs-path-resolve.ts
+++ b/node/src/ipfs-path-resolve.ts
@@ -44,6 +44,25 @@ export class PathResolveError extends Error {
     this.kind = kind
     this.depth = depth
   }
+
+  /**
+   * #15 (audit follow-up): the constructor's `message` carries the
+   * specific CID + path segment that failed (useful for operator
+   * logs), but echoing it back to anonymous callers is a side-channel
+   * — by enumerating `<known-dir-cid>/<guess>` an attacker can learn
+   * which CIDs the node has resolved (timing + "no link named 'foo'"
+   * vs "block not found" distinguishes hot/cold paths) and which
+   * link names exist inside a private directory.
+   *
+   * HTTP responders MUST surface `publicMessage` rather than `message`
+   * so the wire body is a non-enumerable short code; full detail
+   * still lands in `log.warn`.
+   */
+  get publicMessage(): string {
+    return this.kind === "not_a_directory"
+      ? "this dag node is not a directory"
+      : "no such file"
+  }
 }
 
 export interface ResolvedEntry {

--- a/node/src/ipfs-unixfs-dir.ts
+++ b/node/src/ipfs-unixfs-dir.ts
@@ -61,11 +61,18 @@ export interface DirectoryImportResult {
 export async function buildDirectoryDag(
   entries: DirEntryInput[],
   blockstore: InterfaceBlockstoreAdapter,
+  signal?: AbortSignal,
 ): Promise<DirectoryImportResult> {
   const candidates = entries.map((e) =>
     e.content !== undefined ? { path: e.path, content: e.content } : { path: e.path },
   )
 
+  // #15 (audit follow-up): honour an optional abort signal. The read
+  // path (`resolveUnixfsPath`) has been timeout-bounded since #468;
+  // the write path was not, leaving room for a slow / large upload to
+  // pin the importer indefinitely. Callers in `ipfs-http.ts` set a
+  // bounded `AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)` so a stalled
+  // importer surfaces as a fast error rather than wedging the handler.
   const all: ImportedNode[] = []
   for await (const node of importer(candidates, blockstore, {
     wrapWithDirectory: true,
@@ -74,7 +81,14 @@ export async function buildDirectoryDag(
     rawLeaves: false,
     leafType: "file",
     cidVersion: 1,
-  })) {
+    signal,
+  } as Parameters<typeof importer>[2])) {
+    // Fast-bail mid-import if the caller aborted (rare — the importer
+    // already honours `signal` internally, but the throw-on-abort
+    // contract is centralised here).
+    if (signal?.aborted) {
+      throw new Error(`buildDirectoryDag aborted: ${String(signal.reason ?? "AbortError")}`)
+    }
     all.push({
       path: node.path ?? "",
       cid: node.cid.toString(),


### PR DESCRIPTION
## Summary

Audit follow-up #14 (MEDIUM) and 3 of 8 #15 items, bundled into a single node-side IPFS PR. All changes are pure additions or response-body redactions — no protocol changes, no behaviour change for legitimate flows.

### #14 — handleAddDirectory partial-import cleanup

`ipfs-unixfs-importer` streams blocks into the blockstore as it walks the candidate list; a mid-import failure (oversized input, malformed path, abort signal) left every block put-so-far on disk, **unpinned**, until the next `repo/gc` cycle. An attacker who could reliably trigger the failing shape could slowly fill disk between GC cycles.

**Fix:**
- `InterfaceBlockstoreAdapter` records every CID that successfully `put` through it (`_putCids` Set, exposed via `putCids` getter).
- `handleAddDirectory` wraps `buildDirectoryDag` in try/catch; the catch iterates `adapter.putCids` and issues best-effort `store.removeBlock(cid)`. Cleanup errors are swallowed so the operator still sees the original importer failure.

### #15 — three independent items bundled

| # | What | How |
|---|---|---|
| (4) | `PathResolveError` enumeration oracle | `publicMessage` getter returns kind-only string; CID/segments routed to `log.warn` for operator-side debugging. Response body no longer echoes specific identifiers. |
| (6) | `buildDirectoryDag` AbortSignal | Read-path was timeout-bounded since #468; write-path was not. Now `buildDirectoryDag(entries, blockstore, signal?)` threads through, `handleAddDirectory` attaches `AbortSignal.timeout(IPFS_RESOLVE_TIMEOUT_MS)`. |
| (7) | `index.ts` `console.log` → `log.info` | DID resolver boot line was free-form stdout. Now structured via project logger. |

**Other #15 items deferred** to dedicated PRs:
- (1) multiformats overrides / dedupe — needs package-lock work, separate "deps" PR
- (2) PoSeManagerV2 DOMAIN_SEPARATOR dynamic chainId — contract layer
- (3) Treasury signer re-add re-activates stale `confirmed[]` — contract layer
- (5) BFT RPC↔relayer field round-trip test — test-only PR
- (8) ipfs-http malicious-input test extensions — separate test PR

## Test plan

- [x] **NEW**: `#14 handleAddDirectory partial-import cleanup` in ipfs-http.test.ts — monkey-patches `store.put` to throw on the 3rd call, confirms (a) request surfaces as 500, (b) every CID written before the failure is no longer in the blockstore.
- [x] **UPDATED**: `#545 gateway subpath returns 404 'no such file'` — assertions inverted from "MUST include CID + segment for clarity" to "MUST NOT include CID / subpath" to match the new privacy model.
- [x] Full IPFS-related suites: **271/271 pass** (ipfs-http + adapter + blockstore + byte-quota + path-resolve + unixfs-dir + unixfs + config). Zero regressions.

## Behaviour change for HTTP clients

Error response bodies on `/ipfs/<cid>/<sub>` / `/api/v0/cat` / `/api/v0/ls` etc. that previously included the failing CID + segment now carry only the generic kind:

| Before | After |
|---|---|
| `{"error":"no such file","message":"no link named 'docs' under bafy…"}` | `{"error":"no such file","message":"no link found at requested path"}` |
| `{"error":"not a directory","message":"cannot descend into 'foo': bafy… is not a directory"}` | `{"error":"not a directory","message":"this dag node is not a directory"}` |

Operators retain full detail via `log.warn` lines: `path resolve miss { rootCid: 'bafy…', segments: […], kind: 'not_found', depth: N, detail: '…' }`.

## Background

Part of the 2026-05-24 audit batch (`14d5ccc..0dc653e`). This closes #14 and 3 of 5 #15 items. Remaining task list:

| # | Status | PR |
|---|---|---|
| #7 | ✅ merged | #737 |
| #8 #9 #10 | ✅ merged | #731 |
| #11 #12 | review pending | #738 |
| **#14 + #15 subset (this PR)** | review pending | this |
| #13 (DHT IP binding) | pending | — |
| #15 remaining (deps/contract/test items) | pending | — |