### PR TITLE
fix(security): DHT prefers wire-server observed IP + multiformats dedupe (#13 + #15 deps)

### DIFF
--- a/node/src/dht.test.ts
+++ b/node/src/dht.test.ts
@@ -302,3 +302,67 @@ describe("RoutingTable", () => {
     assert.equal(stats.nonEmptyBuckets, 5)
   })
 })
+
+// #13 (audit follow-up): RoutingTable's per-IP Sybil cap had been keyed
+// off the peer-self-reported `peer.address`. A Sybil attacker connecting
+// from one real IP but advertising N distinct addresses would occupy N
+// bucket slots that look distinct to the cap. The fix lets the wire
+// server inject an observedIpResolver that returns the IP the verified
+// handshake actually came from; the cap now uses observed when known.
+describe("#13 RoutingTable observed-IP cap", () => {
+  it("falls back to advertised host when no resolver attached", async () => {
+    const rt = new RoutingTable("0x" + "00".repeat(32))
+    const p = { id: "0x" + "11".repeat(32), address: "203.0.113.5:1000" } as DhtPeer
+    assert.equal(await rt.addPeer(p), true)
+    assert.equal(rt.size(), 1)
+  })
+
+  it("falls back to advertised when resolver returns null for the nodeId", async () => {
+    const rt = new RoutingTable("0x" + "00".repeat(32), {
+      observedIpResolver: () => null,
+    })
+    const p = { id: "0x" + "22".repeat(32), address: "198.51.100.7:1000" } as DhtPeer
+    assert.equal(await rt.addPeer(p), true)
+  })
+
+  it("uses observed IP — collapses two distinct-advertised peers into one bucket slot when observed matches", async () => {
+    // Setup: 2 peers, each advertising different IPs but both observed
+    // from the SAME real source. Without the fix both pass the per-IP
+    // cap because peer.address differs. With the fix, observed wins and
+    // the second is rejected once we hit MAX_PEERS_PER_IP_PER_BUCKET=2.
+    const observed = "10.0.0.1"
+    const observedByNodeId = new Map<string, string>()
+    const rt = new RoutingTable("0x" + "00".repeat(32), {
+      observedIpResolver: (nodeId) => observedByNodeId.get(nodeId.toLowerCase()) ?? null,
+    })
+    // 3 peers in the same bucket (bucket 0 — leading byte 0x01) so they
+    // compete for MAX_PEERS_PER_IP_PER_BUCKET=2.
+    const peerIds = [
+      "0x01" + "11".repeat(31),
+      "0x01" + "22".repeat(31),
+      "0x01" + "33".repeat(31),
+    ]
+    for (let i = 0; i < peerIds.length; i++) {
+      observedByNodeId.set(peerIds[i].toLowerCase(), observed)
+    }
+    // All advertise different addresses; observed is the same for all.
+    assert.equal(await rt.addPeer({ id: peerIds[0], address: "203.0.113.1:1000" } as DhtPeer), true)
+    assert.equal(await rt.addPeer({ id: peerIds[1], address: "203.0.113.2:1000" } as DhtPeer), true)
+    // 3rd would push same-host count to 3 > MAX_PEERS_PER_IP_PER_BUCKET=2.
+    assert.equal(await rt.addPeer({ id: peerIds[2], address: "203.0.113.3:1000" } as DhtPeer), false,
+      "3rd peer with same observed IP MUST be capped even though advertised IPs differ")
+  })
+
+  it("setObservedIpResolver attaches post-construction (wiring injection)", async () => {
+    const observed = "10.0.0.42"
+    const rt = new RoutingTable("0x" + "00".repeat(32))
+    // Pre-injection: cap uses advertised — both peers admitted (different addresses)
+    rt.setObservedIpResolver((nodeId) => nodeId.startsWith("0xaa") ? observed : null)
+    // Verify the resolver is consulted — but exact effect depends on
+    // bucket placement; a more granular assertion would duplicate the
+    // cap-test above. Smoke check that setObservedIpResolver doesn't
+    // throw and the routing table keeps accepting peers.
+    const p = { id: "0xaa" + "00".repeat(31), address: "203.0.113.1:1000" } as DhtPeer
+    assert.equal(await rt.addPeer(p), true)
+  })
+})

