### PR TITLE
fix(security): gate GovernanceDAO.onlyRegistered on isVerified (#735)

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,3 +1,5 @@
 # OZ upgrade prepareUpgrade output — pinned per-run, consumed by
 # scripts/safe-propose-pose-upgrade.ts.
 tmp/
+
+grandfather-verified-735-*.json

--- a/contracts/contracts-src/governance/GovernanceDAO.sol
+++ b/contracts/contracts-src/governance/GovernanceDAO.sol
@@ -67,6 +67,7 @@ contract GovernanceDAO is Initializable, UUPSUpgradeable {
     event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
     error NotRegistered();
+    error NotVerified();
     error AlreadyVoted();
     error VotingClosed();
     error VotingNotEnded();
@@ -85,8 +86,22 @@ contract GovernanceDAO is Initializable, UUPSUpgradeable {
         _;
     }
 
+    // #735 (audit follow-up): gate proposing/voting on `isVerified` instead
+    // of `getFaction() != None`. FactionRegistry.registerHuman/registerClaw
+    // are both permissionless (zero cost, self-signed attestation), so a
+    // pure `Faction.None` check enabled end-to-end Sybil — N cheap EOAs
+    // could swing votes, inflate quorum denominators (registrations after
+    // proposal creation don't dilute `registeredSnapshot` but do count toward
+    // `totalVotes`), and pass bicameral approval with single-faction sybils.
+    // `Identity.verified` is owner/verifier-gated (`FactionRegistry.verify`),
+    // raising the attacker's cost from "1 tx per sybil" to "convince the
+    // verifier" — a single-point bottleneck but a real bar where there was
+    // none. Tracked as defence-in-depth: follow-up issue covers a structural
+    // anti-Sybil cost (registration bond) to remove the verifier single
+    // point of trust.
     modifier onlyRegistered() {
         if (factionRegistry.getFaction(msg.sender) == FactionRegistry.Faction.None) revert NotRegistered();
+        if (!factionRegistry.isVerified(msg.sender)) revert NotVerified();
         _;
     }
 

--- a/contracts/hardhat.config.cjs
+++ b/contracts/hardhat.config.cjs
@@ -15,12 +15,36 @@ const cocNetwork = {
 
 module.exports = {
   solidity: {
-    version: "0.8.24",
-    settings: {
-      viaIR: true,
-      optimizer: {
-        enabled: true,
-        runs: 200
+    compilers: [
+      {
+        version: "0.8.24",
+        settings: {
+          viaIR: true,
+          optimizer: { enabled: true, runs: 200 }
+        }
+      }
+    ],
+    overrides: {
+      // After the #737/#738/#741 audit batch (dynamic domain separator,
+      // receipts cap, operator dedup, etc.) PoSeManagerV2 bytecode hit
+      // 24624 B — 48 B past the EIP-170 24576 B ceiling. The default
+      // `runs:200` optimizer therefore produced a contract that
+      // hardhat-upgrades refuses to deploy ("code is too large"), which
+      // broke every test that deploys PoSeManagerV2 via the upgrades
+      // plugin (UUPS upgrade-safety suite, v2 E2E lifecycle, #667
+      // witness-quorum, #686 ownership transfer).
+      //
+      // Dropping the optimizer to `runs:1` for PoSeManagerV2 only trims
+      // ~hundreds of bytes; runtime gas is a touch higher for V2-internal
+      // logic but storage-bound paths (the majority of finalizeEpochV2 /
+      // submitBatchV2 cost) are largely unaffected. The rest of the suite
+      // keeps `runs:200`.
+      "contracts-src/settlement/PoSeManagerV2.sol": {
+        version: "0.8.24",
+        settings: {
+          viaIR: true,
+          optimizer: { enabled: true, runs: 1 }
+        }
       }
     }
   },

--- a/contracts/scripts/grandfather-verified-735.cjs
+++ b/contracts/scripts/grandfather-verified-735.cjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * grandfather-verified-735.cjs
+ *
+ * Operational companion to the #735 GovernanceDAO patch (onlyRegistered now
+ * requires `isVerified` on FactionRegistry). On any deployment that already
+ * has registered-but-unverified accounts (the entire 88780 testnet at the
+ * time of the patch), the gate will silently lock everyone out of
+ * createProposal/vote until the verifier runs `verify(account)` for each
+ * legitimate registrant.
+ *
+ * What this script does (read-only, no transactions):
+ *
+ *   1. Loads FactionRegistry address from configs/deployed-contracts-88780.json
+ *      (or the env-var network specified by --network / FR_ADDRESS).
+ *   2. Replays `HumanRegistered` + `ClawRegistered` events from the deployment
+ *      block to head and collects the unique set of registered addresses.
+ *   3. For each, calls `isVerified(addr)` to filter the ones that still need
+ *      grandfathering.
+ *   4. Emits, on stdout, two artefacts:
+ *
+ *      - `grandfather-verified-735-plan.json` — the address list + per-address
+ *        status (already verified vs needs verify), so operators can review
+ *        before signing.
+ *      - `grandfather-verified-735-multisig.json` — a single MultiSigWallet
+ *        proposal for the 88780 multisig (owner of FactionRegistry as of
+ *        gen-4), where each entry contains:
+ *          { to: <FactionRegistry>, value: 0, data: <calldata for verify(addr)> }
+ *        Operators feed each entry through `MultiSigWallet.submitProposal` and
+ *        collect the 3-of-5 confirmations as usual. The script does NOT
+ *        broadcast anything itself — it produces signable artefacts only.
+ *
+ * Usage:
+ *
+ *   # against the default 88780 manifest
+ *   node contracts/scripts/grandfather-verified-735.cjs
+ *
+ *   # against a custom deployment
+ *   FR_ADDRESS=0x... RPC_URL=http://... node contracts/scripts/grandfather-verified-735.cjs
+ *
+ *   # skip addresses already verified (default is to include them as no-ops)
+ *   FILTER_ONLY_UNVERIFIED=1 node contracts/scripts/grandfather-verified-735.cjs
+ *
+ * Safety notes:
+ *
+ * - Honest open-registration users do not need to re-register; one verify()
+ *   per address restores their voting rights.
+ * - Suspected sybils can simply be omitted from the multisig batch — the
+ *   gate naturally excludes them.
+ * - This script never moves funds and never sends a transaction; the worst
+ *   it can do is produce a wrong plan that a multisig signer must still
+ *   approve manually.
+ *
+ * Refs: chainofclaw/COC#735.
+ */
+
+const path = require("node:path")
+const fs = require("node:fs")
+const { ethers } = require("ethers")
+
+const MANIFEST_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "configs",
+  "deployed-contracts-88780.json",
+)
+
+const FACTION_REGISTRY_ABI = [
+  "event HumanRegistered(address indexed account, uint64 registeredAt)",
+  "event ClawRegistered(address indexed account, bytes32 indexed agentId, uint64 registeredAt)",
+  "function isVerified(address account) view returns (bool)",
+  "function verify(address account)",
+]
+
+function loadManifest() {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    throw new Error(`manifest not found at ${MANIFEST_PATH}`)
+  }
+  return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"))
+}
+
+function getEnvOrDefault(name, fallback) {
+  const v = process.env[name]
+  return v && v.length > 0 ? v : fallback
+}
+
+async function main() {
+  const manifest = loadManifest()
+  const factionRegistryAddress =
+    process.env.FR_ADDRESS || manifest.contracts.FactionRegistry
+  const multisigAddress = manifest.owner
+  const rpcUrl = getEnvOrDefault("RPC_URL", "http://209.74.64.88:38780")
+  const fromBlock = parseInt(getEnvOrDefault("FROM_BLOCK", "0"), 10)
+  const filterOnlyUnverified = !!process.env.FILTER_ONLY_UNVERIFIED
+
+  console.error(`# FactionRegistry: ${factionRegistryAddress}`)
+  console.error(`# Multisig (FR owner): ${multisigAddress}`)
+  console.error(`# RPC: ${rpcUrl}`)
+  console.error(`# Scanning events from block ${fromBlock}…`)
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl)
+  const fr = new ethers.Contract(
+    factionRegistryAddress,
+    FACTION_REGISTRY_ABI,
+    provider,
+  )
+
+  // Two query passes — Human and Claw register events. Chunk the scan
+  // because many 88780-class RPC endpoints cap eth_getLogs at 10k blocks.
+  const head = await provider.getBlockNumber()
+  const chunkSize = parseInt(getEnvOrDefault("LOG_CHUNK_BLOCKS", "9000"), 10)
+  const humanFilter = fr.filters.HumanRegistered()
+  const clawFilter = fr.filters.ClawRegistered()
+  const humanEvents = []
+  const clawEvents = []
+  for (let start = fromBlock; start <= head; start += chunkSize) {
+    const end = Math.min(start + chunkSize - 1, head)
+    const [h, c] = await Promise.all([
+      fr.queryFilter(humanFilter, start, end),
+      fr.queryFilter(clawFilter, start, end),
+    ])
+    humanEvents.push(...h)
+    clawEvents.push(...c)
+    if ((start - fromBlock) % (chunkSize * 10) === 0) {
+      console.error(`#   scanned ${end - fromBlock + 1}/${head - fromBlock + 1} blocks (human=${humanEvents.length} claw=${clawEvents.length})`)
+    }
+  }
+
+  const seen = new Map() // address → { faction, registeredAtBlock }
+  for (const ev of humanEvents) {
+    const addr = ev.args.account.toLowerCase()
+    if (!seen.has(addr)) {
+      seen.set(addr, { faction: "Human", block: ev.blockNumber })
+    }
+  }
+  for (const ev of clawEvents) {
+    const addr = ev.args.account.toLowerCase()
+    if (!seen.has(addr)) {
+      seen.set(addr, { faction: "Claw", block: ev.blockNumber })
+    }
+  }
+
+  console.error(`# Found ${seen.size} unique registered addresses.`)
+
+  // Resolve verified state for each, in small batches to avoid RPC flood.
+  const addresses = Array.from(seen.keys())
+  const plan = []
+  const BATCH = 25
+  for (let i = 0; i < addresses.length; i += BATCH) {
+    const slice = addresses.slice(i, i + BATCH)
+    const statuses = await Promise.all(slice.map(a => fr.isVerified(a)))
+    for (let j = 0; j < slice.length; j++) {
+      const addr = slice[j]
+      const meta = seen.get(addr)
+      plan.push({
+        address: ethers.getAddress(addr),
+        faction: meta.faction,
+        registeredAtBlock: meta.block,
+        alreadyVerified: statuses[j],
+      })
+    }
+  }
+
+  const needsVerify = plan.filter(e => !e.alreadyVerified)
+  console.error(
+    `# Plan: ${plan.length} total, ${needsVerify.length} need verify(), ${plan.length - needsVerify.length} already verified.`,
+  )
+
+  // Persist plan artefact.
+  const planArtefact = {
+    issue: "https://github.com/chainofclaw/COC/issues/735",
+    factionRegistry: ethers.getAddress(factionRegistryAddress),
+    multisig: ethers.getAddress(multisigAddress),
+    scannedAt: new Date().toISOString(),
+    fromBlock,
+    totalRegistered: plan.length,
+    needingVerify: needsVerify.length,
+    alreadyVerified: plan.length - needsVerify.length,
+    entries: plan,
+  }
+  const planPath = path.join(process.cwd(), "grandfather-verified-735-plan.json")
+  fs.writeFileSync(planPath, JSON.stringify(planArtefact, null, 2))
+  console.error(`# Wrote plan → ${planPath}`)
+
+  // Persist multisig calldata bundle.
+  const verifyFragment = fr.interface.getFunction("verify")
+  const targetSet = filterOnlyUnverified ? needsVerify : plan
+  const calls = targetSet.map(e => ({
+    to: ethers.getAddress(factionRegistryAddress),
+    value: "0",
+    data: fr.interface.encodeFunctionData(verifyFragment, [e.address]),
+    description: `FactionRegistry.verify(${e.address}) — ${e.faction}, registered block ${e.registeredAtBlock}`,
+  }))
+  const multisigArtefact = {
+    issue: "https://github.com/chainofclaw/COC/issues/735",
+    multisig: ethers.getAddress(multisigAddress),
+    factionRegistry: ethers.getAddress(factionRegistryAddress),
+    filterOnlyUnverified,
+    count: calls.length,
+    notes: [
+      "Feed each call into MultiSigWallet.submitProposal({to,value,data}) and gather 3/5 confirmations.",
+      "Calls are independent — failing one does not block the others.",
+      "Re-running this script after partial execution is safe; already-verified entries become no-ops in the gate but verify() itself reverts AlreadyVerified.",
+      "Set FILTER_ONLY_UNVERIFIED=1 to exclude already-verified addresses from the bundle (avoids the AlreadyVerified revert).",
+    ],
+    calls,
+  }
+  const multisigPath = path.join(
+    process.cwd(),
+    "grandfather-verified-735-multisig.json",
+  )
+  fs.writeFileSync(multisigPath, JSON.stringify(multisigArtefact, null, 2))
+  console.error(`# Wrote multisig bundle → ${multisigPath}`)
+
+  // Also dump address list to stdout (machine-friendly).
+  console.log(JSON.stringify({ plan: planArtefact, multisig: multisigArtefact }, null, 2))
+}
+
+main().catch(err => {
+  console.error(err.stack || err.message || err)
+  process.exit(1)
+})

--- a/contracts/test/gas-benchmarks.test.cjs
+++ b/contracts/test/gas-benchmarks.test.cjs
@@ -72,12 +72,17 @@ describe("Gas Benchmarks: GovernanceDAO", function () {
     await dao.waitForDeployment()
 
     await registry.connect(owner).registerHuman()
+    // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+    await registry.connect(owner).verify(owner.address)
   })
 
-  it("createProposal gas < 270k", async function () {
+  it("createProposal gas < 280k", async function () {
     // Budget bumped from 250k → 270k in gen-5: GovernanceDAO.createProposal
     // now writes humanSnapshot + clawSnapshot per proposal (#706 / #705) for
     // the silent-faction bicameral check, adding ~2 SSTOREs per call.
+    // Bumped 270k → 280k in #735 (audit follow-up): onlyRegistered now
+    // performs a second SLOAD via FactionRegistry.isVerified, adding ~2.1k
+    // gas across cross-contract call + storage read.
     const tx = await dao.createProposal(
       0, // ValidatorAdd
       "Benchmark proposal",
@@ -87,10 +92,10 @@ describe("Gas Benchmarks: GovernanceDAO", function () {
       0
     )
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.be.lessThan(270000n)
+    expect(receipt.gasUsed).to.be.lessThan(280000n)
   })
 
-  it("vote gas < 120k", async function () {
+  it("vote gas < 130k", async function () {
     await dao.createProposal(
       0,
       "Vote benchmark",
@@ -101,7 +106,8 @@ describe("Gas Benchmarks: GovernanceDAO", function () {
     )
     const tx = await dao.vote(1, 1) // 1 = For
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.be.lessThan(120000n)
+    // Budget 120k → 130k in #735: same isVerified() SLOAD added to vote.
+    expect(receipt.gasUsed).to.be.lessThan(130000n)
   })
 })
 

--- a/contracts/test/governance-dao-verified-gate-735.test.cjs
+++ b/contracts/test/governance-dao-verified-gate-735.test.cjs
@@ -1,0 +1,163 @@
+/**
+ * GovernanceDAO — #735 isVerified gate on onlyRegistered.
+ *
+ * Bug: FactionRegistry.registerHuman/registerClaw are permissionless and
+ * have no anti-Sybil cost (registerClaw's "attestation" is signed by
+ * msg.sender itself, so any fresh EOA passes). The old onlyRegistered
+ * modifier only checked `getFaction() != None`, so any number of EOAs
+ * could spawn, register, and vote — fully Sybil-able governance.
+ *
+ * Fix: onlyRegistered now also requires `isVerified(msg.sender)`. The
+ * `verified` flag is owner/verifier-gated via `FactionRegistry.verify()`,
+ * so the bar moves from "1 tx per sybil" to "convince the verifier".
+ *
+ * This file proves:
+ *  (1) registered-but-unverified accounts are blocked from createProposal/vote
+ *  (2) verified accounts succeed normally
+ *  (3) the verifier role can actually un-block an unverified registrant
+ *  (4) the Sybil attack reproduction is blocked end-to-end:
+ *      attacker spawns N EOAs, registers them all, none can vote
+ *  (5) totally-unregistered addresses still revert with NotRegistered
+ *      (the first leg of the modifier — preserves the existing error path)
+ */
+
+const { expect } = require("chai")
+const { ethers, upgrades } = require("hardhat")
+
+describe("Security: GovernanceDAO #735 isVerified gate", function () {
+  let registry, dao
+  let owner, alice, bob, claw1, attacker
+
+  beforeEach(async function () {
+    ;[owner, alice, bob, claw1, attacker] = await ethers.getSigners()
+
+    const FR = await ethers.getContractFactory("FactionRegistry")
+    registry = await upgrades.deployProxy(
+      FR,
+      [owner.address, owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await registry.waitForDeployment()
+
+    const DAO = await ethers.getContractFactory("GovernanceDAO")
+    dao = await upgrades.deployProxy(
+      DAO,
+      [await registry.getAddress(), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await dao.waitForDeployment()
+  })
+
+  async function createProposalAs(signer) {
+    return dao.connect(signer).createProposal(
+      5, // FreeText
+      "title",
+      ethers.keccak256(ethers.toUtf8Bytes("desc")),
+      ethers.ZeroAddress,
+      "0x",
+      0,
+    )
+  }
+
+  it("registered-but-unverified human cannot createProposal", async function () {
+    await registry.connect(alice).registerHuman()
+    // alice is registered (faction != None) but verified == false.
+    expect(await registry.isRegistered(alice.address)).to.equal(true)
+    expect(await registry.isVerified(alice.address)).to.equal(false)
+    await expect(createProposalAs(alice))
+      .to.be.revertedWithCustomError(dao, "NotVerified")
+  })
+
+  it("registered-but-unverified human cannot vote", async function () {
+    // Need a proposal first — created by a verified user.
+    await registry.connect(alice).registerHuman()
+    await registry.connect(owner).verify(alice.address)
+    await createProposalAs(alice)
+
+    // bob registers but is NOT verified — vote must revert.
+    await registry.connect(bob).registerHuman()
+    await expect(dao.connect(bob).vote(1, 1))
+      .to.be.revertedWithCustomError(dao, "NotVerified")
+  })
+
+  it("totally-unregistered address still reverts with NotRegistered (legacy error path)", async function () {
+    // alice is fully unregistered. The first leg of onlyRegistered fires,
+    // so the externally-visible error stays NotRegistered (not NotVerified)
+    // — important for any indexer/UI that already keys on the original
+    // error selector.
+    await expect(createProposalAs(alice))
+      .to.be.revertedWithCustomError(dao, "NotRegistered")
+  })
+
+  it("verifier can lift the gate — verified registrant succeeds", async function () {
+    await registry.connect(alice).registerHuman()
+    await registry.connect(owner).verify(alice.address)
+    expect(await registry.isVerified(alice.address)).to.equal(true)
+
+    await createProposalAs(alice)
+    expect(await dao.proposalCount()).to.equal(1)
+
+    await dao.connect(alice).vote(1, 1)
+    const [forHuman] = await dao.getVoteTotals(1)
+    expect(forHuman).to.equal(1n)
+  })
+
+  it("verified claw also passes the gate", async function () {
+    const agentId = ethers.keccak256(ethers.toUtf8Bytes("agent-735"))
+    const messageHash = ethers.keccak256(
+      ethers.solidityPacked(["bytes32", "address"], [agentId, claw1.address]),
+    )
+    const attestation = await claw1.signMessage(ethers.getBytes(messageHash))
+    await registry.connect(claw1).registerClaw(agentId, attestation)
+    await registry.connect(owner).verify(claw1.address)
+
+    await createProposalAs(claw1)
+    await dao.connect(claw1).vote(1, 1)
+    const [, , forClaw] = await dao.getVoteTotals(1)
+    expect(forClaw).to.equal(1n)
+  })
+
+  it("Sybil reproduction is now blocked: attacker spawns 10 EOAs, registers all, zero can vote", async function () {
+    // Set up a legitimate proposal (proposer is owner, who self-verifies).
+    await registry.connect(owner).registerHuman()
+    await registry.connect(owner).verify(owner.address)
+    await createProposalAs(owner)
+
+    // Attacker spawns 10 fresh sybils, funds each, registers each. None
+    // are verified. The pre-fix world: every one of them would vote().
+    const sybils = []
+    for (let i = 0; i < 10; i++) {
+      const w = ethers.Wallet.createRandom().connect(ethers.provider)
+      await attacker.sendTransaction({ to: w.address, value: ethers.parseEther("0.1") })
+      await registry.connect(w).registerHuman()
+      sybils.push(w)
+    }
+    expect(await registry.humanCount()).to.equal(11n) // owner + 10 sybils
+
+    for (const s of sybils) {
+      await expect(dao.connect(s).vote(1, 1))
+        .to.be.revertedWithCustomError(dao, "NotVerified")
+    }
+
+    // Owner is the only voter who got through.
+    await dao.connect(owner).vote(1, 1)
+    const [forHuman] = await dao.getVoteTotals(1)
+    expect(forHuman).to.equal(1n)
+  })
+
+  it("verifier role transfer still gates verification correctly", async function () {
+    // Sanity check that the verifier hand-off works — operationally,
+    // the verifier role is what stands between "permissionless governance"
+    // and "permissioned governance" under this fix.
+    await registry.connect(alice).registerHuman()
+    await registry.connect(owner).setVerifier(bob.address)
+    // alice can be verified by either owner (the `onlyVerifier` modifier
+    // accepts owner too) or by the new verifier bob.
+    await registry.connect(bob).verify(alice.address)
+    expect(await registry.isVerified(alice.address)).to.equal(true)
+    // bob registers; attacker (not owner, not verifier) cannot verify them.
+    await registry.connect(bob).registerHuman()
+    await expect(registry.connect(attacker).verify(bob.address))
+      .to.be.revertedWithCustomError(registry, "NotVerifier")
+  })
+})

--- a/contracts/test/governance-lifecycle.test.cjs
+++ b/contracts/test/governance-lifecycle.test.cjs
@@ -57,6 +57,13 @@ describe("Governance Lifecycle: Prowl Testnet Proposals", function () {
     await registry.connect(human3).registerHuman()
     await registry.connect(human4).registerHuman()
     await registry.connect(human5).registerHuman()
+
+    // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+    // Verify all six so the lifecycle path mirrors a real network where the
+    // verifier has whitelisted active humans.
+    for (const s of [owner, human1, human2, human3, human4, human5]) {
+      await registry.connect(owner).verify(s.address)
+    }
   })
 
   it("creates and approves the first testnet parameter proposal", async function () {

--- a/contracts/test/governance-quorum-snapshot.test.cjs
+++ b/contracts/test/governance-quorum-snapshot.test.cjs
@@ -46,6 +46,8 @@ describe("Security: GovernanceDAO quorum snapshot", function () {
 
     for (const m of members) {
       await factionRegistry.connect(m).registerHuman()
+      // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+      await factionRegistry.connect(all[0]).verify(m.address)
     }
   })
 

--- a/contracts/test/governance.test.cjs
+++ b/contracts/test/governance.test.cjs
@@ -114,6 +114,12 @@ describe("Governance Contracts", function () {
       )
       const attestation = await claw1.signMessage(ethers.getBytes(messageHash))
       await factionRegistry.connect(claw1).registerClaw(agentId, attestation)
+
+      // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+      // Verify the participants we expect to act on governance.
+      await factionRegistry.connect(owner).verify(human1.address)
+      await factionRegistry.connect(owner).verify(human2.address)
+      await factionRegistry.connect(owner).verify(claw1.address)
     })
 
     it("should create a proposal", async function () {

--- a/contracts/test/security-audit.test.cjs
+++ b/contracts/test/security-audit.test.cjs
@@ -212,6 +212,11 @@ describe("Security: GovernanceDAO", function () {
     await factionRegistry.connect(human2).registerHuman()
     await registerClaw(factionRegistry, claw1)
     await registerClaw(factionRegistry, claw2)
+
+    // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+    for (const s of [human1, human2, claw1, claw2]) {
+      await factionRegistry.connect(owner).verify(s.address)
+    }
   })
 
   it("rejects empty title proposal", async function () {
@@ -412,6 +417,9 @@ describe("Security: GovernanceDAO", function () {
     await dao2.setBicameralEnabled(true)
     await reg2.connect(human1).registerHuman()
     await reg2.connect(human2).registerHuman()
+    // #735: GovernanceDAO.onlyRegistered now requires verified=true.
+    await reg2.connect(owner).verify(human1.address)
+    await reg2.connect(owner).verify(human2.address)
 
     const descHash = ethers.keccak256(ethers.toUtf8Bytes("no-claws"))
     await dao2.connect(human1).createProposal(5, "Humans Only", descHash, ethers.ZeroAddress, "0x", 0)


### PR DESCRIPTION
## Summary

Closes #735 — end-to-end Sybil on GovernanceDAO via permissionless `FactionRegistry.registerHuman/registerClaw`.

`onlyRegistered` now requires `factionRegistry.isVerified(msg.sender)` in addition to `getFaction() != None`. The `verified` flag is owner/verifier-gated via `FactionRegistry.verify()`, raising the attacker bar from \"1 tx per sybil\" to \"convince the verifier\". This is **Option A** from the issue body — the minimal-blast-radius UUPS-safe patch. **Option B** (structural anti-Sybil cost on register) is tracked separately as #744 for the design-decision questions it raises.

### Impact closed

End-to-end Sybil on:
- vote-flipping on existing proposals (N cheap EOAs each vote)
- quorum-denominator inflation (sybils register **after** proposal creation so `registeredSnapshot` doesn't dilute, but votes count toward `totalVotes` → effective quorum bar lowered)
- bicameral approval bypass via single-faction sybils (#705 bicameral safety relied on \"verified\" being a real gate)
- Treasury >5% withdrawals via `Treasury.governanceApprove`

### What changed

| File | Change |
|---|---|
| `contracts-src/governance/GovernanceDAO.sol` | `NotVerified()` error + isVerified check in `onlyRegistered`. Comment captures why the first leg still reverts `NotRegistered` (preserves existing error selectors for unregistered case — important for indexers / UIs). |
| `test/governance-dao-verified-gate-735.test.cjs` (new) | 7 tests: unverified blocked, verified passes, unregistered still reverts `NotRegistered`, verifier hand-off works, **Sybil reproduction blocked** (10 EOAs spawn + register, 0 can vote) |
| `test/{governance,governance-lifecycle,governance-quorum-snapshot,security-audit,gas-benchmarks}.test.cjs` | Regression: call `verify()` for participants we expect to act on governance. No semantic test changes. Gas budgets bumped 270k→280k / 120k→130k for the extra cross-contract SLOAD. |
| `scripts/grandfather-verified-735.cjs` (new) | Read-only chunked-eth_getLogs scan over FactionRegistry. Emits a JSON plan + a MultiSigWallet calldata bundle (one `verify(addr)` per registrant) for operators to push through the 88780 3-of-5 multisig. **88780 dry-run returned 0 registrants** → no grandfathering needed when this ships. |
| `hardhat.config.cjs` | Pre-existing PoSeManagerV2 EIP-170 ceiling broke 5 unrelated `before each` hooks (24624 B > 24576 B). Added a per-file `runs:1` override for PoSeManagerV2 only — same fix that was sitting in local working tree and never got pushed. Without this, contracts CI was red on main for unrelated reasons. |
| `.gitignore` | Ignore generated grandfather artefacts. |

### UUPS-safety

No storage changes — only adds a new `error NotVerified()` and a check to an existing modifier. Safe under `upgradeProxy()` against the live `0x4b948567…` GovernanceDAO proxy.

### Test plan

- [x] `cd contracts && npx hardhat test` → **565 passing, 0 failing** (was 486 passing, 5 failing pre-fix — those 5 were unrelated EIP-170 failures, now fixed by the hardhat.config override)
- [x] `governance-dao-verified-gate-735.test.cjs` — 7/7 pass
- [x] `governance.test.cjs` + `governance-lifecycle.test.cjs` + `governance-quorum-snapshot.test.cjs` + `security-audit.test.cjs` regression — all green after verify() injection
- [x] `gas-benchmarks.test.cjs` — createProposal < 280k ✓, vote < 130k ✓
- [x] Dry-ran `grandfather-verified-735.cjs` against live 88780 RPC (`http://209.74.64.88:38780`, FactionRegistry `0xc37d28297dB885d2B8d9966Cbb5df2e142671287`) → scanned all 371k blocks, 0 registrants found → grandfather step is a no-op on the testnet
- [ ] Maintainer to schedule `upgradeProxy()` via 88780 multisig (`0x3c055D83…`) when ready

### Deployment notes

1. Merge this PR
2. Multisig deploys new GovernanceDAO impl + signs `upgradeProxy(0x4b948567…, newImpl)` via existing UUPS plumbing
3. No grandfather step needed (88780 has 0 registrants); if mainnet or other networks have registrants, run `node contracts/scripts/grandfather-verified-735.cjs` first and feed the produced multisig bundle through `MultiSigWallet.submitProposal` 3-of-5

### Follow-up

#744 — Option B (anti-Sybil economic cost on registration) — open design-decision issue covering bond vs burn vs lock-stake, magnitude calibration, grandfathering, and faction symmetry.