### PR TITLE
fix(security): PoSeManagerV2 dynamic domain separator + Treasury historical-signer warning (#15 (2) + (3))

### DIFF
--- a/contracts/contracts-src/governance/Treasury.sol
+++ b/contracts/contracts-src/governance/Treasury.sol
@@ -36,6 +36,18 @@ contract Treasury is Initializable, UUPSUpgradeable {
     mapping(uint256 => Proposal) public proposals;
     mapping(address => uint256) public pendingWithdrawals;
     uint256 public pendingWithdrawalTotal;
+    /**
+     * #15 (audit follow-up): address has historically served as a
+     * signer at least once. Set in `replaceSigner` for the OLD signer
+     * being removed, never cleared. Used to surface a warning event
+     * when `replaceSigner` re-adds an address that previously served:
+     * that address's `confirmed[]` bits on pending proposals are still
+     * `true` and will silently re-count once the address is back in
+     * `signers[]`, so operators must `cancel + re-propose` any pending
+     * proposals before re-adding. Append-only storage slot — safe to
+     * add under UUPS without breaking layout.
+     */
+    mapping(address => bool) public wasSignerHistorical;
 
     event Deposit(address indexed from, uint256 amount);
     event ProposalCreated(uint256 indexed proposalId, address indexed to, uint256 amount);
@@ -46,6 +58,18 @@ contract Treasury is Initializable, UUPSUpgradeable {
     event GovernanceUpdated(address indexed newGovernance);
     event SignerUpdated(uint8 indexed index, address indexed oldSigner, address indexed newSigner);
     event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
+    /**
+     * #15: emitted when `replaceSigner` re-adds an address that has
+     * served as a signer in the past. The address's `confirmed[]` bits
+     * on any pending proposals are still set from the previous tenure
+     * and will silently re-count toward the 3-of-5 threshold once the
+     * address is back in `signers[]`. Operators MUST cancel + recreate
+     * any pending proposals (or wait for them to execute) before
+     * re-adding a historical signer, otherwise stale confirmations
+     * from the prior tenure resurrect on re-entry. Defence-in-depth
+     * warning only — the runtime path is not blocked.
+     */
+    event ReusingHistoricalSigner(uint8 indexed index, address indexed signer);
 
     error NotSigner();
     error NotOwner();
@@ -188,9 +212,23 @@ contract Treasury is Initializable, UUPSUpgradeable {
         if (newSigner == address(0)) revert ZeroAddress();
         address old = signers[index];
         if (newSigner != old && isSigner[newSigner]) revert DuplicateSigner();
+        // #15: record OLD signer as historical BEFORE we remove them.
+        // This catches the case where `replaceSigner` is called with
+        // `newSigner == old` (no-op identity churn) — they're already
+        // a current signer, so we don't need to flag them as historical,
+        // but updating the bit is harmless and keeps the semantics
+        // simple: "this address has ever been a signer".
+        wasSignerHistorical[old] = true;
         isSigner[old] = false;
         signers[index] = newSigner;
         isSigner[newSigner] = true;
+        // #15: surface a warning event if the new signer is being
+        // re-added after a prior tenure — operators must verify no
+        // pending proposals carry stale confirmations from their
+        // previous slot before relying on the 3-of-5 threshold.
+        if (wasSignerHistorical[newSigner] && newSigner != old) {
+            emit ReusingHistoricalSigner(index, newSigner);
+        }
         emit SignerUpdated(index, old, newSigner);
     }
 

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -132,7 +132,30 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
         __PoSeManagerStorage_init(initialOwner);
 
         initialized = true;
-        DOMAIN_SEPARATOR = keccak256(
+        // #15 (audit follow-up): keep `DOMAIN_SEPARATOR` populated for
+        // backwards-compat with off-chain readers that hard-coded the
+        // public field, but signature verification now uses the dynamic
+        // {@link domainSeparator} view below — `block.chainid` is read
+        // at every digest build, so a chain fork that keeps the same
+        // proxy address can no longer have witness signatures from the
+        // pre-fork chain replayed against the post-fork chain.
+        DOMAIN_SEPARATOR = _computeDomainSeparator();
+        challengeBondMin = _challengeBondMin;
+        emit Initialized(block.chainid, address(this), _challengeBondMin);
+    }
+
+    /// @notice #15 (audit follow-up): dynamic EIP-712 domain separator
+    ///         that reads `block.chainid` at call time. Used by every
+    ///         signature digest builder so chain forks cannot replay
+    ///         pre-fork witness signatures against the post-fork chain.
+    ///         The stored `DOMAIN_SEPARATOR` snapshot is retained for
+    ///         backwards-compat with off-chain integrations.
+    function domainSeparator() public view returns (bytes32) {
+        return _computeDomainSeparator();
+    }
+
+    function _computeDomainSeparator() internal view returns (bytes32) {
+        return keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256("COCPoSe"),
@@ -141,8 +164,6 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
                 address(this)
             )
         );
-        challengeBondMin = _challengeBondMin;
-        emit Initialized(block.chainid, address(this), _challengeBondMin);
     }
 
     /**
@@ -903,10 +924,14 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
             if (witnessBitmap & (1 << i) != 0) {
                 if (sigIdx >= witnessSignatures.length) revert InvalidWitnessQuorum();
                 // Verify witness signature over the batch merkle root
+                // #15: dynamic domain separator (block.chainid is read
+                // at call time) prevents pre-fork witness signatures
+                // being replayed against a post-fork chain that kept
+                // the same proxy address.
                 bytes32 witnessHash = keccak256(
                     abi.encodePacked(
                         "\x19\x01",
-                        DOMAIN_SEPARATOR,
+                        _computeDomainSeparator(),
                         keccak256(abi.encode(
                             PoSeTypesV2.WITNESS_TYPEHASH,
                             merkleRoot, // challengeId field used as batch root
@@ -1059,10 +1084,11 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
         bytes32 responseBodyHash,
         uint8 witnessIndex
     ) internal view returns (bytes32) {
+        // #15: dynamic domain separator — see initialize() / domainSeparator()
         return keccak256(
             abi.encodePacked(
                 "\x19\x01",
-                DOMAIN_SEPARATOR,
+                _computeDomainSeparator(),
                 keccak256(abi.encode(
                     PoSeTypesV2.WITNESS_TYPEHASH,
                     challengeId,
@@ -1084,10 +1110,11 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
         uint8 witnessIndex,
         uint64 epochId
     ) internal view returns (bytes32) {
+        // #15: dynamic domain separator — see initialize() / domainSeparator()
         return keccak256(
             abi.encodePacked(
                 "\x19\x01",
-                DOMAIN_SEPARATOR,
+                _computeDomainSeparator(),
                 keccak256(abi.encode(
                     PoSeTypesV2.WITNESS_TYPEHASH_V2,
                     challengeId,

--- a/contracts/test/pose-v2-witness-quorum-667.test.cjs
+++ b/contracts/test/pose-v2-witness-quorum-667.test.cjs
@@ -429,6 +429,59 @@ describe("PoSeManagerV2 — #667 witness-quorum independent verification", funct
   // that one entity deliver the K-of-N quorum singlehandedly — collapsing
   // the security threshold to 1-of-1. The fix rejects on second appearance
   // of the same operator within a single quorum vote.
+  // #15 (audit follow-up): dynamic EIP-712 domain separator.
+  // initialize() snapshots DOMAIN_SEPARATOR at deploy time using
+  // block.chainid; pre-fix every signature digest used that snapshot,
+  // so a chain fork that kept the same proxy address could replay
+  // pre-fork witness sigs against the post-fork chain. Fix: the
+  // _buildWitnessDigest{V1,V2} paths call _computeDomainSeparator()
+  // which reads block.chainid at call time. The public domainSeparator()
+  // view exposes the dynamic value; the legacy DOMAIN_SEPARATOR field
+  // is retained as a back-compat snapshot.
+  describe("#15 dynamic EIP-712 domain separator", function () {
+    it("exposes domainSeparator() view that matches the snapshotted DOMAIN_SEPARATOR on the initial chain", async function () {
+      const dynamic = await manager.domainSeparator()
+      const stored = await manager.DOMAIN_SEPARATOR()
+      expect(dynamic).to.not.equal(ethers.ZeroHash)
+      expect(stored).to.not.equal(ethers.ZeroHash)
+      // Same chain → same value as the deploy-time snapshot.
+      expect(dynamic).to.equal(stored)
+    })
+
+    it("dynamic separator is deterministic when block.chainid is stable", async function () {
+      // Real protection (forked chain refusing pre-fork sigs) needs
+      // cross-chain fixtures; here we just confirm the view is pure
+      // and stable across calls on the same chain.
+      const a = await manager.domainSeparator()
+      const b = await manager.domainSeparator()
+      expect(a).to.equal(b)
+    })
+
+    it("happy-path signature still verifies with the new dynamic separator", async function () {
+      // Regression: the witness verifier paths (V1 + V2) now build
+      // their domain separator via _computeDomainSeparator(); confirm
+      // a legitimate witness signature still passes end-to-end.
+      const witness = await registerWitness(manager, deployer, "ds-dyn")
+      const receipt = makeReceipt("ds-dyn")
+      const sampleLeaf = receipt.leafHash
+      const epochId = Math.floor((await ethers.provider.getBlock("latest")).timestamp / 3600)
+      const witnessIndex = 0
+      const sig = await signWitnessV2(manager, witness, {
+        challengeId: receipt.challengeId,
+        responseBodyHash: receipt.responseBodyHash,
+        witnessIndex, epochId,
+      })
+      await expect(submitV2Metadata(manager, {
+        epochId,
+        merkleRoot: buildMerkleRoot([receipt.leafHash]),
+        sampleLeaf,
+        witnessBitmap: 1 << witnessIndex,
+        witnessSignatures: [sig],
+        metadata: buildMetadata([receipt], [[witnessIndex, 0]]),
+      })).to.emit(manager, "ReceiptBatchMetadataSubmitted")
+    })
+  })
+
   describe("#7 per-operator quorum dedup", function () {
     // Register an "alias" nodeId under an existing operator EOA. The alias
     // is a fresh signing key whose public key derives the nodeId; the

--- a/contracts/test/treasury-signer-rotation-719.test.cjs
+++ b/contracts/test/treasury-signer-rotation-719.test.cjs
@@ -75,4 +75,35 @@ describe("Treasury — #719 signer rotation confirmation accounting", function (
     const after = await ethers.provider.getBalance(recipient.address)
     expect(after - before).to.equal(ethers.parseEther("1"))
   })
+
+  // #15 (audit follow-up): signer rotation history surface.
+  describe("#15 historical-signer hygiene warnings", function () {
+    it("records wasSignerHistorical when a signer is replaced", async function () {
+      expect(await treasury.wasSignerHistorical(s0.address)).to.equal(false)
+      await treasury.connect(owner).replaceSigner(0, newSigner.address)
+      expect(await treasury.wasSignerHistorical(s0.address)).to.equal(true,
+        "old signer must be flagged as historical after being removed")
+      expect(await treasury.wasSignerHistorical(newSigner.address)).to.equal(false,
+        "fresh signer who was never in the set should not be marked historical")
+    })
+
+    it("emits ReusingHistoricalSigner when re-adding an address that previously served", async function () {
+      // Cycle s0 out, then back in — second replaceSigner must surface
+      // the warning because s0 has pending-proposal confirmation history.
+      await treasury.connect(owner).replaceSigner(0, newSigner.address)
+      // Now re-add s0 to slot 0 (replacing newSigner). s0.wasSignerHistorical
+      // is already true → ReusingHistoricalSigner event MUST fire.
+      const tx = await treasury.connect(owner).replaceSigner(0, s0.address)
+      await expect(tx).to.emit(treasury, "ReusingHistoricalSigner")
+        .withArgs(0, s0.address)
+      // SignerUpdated still fires too — they coexist.
+      await expect(tx).to.emit(treasury, "SignerUpdated")
+        .withArgs(0, newSigner.address, s0.address)
+    })
+
+    it("does NOT emit ReusingHistoricalSigner when adding a fresh signer", async function () {
+      const tx = await treasury.connect(owner).replaceSigner(0, newSigner.address)
+      await expect(tx).to.not.emit(treasury, "ReusingHistoricalSigner")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Two remaining LOW audit items on the gen-5 contract surface, bundled. Both are pure additions, fully UUPS-upgrade-safe; Treasury picks up one append-only mapping slot.

### #15 (2) — PoSeManagerV2 dynamic EIP-712 domain separator

`initialize()` snapshotted `DOMAIN_SEPARATOR` at deploy time using `block.chainid`. Every signature digest builder used that snapshot. A chain fork that kept the same proxy address could replay pre-fork witness signatures against the post-fork chain.

**Fix:**
- New `_computeDomainSeparator()` internal view reads `block.chainid` at call time.
- New `domainSeparator()` public view exposes the dynamic value.
- Every digest builder (`_buildWitnessDigestV1` / `_buildWitnessDigestV2` / v1-path `_validateWitnessQuorum`) now calls `_computeDomainSeparator()` instead of reading the storage snapshot.
- The storage `DOMAIN_SEPARATOR` field is preserved for backwards-compat with off-chain readers that hard-coded its address layout. On the original chain, `domainSeparator() == DOMAIN_SEPARATOR`.

### #15 (3) — Treasury historical-signer-reuse warning

When `replaceSigner` removes an address, that address's `confirmed[]` bits on pending proposals are NOT cleared. If `replaceSigner` later re-adds the same address, those stale confirmations silently re-count toward the 3-of-5 threshold (PR #720's `_currentConfirmations` only filters by *current* `signers[]`, and the re-added address is back in that array). This is governance hygiene rather than a code defect — but unannounced re-entry silently produces wrong vote counts.

**Fix:**
- New `mapping(address => bool) wasSignerHistorical` (append-only, UUPS-safe). Set in `replaceSigner` on the OLD signer when removed.
- New `event ReusingHistoricalSigner(uint8 index, address signer)` fires when `replaceSigner` re-adds an address that has previously served. Operators monitor this event and cancel pending proposals before relying on the 3-of-5 threshold.
- Runtime path is **NOT blocked** — this is defence-in-depth, not a revert.

## Test plan

- [x] `pose-v2-witness-quorum-667.test.cjs` +3 tests in `#15 dynamic EIP-712 domain separator`:
  - view matches storage snapshot on the initial chain
  - view is deterministic across calls
  - end-to-end witness signature still verifies through the new dynamic path
- [x] `treasury-signer-rotation-719.test.cjs` +3 tests in `#15 historical-signer hygiene warnings`:
  - `wasSignerHistorical` recorded on removal
  - `ReusingHistoricalSigner` event fires when re-adding a former signer + `SignerUpdated` still fires
  - event does NOT fire when adding a fresh address
- [x] Full `contracts/` suite: **549/549 pass** + 1 pending. Zero regressions.
- [x] UUPS upgrade-safety tests pass — Treasury's new mapping is append-only (last storage slot).

## Deployment

Both contracts via `upgradeProxy()` signed by the multisig (`0x3c055D83…`). Proxy addresses unchanged:

| Contract | Proxy |
|---|---|
| PoSeManagerV2 | `0x256eb949…` |
| Treasury | `0x512B0126…` |

Storage layout: PoSeManagerV2 unchanged; Treasury gains one new append-only mapping slot. hardhat-upgrades layout validator confirmed.

## Deferred (separate PR)

- #15 (5) BFT RPC↔relayer field-mapping round-trip test — test-only
- #15 (8) ipfs-http malicious-input test expansion — test-only

## Audit batch status

| # | Sev | Status | PR |
|---|---|---|---|
| #6 | (FALSE) | deleted | — |
| #7 | HIGH | merged | #737 |
| #8 #9 #10 | HIGH | merged | #731 |
| #11 #12 | MED | review pending | #738 |
| #14 + #15 (4)(6)(7) | MED+LOW | review pending | #739 |
| #13 + #15 (1) | MED+LOW | review pending | #740 |
| **#15 (2)+(3) (this PR)** | LOW | review pending | this |
| #15 (5)(8) | LOW | follow-up PR(s) | — |