### PR TITLE
fix(security): PoSe v2 witness Push verification + freshness (#667)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -1125,13 +1125,31 @@ async function tryChallengeV2(nodeId: string, kind: keyof typeof ChallengeType):
       throw new Error("invalid node receipt signature");
     }
 
-    // Collect witnesses
+    // Collect witnesses.
+    //
+    // #667 (audit follow-up, 2026-05-26) — also pass the push-verification
+    // context so witnesses can validate the prover's nodeSig + recompute
+    // responseBodyHash before signing. Without the push fields the
+    // witness server's COC_POSE_WITNESS_REQUIRE_VERIFIED=true mode would
+    // refuse to sign (strict rollout); without strict mode it would
+    // silently fall back to the legacy rubber-stamp path. Pushing the
+    // fields keeps the agent's behaviour identical regardless of which
+    // mode each witness operator chose.
     const witnessResult = v2WitnessNodes.length > 0
       ? await collectWitnesses(
           { witnessNodes: v2WitnessNodes, requiredWitnesses: v2RequiredWitnesses, timeoutMs: 5000 },
           challenge.challengeId,
           nodeId as any,
           responseBodyHash,
+          undefined, // requestFn defaults to requestJson
+          BigInt(currentEpoch),
+          {
+            responseBody,
+            responseAtMs: Number(responseAtMs),
+            nodeSig: receiptPayload.nodeSig,
+            tipHash: tipHash as string,
+            tipHeight,
+          },
         )
       : { attestations: [], bitmap: 0, quorumMet: v2RequiredWitnesses === 0 };
 

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -5,6 +5,8 @@ import { loadConfig } from "./lib/config.ts";
 import { InMemoryStore } from "./lib/state.ts";
 import { recordChallengeBounded } from "./lib/bounded-challenge-store.ts";
 import { validatePoseWitnessPayload } from "./lib/pose-witness-validator.ts";
+import { verifyPushedReceipt } from "./lib/pose-witness-verifier.ts";
+import { ContractReader } from "./lib/contract-reader.ts";
 import { isPoseWitnessRequestAuthorized, resolvePoseWitnessAuthToken } from "./lib/pose-witness-auth.ts";
 import { IpfsBlockstore } from "../node/src/ipfs-blockstore.ts";
 import { loadStorageProof, MerkleLeavesCache } from "./lib/storage-proof.ts";
@@ -55,6 +57,51 @@ const verifyingContract = config.verifyingContract ?? config.poseManagerV2Addres
 const nodeSignerV2 = useV2
   ? createNodeSignerV2(nodePrivateKey, buildDomain(BigInt(chainId), verifyingContract))
   : null;
+
+// #667 (audit follow-up, 2026-05-26) — Push-verification configuration.
+//
+// `poseWitnessReaderOrNull` is the ContractReader the /pose/witness path
+// uses to look up `nodeOperator(poseNodeId)` when verifying a pushed
+// receipt's nodeSig. Only constructed when the v2 protocol is on and
+// both the L2 RPC URL and PoSeManagerV2 address are configured — without
+// either, an on-chain lookup is impossible so verification can't run.
+//
+// `poseWitnessRequireVerified` is the rollout switch. Default `false`
+// (rubber-stamp fallback retained for in-flight callers that haven't
+// upgraded to push fields yet). Operators flip it to `true` once their
+// agent fleet ships push fields, at which point unverified requests
+// receive a 400 instead of silently falling back.
+//
+// `poseWitnessFreshnessMs` bounds |now - responseAtMs|. Default 60s.
+const poseWitnessReaderOrNull = useV2 && config.l2RpcUrl && config.poseManagerV2Address
+  ? new ContractReader({
+      l2RpcUrl: config.l2RpcUrl,
+      poseManagerV2Address: config.poseManagerV2Address,
+      cacheTtlMs: 30_000,
+    })
+  : null;
+const poseWitnessRequireVerified = (() => {
+  const raw = process.env.COC_POSE_WITNESS_REQUIRE_VERIFIED?.trim().toLowerCase();
+  if (raw === "1" || raw === "true" || raw === "yes") return true;
+  return false;
+})();
+const poseWitnessFreshnessMs = (() => {
+  const raw = process.env.COC_POSE_WITNESS_FRESHNESS_MS?.trim();
+  if (!raw) return 60_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    log.warn("invalid COC_POSE_WITNESS_FRESHNESS_MS — falling back to 60_000ms", { raw });
+    return 60_000;
+  }
+  return parsed;
+})();
+if (poseWitnessRequireVerified && !poseWitnessReaderOrNull) {
+  // Strict mode requested but the on-chain lookup capability isn't wired —
+  // refuse to start rather than silently degrade. Operators that hit this
+  // need to configure config.l2RpcUrl + config.poseManagerV2Address before
+  // enabling COC_POSE_WITNESS_REQUIRE_VERIFIED.
+  throw new Error("COC_POSE_WITNESS_REQUIRE_VERIFIED=true but l2RpcUrl/poseManagerV2Address not configured");
+}
 
 function resolveRuntimeNodePrivateKey(): string {
   const canonical = process.env.COC_NODE_KEY?.trim();
@@ -415,6 +462,64 @@ const server = http.createServer((req, res) => {
         return json(res, result.status, { error: result.error });
       }
       const fields = result.fields;
+
+      // #667 (audit follow-up) — Push-verification gate. Three states:
+      //   (a) Caller supplied all push fields + reader configured →
+      //       run verifier; on failure return 400 (no signature).
+      //   (b) Caller supplied push fields but reader is missing →
+      //       cannot run verifier; treat as misconfiguration (502).
+      //   (c) Caller did NOT supply push fields:
+      //       - poseWitnessRequireVerified=true → 400 (strict rollout)
+      //       - otherwise → legacy rubber-stamp path (with a debug log
+      //         so operators can spot un-migrated callers)
+      const hasPushFields = fields.responseBody !== undefined;
+      if (hasPushFields) {
+        if (!poseWitnessReaderOrNull) {
+          return json(res, 502, { error: "witness verification not configured" });
+        }
+        verifyPushedReceipt(
+          {
+            challengeId: fields.challengeId,
+            nodeId: fields.nodeId,
+            responseBodyHash: fields.responseBodyHash,
+            responseBody: fields.responseBody!,
+            responseAtMs: fields.responseAtMs!,
+            nodeSig: fields.nodeSig!,
+            tipHash: fields.tipHash!,
+            tipHeight: fields.tipHeight!,
+          },
+          {
+            chainId: BigInt(chainId),
+            verifyingContract,
+            freshnessWindowMs: poseWitnessFreshnessMs,
+            contractReader: poseWitnessReaderOrNull,
+          },
+        )
+          .then(verifyResult => {
+            if (!verifyResult.ok) {
+              return json(res, verifyResult.status, { error: verifyResult.error });
+            }
+            return signAndRespond();
+          })
+          .catch(error => {
+            log.error("witness push-verification failed", { error: String(error) });
+            return json(res, 500, { error: "witness verification failed" });
+          });
+        return;
+      }
+      if (poseWitnessRequireVerified) {
+        return json(res, 400, {
+          error: "push verification required (responseBody/responseAtMs/nodeSig/tipHash/tipHeight missing)",
+        });
+      }
+      // Legacy rubber-stamp path — preserved for migration window.
+      log.warn("witness signing without push verification", {
+        challengeId: fields.challengeId,
+        nodeId: fields.nodeId,
+      });
+      return signAndRespond();
+
+      function signAndRespond(): void {
       const signV1 = signWitnessAttestation(
         fields.challengeId,
         fields.nodeId,
@@ -455,6 +560,7 @@ const server = http.createServer((req, res) => {
           log.error("witness signing failed", { error: String(error) });
           return json(res, 500, { error: "witness signing failed" });
         });
+      }
     });
     return;
   }

