### PR TITLE
chore(contracts): record 2026-05-26 r3 security-batch impl upgrades on 88780

### DIFF
--- a/contracts/.openzeppelin/unknown-88780.json
+++ b/contracts/.openzeppelin/unknown-88780.json
@@ -7300,7 +7300,7 @@
             "label": "proposals",
             "offset": 0,
             "slot": "9",
-            "type": "t_mapping(t_uint256,t_struct(Proposal)1518_storage)",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)10497_storage)",
             "contract": "Treasury",
             "src": "contracts-src/governance/Treasury.sol:36"
           },
@@ -7342,7 +7342,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)130_storage": {
+          "t_struct(InitializableStorage)172_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -7384,11 +7384,11 @@
             "label": "mapping(address => uint256)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(Proposal)1518_storage)": {
+          "t_mapping(t_uint256,t_struct(Proposal)10497_storage)": {
             "label": "mapping(uint256 => struct Treasury.Proposal)",
             "numberOfBytes": "32"
           },
-          "t_struct(Proposal)1518_storage": {
+          "t_struct(Proposal)10497_storage": {
             "label": "struct Treasury.Proposal",
             "members": [
               {
@@ -7437,6 +7437,1127 @@
           "t_uint8": {
             "label": "uint8",
             "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7975d96b45ca58e78930915b6f25f2ccb3f186621a2749c9da4466be0a4b1229": {
+      "address": "0x0e8B945060AC6Ebe37DA2BE06406Dd7F49C8d356",
+      "txHash": "0xcb70c0bfe9b8ca906ba05ac799987dccf3ed011f786ee246fbc451e8b0e2ced4",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:15"
+          },
+          {
+            "label": "roles",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:16"
+          },
+          {
+            "label": "nodes",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:18"
+          },
+          {
+            "label": "nodeOperator",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:19"
+          },
+          {
+            "label": "operatorNodeCount",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_uint8)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:20"
+          },
+          {
+            "label": "epochBatches",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:22"
+          },
+          {
+            "label": "batches",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:23"
+          },
+          {
+            "label": "batchSampleCount",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_bytes32,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:24"
+          },
+          {
+            "label": "batchSampleCommitment",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_bytes32,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:25"
+          },
+          {
+            "label": "batchSampledLeaf",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:26"
+          },
+          {
+            "label": "usedReplayKeys",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:29"
+          },
+          {
+            "label": "epochFinalized",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:32"
+          },
+          {
+            "label": "epochSettlementRoot",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:33"
+          },
+          {
+            "label": "epochValidBatchCount",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_mapping(t_uint64,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:34"
+          },
+          {
+            "label": "unbondRequested",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:35"
+          },
+          {
+            "label": "endpointCommitmentUsed",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:38"
+          },
+          {
+            "label": "rewardPoolBalance",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_uint256",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "epochRewardsDistributed",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "pendingRewards",
+            "offset": 0,
+            "slot": "18",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:43"
+          },
+          {
+            "label": "v1SunsetEpoch",
+            "offset": 0,
+            "slot": "19",
+            "type": "t_uint64",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:108"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "20",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:112"
+          },
+          {
+            "label": "challengeNonces",
+            "offset": 0,
+            "slot": "69",
+            "type": "t_mapping(t_uint64,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:43"
+          },
+          {
+            "label": "epochRewardRoots",
+            "offset": 0,
+            "slot": "70",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:44"
+          },
+          {
+            "label": "rewardClaimed",
+            "offset": 0,
+            "slot": "71",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:45"
+          },
+          {
+            "label": "epochTotalReward",
+            "offset": 0,
+            "slot": "72",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:46"
+          },
+          {
+            "label": "epochSlashTotal",
+            "offset": 0,
+            "slot": "73",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:47"
+          },
+          {
+            "label": "epochTreasuryDelta",
+            "offset": 0,
+            "slot": "74",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:48"
+          },
+          {
+            "label": "challenges",
+            "offset": 0,
+            "slot": "75",
+            "type": "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:49"
+          },
+          {
+            "label": "epochNodeSlashed",
+            "offset": 0,
+            "slot": "76",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:50"
+          },
+          {
+            "label": "challengeFaultConfirmed",
+            "offset": 0,
+            "slot": "77",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:51"
+          },
+          {
+            "label": "epochClaimedReward",
+            "offset": 0,
+            "slot": "78",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:52"
+          },
+          {
+            "label": "consumedFaultEvidence",
+            "offset": 0,
+            "slot": "79",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:53"
+          },
+          {
+            "label": "challengeFaultEpochPlusOne",
+            "offset": 0,
+            "slot": "80",
+            "type": "t_mapping(t_bytes32,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:54"
+          },
+          {
+            "label": "pendingWithdrawals",
+            "offset": 0,
+            "slot": "81",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:55"
+          },
+          {
+            "label": "epochMerkleRootUsed",
+            "offset": 0,
+            "slot": "82",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:61"
+          },
+          {
+            "label": "epochBatchCursor",
+            "offset": 0,
+            "slot": "83",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:66"
+          },
+          {
+            "label": "challengeBondMin",
+            "offset": 0,
+            "slot": "84",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:68"
+          },
+          {
+            "label": "insuranceBalance",
+            "offset": 0,
+            "slot": "85",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:69"
+          },
+          {
+            "label": "DOMAIN_SEPARATOR",
+            "offset": 0,
+            "slot": "86",
+            "type": "t_bytes32",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:70"
+          },
+          {
+            "label": "allowEmptyWitnessSubmission",
+            "offset": 0,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:71"
+          },
+          {
+            "label": "initialized",
+            "offset": 1,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:74"
+          },
+          {
+            "label": "_challengeCounter",
+            "offset": 0,
+            "slot": "88",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:75"
+          },
+          {
+            "label": "cocToken",
+            "offset": 0,
+            "slot": "89",
+            "type": "t_contract(ICOCToken)2239",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:78"
+          },
+          {
+            "label": "genesisEpoch",
+            "offset": 20,
+            "slot": "89",
+            "type": "t_uint64",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:79"
+          },
+          {
+            "label": "emissionEnabled",
+            "offset": 28,
+            "slot": "89",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:80"
+          },
+          {
+            "label": "foundationAddress",
+            "offset": 0,
+            "slot": "90",
+            "type": "t_address",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:81"
+          },
+          {
+            "label": "epochFinalizedAt",
+            "offset": 0,
+            "slot": "91",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:86"
+          },
+          {
+            "label": "epochSwept",
+            "offset": 0,
+            "slot": "92",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:87"
+          },
+          {
+            "label": "_activeNodeIds",
+            "offset": 0,
+            "slot": "93",
+            "type": "t_array(t_bytes32)dyn_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:94"
+          },
+          {
+            "label": "_activeNodeIndex",
+            "offset": 0,
+            "slot": "94",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:95"
+          },
+          {
+            "label": "_witnessSigUsed",
+            "offset": 0,
+            "slot": "95",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:103"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "96",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:1344"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)130_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ICOCToken)2239": {
+            "label": "contract ICOCToken",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint8)": {
+            "label": "mapping(address => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(bytes32 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.BatchRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypesV2.ChallengeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.NodeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint32)": {
+            "label": "mapping(bytes32 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint64)": {
+            "label": "mapping(bytes32 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(uint64 => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bytes32)": {
+            "label": "mapping(uint64 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(uint64 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(uint64 => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint32)": {
+            "label": "mapping(uint64 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint64)": {
+            "label": "mapping(uint64 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BatchRecord)6927_storage": {
+            "label": "struct PoSeTypes.BatchRecord",
+            "members": [
+              {
+                "label": "epochId",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "merkleRoot",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "summaryHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "aggregator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "submittedAtEpoch",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "3"
+              },
+              {
+                "label": "disputeDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "finalized",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "4"
+              },
+              {
+                "label": "disputed",
+                "type": "t_bool",
+                "offset": 9,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(ChallengeRecord)7002_storage": {
+            "label": "struct PoSeTypesV2.ChallengeRecord",
+            "members": [
+              {
+                "label": "commitHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "challenger",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "bond",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "commitEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "revealDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "3"
+              },
+              {
+                "label": "revealed",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "3"
+              },
+              {
+                "label": "settled",
+                "type": "t_bool",
+                "offset": 17,
+                "slot": "3"
+              },
+              {
+                "label": "targetNodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "faultType",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(NodeRecord)6910_storage": {
+            "label": "struct PoSeTypes.NodeRecord",
+            "members": [
+              {
+                "label": "nodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "pubkeyNode",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "serviceFlags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "serviceCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "endpointCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "bondAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "registeredAtEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "unlockEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "7"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "7"
+              }
+            ],
+            "numberOfBytes": "256"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e462eff4f7f7c0579c2a8ac27b5b2148f3139a76bea83f45b4c524d98c1608ec": {
+      "address": "0xF2921b9AEA9Ad355406553527E4d69ec4FE64FC4",
+      "txHash": "0x96d156a3ba66577c76f7dd5569e84c37f1851abbd67a90311fc9f9bd58ec9833",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "factionRegistry",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FactionRegistry)5350",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:45"
+          },
+          {
+            "label": "proposalCount",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:47"
+          },
+          {
+            "label": "proposals",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)5421_storage)",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:48"
+          },
+          {
+            "label": "hasVoted",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:49"
+          },
+          {
+            "label": "votingPeriod",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:52"
+          },
+          {
+            "label": "timelockDelay",
+            "offset": 8,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:53"
+          },
+          {
+            "label": "quorumPercent",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:54"
+          },
+          {
+            "label": "approvalPercent",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:55"
+          },
+          {
+            "label": "bicameralEnabled",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:56"
+          },
+          {
+            "label": "owner",
+            "offset": 1,
+            "slot": "7",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:58"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:332"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)172_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(FactionRegistry)5350": {
+            "label": "contract FactionRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ProposalState)5378": {
+            "label": "enum GovernanceDAO.ProposalState",
+            "members": [
+              "Pending",
+              "Approved",
+              "Rejected",
+              "Queued",
+              "Executed",
+              "Cancelled",
+              "Expired"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(ProposalType)5370": {
+            "label": "enum GovernanceDAO.ProposalType",
+            "members": [
+              "ValidatorAdd",
+              "ValidatorRemove",
+              "ParameterChange",
+              "TreasurySpend",
+              "ContractUpgrade",
+              "FreeText"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Proposal)5421_storage)": {
+            "label": "mapping(uint256 => struct GovernanceDAO.Proposal)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Proposal)5421_storage": {
+            "label": "struct GovernanceDAO.Proposal",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "registeredSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "humanSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "clawSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "proposalType",
+                "type": "t_enum(ProposalType)5370",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "proposer",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "4"
+              },
+              {
+                "label": "title",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "descriptionHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "executionTarget",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "executionData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "createdAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "votingDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "10"
+              },
+              {
+                "label": "executionDeadline",
+                "type": "t_uint64",
+                "offset": 16,
+                "slot": "10"
+              },
+              {
+                "label": "forVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              },
+              {
+                "label": "againstVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "12"
+              },
+              {
+                "label": "forVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "13"
+              },
+              {
+                "label": "againstVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "14"
+              },
+              {
+                "label": "abstainVotes",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "15"
+              },
+              {
+                "label": "state",
+                "type": "t_enum(ProposalState)5378",
+                "offset": 0,
+                "slot": "16"
+              }
+            ],
+            "numberOfBytes": "544"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
           }
         },
         "namespaces": {


### PR DESCRIPTION
## Summary

Two UUPS proxies upgraded via the 3-of-5 multisig (\`0x3c055D83…\`) to take on the 2026-05-26 sprint's audit-batch contract changes:

| Proxy | Old impl | New impl | Source |
|-------|----------|----------|--------|
| PoSeManagerV2 \`0x256eb949…\` | \`0x4111040372…\` | \`0x0e8B945060AC6Ebe37DA2BE06406Dd7F49C8d356\` | #751 push-verify hook (\`IPoSeManagerV2\`) + #752 v1 sunset cap (#748) + multi-block RANDAO seed (#749) + #754 challengeId derivation (#747) |
| GovernanceDAO \`0x4b948567…\` | \`0xC0D08bceb…\` | \`0xF2921b9AEA9Ad355406553527E4d69ec4FE64FC4\` | #745 \`isVerified\` gate (#735 Sybil) |

Multisig txIds 8/9. ERC-1967 impl slot on each proxy verified equal to the new impl post-execute. 6-val 88780 testnet continued producing at ~2 s/block throughout (block 378554 at restart, climbing).

**Treasury was prepared in this batch but skipped at Phase B** — its r2 impl \`0x907EEb4220…\` is unchanged in this sprint, and the chain was already at that address from the 2026-05-25 batch (PR #743), so a fresh \`upgradeToAndCall\` would have been a noop.

## OZ manifest delta

- new **PoSeManagerV2** impl entry (storage layout grew by \`v1SunsetEpoch\` with \`__gap[50→49]\`; OZ Phase-A \`validateUpgrade\` confirmed the layout drift was an append, not a re-slot)
- new **GovernanceDAO** impl entry (no storage change; the new \`NotVerified()\` error + \`isVerified\` modifier check are pure logic)

## What's on-chain vs. what's still off-chain

Closes (chain-side) for: #735 #747 #748 #749.

Off-chain pieces of #667 (push verification) and #750 (loopback auth gate) are in main but **not yet exercised in production**, because the 6 88780 nodes only run \`coc-node@N\` (\`node/src/index.ts\` chain engine) and do not run \`runtime/coc-node.ts\` (PoSe witness HTTP server). Those fixes will activate the day the v2 PoSe pipeline is brought up — at which point the strict-mode env flags (\`COC_POSE_WITNESS_REQUIRE_VERIFIED=true\`, \`COC_POSE_REQUIRE_VERIFIED_CHALLENGE=true\`, \`COC_POSE_WITNESS_AUTH_TOKEN\`, \`COC_POSE_WITNESS_TRUSTED_PROXIES\`) should be set per node.

## Test plan

- [x] Phase A: \`upgrades.validateUpgrade\` + \`upgrades.prepareUpgrade\` succeeded for both contracts on 88780.
- [x] Phase B: multisig submit → 3 confirmations (owner-1/-2/-3) → execute → ERC-1967 impl slot verified for each proxy.
- [x] All 6 nodes (v1/v2/v3/v4/v5/obs-1) rolled to \`2b1cb01\`; chain continued producing through the rolling restart window.