--- a/node/src/dht.ts
+++ b/node/src/dht.ts
@@ -88,11 +88,53 @@ export class RoutingTable {
   private readonly pingPeer: ((peer: DhtPeer) => Promise<boolean>) | null
   // Pre-computed global IP count index for O(1) Sybil checks (avoids O(n²) full scan)
   private readonly globalIpCount = new Map<string, number>()
+  /**
+   * #13 (audit follow-up): resolver for the *observed* source IP of a
+   * given nodeId — the IP a verified inbound wire handshake came from,
+   * supplied by `WireServer.observedIpForNodeId`. When attached, the
+   * per-IP Sybil cap (`MAX_PEERS_PER_IP_*`) prefers this over the
+   * peer-self-reported `peer.address`. Without it, an attacker who
+   * connects from one real IP but advertises N different addresses can
+   * occupy N bucket slots that look distinct to the cap.
+   *
+   * Returns null when:
+   *   - the wire server has no verifier (we can't trust the link
+   *     between nodeId and IP), OR
+   *   - we've never had a verified handshake from that nodeId (e.g.
+   *     learned via DHT gossip, not a direct connection).
+   * Falls back to the advertised host in either case.
+   */
+  private readonly observedIpResolver: ((nodeId: string) => string | null) | null
 
-  constructor(localId: string, opts?: { pingPeer?: (peer: DhtPeer) => Promise<boolean> }) {
+  constructor(localId: string, opts?: {
+    pingPeer?: (peer: DhtPeer) => Promise<boolean>
+    observedIpResolver?: (nodeId: string) => string | null
+  }) {
     this.localId = localId
     this.buckets = Array.from({ length: ID_BITS }, () => ({ peers: [] }))
     this.pingPeer = opts?.pingPeer ?? null
+    this.observedIpResolver = opts?.observedIpResolver ?? null
+  }
+
+  /**
+   * #13: attach the wire-server observed-IP resolver post-construction.
+   * The routing table is built before the wire server is wired up in
+   * `coc-ipfs-wiring.ts`; this hook lets the wiring inject the resolver
+   * once both are alive, mirroring `setAwaitReplicationResult` and the
+   * other post-construction injection sites in `IpfsHttpServer`.
+   */
+  setObservedIpResolver(resolver: (nodeId: string) => string | null): void {
+    ;(this as { observedIpResolver: ((nodeId: string) => string | null) | null }).observedIpResolver = resolver
+  }
+
+  /**
+   * #13: resolve a peer's effective host for Sybil-cap purposes —
+   * observed IP wins when known (it's the cryptographically attested
+   * source), else fall back to whatever the peer advertised.
+   */
+  private effectiveHost(peer: DhtPeer): string {
+    const observed = this.observedIpResolver?.(peer.id) ?? null
+    return normalizeHostForBucket(observed ?? extractHost(peer.address))
   }
 
   /**
@@ -110,14 +152,17 @@ export class RoutingTable {
 
     const idx = bucketIndex(this.localId, peer.id)
     const bucket = this.buckets[idx]
-    const peerHost = normalizeHostForBucket(extractHost(peer.address))
+    // #13: prefer the observed source IP when the wire server has
+    // cryptographically attested it. Falls back to the peer's
+    // self-reported `address` when no verified handshake has happened.
+    const peerHost = this.effectiveHost(peer)
 
     // Check if peer already exists
     const existing = bucket.peers.findIndex((p) => p.id === peer.id)
     if (existing >= 0) {
       // Move to tail (most recently seen); update global IP count if address changed
       const oldPeer = bucket.peers[existing]
-      const oldHost = normalizeHostForBucket(extractHost(oldPeer.address))
+      const oldHost = this.effectiveHost(oldPeer)
       // #729: when the address normalises to a different host, re-validate
       // the per-IP Sybil caps against the new host BEFORE swapping. Without
       // this gate, an attacker who established N peers across N distinct
@@ -129,7 +174,7 @@ export class RoutingTable {
         let sameHostInBucket = 0
         for (let i = 0; i < bucket.peers.length; i++) {
           if (i === existing) continue // exclude the entry we'd be updating
-          const h = normalizeHostForBucket(extractHost(bucket.peers[i].address))
+          const h = this.effectiveHost(bucket.peers[i])
           if (h === peerHost) sameHostInBucket++
         }
         if (sameHostInBucket >= MAX_PEERS_PER_IP_PER_BUCKET) {
@@ -166,7 +211,7 @@ export class RoutingTable {
     if (!isLoopbackHost(peerHost)) {
       let sameHostInBucket = 0
       for (const p of bucket.peers) {
-        const existingHost = normalizeHostForBucket(extractHost(p.address))
+        const existingHost = this.effectiveHost(p)
         if (existingHost === peerHost) sameHostInBucket++
       }
       if (sameHostInBucket >= MAX_PEERS_PER_IP_PER_BUCKET) {
@@ -206,7 +251,7 @@ export class RoutingTable {
         }
       } else if (!alive) {
         // Evict unreachable peer, add new peer at tail (only if bucket won't exceed K)
-        const evictedHost = normalizeHostForBucket(extractHost(bucket.peers[pos].address))
+        const evictedHost = this.effectiveHost(bucket.peers[pos])
         bucket.peers.splice(pos, 1)
         this.decrementGlobalIpCount(evictedHost)
         if (bucket.peers.length < K) {
@@ -234,7 +279,7 @@ export class RoutingTable {
     const bucket = this.buckets[idx]
     const pos = bucket.peers.findIndex((p) => p.id === peerId)
     if (pos >= 0) {
-      const removedHost = normalizeHostForBucket(extractHost(bucket.peers[pos].address))
+      const removedHost = this.effectiveHost(bucket.peers[pos])
       bucket.peers.splice(pos, 1)
       this.decrementGlobalIpCount(removedHost)
       return true

--- a/node/src/wire-server.ts
+++ b/node/src/wire-server.ts
@@ -136,6 +136,18 @@ export class WireServer {
   // #733: inbound wire roster (lowercased peer/validator nodeIds + self).
   private readonly knownPeerIds: Set<string>
   private rosterRejectedHandshakes = 0
+  // #13 (audit follow-up): observed source IP per cryptographically-
+  // authenticated nodeId. The handshake's `nodeId` field is peer-self-
+  // reported (Sybil attackers can claim any), and the DHT's per-IP cap
+  // is currently fed by `peer.address` (also self-reported). Recording
+  // the observed `socket.remoteAddress` here lets downstream cap logic
+  // (DHT, rate-limiter) reach back for the real source and refuse to
+  // trust peers' advertised hosts. Map is populated only after the
+  // signature verifier confirms `recovered === claimed`, so any nodeId
+  // present here is genuine (the EOA that owns the signing key did
+  // really connect from that IP).
+  private readonly _observedIpByNodeId = new Map<string, string>()
+  private observedIpMismatchCount = 0
 
   constructor(cfg: WireServerConfig) {
     this.cfg = cfg
@@ -165,6 +177,22 @@ export class WireServer {
     if (typeof nodeId === "string" && nodeId.length > 0) {
       this.knownPeerIds.add(nodeId.toLowerCase())
     }
+  }
+
+  /**
+   * #13 (audit follow-up): observed source IP for a verified nodeId,
+   * or null when we've never seen a successful (signature-verified)
+   * inbound handshake from this nodeId. DHT cap logic should prefer
+   * this over the peer-self-reported `peer.address` so Sybil attackers
+   * cannot pretend to come from arbitrary IPs.
+   *
+   * Returns null when the wire server isn't configured with a verifier
+   * — without cryptographic authentication of nodeId, "observed IP"
+   * for a self-claimed nodeId would lie about authenticity.
+   */
+  observedIpForNodeId(nodeId: string): string | null {
+    if (!this.cfg.verifier) return null
+    return this._observedIpByNodeId.get(nodeId.toLowerCase()) ?? null
   }
 
   /**
@@ -527,6 +555,31 @@ export class WireServer {
         }
         conn.nodeId = hs.nodeId
         conn.handshakeComplete = true
+        // #13: record observed IP for this verified nodeId. Only meaningful
+        // when the signature verifier is active — without it `nodeId` is
+        // pure self-report and binding it to an IP would lie about
+        // authenticity. The IP is normalised the same way the per-IP cap
+        // normalises it (strip IPv4-mapped IPv6 prefix).
+        if (this.cfg.verifier) {
+          const observedRaw = conn.socket.remoteAddress ?? ""
+          const observed = observedRaw.startsWith("::ffff:") ? observedRaw.slice(7) : observedRaw
+          if (observed) {
+            const previous = this._observedIpByNodeId.get(hs.nodeId.toLowerCase())
+            if (previous && previous !== observed) {
+              // Same nodeId now connecting from a different IP — could be a
+              // legitimate roaming validator OR a key-compromise / Sybil
+              // attempt. Log + count; the latest IP wins (avoids ossifying
+              // on a stale entry for a peer that genuinely moved hosts).
+              this.observedIpMismatchCount++
+              log.warn("nodeId observed-IP changed", {
+                nodeId: hs.nodeId,
+                previous,
+                observed,
+              })
+            }
+            this._observedIpByNodeId.set(hs.nodeId.toLowerCase(), observed)
+          }
+        }
         if (conn.handshakeTimer) clearTimeout(conn.handshakeTimer)
         // Reply with ack if this was a handshake (not ack)
         if (frame.type === MessageType.Handshake) {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "storage"
   ],
   "author": "ChainOfClaw",
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "multiformats": "^13.3.2"
+  }
 }


### PR DESCRIPTION
## Summary

Two related node-side hardening items from the 2026-05-24 audit batch, bundled because both are about getting Sybil-defense primitives right at the dependency / cross-module boundary.

### #13 — DHT per-IP Sybil cap uses observed IP, not peer-self-reported

`RoutingTable.addPeer` keyed `MAX_PEERS_PER_IP_PER_BUCKET` and `MAX_PEERS_PER_IP_GLOBAL` off `extractHost(peer.address)`, where `peer.address` is **whatever the peer advertised** — purely self-report. A Sybil attacker connecting from one real IP but advertising N distinct addresses occupied N bucket slots that all looked distinct to the cap, which is the entire eclipse-attack precursor the cap was supposed to block.

**Fix — bind the cap to the cryptographically-attested source:**

- `WireServer` records `observedIpByNodeId` whenever a signature-verified inbound handshake completes (**only when `verifier` is configured** — without it, "observed IP for self-reported nodeId" doesn't carry authenticity). Exposes `observedIpForNodeId(nodeId)` getter.
- `RoutingTable` constructor accepts `observedIpResolver`; new `setObservedIpResolver` post-construction hook mirrors the existing wiring pattern. Every per-IP cap callsite (`addPeer` / `removePeer` / evict / update) switches to `this.effectiveHost(peer)`, which returns observed when known, else falls back to advertised.

Mismatch (`nodeId` reconnecting from a different observed IP) is logged + counted (`observedIpMismatchCount`) — could be a legitimate roaming validator OR a key-compromise; latest IP wins so we don't ossify on stale entries when a peer genuinely moves hosts.

### #15 (1) — multiformats dedupe via npm overrides

Pre-fix `node_modules/uint8arrays/node_modules/multiformats` (v14) and `node_modules/@multiformats/murmur3/node_modules/multiformats` (v14) coexisted with the top-level v13.4.2 → **3 copies of the CID class**. The exporter / importer / our adapter all survived because they only ever `.toString()` the CID, but any future code that does `instanceof CID` (e.g. dag-cbor codec validation, new HAMT helpers) would silently false-negative across module boundaries.

**Fix** — `package.json` `overrides.multiformats = ^13.3.2`. After a clean `rm -rf node_modules package-lock.json && npm install`, `find node_modules -name multiformats -type d` returns exactly **1 copy** (was 3).

## Test plan

- [x] `node/src/dht.test.ts` +4 new tests in `#13 RoutingTable observed-IP cap`:
  - falls back to advertised when no resolver attached
  - falls back to advertised when resolver returns null
  - **uses observed — caps 2 distinct-advertised peers as same-host when observed matches** (the actual Sybil-defense assertion)
  - `setObservedIpResolver` post-construction hook smoke check
- [x] `dht.test.ts` + `wire-server.test.ts` + `wire-auth-handshake.test.ts` all green after the changes — zero regression.
- [x] Full node layer: **1939/1940 pass**. The single failure (`Block Production Throughput`) is a pre-existing timing-sensitive benchmark confirmed flaky on main baseline.
- [x] IPFS-related suites (ipfs-http / ipfs-blockstore* / ipfs-path-resolve / ipfs-unixfs*) all pass after the multiformats dedupe — exporter / importer / adapter all keep working with the single shared instance.

## Wiring task for follow-up

The actual `wire-server → RoutingTable.setObservedIpResolver` injection happens in `node/src/index.ts` boot sequence + `node/src/coc-ipfs-wiring.ts`. **Not included in this PR** because the wiring touches startup ordering that's safer reviewed separately; ship the API surface here, file a wiring follow-up. Without the wiring, the `observedIpResolver` stays null and the cap falls back to advertised host (pre-PR behaviour) — so this PR is safe to merge before the wiring lands.

## Deferred (separate PRs)

- #15 (2) PoSeManagerV2 DOMAIN_SEPARATOR dynamic chainId — contract layer
- #15 (3) Treasury signer re-add re-activates stale `confirmed[]` — contract layer
- #15 (5) BFT RPC↔relayer field-mapping round-trip test — test-only
- #15 (8) ipfs-http malicious-input test expansion — test-only

## Status of the 2026-05-24 audit batch

| # | Sev | Status | PR |
|---|---|---|---|
| #6 | (FALSE) | deleted | — |
| #7 | HIGH | merged | #737 |
| #8 #9 #10 | HIGH | merged | #731 |
| #11 #12 | MED | review pending | #738 |
| #14 + #15 subset | MED+LOW | review pending | #739 |
| **#13 + #15 deps (this PR)** | MED+LOW | review pending | this |
| #15 contract + test-only items | LOW | follow-up PRs | — |