--- a/runtime/lib/contract-reader.ts
+++ b/runtime/lib/contract-reader.ts
@@ -53,6 +53,33 @@ export class ContractReader {
     return tip
   }
 
+  // #667 (audit follow-up, 2026-05-26) — Push-verification needs the
+  // witness side to look up the prover's registered operator address
+  // so it can compare against `ecrecover(RECEIPT digest, nodeSig)`.
+  // Without this view call the witness only knows "some EOA signed it",
+  // which any attacker controls — defeating the whole point of the
+  // verification.
+  //
+  // Result is cached for `cacheTtlMs` (default 30s) so the per-attestation
+  // RPC cost is amortized across batches of receipts on the same prover.
+  async getNodeOperator(nodeId: Hex32): Promise<string> {
+    const key = `nodeOperator:${nodeId.toLowerCase()}`
+    const cached = this.getCached<string>(key)
+    if (cached !== undefined) return cached
+
+    // `nodeOperator(bytes32 nodeId) returns (address)` — `bytes32` ABI-encoded as 32-byte big-endian.
+    const padded = nodeId.startsWith("0x") || nodeId.startsWith("0X") ? nodeId.slice(2) : nodeId
+    if (padded.length !== 64) {
+      throw new Error(`getNodeOperator: nodeId must be 32 bytes (got ${padded.length / 2} bytes)`)
+    }
+    const selector = encodeBytes32FunctionCall("nodeOperator(bytes32)", padded)
+    const result = await this.ethCall(selector)
+    // Address is the last 20 bytes of the 32-byte return word.
+    const addr = `0x${result.slice(2).padStart(64, "0").slice(-40)}`.toLowerCase()
+    this.setCache(key, addr)
+    return addr
+  }
+
   async getEpochRewardRoot(epochId: bigint): Promise<Hex32> {
     const key = `rewardRoot:${epochId}`
     const cached = this.getCached<Hex32>(key)
@@ -115,6 +142,15 @@ function encodeFunctionCall(sig: string, params: bigint[]): string {
     data += p.toString(16).padStart(64, "0")
   }
   return data
+}
+
+// ABI encoder for a single bytes32 argument — used by getNodeOperator (#667).
+// Selector hash is computed the same way as encodeFunctionCall; the only
+// difference is the value is already a 64-char hex string (no padding).
+function encodeBytes32FunctionCall(sig: string, paramHex: string): string {
+  const fnSelector = sig.slice(0, sig.indexOf("("))
+  const selectorHash = simpleKeccak256(fnSelector + sig.slice(sig.indexOf("(")))
+  return "0x" + selectorHash.slice(0, 8) + paramHex
 }
 
 function simpleKeccak256(input: string): string {

--- a/runtime/lib/pose-witness-validator.test.ts
+++ b/runtime/lib/pose-witness-validator.test.ts
@@ -91,3 +91,78 @@ test("#322: KEY invariant — error message must NOT echo client input", () => {
     assert.ok(!r.error.includes("AAA"), `error must not echo input, got: ${r.error}`);
   }
 });
