### PR TITLE
fix(security): validate /pose/challenge v2 challengerSig + derived challengeId (#747)

### DIFF
--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "./lib/config.ts";
 import { InMemoryStore } from "./lib/state.ts";
 import { recordChallengeBounded } from "./lib/bounded-challenge-store.ts";
 import { validatePoseWitnessPayload } from "./lib/pose-witness-validator.ts";
+import { validatePoseChallengePayload } from "./lib/pose-challenge-validator.ts";
 import { verifyPushedReceipt } from "./lib/pose-witness-verifier.ts";
 import { ContractReader } from "./lib/contract-reader.ts";
 import {
@@ -57,6 +58,26 @@ log.info("pose-witness auth configured", {
   trustedProxies: poseWitnessTrustedProxies.length,
   allowInsecure: poseWitnessAllowInsecure,
 });
+
+// #747 (#667 F4, audit follow-up 2026-05-26) — strict-verified-challenge mode.
+// When enabled, /pose/challenge rejects v1-shape payloads (no challengerSig,
+// no derived challengeId). Default false to preserve in-flight callers
+// during rollout. Once all challengers ship v2 payloads, operators flip
+// this on to lock down the challenge submission path.
+const poseRequireVerifiedChallenge = (() => {
+  const raw = process.env.COC_POSE_REQUIRE_VERIFIED_CHALLENGE?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+})();
+const poseChallengeIssuedAtDriftMs = (() => {
+  const raw = process.env.COC_POSE_CHALLENGE_DRIFT_MS?.trim();
+  if (!raw) return 5 * 60_000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    log.warn("invalid COC_POSE_CHALLENGE_DRIFT_MS — falling back to 5m", { raw });
+    return 5 * 60_000;
+  }
+  return parsed;
+})();
 
 // Phase C2.1: when FF is on, the receipt handler reads real chunk bytes
 // from the IPFS blockstore rooted at `storageDir` (same path the main
@@ -272,29 +293,37 @@ const server = http.createServer((req, res) => {
       // the async callback and bubbled to process.on("uncaughtException"),
       // either crashing coc-node or leaking the V8 SyntaxError wording.
       // Unauthenticated DoS / destabilisation vector.
-      let payload: { challengeId?: string };
+      let payload: Record<string, unknown>;
       try {
-        payload = JSON.parse(body || "{}");
+        payload = JSON.parse(body || "{}") as Record<string, unknown>;
       } catch {
         return json(res, 400, { error: "invalid JSON body" });
       }
-      // #320: tighten challengeId shape — pre-fix the falsy check accepted
-      // objects, arrays, numbers as keys via `challenges.set(key, ...)`,
-      // and Map.set treats {} / [] as fresh references, so even a fixed
-      // JSON like {"challengeId":{}} produced a brand-new Map entry on
-      // every request. Require a non-empty string so each entry is
-      // addressable from /pose/receipt by hex/uuid.
-      if (typeof payload.challengeId !== "string" || payload.challengeId.length === 0) {
-        return json(res, 400, { error: "missing or invalid challengeId (must be non-empty string)" });
+      // #747 (#667 F4) — validate the challenge. v2 shape gets the full
+      // deterministic-derivation + EIP-712 signature check; v1 shape
+      // falls through to the legacy non-empty-string check (preserves
+      // the #320 hardening) unless the operator has flipped
+      // `requireVerified` on. Either way the challenges Map key remains
+      // the canonical (lowercased) challengeId so /pose/receipt /
+      // /pose/witness lookups stay consistent.
+      const validated = validatePoseChallengePayload(payload, {
+        chainId: BigInt(chainId),
+        verifyingContract,
+        requireVerified: poseRequireVerifiedChallenge,
+        maxIssuedAtDriftMs: poseChallengeIssuedAtDriftMs,
+      });
+      if (!validated.ok) {
+        return json(res, validated.status, { error: validated.error });
       }
-      // Cap the challenge ID length so an attacker cannot amplify the
-      // payload by spamming many giant strings — even with the FIFO cap
-      // below, each entry holds the full string as a Map key.
-      if (payload.challengeId.length > 256) {
-        return json(res, 400, { error: "challengeId too long (max 256 chars)" });
+      if (validated.challenge.version === 1) {
+        // Legacy length cap retained for v1 (raw string keys could be
+        // up to 256 chars — sized for hex/uuid).
+        if (validated.challenge.challengeId.length > 256) {
+          return json(res, 400, { error: "challengeId too long (max 256 chars)" });
+        }
       }
-      recordChallengeBounded(challenges, payload.challengeId, payload);
-      return json(res, 200, { accepted: true });
+      recordChallengeBounded(challenges, validated.challenge.challengeId, payload);
+      return json(res, 200, { accepted: true, version: validated.challenge.version });
     });
     return;
   }

--- a/runtime/lib/pose-challenge-validator.test.ts
+++ b/runtime/lib/pose-challenge-validator.test.ts
@@ -1,0 +1,260 @@
+/**
+ * pose-challenge-validator.test.ts — #747 (#667 F4, audit follow-up 2026-05-26).
+ *
+ * Covers:
+ *  - v1-shape passthrough in lenient mode (backwards-compat)
+ *  - v1 rejected in `requireVerified` mode
+ *  - v2 happy path: deterministic challengeId + EIP-712 sig accepted
+ *  - tampered challengeId rejected (caller substitutes a different value)
+ *  - tampered querySpec rejected (hash mismatch)
+ *  - tampered challengerSig rejected (recover mismatch)
+ *  - issuedAtMs drift window
+ *  - schema validation (deterministic 400s, no echo)
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Wallet } from "ethers";
+
+import { validatePoseChallengePayload } from "./pose-challenge-validator.ts";
+import { CHALLENGE_TYPES, buildDomain, toEthersDomain } from "../../node/src/crypto/eip712-types.ts";
+import { keccak256Hex } from "../../services/relayer/keccak256.ts";
+import { stableStringify, u64Bytes, hex32Bytes, hexSizedBytes } from "../../services/common/encoding.ts";
+
+const CHAIN_ID = 88780n;
+const VERIFYING_CONTRACT = "0x256eb949c50d5f2af8699191b1bc043203263549";
+
+async function buildSignedChallenge(opts?: {
+  privateKey?: string;
+  issuedAtMs?: number;
+}) {
+  const wallet = new Wallet(opts?.privateKey ?? "0x" + "1".repeat(64));
+  const challengerAddr = wallet.address.toLowerCase();
+  const challengerId = `0x${"00".repeat(12)}${challengerAddr.slice(2)}`;
+  const nodeId = "0x" + "ab".repeat(32);
+  const nonce = "0x" + "cd".repeat(16);
+  const epochId = 100n;
+  const challengeNonce = 42n;
+  const issuedAtMs = BigInt(opts?.issuedAtMs ?? Date.now());
+  const deadlineMs = 6000n;
+  const typeCode = "U";
+  const querySpec = { kind: "uptime", blockNumber: 1234 };
+  const querySpecHash = `0x${keccak256Hex(Buffer.from(stableStringify(querySpec), "utf8"))}`;
+
+  const digest = Buffer.concat([
+    u64Bytes(epochId),
+    hex32Bytes(nodeId as `0x${string}`),
+    Buffer.from(typeCode, "utf8"),
+    hexSizedBytes(nonce as `0x${string}`, 16),
+    hex32Bytes(challengerId as `0x${string}`),
+    u64Bytes(challengeNonce),
+  ]);
+  const challengeId = `0x${keccak256Hex(digest)}`;
+
+  const challengeData = {
+    challengeId,
+    epochId,
+    nodeId,
+    challengeType: 0, // U
+    nonce,
+    challengeNonce,
+    querySpecHash,
+    issuedAtMs,
+    deadlineMs,
+    challengerId,
+  };
+  const domain = toEthersDomain(buildDomain(CHAIN_ID, VERIFYING_CONTRACT));
+  const challengerSig = await wallet.signTypedData(domain, CHALLENGE_TYPES, challengeData);
+
+  return {
+    version: 2 as const,
+    challengeId,
+    epochId: epochId.toString(),
+    nodeId,
+    challengeType: typeCode,
+    nonce,
+    challengeNonce: challengeNonce.toString(),
+    querySpec,
+    querySpecHash,
+    issuedAtMs: issuedAtMs.toString(),
+    deadlineMs: deadlineMs.toString(),
+    challengerId,
+    challengerSig,
+    _challengerAddress: challengerAddr,
+  };
+}
+
+test("#747: v1 payload (no challengerSig) accepted in lenient mode", () => {
+  const r = validatePoseChallengePayload(
+    { challengeId: "abc-123", challengeType: "U", nodeId: "0x0" },
+    { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+  );
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.challenge.version, 1);
+    assert.equal(r.challenge.challengeId, "abc-123");
+  }
+});
+
+test("#747: v1 payload rejected in requireVerified mode", () => {
+  const r = validatePoseChallengePayload(
+    { challengeId: "abc-123" },
+    { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT, requireVerified: true },
+  );
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 400);
+    assert.match(r.error, /verified v2 challenge required/);
+  }
+});
+
+test("#747: v2 happy path — derived challengeId + valid sig accepted", async () => {
+  const c = await buildSignedChallenge({});
+  const r = validatePoseChallengePayload(c, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+  });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.challenge.version, 2);
+    assert.equal(r.challenge.challengerAddress, c._challengerAddress);
+  }
+});
+
+test("#747: tampered challengeId rejected (deterministic derivation mismatch)", async () => {
+  const c = await buildSignedChallenge({});
+  const tampered = { ...c, challengeId: "0x" + "ff".repeat(32) };
+  const r = validatePoseChallengePayload(tampered, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /does not match deterministic derivation/);
+});
+
+test("#747: tampered querySpec (hash mismatch) rejected", async () => {
+  const c = await buildSignedChallenge({});
+  const tampered = { ...c, querySpec: { kind: "uptime", blockNumber: 9999 } };
+  const r = validatePoseChallengePayload(tampered, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /querySpec does not hash to querySpecHash/);
+});
+
+test("#747: tampered challengerSig rejected (recover mismatch)", async () => {
+  const c = await buildSignedChallenge({});
+  const otherWallet = new Wallet("0x" + "00".repeat(31) + "ab");
+  // Sign with the wrong key but claim the original challengerId.
+  const domain = toEthersDomain(buildDomain(CHAIN_ID, VERIFYING_CONTRACT));
+  const challengeData = {
+    challengeId: c.challengeId,
+    epochId: BigInt(c.epochId),
+    nodeId: c.nodeId,
+    challengeType: 0,
+    nonce: c.nonce,
+    challengeNonce: BigInt(c.challengeNonce),
+    querySpecHash: c.querySpecHash,
+    issuedAtMs: BigInt(c.issuedAtMs),
+    deadlineMs: BigInt(c.deadlineMs),
+    challengerId: c.challengerId,
+  };
+  const wrongSig = await otherWallet.signTypedData(domain, CHALLENGE_TYPES, challengeData);
+  const tampered = { ...c, challengerSig: wrongSig };
+  const r = validatePoseChallengePayload(tampered, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /does not recover to challengerId/);
+});
+
+test("#747: malformed challengerSig returns 400 without ethers leak", async () => {
+  const c = await buildSignedChallenge({});
+  const r = validatePoseChallengePayload(
+    { ...c, challengerSig: "0x" + "00".repeat(65) },
+    { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+  );
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.match(r.error, /malformed or does not recover/);
+    assert.doesNotMatch(r.error, /TypeError|stack/);
+  }
+});
+
+test("#747: issuedAtMs out of drift window rejected", async () => {
+  const now = 1_700_000_000_000;
+  const c = await buildSignedChallenge({ issuedAtMs: now - 10 * 60_000 }); // 10 minutes ago
+  const r = validatePoseChallengePayload(c, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+    maxIssuedAtDriftMs: 60_000,
+    nowMs: () => now,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /drift/);
+});
+
+test("#747: issuedAtMs at drift boundary accepted", async () => {
+  const now = 1_700_000_000_000;
+  const c = await buildSignedChallenge({ issuedAtMs: now - 60_000 });
+  const r = validatePoseChallengePayload(c, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+    maxIssuedAtDriftMs: 60_000,
+    nowMs: () => now,
+  });
+  assert.equal(r.ok, true);
+});
+
+test("#747: malformed v2 shape (missing fields) returns deterministic 400", () => {
+  // Has version:2 but missing required v2 fields.
+  const r = validatePoseChallengePayload(
+    { version: 2, challengeId: "abc" },
+    { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+  );
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 400);
+    // The error must be schema-class, not echo the bogus "abc".
+    assert.doesNotMatch(r.error, /abc/);
+  }
+});
+
+test("#747: pre-mined attack reproduction — caller cannot swap nodeId under same sig", async () => {
+  // Attacker generates a valid signed challenge for target node A, then
+  // tries to submit it claiming target node B. Since nodeId is in the
+  // signed digest, ecrecover succeeds against the WRONG challengerId-
+  // claimed value but the derived challengeId no longer matches — the
+  // first guard fires.
+  const c = await buildSignedChallenge({});
+  const tampered = { ...c, nodeId: "0x" + "99".repeat(32) };
+  const r = validatePoseChallengePayload(tampered, {
+    chainId: CHAIN_ID,
+    verifyingContract: VERIFYING_CONTRACT,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /does not match deterministic derivation/);
+});
+
+test("#747: invalid epochId / challengeNonce shapes rejected", async () => {
+  const c = await buildSignedChallenge({});
+  for (const bad of ["abc", -1, 1.5, {}, null]) {
+    const r = validatePoseChallengePayload(
+      { ...c, epochId: bad as any },
+      { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+    );
+    assert.equal(r.ok, false, `epochId=${JSON.stringify(bad)} must reject`);
+  }
+});
+
+test("#747: invalid challengeType normalisation rejected", async () => {
+  const c = await buildSignedChallenge({});
+  const r = validatePoseChallengePayload(
+    { ...c, challengeType: "Garbage" },
+    { chainId: CHAIN_ID, verifyingContract: VERIFYING_CONTRACT },
+  );
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.error, /U\/S\/R/);
+});

--- a/runtime/lib/pose-challenge-validator.ts
+++ b/runtime/lib/pose-challenge-validator.ts
@@ -1,0 +1,242 @@
+/**
+ * pose-challenge-validator.ts — #747 (#667 F4, audit follow-up 2026-05-26).
+ *
+ * Pre-fix `runtime/coc-node.ts:/pose/challenge` accepted an arbitrary
+ * caller-supplied `challengeId` string. Combined with the witness path
+ * never verifying the challenger's identity (#667 main issue), this
+ * gave the challenger a free degree of freedom: pre-mine a pool of
+ * challengeIds, rotate them through witness collection to maximise
+ * `(challengeId, responseBodyHash)` collision opportunities for v1
+ * fallback replay (#748).
+ *
+ * This module validates a v2-shape challenge payload by recomputing the
+ * deterministic challengeId digest the same way services/challenger/
+ * challenge-factory-v2.ts produces it, then verifying the EIP-712
+ * CHALLENGE_TYPES signature recovers to `challengerId` derived as the
+ * trailing 20 bytes of the bytes32 challenger identifier.
+ *
+ * Legacy v1 payloads (no `version: 2` field, no challengerSig) are
+ * accepted in lenient mode so existing in-flight callers keep working
+ * during the rollout; the gate is `COC_POSE_REQUIRE_VERIFIED_CHALLENGE=1`.
+ *
+ * Rejections all return deterministic error messages — never echo
+ * client input (#322 class).
+ */
+
+import { verifyTypedData } from "ethers";
+import { CHALLENGE_TYPES, buildDomain, toEthersDomain } from "../../node/src/crypto/eip712-types.ts";
+import { keccak256Hex } from "../../services/relayer/keccak256.ts";
+import { stableStringify, u64Bytes, hex32Bytes, hexSizedBytes } from "../../services/common/encoding.ts";
+import { ChallengeType } from "../../services/common/pose-types.ts";
+
+const HEX32_RE = /^0[xX][0-9a-fA-F]{64}$/;
+const HEX16_RE = /^0[xX][0-9a-fA-F]{32}$/;
+const SIG_HEX_RE = /^0[xX][0-9a-fA-F]{130}$/;
+const MAX_UINT64 = (1n << 64n) - 1n;
+
+const TYPE_TO_CODE: Record<string, "U" | "S" | "R"> = {
+  U: "U",
+  S: "S",
+  R: "R",
+  Uptime: "U",
+  Storage: "S",
+  Relay: "R",
+  "0": "U",
+  "1": "S",
+  "2": "R",
+};
+
+const TYPE_TO_INT: Record<"U" | "S" | "R", number> = { U: 0, S: 1, R: 2 };
+
+export interface ValidatedChallenge {
+  version: 1 | 2;
+  challengeId: string;
+  nodeId?: string;
+  challengeType?: "U" | "S" | "R";
+  querySpec?: Record<string, unknown>;
+  challengerId?: string;
+  challengerAddress?: string;
+}
+
+export interface ChallengeValidateOpts {
+  chainId: bigint;
+  verifyingContract: string;
+  /** When true, v1-shape (no challengerSig) payloads are rejected. */
+  requireVerified?: boolean;
+  /** Maximum age tolerated for `issuedAtMs` drift. Default 5 minutes. */
+  maxIssuedAtDriftMs?: number;
+  /** For deterministic tests. */
+  nowMs?: () => number;
+}
+
+export type ChallengeValidateResult =
+  | { ok: true; challenge: ValidatedChallenge }
+  | { ok: false; status: number; error: string };
+
+export function validatePoseChallengePayload(
+  payload: unknown,
+  opts: ChallengeValidateOpts,
+): ChallengeValidateResult {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { ok: false, status: 400, error: "invalid JSON body" };
+  }
+  const p = payload as Record<string, unknown>;
+
+  const hasV2Shape = p.version === 2 || typeof p.challengerSig === "string";
+
+  // ── Legacy v1 payload ────────────────────────────────────────────
+  if (!hasV2Shape) {
+    if (opts.requireVerified) {
+      return {
+        ok: false,
+        status: 400,
+        error: "verified v2 challenge required (set version:2 + challengerSig + querySpecHash)",
+      };
+    }
+    if (typeof p.challengeId !== "string" || p.challengeId.length === 0 || p.challengeId.length > 256) {
+      return { ok: false, status: 400, error: "missing or invalid challengeId" };
+    }
+    return { ok: true, challenge: { version: 1, challengeId: p.challengeId } };
+  }
+
+  // ── v2 — full verification ───────────────────────────────────────
+  if (typeof p.challengeId !== "string" || !HEX32_RE.test(p.challengeId)) {
+    return { ok: false, status: 400, error: "challengeId must match 0x-prefixed 32-byte hex" };
+  }
+  if (typeof p.nodeId !== "string" || !HEX32_RE.test(p.nodeId)) {
+    return { ok: false, status: 400, error: "nodeId must match 0x-prefixed 32-byte hex" };
+  }
+  if (typeof p.nonce !== "string" || !HEX16_RE.test(p.nonce)) {
+    return { ok: false, status: 400, error: "nonce must match 0x-prefixed 16-byte hex" };
+  }
+  if (typeof p.querySpecHash !== "string" || !HEX32_RE.test(p.querySpecHash)) {
+    return { ok: false, status: 400, error: "querySpecHash must match 0x-prefixed 32-byte hex" };
+  }
+  if (typeof p.challengerId !== "string" || !HEX32_RE.test(p.challengerId)) {
+    return { ok: false, status: 400, error: "challengerId must match 0x-prefixed 32-byte hex" };
+  }
+  if (typeof p.challengerSig !== "string" || !SIG_HEX_RE.test(p.challengerSig)) {
+    return { ok: false, status: 400, error: "challengerSig must match 0x-prefixed 65-byte hex" };
+  }
+
+  const epochId = coerceUint64(p.epochId);
+  if (epochId === undefined) return { ok: false, status: 400, error: "epochId must be a non-negative uint64" };
+  const challengeNonce = coerceUint64(p.challengeNonce);
+  if (challengeNonce === undefined) return { ok: false, status: 400, error: "challengeNonce must be a non-negative uint64" };
+  const issuedAtMs = coerceUint64(p.issuedAtMs);
+  if (issuedAtMs === undefined) return { ok: false, status: 400, error: "issuedAtMs must be a non-negative uint64" };
+  const deadlineMs = coerceUint64(p.deadlineMs);
+  if (deadlineMs === undefined) return { ok: false, status: 400, error: "deadlineMs must be a non-negative uint64" };
+
+  // challengeType normalisation: accept "U" / "S" / "R" / int / long name.
+  const rawType = p.challengeType;
+  const typeCode = TYPE_TO_CODE[String(rawType)];
+  if (!typeCode) {
+    return { ok: false, status: 400, error: "challengeType must be one of U/S/R" };
+  }
+
+  // ── Recompute the deterministic challengeId digest (must match
+  //    services/challenger/challenge-factory-v2.ts:48). Mismatch =>
+  //    caller is supplying a stolen / replayed / fabricated triple.
+  const digest = Buffer.concat([
+    u64Bytes(epochId),
+    hex32Bytes(p.nodeId as `0x${string}`),
+    Buffer.from(typeCode, "utf8"),
+    hexSizedBytes(p.nonce as `0x${string}`, 16),
+    hex32Bytes(p.challengerId as `0x${string}`),
+    u64Bytes(challengeNonce),
+  ]);
+  const expectedChallengeId = `0x${keccak256Hex(digest)}`.toLowerCase();
+  if (expectedChallengeId !== (p.challengeId as string).toLowerCase()) {
+    return {
+      ok: false,
+      status: 400,
+      error: "challengeId does not match deterministic derivation",
+    };
+  }
+
+  // ── Freshness: bound the issuedAtMs drift so an old signed
+  //    challenge can't be re-fed years later.
+  const drift = (opts.maxIssuedAtDriftMs ?? 5 * 60_000);
+  const now = (opts.nowMs ?? Date.now)();
+  if (Math.abs(now - Number(issuedAtMs)) > drift) {
+    return {
+      ok: false,
+      status: 400,
+      error: `issuedAtMs out of drift window (drift > ${drift}ms)`,
+    };
+  }
+
+  // ── EIP-712 signature verification against CHALLENGE_TYPES.
+  //    Must match ChallengeFactoryV2.issue() field shape exactly.
+  const domain = toEthersDomain(buildDomain(opts.chainId, opts.verifyingContract));
+  const challengeData = {
+    challengeId: p.challengeId,
+    epochId,
+    nodeId: p.nodeId,
+    challengeType: TYPE_TO_INT[typeCode],
+    nonce: p.nonce,
+    challengeNonce,
+    querySpecHash: p.querySpecHash,
+    issuedAtMs,
+    deadlineMs,
+    challengerId: p.challengerId,
+  };
+
+  let recovered: string;
+  try {
+    recovered = verifyTypedData(domain, CHALLENGE_TYPES, challengeData, p.challengerSig as string).toLowerCase();
+  } catch {
+    return { ok: false, status: 400, error: "challengerSig malformed or does not recover" };
+  }
+
+  // challengerId is bytes32; the EOA is the trailing 20 bytes.
+  const challengerAddress = `0x${(p.challengerId as string).toLowerCase().slice(-40)}`;
+  if (recovered !== challengerAddress) {
+    return { ok: false, status: 400, error: "challengerSig does not recover to challengerId" };
+  }
+
+  // querySpec optional — if provided, validate the hash matches so the
+  // caller can't lie about what query they signed.
+  let querySpec: Record<string, unknown> | undefined;
+  if (p.querySpec !== undefined && p.querySpec !== null) {
+    if (typeof p.querySpec !== "object" || Array.isArray(p.querySpec)) {
+      return { ok: false, status: 400, error: "querySpec must be a JSON object when provided" };
+    }
+    const recomputed = `0x${keccak256Hex(Buffer.from(stableStringify(p.querySpec), "utf8"))}`.toLowerCase();
+    if (recomputed !== (p.querySpecHash as string).toLowerCase()) {
+      return { ok: false, status: 400, error: "querySpec does not hash to querySpecHash" };
+    }
+    querySpec = p.querySpec as Record<string, unknown>;
+  }
+
+  return {
+    ok: true,
+    challenge: {
+      version: 2,
+      challengeId: (p.challengeId as string).toLowerCase(),
+      nodeId: (p.nodeId as string).toLowerCase(),
+      challengeType: typeCode,
+      querySpec,
+      challengerId: (p.challengerId as string).toLowerCase(),
+      challengerAddress,
+    },
+  };
+}
+
+function coerceUint64(value: unknown): bigint | undefined {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) return undefined;
+    return BigInt(value);
+  }
+  if (typeof value === "string" && /^[0-9]+$/.test(value)) {
+    const v = BigInt(value);
+    if (v < 0n || v > MAX_UINT64) return undefined;
+    return v;
+  }
+  if (typeof value === "bigint") {
+    if (value < 0n || value > MAX_UINT64) return undefined;
+    return value;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Closes #747 (#667 F4). Pre-fix \`/pose/challenge\` accepted an arbitrary caller-supplied \`challengeId\` string and stored it as-is in the challenges Map. Combined with the witness-side gaps already addressed by PR #751 (#667 main), this gave a hostile challenger a free degree of freedom: pre-mine a pool of challengeIds, rotate them through witness collection to maximise \`(challengeId, responseBodyHash)\` collision opportunities for the v1 fallback replay window (#748).

This PR ties \`challengeId\` to the same EIP-712 \`CHALLENGE_TYPES\` signature that \`services/challenger/challenge-factory-v2.ts\` already produces — so the witness/agent path can independently rebuild and verify it.

## What the new validator checks (v2 payloads)

| Check | Reject reason |
|---|---|
| Deterministic challengeId rebuild matches \`keccak256(epochId, nodeId, challengeType, nonce, challengerId, challengeNonce)\` | \`challengeId does not match deterministic derivation\` |
| EIP-712 \`CHALLENGE_TYPES\` signature recovers to the trailing 20-byte EOA of \`challengerId\` | \`challengerSig does not recover to challengerId\` |
| Optional \`querySpec\` matches \`querySpecHash\` (recompute \`keccak256(stableStringify(querySpec))\`) | \`querySpec does not hash to querySpecHash\` |
| \`issuedAtMs\` drift bounded against wall-clock | \`issuedAtMs out of drift window\` |

Legacy v1 payloads (no \`challengerSig\`) keep working in lenient mode for rollout. \`COC_POSE_REQUIRE_VERIFIED_CHALLENGE=1\` flips strict-mode on once all challengers ship v2.

## New env vars

| Env | Default | Meaning |
|---|---|---|
| \`COC_POSE_REQUIRE_VERIFIED_CHALLENGE\` | \`false\` | \`1\` / \`true\` / \`yes\` → reject v1 payloads |
| \`COC_POSE_CHALLENGE_DRIFT_MS\` | \`300000\` (5 min) | Max abs(now - issuedAtMs) accepted in v2 mode |

## Pre-mined attack reproduction blocked

The new test \`#747: pre-mined attack reproduction — caller cannot swap nodeId under same sig\` walks the exact scenario: attacker generates a valid signed challenge for node A, then resubmits it claiming node B. Since nodeId is in the signed digest, the derived challengeId no longer matches and the first guard fires.

## Test plan

- [x] \`pose-challenge-validator.test.ts\` (new, 13 tests): v1 lenient/strict, v2 happy path, tampered challengeId/querySpec/challengerSig, malformed sig (no ethers leak), drift past/boundary, deterministic schema 400s (no input echo)
- [x] Full runtime layer: **227/227 passing** (was 214/214 — +13 from this PR; no regressions)

## Deployment

Default behaviour is unchanged: v1 callers keep working, v2 callers get the new verification automatically. Operators flip \`COC_POSE_REQUIRE_VERIFIED_CHALLENGE=1\` once their challenger fleet ships v2 payloads.

Refs:
- Fixes #747 (#667 F4)
- Parent #667 closed cryptographic rubber-stamp in PR #751