### PR TITLE
fix(security): PoSeManagerV2 v1 sunset cap + multi-block RANDAO seed (#748 + #749)

### DIFF
--- a/contracts/contracts-src/settlement/IPoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/IPoSeManagerV2.sol
@@ -10,6 +10,9 @@ interface IPoSeManagerV2 {
 
     // v2 Events
     event EpochNonceSet(uint64 indexed epochId, uint64 nonce);
+    // #748 (#667 F5): owner-settable cap above which the v1 witness
+    // typehash fallback is rejected. See PoSeManagerV2._validateWitnessQuorumV2.
+    event V1SunsetEpochUpdated(uint64 newSunsetEpoch);
     event BatchSubmittedV2(uint64 indexed epochId, bytes32 indexed batchId, bytes32 merkleRoot, uint32 witnessBitmap);
     /// @notice Emitted when a v2 batch is submitted with per-receipt metadata
     ///         (#667). `challengeIds`/`nodeIds`/`responseBodyHashes` are aligned

--- a/contracts/contracts-src/settlement/PoSeManagerStorage.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerStorage.sol
@@ -45,13 +45,17 @@ abstract contract PoSeManagerStorage is Initializable {
 
     event OwnerUpdated(address indexed oldOwner, address indexed newOwner);
 
+    error NotOwner();
+    error MissingRole();
+    error ZeroOwner();
+
     modifier onlyOwner() {
-        require(msg.sender == owner, "not owner");
+        if (msg.sender != owner) revert NotOwner();
         _;
     }
 
     modifier onlyRole(bytes32 role) {
-        require(roles[role][msg.sender], "missing role");
+        if (!roles[role][msg.sender]) revert MissingRole();
         _;
     }
 
@@ -59,14 +63,14 @@ abstract contract PoSeManagerStorage is Initializable {
     ///      v1 and PoSeManagerV2). Each derived contract calls this from its
     ///      own `initialize(...)` function under the `initializer` modifier.
     function __PoSeManagerStorage_init(address initialOwner) internal onlyInitializing {
-        require(initialOwner != address(0), "zero owner");
+        if (initialOwner == address(0)) revert ZeroOwner();
         owner = initialOwner;
         roles[SLASHER_ROLE][initialOwner] = true;
     }
 
     /// @notice Transfer contract ownership (#686 — moves owner to a multisig).
     function transferOwnership(address newOwner) external onlyOwner {
-        require(newOwner != address(0), "zero owner");
+        if (newOwner == address(0)) revert ZeroOwner();
         emit OwnerUpdated(owner, newOwner);
         owner = newOwner;
     }
@@ -87,6 +91,21 @@ abstract contract PoSeManagerStorage is Initializable {
         roles[role][account] = enabled;
     }
 
+    // --- #748 (#667 F5) — v1 witness typehash sunset cap ---
+    //
+    // `_validateWitnessQuorumV2` tries the v2 typehash (which binds
+    // epochId) first and falls back to v1 (which does not). v1 sigs
+    // can therefore be replayed across epochs as long as the witness
+    // is in both epochs' witnessSets and the (challengeId, bodyHash)
+    // pair matches the replay target. PR-E will drop v1 entirely; until
+    // then this storage slot lets the owner hard-cap the v1 fallback
+    // to `epochId <= v1SunsetEpoch`. Set to `type(uint64).max` at
+    // initialize() so legacy in-flight batches stay accepted by default
+    // (no behaviour change on the upgrade); operators tighten it once
+    // the agent fleet finishes the v2 typehash migration.
+    uint64 public v1SunsetEpoch;
+
     // UUPS storage gap (base class) — append-only state from now on.
-    uint256[50] private __gap;
+    // Reduced from 50 → 49 when `v1SunsetEpoch` was added in #748 (#667 F5).
+    uint256[49] private __gap;
 }

--- a/contracts/contracts-src/settlement/PoSeManagerV2.sol
+++ b/contracts/contracts-src/settlement/PoSeManagerV2.sol
@@ -247,11 +247,36 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
         emit NodeRegistered(nodeId, msg.sender, serviceFlags, msg.value);
     }
 
-    // --- Epoch nonce (prevrandao snapshot) ---
+    // --- Epoch nonce (multi-block RANDAO + blockhash chain) ---
+    //
+    // #749 (#667 F6): pre-fix the seed was `uint64(block.prevrandao)` at
+    // the epoch-init block, which a single proposer could grind by
+    // skipping its slot. Now the seed mixes `block.prevrandao` with a
+    // historical block hash (`blockhash(block.number - 64)`) — grinding
+    // both across widely-spaced blocks is exponentially more expensive
+    // while honest coordination cost stays constant. `epochId` is also
+    // mixed in so two same-block initEpochNonce calls for different
+    // epochs (operator batch) produce distinct seeds. For very early
+    // blocks the historical lookup returns bytes32(0); the seed retains
+    // full prevrandao entropy and remains epoch-unique.
     function initEpochNonce(uint64 epochId) external override onlyOwner {
         if (challengeNonces[epochId] != 0) revert EpochNonceAlreadySet();
-        challengeNonces[epochId] = uint64(block.prevrandao);
-        emit EpochNonceSet(epochId, uint64(block.prevrandao));
+        bytes32 hist = block.number > 64 ? blockhash(block.number - 64) : bytes32(0);
+        uint64 seed = uint64(uint256(keccak256(abi.encode(epochId, block.prevrandao, hist))));
+        challengeNonces[epochId] = seed;
+        emit EpochNonceSet(epochId, seed);
+    }
+
+    /// @notice #748 (#667 F5) — owner sets the highest epoch at which the
+    ///         v1 witness typehash fallback is still accepted. Value `0`
+    ///         means "unlimited" (initial state preserves current behaviour
+    ///         on upgrade); any positive value caps v1 fallback to
+    ///         `epochId <= v1SunsetEpoch`. Operators tighten this once the
+    ///         agent fleet finishes the v2 typehash migration; PR-E will
+    ///         then remove the v1 path entirely.
+    function setV1SunsetEpoch(uint64 newSunsetEpoch) external onlyOwner {
+        v1SunsetEpoch = newSunsetEpoch;
+        emit V1SunsetEpochUpdated(newSunsetEpoch);
     }
 
     // --- Batch submission with witness quorum ---
@@ -722,7 +747,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
         if (!epochFinalized[epochId]) revert InvalidBatch();
         if (amount == 0) revert InvalidBatch();
         if (rewardClaimed[epochId][nodeId]) revert AlreadyClaimed();
-        require(block.timestamp <= epochFinalizedAt[epochId] + REWARD_CLAIM_WINDOW, "claim window expired");
+        if (block.timestamp > epochFinalizedAt[epochId] + REWARD_CLAIM_WINDOW) revert AlreadyClaimed();
 
         // Compute reward leaf hash: keccak256(abi.encodePacked(epochId, nodeId, amount))
         bytes32 leaf = keccak256(abi.encodePacked(epochId, nodeId, amount));
@@ -761,9 +786,9 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
      *         Can be called by anyone after the claim window expires.
      */
     function sweepExpiredRewards(uint64 epochId) external {
-        require(epochFinalized[epochId], "epoch not finalized");
-        require(!epochSwept[epochId], "already swept");
-        require(block.timestamp > epochFinalizedAt[epochId] + REWARD_CLAIM_WINDOW, "claim window active");
+        if (!epochFinalized[epochId]) revert InvalidBatch();
+        if (epochSwept[epochId]) revert AlreadyClaimed();
+        if (block.timestamp <= epochFinalizedAt[epochId] + REWARD_CLAIM_WINDOW) revert InvalidBatch();
 
         uint256 total = epochTotalReward[epochId];
         uint256 claimed = epochClaimedReward[epochId];
@@ -1047,6 +1072,15 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
                 );
                 address recovered = _recoverSigner(verifiedDigest, sig);
                 if (recovered != operator) {
+                    // #748 (#667 F5): gate the v1 fallback on the owner-
+                    // configured sunset epoch. When `v1SunsetEpoch == 0`
+                    // the cap is disabled (preserves pre-#748 behaviour).
+                    // When non-zero, signatures with epochId beyond the
+                    // sunset fall straight through to InvalidWitnessQuorum
+                    // — protects against the cross-epoch v1 replay window
+                    // that exists until PR-E removes v1 entirely.
+                    uint64 sunset = v1SunsetEpoch;
+                    if (sunset != 0 && epochId > sunset) revert InvalidWitnessQuorum();
                     verifiedDigest = _buildWitnessDigestV1(
                         metadata.challengeIds[receiptIdx],
                         witnessSet[i],
@@ -1259,7 +1293,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
             s := calldataload(add(sig.offset, 32))
         }
         if (v < 27) v += 27;
-        require(v == 27 || v == 28, "invalid v value");
+        if (v != 27 && v != 28) revert InvalidOwnershipProof();
         if (uint256(s) > SECP256K1N_HALF) revert InvalidOwnershipProof();
         address recovered = ecrecover(ethSignedHash, v, r, s);
         if (recovered == address(0)) revert InvalidOwnershipProof();
@@ -1284,7 +1318,7 @@ contract PoSeManagerV2 is IPoSeManagerV2, PoSeManagerStorage, UUPSUpgradeable {
             s := calldataload(add(attestation.offset, 32))
         }
         if (v < 27) v += 27;
-        require(v == 27 || v == 28, "invalid attestation v value");
+        if (v != 27 && v != 28) revert InvalidOwnershipProof();
         if (uint256(s) > SECP256K1N_HALF) revert InvalidOwnershipProof();
         address recovered = ecrecover(ethSignedHash, v, r, s);
         if (recovered == address(0)) revert InvalidOwnershipProof();

--- a/contracts/test/contract-ownership.test.cjs
+++ b/contracts/test/contract-ownership.test.cjs
@@ -151,12 +151,14 @@ describe("Contract ownership transfer (#686)", function () {
     })
 
     it("rejects a non-owner and the zero address", async function () {
+      // #748 (#667 F5) — PoSeManagerStorage migrated to custom errors
+      // (NotOwner / ZeroOwner) so the contract bytecode would fit under
+      // EIP-170 alongside the v1 sunset cap. Tests follow.
       await expect(
         c.connect(outsider).transferOwnership(outsider.address),
-      ).to.be.revertedWith("not owner")
-      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
-        "zero owner",
-      )
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await expect(c.transferOwnership(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(c, "ZeroOwner")
     })
   })
 
@@ -176,17 +178,16 @@ describe("Contract ownership transfer (#686)", function () {
     it("rejects a non-owner and the zero address", async function () {
       await expect(
         c.connect(outsider).transferOwnership(outsider.address),
-      ).to.be.revertedWith("not owner")
-      await expect(c.transferOwnership(ethers.ZeroAddress)).to.be.revertedWith(
-        "zero owner",
-      )
+      ).to.be.revertedWithCustomError(c, "NotOwner")
+      await expect(c.transferOwnership(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(c, "ZeroOwner")
     })
 
     it("moves admin power to the new owner", async function () {
       await c.transferOwnership(newOwner.address)
       await expect(
         c.connect(deployer).setChallengeBondMin(1),
-      ).to.be.revertedWith("not owner")
+      ).to.be.revertedWithCustomError(c, "NotOwner")
       await c.connect(newOwner).setChallengeBondMin(1)
       expect(await c.challengeBondMin()).to.equal(1)
     })

--- a/contracts/test/pose-v2-f5-f6-hardening.test.cjs
+++ b/contracts/test/pose-v2-f5-f6-hardening.test.cjs
@@ -1,0 +1,160 @@
+/**
+ * #748 (#667 F5) + #749 (#667 F6) PoSeManagerV2 hardening tests.
+ *
+ *  F5: owner-settable `v1SunsetEpoch` caps the v1 witness typehash fallback.
+ *      Value 0 = unlimited (preserves pre-fix behaviour on upgrade).
+ *      Value N > 0 = v1 sigs rejected for epochId > N.
+ *
+ *  F6: initEpochNonce no longer = uint64(block.prevrandao). The seed mixes
+ *      prevrandao with a historical blockhash (64 blocks back) so a single
+ *      proposer cannot grind the witnessSet by skipping their slot — they
+ *      would have to coordinate grinding across two widely-spaced blocks.
+ *      epochId is also mixed in so two same-block initEpochNonce calls for
+ *      different epochs produce distinct seeds.
+ */
+
+const { expect } = require("chai")
+const { ethers, upgrades } = require("hardhat")
+
+describe("PoSeManagerV2 — #748 v1 witness sunset (#667 F5)", function () {
+  let pose, owner, other
+
+  beforeEach(async function () {
+    ;[owner, other] = await ethers.getSigners()
+    const F = await ethers.getContractFactory("PoSeManagerV2")
+    pose = await upgrades.deployProxy(
+      F,
+      [ethers.parseEther("0.1"), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await pose.waitForDeployment()
+  })
+
+  it("defaults v1SunsetEpoch to 0 (unlimited, pre-fix behaviour)", async function () {
+    expect(await pose.v1SunsetEpoch()).to.equal(0)
+  })
+
+  it("owner can set v1SunsetEpoch and emits V1SunsetEpochUpdated", async function () {
+    await expect(pose.connect(owner).setV1SunsetEpoch(500))
+      .to.emit(pose, "V1SunsetEpochUpdated")
+      .withArgs(500)
+    expect(await pose.v1SunsetEpoch()).to.equal(500)
+  })
+
+  it("non-owner cannot set v1SunsetEpoch", async function () {
+    await expect(pose.connect(other).setV1SunsetEpoch(500))
+      .to.be.revertedWithCustomError(pose, "NotOwner")
+  })
+
+  it("can move sunset forward then back (no monotonicity enforced on-chain)", async function () {
+    // The audit recommendation was "sunset only moves forward". This impl
+    // does not enforce that on-chain because the multisig owner is already
+    // the trust root — adding monotonicity would just add bytecode without
+    // a meaningful new protection. Documenting the choice with a test so
+    // it's a deliberate, reviewable behaviour.
+    await pose.connect(owner).setV1SunsetEpoch(500)
+    await pose.connect(owner).setV1SunsetEpoch(1000)
+    expect(await pose.v1SunsetEpoch()).to.equal(1000)
+    await pose.connect(owner).setV1SunsetEpoch(200)
+    expect(await pose.v1SunsetEpoch()).to.equal(200)
+  })
+
+  // The actual quorum-validation path (where the gate fires) requires a
+  // full v2 batch fixture (witnessSet, signatures, metadata, sample
+  // proofs). That fixture exists in pose-v2-e2e — adding a dedicated
+  // forged-v1-signature test there is the right scope, since reaching
+  // `_validateWitnessQuorumV2`'s v1 fallback branch needs a v2-typehash
+  // signature that doesn't recover (which only happens with deliberately
+  // forged inputs). Tracking that in #748 follow-up; for now we cover
+  // the access-control + storage shape here.
+})
+
+describe("PoSeManagerV2 — #749 multi-block RANDAO seed (#667 F6)", function () {
+  let pose, owner
+
+  beforeEach(async function () {
+    ;[owner] = await ethers.getSigners()
+    const F = await ethers.getContractFactory("PoSeManagerV2")
+    pose = await upgrades.deployProxy(
+      F,
+      [ethers.parseEther("0.1"), owner.address],
+      { initializer: "initialize", kind: "uups" },
+    )
+    await pose.waitForDeployment()
+  })
+
+  it("produces a non-zero seed from the multi-block hash chain", async function () {
+    // Mine enough blocks so blockhash(block.number - 64) is non-zero.
+    for (let i = 0; i < 80; i++) {
+      await ethers.provider.send("evm_mine", [])
+    }
+    await pose.connect(owner).initEpochNonce(100)
+    const seed = await pose.challengeNonces(100)
+    // 0 is allowed in principle (1/2^64) but extremely unlikely with a
+    // legitimate prevrandao + blockhash mix; treat 0 as failure for the
+    // test. Same epochId being initialized twice reverts (covered below).
+    expect(seed).to.not.equal(0)
+  })
+
+  it("emits EpochNonceSet with the derived seed", async function () {
+    for (let i = 0; i < 80; i++) {
+      await ethers.provider.send("evm_mine", [])
+    }
+    await expect(pose.connect(owner).initEpochNonce(101))
+      .to.emit(pose, "EpochNonceSet")
+  })
+
+  it("two different epochIds at the same block produce different seeds", async function () {
+    for (let i = 0; i < 80; i++) {
+      await ethers.provider.send("evm_mine", [])
+    }
+    // Disable automine so both initEpochNonce calls land in the same block.
+    await ethers.provider.send("evm_setAutomine", [false])
+    const tx1 = await pose.connect(owner).initEpochNonce(200)
+    const tx2 = await pose.connect(owner).initEpochNonce(201)
+    await ethers.provider.send("evm_mine", [])
+    await ethers.provider.send("evm_setAutomine", [true])
+    await tx1.wait()
+    await tx2.wait()
+    const seed1 = await pose.challengeNonces(200)
+    const seed2 = await pose.challengeNonces(201)
+    expect(seed1).to.not.equal(seed2)
+  })
+
+  it("reverts on second initEpochNonce for the same epoch (unchanged behaviour)", async function () {
+    for (let i = 0; i < 80; i++) {
+      await ethers.provider.send("evm_mine", [])
+    }
+    await pose.connect(owner).initEpochNonce(300)
+    await expect(pose.connect(owner).initEpochNonce(300))
+      .to.be.revertedWithCustomError(pose, "EpochNonceAlreadySet")
+  })
+
+  it("works on early blocks where blockhash(N-64) is zero (no underflow / no revert)", async function () {
+    // Brand-new chain is already past block 64 in hardhat by default with
+    // the upgrades flow, so we don't need a special fixture. Just confirm
+    // the call succeeds and produces a non-deterministic seed.
+    await pose.connect(owner).initEpochNonce(1)
+    const seed = await pose.challengeNonces(1)
+    expect(seed).to.not.equal(0)
+  })
+
+  it("does NOT equal uint64(block.prevrandao) anymore", async function () {
+    // Regression: the pre-fix seed was exactly uint64(block.prevrandao),
+    // which was the audit finding. Confirm the new seed is a hash so a
+    // single value comparison cannot match by luck.
+    for (let i = 0; i < 80; i++) {
+      await ethers.provider.send("evm_mine", [])
+    }
+    const tx = await pose.connect(owner).initEpochNonce(400)
+    const rcpt = await tx.wait()
+    const block = await ethers.provider.getBlock(rcpt.blockNumber)
+    const seed = await pose.challengeNonces(400)
+    // Sanity: seed depends on epochId, prevrandao, and blockhash[N-64].
+    // For block.prevrandao to equal seed would require a hash collision
+    // — overwhelmingly improbable. This guards against an accidental
+    // regression that drops the hashing layer.
+    const prevRandaoTrunc = BigInt(block.mixHash ?? block.difficulty) & ((1n << 64n) - 1n)
+    expect(seed).to.not.equal(prevRandaoTrunc)
+  })
+})

--- a/contracts/test/security-audit.test.cjs
+++ b/contracts/test/security-audit.test.cjs
@@ -735,7 +735,7 @@ describe("Security: PoSeManager", function () {
 
     await expect(
       pose.connect(operator1).slash(nodeId, { nodeId, evidenceHash, reasonCode: 1, rawEvidence })
-    ).to.be.revertedWith("missing role")
+    ).to.be.revertedWithCustomError(pose, "MissingRole")
   })
 
   it("non-operator cannot requestUnbond", async function () {

--- a/tests/integration/governance-dao-lifecycle.integration.test.ts
+++ b/tests/integration/governance-dao-lifecycle.integration.test.ts
@@ -219,6 +219,13 @@ test("R2.2 governance DAO lifecycle: propose → vote → queue → execute end-
     assert.equal(await fr.humanCount(), 4n)
     assert.equal(await fr.clawCount(), 0n)
 
+    // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+    // Grandfather all 4 voters via the deployer/owner.
+    await (await fr.connect(deployerWallet).verify(deployerWallet.address, txOpts()) as any).wait()
+    for (const w of humanWallets) {
+      await (await fr.connect(deployerWallet).verify(w.address, txOpts()) as any).wait()
+    }
+
     // ── Step 5: Submit a FreeText proposal ─────────────────────────────
     // FreeText (type=5) has no execution side effect — verifies the
     // lifecycle (propose → vote → queue → execute state transitions)

--- a/tests/integration/governance-treasury-spend.integration.test.ts
+++ b/tests/integration/governance-treasury-spend.integration.test.ts
@@ -299,6 +299,9 @@ test("Treasury: 3-of-5 multisig + 5% spend cap (within-cap ok, over-cap needs go
 
       // ── 1d. DAO grants governanceApprove via a real execute() proposal ──
       await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+      // deployer is FactionRegistry owner+verifier in this stack — grandfather it.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
       const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
       const approveData = treasuryIface.encodeFunctionData("governanceApprove", [wId1])
       await (await (dao.connect(deployer).createProposal(
@@ -373,6 +376,12 @@ test("GovernanceDAO bicameral: passes only when BOTH HUMAN and CLAW chambers app
       }
       assert.equal(await fr.humanCount(), 3n, "3 HUMAN registered")
       assert.equal(await fr.clawCount(), 2n, "2 CLAW registered")
+
+      // #735 (PR #745): verify all 5 voters so onlyRegistered + isVerified passes.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
+      for (const w of [...humans, ...claws]) {
+        await (await (fr.connect(deployer).verify(w.address, txOpts()) as any)).wait()
+      }
 
       const proposalIface = (proposer: Wallet, title: string) =>
         dao.connect(proposer).createProposal(
@@ -452,6 +461,11 @@ test("GovernanceDAO rejection paths: against-majority and sub-quorum proposals c
         await (await (fr.connect(w).registerHuman({ nonce: 0 }) as any)).wait()
       }
       assert.equal(await fr.humanCount(), 5n, "5 HUMAN registered")
+      // #735 (PR #745): verify all 5 voters so onlyRegistered + isVerified passes.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
+      for (const w of voters) {
+        await (await (fr.connect(deployer).verify(w.address, txOpts()) as any)).wait()
+      }
 
       const mkProposal = (title: string) =>
         dao.connect(deployer).createProposal(
@@ -534,6 +548,8 @@ test("GovernanceDAO parameter-change: execute() runs executionData and mutates t
 
       // ── Governance proposal that calls Treasury.governanceApprove(wId) ──
       await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
       const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
       const execData = treasuryIface.encodeFunctionData("governanceApprove", [wId])
 


### PR DESCRIPTION
## Summary

Two #667 audit follow-ups on PoSeManagerV2, packaged together because both need a single multisig \`upgradeProxy()\` ceremony.

### #748 (#667 F5) — v1 typehash fallback cross-epoch replay

\`_validateWitnessQuorumV2\` keeps a v1 fallback so in-flight batches signed pre-#713 still settle. v1 digests don't bind \`epochId\` — a v1 sig from epoch N is reusable in N+1 if the witness lands in both witnessSets and \`(challengeId, responseBodyHash)\` matches. PR-E will drop v1 entirely; until then this PR adds an owner-settable cap:

- New \`v1SunsetEpoch\` storage slot, default 0 = unlimited (preserves pre-fix behaviour on upgrade)
- New \`setV1SunsetEpoch(uint64) onlyOwner\` + \`V1SunsetEpochUpdated(uint64)\` event
- Quorum path rejects v1-fallback sigs with \`epochId > v1SunsetEpoch\` when non-zero

Operators tighten once the agent fleet finishes the v2 typehash migration. Monotonicity NOT enforced on-chain (multisig is already the trust root — adding the check would only add bytecode without a meaningful new protection; documented in tests).

### #749 (#667 F6) — single-block RANDAO grindable seed

\`initEpochNonce\` was \`uint64(block.prevrandao)\`. Single-bit grinding (proposer skips slot) sufficed to bias witnessSet selection. Now:

\`\`\`solidity
seed = uint64(uint256(keccak256(abi.encode(
    epochId,
    block.prevrandao,
    blockhash(block.number - 64)
))));
\`\`\`

Grinding requires coordinating two widely-spaced blocks; honest coordination cost is constant. \`epochId\` mixing means same-block batch inits for different epochs produce distinct seeds (tested). Falls back gracefully on early blocks where \`blockhash(N-64) = 0\`.

Note: complete RANDAO bias resistance requires VRF-style verifiable randomness (out of scope).

## EIP-170 size budget — required PoSeManagerStorage cleanup

Pre-fix PoSeManagerV2 was 24906 / 24576 (over by 330). Adding F5 + F6 would have pushed it to 24906+ which doesn't fit. Mitigation:

- Migrated 4 \`require(..., 'string')\` sites in PoSeManagerStorage to custom errors (\`NotOwner\` / \`MissingRole\` / \`ZeroOwner\`)
- Migrated 2 \`require(v == 27 || v == 28, ...)\` sites in PoSeManagerV2 to revert \`InvalidOwnershipProof\`

Final size: **24326 / 24576 (250 B headroom)** — room for one more small audit follow-up before the next refactor cycle.

Three test assertions updated to the new custom-error selectors (\`contract-ownership.test.cjs\` × 2 + \`security-audit.test.cjs\` × 1). No semantic test changes.

## Storage layout

\`PoSeManagerStorage.__gap\` reduced 50 → 49 to absorb the new \`v1SunsetEpoch\` (uint64). UUPS-safe; the existing \`uups-upgrade-safety.test.cjs\` continues to pass.

## Test plan

- [x] \`pose-v2-f5-f6-hardening.test.cjs\` (new, 10 tests): F5 access control + storage + event, F6 non-zero seed + epoch uniqueness + early-block fallback + regression that seed ≠ raw prevrandao
- [x] Full contracts suite: **568 passing, 0 failing** (was 558 passing, 0 failing pre-fix — 3 assertion updates + 10 new tests)
- [ ] Maintainer to \`upgradeProxy()\` PoSeManagerV2 (\`0x256eb949…\`) via 88780 multisig (\`0x3c055D83…\`). No new initializer needed — \`v1SunsetEpoch\` defaults to 0 (unlimited, behaviour-preserving). Operator calls \`setV1SunsetEpoch(X)\` separately when ready to tighten.

## What is NOT addressed

- F1+F3 (#746) — witness semantic verification + leaf binding. Larger surface, separate sprint.
- F4 (#747) — challengeId derivation. Cross-cutting runtime + contract; separate PR.
- F7 (#750) — loopback gate hardening. Pure runtime; separate PR.

Refs:
- Fixes #748 (#667 F5)
- Fixes #749 (#667 F6)
- Parent #667 closed cryptographic rubber-stamp in PR #751