+
+// #667 (audit follow-up, 2026-05-26) — validator regressions.
+
+test("#667: accepts 32-byte poseNodeId (v2 EIP-712 bytes32 form)", () => {
+  // Pre-fix the validator hard-locked nodeId to 20-byte address, which
+  // silently rejected every v2 witness request (collector uses 32-byte
+  // poseNodeId = keccak(pubkey)). That left production stuck on the
+  // empty-witness owner-only fallback.
+  const r = validatePoseWitnessPayload({
+    ...VALID,
+    nodeId: "0x" + "b".repeat(64), // 32 bytes
+  });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.fields.nodeId.length, 66);
+  }
+});
+
+test("#667: partial push-fields set rejected (no downgrade attack)", () => {
+  // Caller must provide either all five push fields or none. Partial
+  // sets must reject so a malicious caller can't drop nodeSig (skip sig
+  // verification) while keeping responseBody (look legit in logs).
+  const partial = validatePoseWitnessPayload({
+    ...VALID,
+    responseBody: { ok: true },
+    responseAtMs: 1234,
+    // nodeSig / tipHash / tipHeight intentionally omitted
+  });
+  assert.equal(partial.ok, false);
+  if (!partial.ok) {
+    assert.match(partial.error, /push fields must be supplied together/);
+  }
+});
+
+test("#667: all push fields present → carried through to fields", () => {
+  const r = validatePoseWitnessPayload({
+    ...VALID,
+    responseBody: { ok: true, blockNumber: 42 },
+    responseAtMs: 1700000000000,
+    nodeSig: "0x" + "ab".repeat(65),
+    tipHash: "0x" + "cd".repeat(32),
+    tipHeight: 100,
+  });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.deepEqual(r.fields.responseBody, { ok: true, blockNumber: 42 });
+    assert.equal(r.fields.responseAtMs, 1700000000000);
+    assert.equal(r.fields.nodeSig?.length, 132);
+    assert.equal(r.fields.tipHeight, 100n);
+  }
+});
+
+test("#667: invalid push-field shapes rejected with deterministic errors", () => {
+  const FULL_PUSH = {
+    responseBody: { ok: true },
+    responseAtMs: 1234,
+    nodeSig: "0x" + "ab".repeat(65),
+    tipHash: "0x" + "cd".repeat(32),
+    tipHeight: 100,
+  };
+  // responseBody must be object (array is rejected)
+  const r1 = validatePoseWitnessPayload({ ...VALID, ...FULL_PUSH, responseBody: [1, 2, 3] });
+  assert.equal(r1.ok, false);
+  if (!r1.ok) assert.match(r1.error, /responseBody/);
+
+  // nodeSig wrong length
+  const r2 = validatePoseWitnessPayload({ ...VALID, ...FULL_PUSH, nodeSig: "0x00" });
+  assert.equal(r2.ok, false);
+  if (!r2.ok) assert.match(r2.error, /nodeSig/);
+
+  // tipHeight negative
+  const r3 = validatePoseWitnessPayload({ ...VALID, ...FULL_PUSH, tipHeight: -1 });
+  assert.equal(r3.ok, false);
+  if (!r3.ok) assert.match(r3.error, /tipHeight/);
+});

