### PR TITLE
fix(security): pose-witness loopback gate honors trusted proxies + startup assert (#750)

### DIFF
--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -7,7 +7,11 @@ import { recordChallengeBounded } from "./lib/bounded-challenge-store.ts";
 import { validatePoseWitnessPayload } from "./lib/pose-witness-validator.ts";
 import { verifyPushedReceipt } from "./lib/pose-witness-verifier.ts";
 import { ContractReader } from "./lib/contract-reader.ts";
-import { isPoseWitnessRequestAuthorized, resolvePoseWitnessAuthToken } from "./lib/pose-witness-auth.ts";
+import {
+  assertPoseWitnessAuthConfigured,
+  createPoseWitnessAuth,
+  resolvePoseWitnessAuthToken,
+} from "./lib/pose-witness-auth.ts";
 import { IpfsBlockstore } from "../node/src/ipfs-blockstore.ts";
 import { loadStorageProof, MerkleLeavesCache } from "./lib/storage-proof.ts";
 import { readBoundedBody } from "./lib/pose-body-reader.ts";
@@ -23,6 +27,36 @@ const bind = process.env.COC_NODE_BIND || config.nodeBind || "127.0.0.1";
 const port = Number(process.env.COC_NODE_PORT || config.nodePort || 18780);
 const storageDir = resolveStorageDir(config.dataDir, config.storageDir);
 const poseWitnessAuthToken = resolvePoseWitnessAuthToken(process.env.COC_POSE_WITNESS_AUTH_TOKEN, config.poseWitnessAuthToken);
+
+// #750 (#667 F7, audit follow-up 2026-05-26) — runtime auth mode.
+// Reads X-Forwarded-For only when the immediate peer is in the
+// trusted-proxy allowlist so an external caller can't spoof loopback
+// by injecting the header themselves. Asserts the mode at startup so
+// a misconfigured deployment (non-loopback bind without a token AND
+// without a trusted proxy) refuses to start instead of silently
+// accepting every external request as loopback after the reverse proxy.
+const poseWitnessTrustedProxies = (process.env.COC_POSE_WITNESS_TRUSTED_PROXIES ?? "")
+  .split(",")
+  .map(s => s.trim())
+  .filter(Boolean);
+const poseWitnessAllowInsecure = (() => {
+  const raw = process.env.COC_POSE_WITNESS_ALLOW_INSECURE?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+})();
+assertPoseWitnessAuthConfigured(
+  { authToken: poseWitnessAuthToken, trustedProxies: poseWitnessTrustedProxies },
+  { bindHost: bind, allowInsecure: poseWitnessAllowInsecure },
+);
+const poseWitnessAuth = createPoseWitnessAuth(
+  { authToken: poseWitnessAuthToken, trustedProxies: poseWitnessTrustedProxies },
+  { bindHost: bind },
+);
+log.info("pose-witness auth configured", {
+  mode: poseWitnessAuth.mode(),
+  bind,
+  trustedProxies: poseWitnessTrustedProxies.length,
+  allowInsecure: poseWitnessAllowInsecure,
+});
 
 // Phase C2.1: when FF is on, the receipt handler reads real chunk bytes
 // from the IPFS blockstore rooted at `storageDir` (same path the main
@@ -435,7 +469,7 @@ const server = http.createServer((req, res) => {
     if (!nodeSignerV2) {
       return json(res, 501, { error: "v2 protocol not enabled" });
     }
-    if (!isPoseWitnessRequestAuthorized(req, poseWitnessAuthToken)) {
+    if (!poseWitnessAuth.isAuthorized(req)) {
       return json(res, 401, { error: "unauthorized witness request" });
     }
     // #292: body bounded via readBody (1 MB cap). Same DoS class as

--- a/runtime/lib/pose-witness-auth.test.ts
+++ b/runtime/lib/pose-witness-auth.test.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  assertPoseWitnessAuthConfigured,
   buildWitnessAuthHeaders,
+  createPoseWitnessAuth,
   isPoseWitnessRequestAuthorized,
   resolvePoseWitnessAuthToken,
 } from "./pose-witness-auth.ts";
@@ -9,6 +11,13 @@ import {
 function request(remoteAddress: string, authorization?: string | string[]) {
   return {
     headers: authorization === undefined ? {} : { authorization },
+    socket: { remoteAddress },
+  };
+}
+
+function requestWithHeaders(remoteAddress: string, headers: Record<string, string | string[] | undefined>) {
+  return {
+    headers,
     socket: { remoteAddress },
   };
 }
@@ -48,4 +57,133 @@ test("#667: witness auth header helper omits empty tokens", () => {
   assert.deepEqual(buildWitnessAuthHeaders(" secret "), { Authorization: "Bearer secret" });
   assert.equal(buildWitnessAuthHeaders("   "), undefined);
   assert.equal(buildWitnessAuthHeaders(undefined), undefined);
+});
+
+// ---- #750 (#667 F7) — auth mode + X-Forwarded-For + startup assertion ----
+
+test("#750: token-required mode signals the auth surface accurately", () => {
+  const auth = createPoseWitnessAuth({ authToken: "secret" }, { bindHost: "0.0.0.0" });
+  assert.equal(auth.mode(), "token-required");
+  // Authorized callers — token wins regardless of source.
+  assert.equal(auth.isAuthorized(request("203.0.113.10", "Bearer secret")), true);
+  assert.equal(auth.isAuthorized(request("127.0.0.1", "Bearer secret")), true);
+  assert.equal(auth.isAuthorized(request("203.0.113.10", "Bearer wrong")), false);
+  assert.equal(auth.isAuthorized(request("127.0.0.1")), false); // token-required: no token → reject
+});
+
+test("#750: loopback-only mode (loopback bind, no token) accepts loopback peers only", () => {
+  const auth = createPoseWitnessAuth({}, { bindHost: "127.0.0.1" });
+  assert.equal(auth.mode(), "loopback-only");
+  assert.equal(auth.isAuthorized(request("127.0.0.1")), true);
+  assert.equal(auth.isAuthorized(request("::1")), true);
+  assert.equal(auth.isAuthorized(request("203.0.113.10")), false);
+});
+
+test("#750: misconfigured mode (non-loopback bind, no token, no trusted proxy) rejects everything", () => {
+  const auth = createPoseWitnessAuth({}, { bindHost: "0.0.0.0" });
+  assert.equal(auth.mode(), "misconfigured");
+  assert.equal(auth.isAuthorized(request("127.0.0.1")), false);
+  assert.equal(auth.isAuthorized(request("203.0.113.10")), false);
+  assert.equal(auth.isAuthorized(request("203.0.113.10", "Bearer anything")), false);
+});
+
+test("#750: assertPoseWitnessAuthConfigured throws when misconfigured", () => {
+  assert.throws(
+    () => assertPoseWitnessAuthConfigured({}, { bindHost: "0.0.0.0" }),
+    /misconfigured/,
+  );
+});
+
+test("#750: assertPoseWitnessAuthConfigured passes when token configured", () => {
+  assert.doesNotThrow(() =>
+    assertPoseWitnessAuthConfigured({ authToken: "x" }, { bindHost: "0.0.0.0" }),
+  );
+});
+
+test("#750: assertPoseWitnessAuthConfigured passes when trusted proxies configured", () => {
+  assert.doesNotThrow(() =>
+    assertPoseWitnessAuthConfigured({ trustedProxies: ["10.0.0.1"] }, { bindHost: "0.0.0.0" }),
+  );
+});
+
+test("#750: ALLOW_INSECURE override bypasses startup assertion", () => {
+  assert.doesNotThrow(() =>
+    assertPoseWitnessAuthConfigured({}, { bindHost: "0.0.0.0", allowInsecure: true }),
+  );
+});
+
+test("#750: trusted-proxy mode reads X-Forwarded-For only from allowlisted peers", () => {
+  const auth = createPoseWitnessAuth(
+    { trustedProxies: ["10.0.0.1"] },
+    { bindHost: "0.0.0.0" },
+  );
+  assert.equal(auth.mode(), "loopback-only-behind-proxy");
+  // From the trusted proxy with a loopback forwarded address → allowed.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("10.0.0.1", { "x-forwarded-for": "127.0.0.1" })),
+    true,
+  );
+  // From the trusted proxy with an external forwarded address → rejected.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("10.0.0.1", { "x-forwarded-for": "8.8.8.8" })),
+    false,
+  );
+});
+
+test("#750: untrusted peer cannot spoof loopback via X-Forwarded-For", () => {
+  // The critical regression test: pre-#750 (with no token), an attacker
+  // could hit a node behind a misconfigured reverse proxy from the
+  // public internet — the socket peer would be 127.0.0.1 (the proxy
+  // upstream) and the request would be signed. With #750 we never
+  // honour X-Forwarded-For unless the immediate peer is in the trusted
+  // proxy allowlist, so an attacker's injected `X-Forwarded-For: 127.0.0.1`
+  // is ignored.
+  const auth = createPoseWitnessAuth(
+    { trustedProxies: ["10.0.0.1"] }, // only 10.0.0.1 is trusted
+    { bindHost: "0.0.0.0" },
+  );
+  // Attacker from 1.2.3.4 tries to claim loopback origin.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("1.2.3.4", { "x-forwarded-for": "127.0.0.1" })),
+    false,
+  );
+});
+
+test("#750: leftmost X-Forwarded-For wins (RFC 7239) — multi-hop attacker can't piggyback", () => {
+  const auth = createPoseWitnessAuth(
+    { trustedProxies: ["10.0.0.1"] },
+    { bindHost: "0.0.0.0" },
+  );
+  // Legitimate loopback origin then proxy hop → loopback.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("10.0.0.1", { "x-forwarded-for": "127.0.0.1, 10.0.0.2" })),
+    true,
+  );
+  // External origin, attacker tries to append a loopback hop downstream
+  // — the leftmost (8.8.8.8) is still external → rejected.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("10.0.0.1", { "x-forwarded-for": "8.8.8.8, 127.0.0.1" })),
+    false,
+  );
+});
+
+test("#750: when token is set, trusted-proxy parsing is moot (token check dominates)", () => {
+  const auth = createPoseWitnessAuth(
+    { authToken: "secret", trustedProxies: ["10.0.0.1"] },
+    { bindHost: "0.0.0.0" },
+  );
+  assert.equal(auth.mode(), "token-required");
+  // Wrong token from anywhere → reject (XFF irrelevant).
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("10.0.0.1", {
+      authorization: "Bearer wrong",
+      "x-forwarded-for": "127.0.0.1",
+    })),
+    false,
+  );
+  // Right token from anywhere → accept.
+  assert.equal(
+    auth.isAuthorized(requestWithHeaders("203.0.113.10", { authorization: "Bearer secret" })),
+    true,
+  );
 });