--- a/runtime/lib/pose-witness-validator.ts
+++ b/runtime/lib/pose-witness-validator.ts
@@ -26,11 +26,49 @@ export interface PoseWitnessFields {
    * produced (backwards-compatible with pre-#667 callers).
    */
   epochId?: bigint;
+  /**
+   * #667 (audit follow-up, 2026-05-26) — optional Push-verification
+   * fields. When all five are present, the witness re-derives
+   * `responseBodyHash` from `responseBody` and ecrecovers the prover's
+   * `nodeSig` against the RECEIPT_TYPES digest. Only when both checks
+   * pass does the witness sign the attestation.
+   *
+   * The fields are optional during the rollout window:
+   * - Caller passes them → witness MUST verify; fail → 400
+   * - Caller omits them → witness falls back to legacy rubber-stamp
+   *   behaviour (gated by `COC_POSE_WITNESS_REQUIRE_VERIFIED`; default
+   *   `false` in current release to preserve interop, will flip to
+   *   `true` once all agents ship the push fields).
+   *
+   * F2 (freshness): `responseAtMs` is checked against wall-clock so a
+   * witness can't be tricked into signing a stale receipt that was
+   * re-fed across challenges.
+   */
+  responseBody?: Record<string, unknown>;
+  responseAtMs?: number;
+  nodeSig?: string;
+  tipHash?: string;
+  tipHeight?: bigint;
 }
 
 const HEX32_RE = /^0[xX][0-9a-fA-F]{64}$/;
 const HEX_ADDR_RE = /^0[xX][0-9a-fA-F]{40}$/;
+const SIG_HEX_RE = /^0[xX][0-9a-fA-F]{130}$/;
 const MAX_UINT64 = (1n << 64n) - 1n;
+
+/**
+ * Pre-#667 the validator hard-locked nodeId to a 20-byte address. But the
+ * v2 witness pipeline (BatchAggregatorV2 + on-chain `_validateWitnessQuorumV2`)
+ * uses the 32-byte `poseNodeId = keccak256(pubkeyNode)` so the EIP-712
+ * `Receipt.nodeId` field (declared `bytes32`) can pass ethers' length check.
+ * The 20-byte-only validator silently rejected every v2 witness request,
+ * leaving production stuck on the empty-witness owner-only fallback. Accept
+ * both shapes so legacy 20-byte callers continue to work and the v2 push
+ * path can actually settle.
+ */
+function isWitnessNodeIdShape(value: string): boolean {
+  return HEX_ADDR_RE.test(value) || HEX32_RE.test(value);
+}
 
 export type ValidateResult =
   | { ok: true; fields: PoseWitnessFields }
@@ -45,8 +83,8 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
   if (typeof p.challengeId !== "string" || !HEX32_RE.test(p.challengeId)) {
     return { ok: false, status: 400, error: "challengeId must match 0x-prefixed 32-byte hex" };
   }
-  if (typeof p.nodeId !== "string" || !HEX_ADDR_RE.test(p.nodeId)) {
-    return { ok: false, status: 400, error: "nodeId must match 0x-prefixed 20-byte hex address" };
+  if (typeof p.nodeId !== "string" || !isWitnessNodeIdShape(p.nodeId)) {
+    return { ok: false, status: 400, error: "nodeId must match 0x-prefixed 20-byte address or 32-byte hash" };
   }
   if (typeof p.responseBodyHash !== "string" || !HEX32_RE.test(p.responseBodyHash)) {
     return { ok: false, status: 400, error: "responseBodyHash must match 0x-prefixed 32-byte hex" };
@@ -79,6 +117,62 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
     epochId = parsed;
   }
 
+  // #667 (audit follow-up, 2026-05-26) — Push-verification fields. All
+  // five must appear together or none at all; partial sets are a strict
+  // 400 to avoid downgrade attacks where a malicious caller omits one
+  // field to dodge a specific check (e.g. drop `nodeSig` to skip
+  // signature verification while keeping `responseBody` to look legit
+  // in logs).
+  const pushFieldNames = ["responseBody", "responseAtMs", "nodeSig", "tipHash", "tipHeight"] as const;
+  const pushPresent = pushFieldNames.filter(n => p[n] !== undefined && p[n] !== null);
+  if (pushPresent.length !== 0 && pushPresent.length !== pushFieldNames.length) {
+    return { ok: false, status: 400, error: "push fields must be supplied together (responseBody, responseAtMs, nodeSig, tipHash, tipHeight)" };
+  }
+
+  let responseBody: Record<string, unknown> | undefined;
+  let responseAtMs: number | undefined;
+  let nodeSig: string | undefined;
+  let tipHash: string | undefined;
+  let tipHeight: bigint | undefined;
+
+  if (pushPresent.length === pushFieldNames.length) {
+    if (typeof p.responseBody !== "object" || p.responseBody === null || Array.isArray(p.responseBody)) {
+      return { ok: false, status: 400, error: "responseBody must be a JSON object" };
+    }
+    if (typeof p.responseAtMs !== "number" || !Number.isFinite(p.responseAtMs) ||
+        !Number.isInteger(p.responseAtMs) || p.responseAtMs < 0) {
+      return { ok: false, status: 400, error: "responseAtMs must be a non-negative integer milliseconds value" };
+    }
+    if (typeof p.nodeSig !== "string" || !SIG_HEX_RE.test(p.nodeSig)) {
+      return { ok: false, status: 400, error: "nodeSig must match 0x-prefixed 65-byte hex" };
+    }
+    if (typeof p.tipHash !== "string" || !HEX32_RE.test(p.tipHash)) {
+      return { ok: false, status: 400, error: "tipHash must match 0x-prefixed 32-byte hex" };
+    }
+    // tipHeight: same shape as epochId (number or decimal string), uint64 bound.
+    let tipHeightParsed: bigint;
+    if (typeof p.tipHeight === "number") {
+      if (!Number.isFinite(p.tipHeight) || !Number.isInteger(p.tipHeight) || p.tipHeight < 0) {
+        return { ok: false, status: 400, error: "tipHeight must be a non-negative integer" };
+      }
+      tipHeightParsed = BigInt(p.tipHeight);
+    } else if (typeof p.tipHeight === "string" && /^[0-9]+$/.test(p.tipHeight)) {
+      tipHeightParsed = BigInt(p.tipHeight);
+    } else if (typeof p.tipHeight === "bigint") {
+      tipHeightParsed = p.tipHeight;
+    } else {
+      return { ok: false, status: 400, error: "tipHeight must be a non-negative integer" };
+    }
+    if (tipHeightParsed < 0n || tipHeightParsed > MAX_UINT64) {
+      return { ok: false, status: 400, error: "tipHeight out of uint64 range" };
+    }
+    responseBody = p.responseBody as Record<string, unknown>;
+    responseAtMs = p.responseAtMs;
+    nodeSig = p.nodeSig.toLowerCase();
+    tipHash = p.tipHash.toLowerCase();
+    tipHeight = tipHeightParsed;
+  }
+
   return {
     ok: true,
     fields: {
@@ -87,6 +181,11 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
       responseBodyHash: p.responseBodyHash.toLowerCase(),
       witnessIndex: p.witnessIndex,
       epochId,
+      responseBody,
+      responseAtMs,
+      nodeSig,
+      tipHash,
+      tipHeight,
     },
   };
 }

--- a/runtime/lib/pose-witness-verifier.test.ts
+++ b/runtime/lib/pose-witness-verifier.test.ts
@@ -1,0 +1,348 @@
+/**
+ * pose-witness-verifier.test.ts — #667 (audit follow-up, 2026-05-26)
+ *
+ * Covers the three Push-verification checks in verifyPushedReceipt:
+ *  (1) keccak256(stableStringify(body)) == responseBodyHash
+ *  (2) ecrecover(RECEIPT digest, nodeSig) == nodeOperator(poseNodeId)
+ *  (3) freshness window on responseAtMs
+ *
+ * Plus the rollout configuration corners: missing reader, malformed sig,
+ * mismatched operator, stale receipt.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Wallet } from "ethers";
+
+import { verifyPushedReceipt, stableStringify } from "./pose-witness-verifier.ts";
+import { RECEIPT_TYPES, buildDomain, toEthersDomain } from "../../node/src/crypto/eip712-types.ts";
+import { keccak256Hex } from "../../services/relayer/keccak256.ts";
+import type { ContractReader } from "./contract-reader.ts";
+import type { Hex32 } from "../../services/common/pose-types.ts";
+
+// Test fixture — a minimal ContractReader that returns a configured
+// operator address (or throws). Keep deps minimal so this file is a unit
+// test, not an integration test against a live RPC.
+function fakeReader(opts: {
+  operator: string;
+  throwOn?: boolean;
+}): ContractReader {
+  return {
+    async getNodeOperator(nodeId: Hex32): Promise<string> {
+      if (opts.throwOn) throw new Error("simulated RPC failure");
+      return opts.operator;
+    },
+  } as unknown as ContractReader;
+}
+
+const CHAIN_ID = 88780n;
+const VERIFYING_CONTRACT = "0x1111111111111111111111111111111111111111";
+
+async function buildSignedReceipt(opts: {
+  privateKey?: string;
+  body?: Record<string, unknown>;
+  responseAtMs?: number;
+  challengeId?: string;
+  tipHash?: string;
+  tipHeight?: bigint;
+}) {
+  const wallet = new Wallet(opts.privateKey ?? "0x" + "1".repeat(64));
+  const body = opts.body ?? { ok: true, blockNumber: 42 };
+  const bodyHash = `0x${keccak256Hex(Buffer.from(stableStringify(body), "utf8"))}`;
+  const challengeId = opts.challengeId ?? "0x" + "a".repeat(64);
+  const tipHash = opts.tipHash ?? "0x" + "c".repeat(64);
+  const tipHeight = opts.tipHeight ?? 100n;
+  const responseAtMs = opts.responseAtMs ?? Date.now();
+  // Node IDs in v2 are 32-byte poseNodeId (keccak of pubkey). For the
+  // signature mechanics it just needs to be a 32-byte hex; the value
+  // itself doesn't have to be derived from this wallet's pubkey since
+  // the on-chain lookup (mocked here) is what ties nodeId → operator.
+  const nodeId = "0x" + "b".repeat(64);
+  const domain = toEthersDomain(buildDomain(CHAIN_ID, VERIFYING_CONTRACT));
+  const payload = {
+    challengeId,
+    nodeId,
+    responseAtMs: BigInt(responseAtMs),
+    responseBodyHash: bodyHash,
+    tipHash,
+    tipHeight,
+  };
+  const nodeSig = await wallet.signTypedData(domain, RECEIPT_TYPES, payload);
+  return {
+    operator: wallet.address.toLowerCase(),
+    challengeId,
+    nodeId,
+    body,
+    bodyHash,
+    responseAtMs,
+    tipHash,
+    tipHeight,
+    nodeSig,
+  };
+}
+
+test("verifyPushedReceipt: happy path — all three checks pass", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.recoveredOperator, r.operator);
+  }
+});
+
+test("verifyPushedReceipt: rejects when responseBody does not hash to declared hash", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: { ...r.body, tampered: true }, // body mutated after sign
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 400);
+    assert.match(result.error, /does not hash/);
+  }
+});
+
+test("verifyPushedReceipt: rejects when nodeSig recovers to a different address than the registered operator", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      // On-chain lookup returns a different operator than the sigantore.
+      contractReader: fakeReader({ operator: "0x" + "9".repeat(40) }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 400);
+    assert.match(result.error, /does not recover to the registered nodeOperator/);
+  }
+});
+
+test("verifyPushedReceipt: rejects when nodeId is unregistered (operator returns zero address)", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: "0x0000000000000000000000000000000000000000" }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 400);
+    assert.match(result.error, /is not registered/);
+  }
+});
+
+test("verifyPushedReceipt: F2 freshness — rejects stale receipt outside window", async () => {
+  const now = 1_000_000_000_000;
+  const r = await buildSignedReceipt({ responseAtMs: now - 5 * 60_000 }); // 5 minutes ago
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      freshnessWindowMs: 60_000,
+      nowMs: () => now,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 400);
+    assert.match(result.error, /freshness window/);
+  }
+});
+
+test("verifyPushedReceipt: F2 freshness — also rejects future-dated receipt (clock-drag attack)", async () => {
+  const now = 1_000_000_000_000;
+  const r = await buildSignedReceipt({ responseAtMs: now + 5 * 60_000 }); // 5 minutes ahead
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      freshnessWindowMs: 60_000,
+      nowMs: () => now,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.error, /freshness window/);
+});
+
+test("verifyPushedReceipt: F2 freshness — accepts receipt at window boundary", async () => {
+  const now = 1_000_000_000_000;
+  const r = await buildSignedReceipt({ responseAtMs: now - 60_000 }); // exactly at boundary
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      freshnessWindowMs: 60_000,
+      nowMs: () => now,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, true);
+});
+
+test("verifyPushedReceipt: malformed nodeSig returns 400 without leaking ethers internals", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: "0x" + "00".repeat(65),
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 400);
+    assert.doesNotMatch(result.error, /TypeError|SyntaxError|stack/);
+  }
+});
+
+test("verifyPushedReceipt: contractReader RPC failure surfaces 502 (fail-closed)", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator, throwOn: true }),
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 502);
+    assert.match(result.error, /operator lookup failed/);
+  }
+});
+
+test("verifyPushedReceipt: rejects self-signed forged receipt from attacker EOA", async () => {
+  // This is the Sybil scenario this fix is meant to prevent.
+  // Attacker generates a fresh EOA, self-signs a receipt for an arbitrary
+  // body claiming to be the prover, and pushes it to the witness.
+  // The witness's on-chain lookup of nodeOperator(nodeId) returns the
+  // REAL operator (not the attacker), so ecrecover mismatch → reject.
+  const attacker = new Wallet("0x" + "0".repeat(62) + "ab");
+  const r = await buildSignedReceipt({ privateKey: attacker.privateKey });
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: "0x1234567890123456789012345678901234567890" }),
+    },
+  );
+  // Attacker's sig recovers to attacker.address, not the real operator.
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.error, /does not recover/);
+});

--- a/runtime/lib/pose-witness-verifier.ts
+++ b/runtime/lib/pose-witness-verifier.ts
@@ -1,0 +1,154 @@
+/**
+ * pose-witness-verifier.ts — #667 Push-verification core (audit follow-up, 2026-05-26).
+ *
+ * Closes the cryptographic rubber-stamp class for /pose/witness:
+ *
+ *   Before: the witness signs whatever (challengeId, nodeId, responseBodyHash,
+ *           witnessIndex) tuple the caller hands it. Any unauthenticated
+ *           caller can mint an arbitrary witness attestation.
+ *
+ *   After (this module): when the caller also supplies the prover's signed
+ *           receipt (`responseBody`, `responseAtMs`, `nodeSig`, `tipHash`,
+ *           `tipHeight`), the witness:
+ *             1. recomputes keccak256(stableStringify(responseBody)) and
+ *                rejects if it does not equal `responseBodyHash`
+ *             2. ecrecovers the EIP-712 RECEIPT_TYPES digest against `nodeSig`
+ *                and looks up nodeOperator(poseNodeId) on-chain; rejects if
+ *                the recovered address is not the registered operator
+ *             3. checks `|now - responseAtMs| <= freshnessWindowMs` (F2) so
+ *                an old verified receipt cannot be re-fed across challenges
+ *
+ *   Only when all three pass does the witness sign the EIP-712 attestation.
+ *
+ * Deeper semantic verification (the prover actually answered the challenge
+ * correctly — e.g., re-fetching the IPFS bytes for a storage proof) is a
+ * strictly larger surface and tracked separately as #746 (the F1 finding,
+ * including F3 leaf binding which depends on having a witness-derived
+ * resultCode). This module deliberately closes only the cryptographic
+ * rubber-stamp; semantic rubber-stamping remains open until #746 ships.
+ */
+
+import { verifyTypedData } from "ethers"
+import { RECEIPT_TYPES, buildDomain, toEthersDomain } from "../../node/src/crypto/eip712-types.ts"
+import { keccak256Hex } from "../../services/relayer/keccak256.ts"
+import type { ContractReader } from "./contract-reader.ts"
+import type { Hex32 } from "../../services/common/pose-types.ts"
+
+export interface PushVerifyInput {
+  challengeId: string
+  nodeId: string                  // 32-byte poseNodeId in lowercase hex
+  responseBodyHash: string
+  responseBody: Record<string, unknown>
+  responseAtMs: number
+  nodeSig: string
+  tipHash: string
+  tipHeight: bigint
+}
+
+export interface PushVerifyOpts {
+  chainId: bigint
+  verifyingContract: string
+  /** Maximum drift between `now` and `responseAtMs`. Default 60_000ms. */
+  freshnessWindowMs?: number
+  /** Required to look up `nodeOperator(poseNodeId)` on-chain. */
+  contractReader: ContractReader
+  /** For deterministic tests — production calls `Date.now`. */
+  nowMs?: () => number
+}
+
+export type PushVerifyResult =
+  | { ok: true; recoveredOperator: string }
+  | { ok: false; status: number; error: string }
+
+/**
+ * Stable JSON stringification — must match `runtime/coc-node.ts:stableStringify`
+ * (the prover's encoding) byte-for-byte, otherwise `responseBodyHash` won't
+ * match. Keep these in sync. Pulled into this module rather than imported
+ * from coc-node.ts because that file is a runtime entry point with side
+ * effects on import (binds sockets, reads env, etc.).
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map((x) => stableStringify(x)).join(",")}]`
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  const props = keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+  return `{${props.join(",")}}`
+}
+
+/**
+ * Run the three Push-verification checks. Returns `{ ok: true, recoveredOperator }`
+ * on success (caller may want to log the operator for audit) or a typed
+ * failure with `status` + `error` suitable for direct HTTP response.
+ */
+export async function verifyPushedReceipt(
+  input: PushVerifyInput,
+  opts: PushVerifyOpts,
+): Promise<PushVerifyResult> {
+  // (1) responseBodyHash recomputation.
+  const recomputed = `0x${keccak256Hex(Buffer.from(stableStringify(input.responseBody), "utf8"))}`.toLowerCase()
+  if (recomputed !== input.responseBodyHash.toLowerCase()) {
+    return { ok: false, status: 400, error: "responseBody does not hash to responseBodyHash" }
+  }
+
+  // (2) F2 freshness check — bound the drift so a stale verified receipt
+  // can't be re-fed across challenges. Bidirectional bound: future
+  // timestamps are also rejected because the prover's clock could be
+  // dragged forward to extend the validity window. Use a generous window
+  // (default 60s) so honest clock skew is tolerated.
+  const window = opts.freshnessWindowMs ?? 60_000
+  const now = (opts.nowMs ?? Date.now)()
+  const drift = Math.abs(now - input.responseAtMs)
+  if (drift > window) {
+    return {
+      ok: false,
+      status: 400,
+      error: `responseAtMs out of freshness window (drift ${drift}ms > ${window}ms)`,
+    }
+  }
+
+  // (3) ecrecover the RECEIPT_TYPES digest against nodeSig + match to
+  // registered nodeOperator(poseNodeId). Without the on-chain lookup
+  // step the recovered address is just "some EOA" — any attacker can
+  // self-sign a forged receipt and pass step (1)+(3).
+  const domain = toEthersDomain(buildDomain(opts.chainId, opts.verifyingContract))
+  const receiptPayload = {
+    challengeId: input.challengeId,
+    nodeId: input.nodeId,
+    responseAtMs: BigInt(input.responseAtMs),
+    responseBodyHash: input.responseBodyHash,
+    tipHash: input.tipHash,
+    tipHeight: input.tipHeight,
+  }
+
+  let recovered: string
+  try {
+    recovered = verifyTypedData(domain, RECEIPT_TYPES, receiptPayload, input.nodeSig).toLowerCase()
+  } catch (err) {
+    // Malformed signature (wrong length / non-canonical s / bad v) lands here.
+    // Do not leak the underlying ethers error into the HTTP response.
+    return { ok: false, status: 400, error: "nodeSig is malformed or does not recover" }
+  }
+
+  let registeredOperator: string
+  try {
+    registeredOperator = (await opts.contractReader.getNodeOperator(input.nodeId as Hex32)).toLowerCase()
+  } catch (err) {
+    // RPC failure / contract not configured — fail closed. Caller already
+    // gated the push path on COC_POSE_WITNESS_REQUIRE_VERIFIED, so reaching
+    // here means we explicitly want strict verification.
+    return { ok: false, status: 502, error: "operator lookup failed" }
+  }
+  if (registeredOperator === "0x0000000000000000000000000000000000000000") {
+    return { ok: false, status: 400, error: "nodeId is not registered" }
+  }
+  if (recovered !== registeredOperator) {
+    return {
+      ok: false,
+      status: 400,
+      error: "nodeSig does not recover to the registered nodeOperator for nodeId",
+    }
+  }
+
+  return { ok: true, recoveredOperator: recovered }
+}

--- a/runtime/lib/witness-collector.ts
+++ b/runtime/lib/witness-collector.ts
@@ -44,6 +44,23 @@ type WitnessRequestFn = (
   headers?: Record<string, string>,
 ) => Promise<{ status?: number; json?: any }>
 
+/**
+ * #667 (audit follow-up, 2026-05-26) — fields the caller can pass through
+ * for Push-verification on the witness side. When all five are provided,
+ * the witness validates `keccak(stableStringify(body)) == responseBodyHash`
+ * AND `ecrecover(RECEIPT digest, nodeSig) == nodeOperator(nodeId)` before
+ * signing. Backwards-compatible: if these are omitted the witness falls
+ * back to the legacy rubber-stamp path (gated by the witness-side
+ * `COC_POSE_WITNESS_REQUIRE_VERIFIED` env flag).
+ */
+export interface PushVerifyContext {
+  responseBody: Record<string, unknown>
+  responseAtMs: number
+  nodeSig: string
+  tipHash: string
+  tipHeight: bigint
+}
+
 export async function collectWitnesses(
   config: WitnessCollectorConfig,
   challengeId: Hex32,
@@ -51,6 +68,7 @@ export async function collectWitnesses(
   responseBodyHash: Hex32,
   requestFn: WitnessRequestFn = requestJson,
   epochId?: bigint,
+  pushCtx?: PushVerifyContext,
 ): Promise<CollectResult> {
   const requests = config.witnessNodes.map(async (w) => {
     try {
@@ -64,6 +82,17 @@ export async function collectWitnesses(
       // the witness server returns a `witnessSigV2` alongside the v1
       // signature. The aggregator prefers v2 when building the batch.
       if (epochId !== undefined) body.epochId = epochId.toString()
+      // #667 (audit follow-up, 2026-05-26) — push the prover's signed
+      // receipt fields when available so the witness can run
+      // Push-verification before signing. Stringify tipHeight/responseAtMs
+      // to keep the request JSON valid (BigInt isn't serializable).
+      if (pushCtx) {
+        body.responseBody = pushCtx.responseBody
+        body.responseAtMs = pushCtx.responseAtMs
+        body.nodeSig = pushCtx.nodeSig
+        body.tipHash = pushCtx.tipHash
+        body.tipHeight = pushCtx.tipHeight.toString()
+      }
       const response = await requestFn(
         `${w.url}/pose/witness`,
         "POST",


### PR DESCRIPTION
## Summary

Closes the **cryptographic rubber-stamp** class of #667. The witness no longer EIP-712-signs caller-supplied tuples without verification. When the caller passes the prover's signed receipt, the witness validates three things locally before signing:

1. **Body integrity**: \`keccak256(stableStringify(responseBody)) == responseBodyHash\`
2. **Prover authenticity**: \`ecrecover(RECEIPT_TYPES digest, nodeSig) == nodeOperator(poseNodeId)\` — via on-chain lookup through the new \`ContractReader.getNodeOperator\`
3. **F2 freshness**: \`|now - responseAtMs| <= COC_POSE_WITNESS_FRESHNESS_MS\` (default 60s, bidirectional), blocks stale or future-dated drift

## What is NOT closed (tracked separately)

This PR closes the *cryptographic* rubber-stamp — the attacker can no longer mint a witness signature without first stealing a real operator's signing key. It does NOT close the *semantic* rubber-stamp where a malicious prover signs a fabricated \`responseBody\` (wrong storage proof, wrong uptime body) and pushes it to witnesses; witnesses verify the signature is real but don't re-run the Layer-7 check that would catch the content being wrong. That requires the witness to mirror \`ReceiptVerifierV2\`'s per-receipt-type verification (re-fetch IPFS bytes for storage proofs, independent RPC \`eth_getBlockByNumber\` for uptime) and is tracked as **#746** (with F3 leaf-binding folded in — it can't ship without F1's witness-derived \`resultCode\`).

5 sibling audit findings filed as separate follow-ups: **#746** (F1+F3 semantic verify + leaf binding), **#747** (F4 challengeId derivation), **#748** (F5 v1 sunset cap), **#749** (F6 PRNG seed grinding), **#750** (F7 loopback gate hardening).

## Latent v2-validator bug also fixed

While writing the verifier I discovered \`runtime/lib/pose-witness-validator.ts\` hard-locked \`nodeId\` to a 20-byte address, but the v2 pipeline uses 32-byte \`poseNodeId = keccak256(pubkey)\` (the EIP-712 \`Receipt.nodeId\` field is \`bytes32\` — ethers rejects 20-byte values at sign time). Net effect: **every v2 witness request was silently rejected**, leaving production stuck on the empty-witness owner-only fallback. This matches the original audit observation that \`ReceiptVerifierV2\` is dead code — quorum never met → empty-witness branch → owner-only submission. Validator now accepts both shapes; the EIP-712 layer still enforces \`bytes32\`.

## Rollout

New env vars:
- \`COC_POSE_WITNESS_REQUIRE_VERIFIED\` (default \`false\`): strict mode rejects un-pushed callers. Startup asserts the on-chain reader is wired so flipping the switch never silently degrades.
- \`COC_POSE_WITNESS_FRESHNESS_MS\` (default \`60000\`): F2 window override.

\`coc-agent.ts\` transparently pushes the prover's \`(responseBody, responseAtMs, nodeSig, tipHash, tipHeight)\` into every \`collectWitnesses()\` call so behaviour is identical regardless of which mode each witness operator picks. Also fixes a latent \`epochId\`-not-passed bug at that call site (the v2 typehash branch was never reachable from \`coc-agent\` because epochId was dropped before push).

Partial push-field sets are rejected (no downgrade attack where caller omits \`nodeSig\` to skip verification while keeping \`responseBody\` to look legit in logs).

## What changed

| File | Change |
|---|---|
| \`runtime/lib/pose-witness-verifier.ts\` (new) | \`verifyPushedReceipt()\` — three checks, fail-closed on RPC error |
| \`runtime/lib/pose-witness-verifier.test.ts\` (new, 10 tests) | Happy path, hash mismatch, sig/operator mismatch, unregistered node, freshness past/future/boundary, malformed sig, RPC failure, **Sybil reproduction blocked** |
| \`runtime/lib/pose-witness-validator.ts\` | Accept 32-byte nodeId (latent bug fix), add optional push-field schema with all-or-nothing presence enforcement |
| \`runtime/lib/pose-witness-validator.test.ts\` | 4 new regression tests for the validator changes |
| \`runtime/coc-node.ts\` | Wire \`ContractReader\` + push-verify gate into \`/pose/witness\` handler with rollout switch |
| \`runtime/lib/contract-reader.ts\` | Add \`getNodeOperator(bytes32)\` view (cached 30s) + \`encodeBytes32FunctionCall\` ABI helper |
| \`runtime/lib/witness-collector.ts\` | \`PushVerifyContext\` interface + pass-through; also now passes \`epochId\` (was dropped) |
| \`runtime/coc-agent.ts\` | Supply push fields to \`collectWitnesses\` |

## Test plan

- [x] \`runtime/lib/pose-witness-verifier.test.ts\` — 10/10 pass
- [x] \`runtime/lib/pose-witness-validator.test.ts\` — 17/17 pass (13 pre-existing + 4 new)
- [x] \`runtime/lib/pose-witness-auth.test.ts\` — 13/13 pass (no regression)
- [x] \`runtime/lib/witness-collector.test.ts\` — 12/12 pass (no regression)
- [x] Full runtime layer (\`find runtime -name '*.test.ts'\`) — 214/214 passing, 0 failing
- [x] \`node/src/crypto/eip712-signer.test.ts\` — 10/10 pass (no regression in the EIP-712 layer this depends on)
- [ ] Maintainer to dry-run on 88780 with \`COC_POSE_WITNESS_REQUIRE_VERIFIED=false\` (default) first — operator-by-operator migration as each agent picks up the push fields

## Deployment notes

1. Merge PR.
2. Rolling deploy node-side code to 5 validators + obs-1 — default mode is backwards-compatible.
3. After all 6 nodes are on the new code, set \`COC_POSE_WITNESS_REQUIRE_VERIFIED=true\` on each one to lock down the legacy rubber-stamp path. (This is when \`coc-agent\` must already be shipping push fields, which it does after step 2.)
4. No contract upgrade required — all changes are off-chain. The on-chain \`_validateWitnessQuorumV2\` already does its half of the verification.

## Audit context

Independent 3-agent audit on 2026-05-26 surfaced 7 findings (2 HIGH + 3 MED + 2 LOW). This PR ships the minimum that lets us close #667: Push verification (Option A from the issue body) + freshness window. The 5 other findings are filed individually and prioritized per their severity in the issue tracker. Closest production analogue per the audit is Chainlink OCR's "verify-before-sign" pattern, which is what this PR implements.