--- a/runtime/lib/pose-witness-auth.ts
+++ b/runtime/lib/pose-witness-auth.ts
@@ -7,6 +7,47 @@ export interface PoseWitnessAuthRequest {
   };
 }
 
+/**
+ * #750 (#667 F7, audit follow-up 2026-05-26) — runtime auth mode for
+ * `/pose/witness`. Surfaced via {@link describePoseWitnessAuthMode} so
+ * operators can grep logs / hit /health to detect misconfiguration
+ * (e.g. token env var dropped on container relaunch, silently degrading
+ * to loopback-only behind a reverse proxy that turns the bind address
+ * into 127.0.0.1).
+ *
+ *  - "token-required": auth token configured; only Bearer-matching
+ *    requests are signed.
+ *  - "loopback-only": no token; only loopback-source requests are
+ *    signed (the original default).
+ *  - "loopback-only-behind-proxy": no token, but a trusted-proxy
+ *    allowlist is configured; loopback is judged from the leftmost
+ *    forwarded address rather than the immediate socket peer.
+ *  - "misconfigured": non-loopback bind without a token AND without a
+ *    trusted-proxy allowlist. Refuse to start the server in this mode.
+ */
+export type PoseWitnessAuthMode =
+  | "token-required"
+  | "loopback-only"
+  | "loopback-only-behind-proxy"
+  | "misconfigured";
+
+export interface PoseWitnessAuthOptions {
+  /** Bearer token. If set, this is the only accepted credential. */
+  authToken?: string;
+  /**
+   * Trusted-proxy allowlist for X-Forwarded-For parsing. ONLY consult
+   * X-Forwarded-For when the immediate socket peer is in this set —
+   * otherwise any external caller could inject a 127.0.0.1 header and
+   * be treated as loopback. Default empty (header ignored).
+   */
+  trustedProxies?: string[];
+}
+
+export interface PoseWitnessAuthRuntime {
+  isAuthorized(req: PoseWitnessAuthRequest): boolean;
+  mode(): PoseWitnessAuthMode;
+}
+
 export function resolvePoseWitnessAuthToken(...values: Array<string | undefined>): string | undefined {
   for (const value of values) {
     const trimmed = value?.trim();
@@ -15,6 +56,83 @@ export function resolvePoseWitnessAuthToken(...values: Array<string | undefined>
   return undefined;
 }
 
+/**
+ * Build a runtime that closes over the auth options. Prefer this in new
+ * call sites — the legacy {@link isPoseWitnessRequestAuthorized} is kept
+ * for backwards-compat with tests / callers that haven't migrated.
+ */
+export function createPoseWitnessAuth(
+  opts: PoseWitnessAuthOptions,
+  ctx: { bindHost: string } = { bindHost: "127.0.0.1" },
+): PoseWitnessAuthRuntime {
+  const trustedProxies = new Set((opts.trustedProxies ?? []).map(s => s.trim()).filter(Boolean));
+  const hasToken = !!opts.authToken;
+  const bindIsLoopback = isLoopbackAddress(ctx.bindHost);
+
+  let resolved: PoseWitnessAuthMode;
+  if (hasToken) {
+    resolved = "token-required";
+  } else if (bindIsLoopback) {
+    resolved = "loopback-only";
+  } else if (trustedProxies.size > 0) {
+    resolved = "loopback-only-behind-proxy";
+  } else {
+    resolved = "misconfigured";
+  }
+
+  return {
+    mode() {
+      return resolved;
+    },
+    isAuthorized(req: PoseWitnessAuthRequest): boolean {
+      if (resolved === "misconfigured") return false;
+      if (hasToken) {
+        const bearer = readBearerToken(req.headers);
+        return !!bearer && constantTimeEqual(bearer, opts.authToken!);
+      }
+      const peerIp = stripIp6Map(req.socket.remoteAddress ?? "");
+      // Behind a trusted proxy, the socket peer is the proxy itself.
+      // The "real" client is in X-Forwarded-For. Only honour it when the
+      // immediate peer is in the allowlist — otherwise the header is a
+      // free spoof.
+      if (trustedProxies.has(peerIp)) {
+        const xff = forwardedFor(req.headers);
+        return xff !== null && isLoopbackAddress(xff);
+      }
+      return isLoopbackAddress(peerIp);
+    },
+  };
+}
+
+/**
+ * Hard-fail when the witness server is bound to a non-loopback address
+ * without a token AND without a trusted-proxy allowlist. The pre-#750
+ * default would have started in "loopback-only" mode behind a reverse
+ * proxy and silently accepted every external request as loopback (the
+ * socket peer is always 127.0.0.1 after TLS termination by the proxy).
+ *
+ * Operators that genuinely want token-less open access must set
+ * `COC_POSE_WITNESS_ALLOW_INSECURE=1` (acknowledged misconfiguration).
+ */
+export function assertPoseWitnessAuthConfigured(
+  opts: PoseWitnessAuthOptions,
+  ctx: { bindHost: string; allowInsecure?: boolean },
+): void {
+  const runtime = createPoseWitnessAuth(opts, { bindHost: ctx.bindHost });
+  if (runtime.mode() === "misconfigured" && !ctx.allowInsecure) {
+    throw new Error(
+      "pose-witness auth misconfigured: non-loopback bind requires either " +
+      "COC_POSE_WITNESS_AUTH_TOKEN or a non-empty COC_POSE_WITNESS_TRUSTED_PROXIES " +
+      "(set COC_POSE_WITNESS_ALLOW_INSECURE=1 to override — not recommended)"
+    );
+  }
+}
+
+/**
+ * @deprecated #750 — prefer {@link createPoseWitnessAuth}. Kept so
+ * callers that haven't migrated continue to work; the new code path in
+ * coc-node.ts is on the runtime form.
+ */
 export function isPoseWitnessRequestAuthorized(
   req: PoseWitnessAuthRequest,
   authToken: string | undefined,
@@ -44,6 +162,24 @@ function readBearerToken(headers: Record<string, string | string[] | undefined>)
   return token || null;
 }
 
+function forwardedFor(headers: Record<string, string | string[] | undefined>): string | null {
+  const raw = headers["x-forwarded-for"];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string") return null;
+  // Leftmost address in the chain is the original client (per RFC 7239).
+  // Subsequent addresses are upstream proxies. We use leftmost so a
+  // legitimate loopback-then-proxy chain (`127.0.0.1, 10.0.0.1`) reads
+  // as loopback, but reject `8.8.8.8, 127.0.0.1` (attacker-from-outside
+  // injects an upstream loopback claim).
+  const first = value.split(",")[0]?.trim();
+  return first && first.length > 0 ? stripIp6Map(first) : null;
+}
+
+function stripIp6Map(ip: string): string {
+  if (!ip) return "";
+  return ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+}
+
 function constantTimeEqual(a: string, b: string): boolean {
   const bufA = Buffer.from(a, "utf8");
   const bufB = Buffer.from(b, "utf8");
@@ -59,6 +195,7 @@ function isLoopbackAddress(ip: string): boolean {
   if (!ip || ip === "unknown") return false;
   const stripped = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
   if (stripped === "::1" || stripped === "0:0:0:0:0:0:0:1") return true;
+  if (stripped === "localhost") return true;
   if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(stripped)) {
     const parts = stripped.split(".").map(Number);
     return parts.every((part) => part >= 0 && part <= 255);

--- a/tests/integration/governance-dao-lifecycle.integration.test.ts
+++ b/tests/integration/governance-dao-lifecycle.integration.test.ts
@@ -219,6 +219,13 @@ test("R2.2 governance DAO lifecycle: propose → vote → queue → execute end-
     assert.equal(await fr.humanCount(), 4n)
     assert.equal(await fr.clawCount(), 0n)
 
+    // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+    // Grandfather all 4 voters via the deployer/owner.
+    await (await fr.connect(deployerWallet).verify(deployerWallet.address, txOpts()) as any).wait()
+    for (const w of humanWallets) {
+      await (await fr.connect(deployerWallet).verify(w.address, txOpts()) as any).wait()
+    }
+
     // ── Step 5: Submit a FreeText proposal ─────────────────────────────
     // FreeText (type=5) has no execution side effect — verifies the
     // lifecycle (propose → vote → queue → execute state transitions)

--- a/tests/integration/governance-treasury-spend.integration.test.ts
+++ b/tests/integration/governance-treasury-spend.integration.test.ts
@@ -299,6 +299,9 @@ test("Treasury: 3-of-5 multisig + 5% spend cap (within-cap ok, over-cap needs go
 
       // ── 1d. DAO grants governanceApprove via a real execute() proposal ──
       await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+      // deployer is FactionRegistry owner+verifier in this stack — grandfather it.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
       const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
       const approveData = treasuryIface.encodeFunctionData("governanceApprove", [wId1])
       await (await (dao.connect(deployer).createProposal(
@@ -373,6 +376,12 @@ test("GovernanceDAO bicameral: passes only when BOTH HUMAN and CLAW chambers app
       }
       assert.equal(await fr.humanCount(), 3n, "3 HUMAN registered")
       assert.equal(await fr.clawCount(), 2n, "2 CLAW registered")
+
+      // #735 (PR #745): verify all 5 voters so onlyRegistered + isVerified passes.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
+      for (const w of [...humans, ...claws]) {
+        await (await (fr.connect(deployer).verify(w.address, txOpts()) as any)).wait()
+      }
 
       const proposalIface = (proposer: Wallet, title: string) =>
         dao.connect(proposer).createProposal(
@@ -452,6 +461,11 @@ test("GovernanceDAO rejection paths: against-majority and sub-quorum proposals c
         await (await (fr.connect(w).registerHuman({ nonce: 0 }) as any)).wait()
       }
       assert.equal(await fr.humanCount(), 5n, "5 HUMAN registered")
+      // #735 (PR #745): verify all 5 voters so onlyRegistered + isVerified passes.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
+      for (const w of voters) {
+        await (await (fr.connect(deployer).verify(w.address, txOpts()) as any)).wait()
+      }
 
       const mkProposal = (title: string) =>
         dao.connect(deployer).createProposal(
@@ -534,6 +548,8 @@ test("GovernanceDAO parameter-change: execute() runs executionData and mutates t
 
       // ── Governance proposal that calls Treasury.governanceApprove(wId) ──
       await (await (fr.connect(deployer).registerHuman(txOpts()) as any)).wait()
+      // #735 (PR #745): onlyRegistered now also requires `isVerified`.
+      await (await (fr.connect(deployer).verify(deployer.address, txOpts()) as any)).wait()
       const treasuryIface = new Interface(loadArtifact("Treasury").abi as any)
       const execData = treasuryIface.encodeFunctionData("governanceApprove", [wId])
 


### PR DESCRIPTION
## Summary

Closes #750 (#667 F7). The pre-fix \`/pose/witness\` auth fallback was \`isLoopbackAddress(req.socket.remoteAddress ?? \"\")\`. Behind a reverse proxy (Caddy / nginx / Cloudflare tunnel) the immediate socket peer is always \`127.0.0.1\` after TLS termination, so **every external request silently passed the loopback check**. If \`COC_POSE_WITNESS_AUTH_TOKEN\` was unset (container relaunch, secret rotation, deployment drift), the witness signing oracle became wide-open to the internet without any startup warning.

## Three layers added

| Layer | What it does |
|---|---|
| **Startup assert** \`assertPoseWitnessAuthConfigured\` | Non-loopback bind + no token + no trusted-proxy allowlist → refuse to start with a clear error. Operators acknowledge intentionally-open mode with \`COC_POSE_WITNESS_ALLOW_INSECURE=1\` |
| **Mode-aware runtime** \`createPoseWitnessAuth\` | Exposes resolved mode (\`token-required\` / \`loopback-only\` / \`loopback-only-behind-proxy\` / \`misconfigured\`) — logged at startup, greppable, available for future /health surface |
| **Trusted-proxy XFF parsing** | \`X-Forwarded-For\` honoured **only** when the immediate socket peer is in the operator-configured allowlist. Leftmost-wins (RFC 7239) so external clients can't piggyback loopback hops |

## New env vars

| Env | Default | Meaning |
|---|---|---|
| \`COC_POSE_WITNESS_TRUSTED_PROXIES\` | empty | Comma-separated upstream reverse-proxy IPs that may carry an XFF header |
| \`COC_POSE_WITNESS_ALLOW_INSECURE\` | \`false\` | \`1\` / \`true\` / \`yes\` skips startup assertion for genuinely open deployments |

Legacy \`isPoseWitnessRequestAuthorized\` retained (deprecated) so out-of-tree callers keep working. New \`coc-node.ts\` call site uses the runtime form.

## Critical regression covered

A test \`#750: untrusted peer cannot spoof loopback via X-Forwarded-For\` codifies the original attack: a request from \`1.2.3.4\` with \`X-Forwarded-For: 127.0.0.1\` and \`1.2.3.4\` **not** in the trusted proxy allowlist must be rejected. Plus a multi-hop test \`#750: leftmost X-Forwarded-For wins\` for the case where an attacker hopes \`8.8.8.8, 127.0.0.1\` will read as loopback.

## Test plan

- [x] \`pose-witness-auth.test.ts\` — 17/17 pass (6 pre-existing + 11 new)
- [x] Full runtime layer — 225/225 pass (was 214/214 pre-fix — +11 from this PR)
- [ ] Maintainer rolling deploy to validator fleet; default mode unchanged so no behaviour-break

## Deployment

Default behaviour is preserved: \`token-required\` when token is set, \`loopback-only\` when bind is loopback. The new \`misconfigured\` startup-throw only fires for deployments that today are silently insecure. Operators who recognize their deployment in that bucket can set \`COC_POSE_WITNESS_ALLOW_INSECURE=1\` while they configure either a token or a trusted-proxy list.

Refs:
- Fixes #750 (#667 F7)
- Parent #667 closed cryptographic rubber-stamp in PR #751