### PR TITLE
feat(reader): persistence test coverage + 88780 enablement SOP (Track 1 of canary plan)

### DIFF
--- a/contracts/.openzeppelin/unknown-88780.json
+++ b/contracts/.openzeppelin/unknown-88780.json
@@ -7300,7 +7300,7 @@
             "label": "proposals",
             "offset": 0,
             "slot": "9",
-            "type": "t_mapping(t_uint256,t_struct(Proposal)1518_storage)",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)10497_storage)",
             "contract": "Treasury",
             "src": "contracts-src/governance/Treasury.sol:36"
           },
@@ -7342,7 +7342,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)130_storage": {
+          "t_struct(InitializableStorage)172_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -7384,11 +7384,11 @@
             "label": "mapping(address => uint256)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(Proposal)1518_storage)": {
+          "t_mapping(t_uint256,t_struct(Proposal)10497_storage)": {
             "label": "mapping(uint256 => struct Treasury.Proposal)",
             "numberOfBytes": "32"
           },
-          "t_struct(Proposal)1518_storage": {
+          "t_struct(Proposal)10497_storage": {
             "label": "struct Treasury.Proposal",
             "members": [
               {
@@ -7437,6 +7437,1127 @@
           "t_uint8": {
             "label": "uint8",
             "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7975d96b45ca58e78930915b6f25f2ccb3f186621a2749c9da4466be0a4b1229": {
+      "address": "0x0e8B945060AC6Ebe37DA2BE06406Dd7F49C8d356",
+      "txHash": "0xcb70c0bfe9b8ca906ba05ac799987dccf3ed011f786ee246fbc451e8b0e2ced4",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:15"
+          },
+          {
+            "label": "roles",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:16"
+          },
+          {
+            "label": "nodes",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:18"
+          },
+          {
+            "label": "nodeOperator",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:19"
+          },
+          {
+            "label": "operatorNodeCount",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_uint8)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:20"
+          },
+          {
+            "label": "epochBatches",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:22"
+          },
+          {
+            "label": "batches",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:23"
+          },
+          {
+            "label": "batchSampleCount",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_bytes32,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:24"
+          },
+          {
+            "label": "batchSampleCommitment",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_bytes32,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:25"
+          },
+          {
+            "label": "batchSampledLeaf",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:26"
+          },
+          {
+            "label": "usedReplayKeys",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:29"
+          },
+          {
+            "label": "epochFinalized",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:32"
+          },
+          {
+            "label": "epochSettlementRoot",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:33"
+          },
+          {
+            "label": "epochValidBatchCount",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_mapping(t_uint64,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:34"
+          },
+          {
+            "label": "unbondRequested",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:35"
+          },
+          {
+            "label": "endpointCommitmentUsed",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:38"
+          },
+          {
+            "label": "rewardPoolBalance",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_uint256",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "epochRewardsDistributed",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "pendingRewards",
+            "offset": 0,
+            "slot": "18",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:43"
+          },
+          {
+            "label": "v1SunsetEpoch",
+            "offset": 0,
+            "slot": "19",
+            "type": "t_uint64",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:108"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "20",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:112"
+          },
+          {
+            "label": "challengeNonces",
+            "offset": 0,
+            "slot": "69",
+            "type": "t_mapping(t_uint64,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:43"
+          },
+          {
+            "label": "epochRewardRoots",
+            "offset": 0,
+            "slot": "70",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:44"
+          },
+          {
+            "label": "rewardClaimed",
+            "offset": 0,
+            "slot": "71",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:45"
+          },
+          {
+            "label": "epochTotalReward",
+            "offset": 0,
+            "slot": "72",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:46"
+          },
+          {
+            "label": "epochSlashTotal",
+            "offset": 0,
+            "slot": "73",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:47"
+          },
+          {
+            "label": "epochTreasuryDelta",
+            "offset": 0,
+            "slot": "74",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:48"
+          },
+          {
+            "label": "challenges",
+            "offset": 0,
+            "slot": "75",
+            "type": "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:49"
+          },
+          {
+            "label": "epochNodeSlashed",
+            "offset": 0,
+            "slot": "76",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:50"
+          },
+          {
+            "label": "challengeFaultConfirmed",
+            "offset": 0,
+            "slot": "77",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:51"
+          },
+          {
+            "label": "epochClaimedReward",
+            "offset": 0,
+            "slot": "78",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:52"
+          },
+          {
+            "label": "consumedFaultEvidence",
+            "offset": 0,
+            "slot": "79",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:53"
+          },
+          {
+            "label": "challengeFaultEpochPlusOne",
+            "offset": 0,
+            "slot": "80",
+            "type": "t_mapping(t_bytes32,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:54"
+          },
+          {
+            "label": "pendingWithdrawals",
+            "offset": 0,
+            "slot": "81",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:55"
+          },
+          {
+            "label": "epochMerkleRootUsed",
+            "offset": 0,
+            "slot": "82",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:61"
+          },
+          {
+            "label": "epochBatchCursor",
+            "offset": 0,
+            "slot": "83",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:66"
+          },
+          {
+            "label": "challengeBondMin",
+            "offset": 0,
+            "slot": "84",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:68"
+          },
+          {
+            "label": "insuranceBalance",
+            "offset": 0,
+            "slot": "85",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:69"
+          },
+          {
+            "label": "DOMAIN_SEPARATOR",
+            "offset": 0,
+            "slot": "86",
+            "type": "t_bytes32",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:70"
+          },
+          {
+            "label": "allowEmptyWitnessSubmission",
+            "offset": 0,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:71"
+          },
+          {
+            "label": "initialized",
+            "offset": 1,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:74"
+          },
+          {
+            "label": "_challengeCounter",
+            "offset": 0,
+            "slot": "88",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:75"
+          },
+          {
+            "label": "cocToken",
+            "offset": 0,
+            "slot": "89",
+            "type": "t_contract(ICOCToken)2239",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:78"
+          },
+          {
+            "label": "genesisEpoch",
+            "offset": 20,
+            "slot": "89",
+            "type": "t_uint64",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:79"
+          },
+          {
+            "label": "emissionEnabled",
+            "offset": 28,
+            "slot": "89",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:80"
+          },
+          {
+            "label": "foundationAddress",
+            "offset": 0,
+            "slot": "90",
+            "type": "t_address",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:81"
+          },
+          {
+            "label": "epochFinalizedAt",
+            "offset": 0,
+            "slot": "91",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:86"
+          },
+          {
+            "label": "epochSwept",
+            "offset": 0,
+            "slot": "92",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:87"
+          },
+          {
+            "label": "_activeNodeIds",
+            "offset": 0,
+            "slot": "93",
+            "type": "t_array(t_bytes32)dyn_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:94"
+          },
+          {
+            "label": "_activeNodeIndex",
+            "offset": 0,
+            "slot": "94",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:95"
+          },
+          {
+            "label": "_witnessSigUsed",
+            "offset": 0,
+            "slot": "95",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:103"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "96",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:1344"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)130_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ICOCToken)2239": {
+            "label": "contract ICOCToken",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint8)": {
+            "label": "mapping(address => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(bytes32 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.BatchRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypesV2.ChallengeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.NodeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint32)": {
+            "label": "mapping(bytes32 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint64)": {
+            "label": "mapping(bytes32 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(uint64 => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bytes32)": {
+            "label": "mapping(uint64 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(uint64 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(uint64 => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint32)": {
+            "label": "mapping(uint64 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint64)": {
+            "label": "mapping(uint64 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BatchRecord)6927_storage": {
+            "label": "struct PoSeTypes.BatchRecord",
+            "members": [
+              {
+                "label": "epochId",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "merkleRoot",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "summaryHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "aggregator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "submittedAtEpoch",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "3"
+              },
+              {
+                "label": "disputeDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "finalized",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "4"
+              },
+              {
+                "label": "disputed",
+                "type": "t_bool",
+                "offset": 9,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(ChallengeRecord)7002_storage": {
+            "label": "struct PoSeTypesV2.ChallengeRecord",
+            "members": [
+              {
+                "label": "commitHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "challenger",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "bond",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "commitEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "revealDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "3"
+              },
+              {
+                "label": "revealed",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "3"
+              },
+              {
+                "label": "settled",
+                "type": "t_bool",
+                "offset": 17,
+                "slot": "3"
+              },
+              {
+                "label": "targetNodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "faultType",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(NodeRecord)6910_storage": {
+            "label": "struct PoSeTypes.NodeRecord",
+            "members": [
+              {
+                "label": "nodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "pubkeyNode",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "serviceFlags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "serviceCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "endpointCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "bondAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "registeredAtEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "unlockEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "7"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "7"
+              }
+            ],
+            "numberOfBytes": "256"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e462eff4f7f7c0579c2a8ac27b5b2148f3139a76bea83f45b4c524d98c1608ec": {
+      "address": "0xF2921b9AEA9Ad355406553527E4d69ec4FE64FC4",
+      "txHash": "0x96d156a3ba66577c76f7dd5569e84c37f1851abbd67a90311fc9f9bd58ec9833",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "factionRegistry",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FactionRegistry)5350",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:45"
+          },
+          {
+            "label": "proposalCount",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:47"
+          },
+          {
+            "label": "proposals",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)5421_storage)",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:48"
+          },
+          {
+            "label": "hasVoted",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:49"
+          },
+          {
+            "label": "votingPeriod",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:52"
+          },
+          {
+            "label": "timelockDelay",
+            "offset": 8,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:53"
+          },
+          {
+            "label": "quorumPercent",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:54"
+          },
+          {
+            "label": "approvalPercent",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:55"
+          },
+          {
+            "label": "bicameralEnabled",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:56"
+          },
+          {
+            "label": "owner",
+            "offset": 1,
+            "slot": "7",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:58"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:332"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)172_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(FactionRegistry)5350": {
+            "label": "contract FactionRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ProposalState)5378": {
+            "label": "enum GovernanceDAO.ProposalState",
+            "members": [
+              "Pending",
+              "Approved",
+              "Rejected",
+              "Queued",
+              "Executed",
+              "Cancelled",
+              "Expired"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(ProposalType)5370": {
+            "label": "enum GovernanceDAO.ProposalType",
+            "members": [
+              "ValidatorAdd",
+              "ValidatorRemove",
+              "ParameterChange",
+              "TreasurySpend",
+              "ContractUpgrade",
+              "FreeText"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Proposal)5421_storage)": {
+            "label": "mapping(uint256 => struct GovernanceDAO.Proposal)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Proposal)5421_storage": {
+            "label": "struct GovernanceDAO.Proposal",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "registeredSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "humanSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "clawSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "proposalType",
+                "type": "t_enum(ProposalType)5370",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "proposer",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "4"
+              },
+              {
+                "label": "title",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "descriptionHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "executionTarget",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "executionData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "createdAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "votingDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "10"
+              },
+              {
+                "label": "executionDeadline",
+                "type": "t_uint64",
+                "offset": 16,
+                "slot": "10"
+              },
+              {
+                "label": "forVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              },
+              {
+                "label": "againstVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "12"
+              },
+              {
+                "label": "forVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "13"
+              },
+              {
+                "label": "againstVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "14"
+              },
+              {
+                "label": "abstainVotes",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "15"
+              },
+              {
+                "label": "state",
+                "type": "t_enum(ProposalState)5378",
+                "offset": 0,
+                "slot": "16"
+              }
+            ],
+            "numberOfBytes": "544"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
           }
         },
         "namespaces": {

--- a/docs/validator-registry-reader-enablement-88780.md
+++ b/docs/validator-registry-reader-enablement-88780.md
@@ -1,0 +1,244 @@
+# ValidatorRegistryReader Enablement on 88780 — Operations SOP
+
+**Status (2026-05-27):** Reader code is implemented, wired, and unit-tested
+(11 cases pass). 88780 nodes do **not** yet have the reader active — they're
+running with the static `validators` config. This document is the
+operational runbook for activating the reader, which is the core of Phase A
+"external validator onboarding" work in the [canary launch plan](../home/bob/.claude/plans/applyblock-delightful-hennessy.md).
+
+## What the reader does
+
+The reader (`runtime/lib/validator-registry-reader.ts`) mirrors the on-chain
+`ValidatorRegistry` proxy (`0x4441299c118373fDC96bE1983d42C79e19CDb4F0` on
+88780) into the node's BFT coordinator. Without it, the BFT validator set is
+hardcoded at startup and external operators who stake 32 ETH via
+`ValidatorRegistry.stake()` are **silently ignored** until each running node
+manually restarts with edited config — breaking the permissionless promise.
+
+After activation, this becomes the canonical flow for adding/removing
+validators:
+
+1. Operator calls `ValidatorRegistry.stake(nodeId, pubkeyNode)` from their
+   signing-key wallet with `msg.value = 32 ETH`
+2. Contract emits `ValidatorRegistered` event
+3. Within `pollIntervalMs` (default 60s), every node's reader sees the event,
+   updates its local active set, and pushes it into the BFT coordinator via
+   `consensus.onValidatorSetChange(next)` (PR-1B path)
+4. From the next BFT round onward, the new validator participates in
+   prepare/commit quorum
+
+## Pre-flight: 6 current validators must register on-chain
+
+The reader's `seedFromContractState()` reads `ValidatorRegistry.getActiveValidators()`.
+Today that returns an empty array because the current 6 validators were
+hardcoded into config, not staked on-chain. If we enable the reader against
+an empty registry, the index.ts wiring falls back to the static config
+(`if (active.length === 0)` → keep fallback), so the reader is harmless. But
+it's also useless until we migrate the 6 to be on-chain registered.
+
+### Step 1 — each validator operator runs the staking transaction
+
+For each validator host, the operator (with the validator's signing key in
+`~/.coc/keys/`) executes:
+
+```bash
+# On the operator's workstation, NOT on the validator node directly.
+# Signing key for validator-i lives in their ~/.coc/keys/ — never check in.
+node -e '
+const { Wallet, JsonRpcProvider, parseEther, Contract } = require("ethers");
+const fs = require("fs");
+
+// Validator signing key — operator-specific.
+const SIGN_KEY = fs.readFileSync(process.env.SIGN_KEY_PATH, "utf-8").trim();
+const PUBKEY   = process.env.PUBKEY;   // 65 B 0x04-prefixed, derive from SIGN_KEY
+const NODE_ID  = process.env.NODE_ID;  // keccak256(pubkey[1:65])
+
+const RPC = "http://209.74.64.88:38780";  // any healthy 88780 RPC
+const REG = "0x4441299c118373fDC96bE1983d42C79e19CDb4F0";  // ValidatorRegistry proxy
+const REG_ABI = ["function stake(bytes32 nodeId, bytes pubkeyNode) external payable"];
+
+(async () => {
+  const p = new JsonRpcProvider(RPC);
+  const w = new Wallet(SIGN_KEY, p);
+  const c = new Contract(REG, REG_ABI, w);
+  const tx = await c.stake(NODE_ID, PUBKEY, { value: parseEther("32") });
+  console.log("stake tx:", tx.hash);
+  const r = await tx.wait();
+  console.log("mined:", r.blockNumber, "status:", r.status);
+})();
+'
+```
+
+Each operator needs to know:
+- **Signing key** — their validator's private key (already in use for BFT signing)
+- **Pubkey** — derivable from signing key as 65-byte uncompressed secp256k1 (`0x04 || X || Y`)
+- **NodeId** — `keccak256(pubkey[1:65])`. Already consistent with how the node has been signing BFT messages (per `node/src/crypto/signer.ts`)
+
+⚠ **Funding**: each validator's signing-key EOA needs ≥ 32 ETH at the time
+of staking. Validators on 88780 likely don't have this on their signing-key
+EOA today (rewards have accumulated to operator addresses, not signing
+addresses). **Pre-fund 32.1 ETH** (extra for gas) from the deployer EOA to
+each signing-key EOA before staking.
+
+Verify pre-staking:
+```bash
+# For each validator's signing addr <V>, expect 32.1+ ETH:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["<V>","latest"]}' \
+  | jq -r '.result' | xargs -I{} python3 -c "print(int('{}', 16)/1e18, 'ETH')"
+```
+
+Verify post-staking:
+```bash
+# ValidatorRegistry.activeValidatorCount() should equal 6:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_call",
+       "params":[{"to":"0x4441299c118373fDC96bE1983d42C79e19CDb4F0",
+                  "data":"0x<selector for activeValidatorCount()>"},"latest"]}' \
+  | jq .result
+# Expected: "0x0000000000000000000000000000000000000000000000000000000000000006"
+```
+
+## Step 2 — enable the reader on each node
+
+Once the 6 validators are on-chain registered, add the env var to each
+node's `coc-node@*.env` file:
+
+```ini
+# /etc/coc/node-<N>.env
+COC_VALIDATOR_REGISTRY_ADDRESS=0x4441299c118373fDC96bE1983d42C79e19CDb4F0
+# Optional — defaults to http://127.0.0.1:<rpcPort>
+COC_VALIDATOR_REGISTRY_RPC_URL=http://127.0.0.1:38780
+# Optional — defaults to 60_000ms
+# COC_VALIDATOR_REGISTRY_POLL_INTERVAL_MS=60000
+```
+
+(There's no `validatorRegistryAddress` field in the existing JSON config;
+the env var is the canonical entry point. See `node/src/config.ts:566`.)
+
+## Step 3 — rolling restart, one validator at a time
+
+**Critical**: per chaos test T2, restarting 2+ validators in parallel risks
+H15 fallback stall. **Restart one at a time, validate, then proceed.**
+
+For each validator host (one at a time, in order v1, v3, v4, v5, obs-1, v2):
+
+```bash
+# Edit env file on the host
+ssh -i ~/.ssh/openclaw_server_key root@<host> '
+  echo "COC_VALIDATOR_REGISTRY_ADDRESS=0x4441299c118373fDC96bE1983d42C79e19CDb4F0" >> /etc/coc/node-<unit>.env
+  systemctl restart coc-node@<unit>
+'
+
+# Wait for the new node to rejoin BFT (~30s) before doing the next.
+# Verify: probe RPC eth_blockNumber + check log for "reader initialized" line.
+ssh -i ~/.ssh/openclaw_server_key root@<host> \
+  'journalctl -u coc-node@<unit> -n 100 --no-pager | grep "reader initialized\|BFT validator set updated"'
+```
+
+Expected log lines after restart:
+```
+[INFO][validator-registry-reader] reader initialized
+  address: 0x4441299c118373fDC96bE1983d42C79e19CDb4F0
+  activeCount: 6
+  lastScannedBlock: <current head>
+
+[INFO][node] BFT validator set updated from ValidatorRegistry
+  count: 6
+  ids: [<6 validator IDs in sorted order>]
+```
+
+If `activeCount` is < 6 or the BFT set update doesn't fire: roll back the
+env var, restart that node, investigate. **Do not proceed to the next node**
+until the current one's reader is healthy.
+
+## Step 4 — end-to-end verification (7th validator dry-run)
+
+Once all 6 nodes have the reader active:
+
+1. **Generate a fresh keypair**:
+   ```bash
+   node -e 'const {Wallet}=require("ethers"); const w=Wallet.createRandom();
+            console.log(JSON.stringify({addr:w.address, pk:w.privateKey, pubkey:w.signingKey.publicKey}))'
+   ```
+
+2. **Fund 32.1 ETH** from deployer or faucet (whichever has 32+ ETH balance).
+
+3. **Stake** via the same script template as Step 1.
+
+4. **Verify within 60s** (one poll cycle) — each node's log must show:
+   ```
+   [INFO][validator-registry-reader] reader initialized OR scan tick added
+   [INFO][node] BFT validator set updated from ValidatorRegistry
+     count: 7
+     ids: [..., <new validator id>]
+   ```
+
+5. **Verify on-chain BFT participation** — query each node's RPC for
+   `coc_validatorSet()` (or `eth_call ValidatorRegistry.getActiveValidators()`).
+   Both should report 7.
+
+6. **Block production** — chain continues at ~2-3s/block with the new
+   validator in the prepare/commit rotation.
+
+7. **Cleanup** — operator calls `requestUnstake()` then `withdrawStake()`
+   after 14d UNSTAKE_LOCKUP. Reader removes the validator from active set on
+   the deactivation event.
+
+## Rollback procedure
+
+If the reader misbehaves (e.g. emits add/remove events with wrong IDs, or
+the BFT coordinator rejects the set), roll back per node:
+
+```bash
+# Remove the env var line
+ssh root@<host> '
+  sed -i "/COC_VALIDATOR_REGISTRY_ADDRESS/d" /etc/coc/node-<unit>.env
+  systemctl restart coc-node@<unit>
+'
+```
+
+The reader sidecar (`<dataDir>/validator-registry-reader.state.json`) is
+safe to leave — it'll just be ignored when the env var is absent. Delete it
+if you suspect corruption (`rm <dataDir>/validator-registry-reader.state.json`).
+
+The hardcoded `validators` config in each node's JSON remains the safety
+net: even with the reader enabled, an empty active set from the registry
+falls back to the static config (index.ts:1043 `if (active.length === 0) ...`).
+
+## Verification commands (cheat sheet)
+
+```bash
+# 1. Reader sidecar exists + cursor advanced:
+ssh root@<host> 'cat /var/lib/coc/node-<unit>/validator-registry-reader.state.json'
+# Expected: {"lastScannedBlock":"<current head>"}
+
+# 2. Most recent reader scan tick + active set on this node:
+ssh root@<host> 'journalctl -u coc-node@<unit> -n 200 --no-pager \
+  | grep -E "reader initialized|validator set updated|scan tick failed" \
+  | tail -10'
+
+# 3. On-chain active validator count (any RPC):
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_call",
+       "params":[{"to":"0x4441299c118373fDC96bE1983d42C79e19CDb4F0",
+                  "data":"0x69d76d09"},"latest"]}'
+# selector 0x69d76d09 = activeValidatorCount() ; result is 32-byte hex int.
+
+# 4. BFT round currently running with the new set:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"coc_getBftStatus"}'
+# Look at `validators` field — should match the on-chain active set.
+```
+
+## References
+
+- Reader implementation: `runtime/lib/validator-registry-reader.ts`
+- Reader unit tests (11 cases): `runtime/lib/validator-registry-reader.test.ts`
+- Wiring + retry logic: `node/src/index.ts:1027-1118`
+- BFT update path: `node/src/consensus.ts:992-995` (`onValidatorSetChange`)
+- ValidatorRegistry contract: `contracts/contracts-src/governance/ValidatorRegistry.sol`
+- ValidatorRegistry proxy: `0x4441299c118373fDC96bE1983d42C79e19CDb4F0`
+  (from `configs/deployed-contracts-88780.json`)
+- Canary readiness plan: `/home/bob/.claude/plans/applyblock-delightful-hennessy.md`
+  § A.1.1

--- a/runtime/lib/validator-registry-reader.test.ts
+++ b/runtime/lib/validator-registry-reader.test.ts
@@ -9,6 +9,9 @@
 
 import test from "node:test"
 import assert from "node:assert/strict"
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { ValidatorRegistryReader } from "./validator-registry-reader.ts"
 
 const NODE_A = "0x" + "a".repeat(64) as `0x${string}`
@@ -134,6 +137,79 @@ test("ValidatorRegistryReader: handler exception does not break further dispatch
   // Must not throw out of replayEventForTest even though first handler does.
   reader._replayEventForTest("ValidatorRegistered", [NODE_A, OP_X, 32n * 10n ** 18n, PUB_X], 100)
   assert.equal(secondHandlerCalled, true)
+})
+
+test("ValidatorRegistryReader: persist writes a parseable JSON sidecar with the scan cursor", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-persist-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+    })
+
+    await reader._persistForTest(12345n)
+
+    assert.equal(existsSync(persistPath), true, "persist sidecar created")
+    const raw = readFileSync(persistPath, "utf-8")
+    const state = JSON.parse(raw)
+    assert.equal(state.lastScannedBlock, "12345", "block stored as decimal string")
+    assert.equal(typeof state.lastScannedBlock, "string", "string form to keep JSON-safe (avoids bigint losing precision)")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("ValidatorRegistryReader: hydrate picks up lastScannedBlock from a pre-existing sidecar", async () => {
+  // Restart scenario: a previous reader run wrote state.json; the new reader
+  // must pick up at that block, not re-scan from genesis. Without this the
+  // reader walks the entire chain history on every node restart — at 88780
+  // testnet height ~380k blocks, that's a 5+ min eth_getLogs storm.
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-hydrate-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    writeFileSync(persistPath, JSON.stringify({ lastScannedBlock: "67890" }) + "\n")
+
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+    })
+
+    await reader._hydrateFromSidecarForTest()
+
+    assert.equal(reader._lastScannedBlockForTest(), 67890n, "cursor hydrated from sidecar")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("ValidatorRegistryReader: corrupted sidecar falls back to configured fromBlock without crashing", async () => {
+  // Defense-in-depth: if the sidecar file is unparseable (disk corruption,
+  // partial write during ungraceful shutdown), the reader must not refuse
+  // to start. Fall back to `fromBlock` and re-scan; we'll catch up to head
+  // on the next tick. Without this, a corrupted sidecar would brick the
+  // node's BFT validator-set reader permanently until manual file deletion.
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-corrupt-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    writeFileSync(persistPath, "{ this is not valid json @@@", "utf-8")
+
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+      fromBlock: 100n,
+    })
+
+    await reader._hydrateFromSidecarForTest()
+
+    // Corrupted sidecar → warned + fell back to fromBlock=100. No throw.
+    assert.equal(reader._lastScannedBlockForTest(), 100n, "fromBlock used as fallback")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test("ValidatorRegistryReader: re-registering same nodeId after deactivation re-adds", () => {

--- a/runtime/lib/validator-registry-reader.ts
+++ b/runtime/lib/validator-registry-reader.ts
@@ -125,21 +125,7 @@ export class ValidatorRegistryReader {
   async init(): Promise<void> {
     if (this.initialized) return
 
-    if (this.cfg.persistPath && existsSync(this.cfg.persistPath)) {
-      try {
-        const raw = await readFile(this.cfg.persistPath, "utf-8")
-        const state = JSON.parse(raw) as PersistState
-        this.lastScannedBlock = BigInt(state.lastScannedBlock)
-      } catch (err) {
-        log.warn("failed to load persisted lastScannedBlock; starting from configured fromBlock", {
-          path: this.cfg.persistPath,
-          error: String(err),
-        })
-        this.lastScannedBlock = this.cfg.fromBlock
-      }
-    } else {
-      this.lastScannedBlock = this.cfg.fromBlock
-    }
+    await this.hydrateFromSidecar()
 
     // Snap-synced nodes don't have block history before the snap point, so
     // ValidatorRegistered events from earlier blocks aren't queryable via
@@ -187,6 +173,34 @@ export class ValidatorRegistryReader {
     if (this.pollTimer) {
       clearInterval(this.pollTimer)
       this.pollTimer = null
+    }
+  }
+
+  /**
+   * Load `lastScannedBlock` from the persisted sidecar (if any). Pulled out
+   * of `init()` so unit tests can verify hydration / corruption-fallback
+   * without standing up an RPC provider (init's `scanToTip` would otherwise
+   * hang on an unreachable endpoint).
+   *
+   * Corrupted sidecar (unparseable JSON, missing field) → log warn and fall
+   * back to `cfg.fromBlock`. Never throws — this path runs before any RPC
+   * work so a corrupt file should not prevent reader startup.
+   */
+  private async hydrateFromSidecar(): Promise<void> {
+    if (this.cfg.persistPath && existsSync(this.cfg.persistPath)) {
+      try {
+        const raw = await readFile(this.cfg.persistPath, "utf-8")
+        const state = JSON.parse(raw) as PersistState
+        this.lastScannedBlock = BigInt(state.lastScannedBlock)
+      } catch (err) {
+        log.warn("failed to load persisted lastScannedBlock; starting from configured fromBlock", {
+          path: this.cfg.persistPath,
+          error: String(err),
+        })
+        this.lastScannedBlock = this.cfg.fromBlock
+      }
+    } else {
+      this.lastScannedBlock = this.cfg.fromBlock
     }
   }
 
@@ -307,6 +321,35 @@ export class ValidatorRegistryReader {
    */
   _replayEventForTest(eventName: "ValidatorRegistered" | "ValidatorDeactivated" | "ValidatorSlashed", args: unknown[], blockNumber: number, index = 0): void {
     this.handleEvent({ eventName, args, blockNumber, index } as unknown as EventLog)
+  }
+
+  /**
+   * Test-only read of the persisted scan cursor. Production code should
+   * never depend on this — it exists so unit tests can verify that
+   * `init()` correctly hydrates `lastScannedBlock` from the sidecar file
+   * and that `persist()` writes a parseable record after a scan tick.
+   */
+  _lastScannedBlockForTest(): bigint {
+    return this.lastScannedBlock
+  }
+
+  /**
+   * Test-only trigger for the persistence write. Mirrors what `scanToTip`
+   * does at the end of a tick but without needing a live RPC. Production
+   * code should never call this — `scanToTip` is the canonical caller.
+   */
+  async _persistForTest(blockNumber: bigint): Promise<void> {
+    this.lastScannedBlock = blockNumber
+    await this.persist()
+  }
+
+  /**
+   * Test-only invocation of the sidecar-hydrate step. Lets unit tests verify
+   * the restart hydration + corrupted-sidecar fallback without standing up
+   * an RPC provider (which init's later scan step requires).
+   */
+  async _hydrateFromSidecarForTest(): Promise<void> {
+    await this.hydrateFromSidecar()
   }
 
   private handleEvent(ev: EventLog): void {


### PR DESCRIPTION
## Summary

Track 1 of the canary readiness plan (\`/home/bob/.claude/plans/applyblock-delightful-hennessy.md\` § A.1.1).

The ValidatorRegistryReader implementation + index.ts wiring is **already complete**; the gap was operational enablement plus test coverage of the restart/hydrate paths. This PR ships both.

## What this adds

### Code: persistence test hooks + 3 new tests

\`runtime/lib/validator-registry-reader.ts\`:
- Extract sidecar-load out of \`init()\` into private \`hydrateFromSidecar()\` so unit tests can verify the persistence/corruption-fallback paths without standing up an EVM provider (init's downstream \`scanToTip\` would otherwise hang on an unreachable RPC).
- Add three test-only hooks: \`_persistForTest\`, \`_hydrateFromSidecarForTest\`, \`_lastScannedBlockForTest\`. Mirror the existing \`_replayEventForTest\` naming.

\`runtime/lib/validator-registry-reader.test.ts\` — three new cases:
1. \`persist\` writes a parseable JSON sidecar with the cursor as decimal string (avoids bigint precision loss across restarts)
2. \`hydrate\` picks up \`lastScannedBlock\` from a pre-existing sidecar (restart safety — avoids re-scanning 380k+ blocks on every reboot)
3. Corrupted sidecar falls back to configured \`fromBlock\` without crashing (disk-corruption / partial-write defense-in-depth)

All 11 tests (8 existing + 3 new) pass; broader reader+BFT integration suite (70 tests) green.

### Docs: 88780 enablement runbook

\`docs/validator-registry-reader-enablement-88780.md\` (new) — operations SOP for activating the reader on the live 88780 cluster. Covers:

- **Pre-flight**: the 6 current validators must \`stake()\` 32 ETH each into the on-chain registry (currently dormant; \`activeValidatorCount()=0\`). Includes funding step (deployer EOA → each validator's signing-key EOA).
- **Env-var rollout per node**: \`COC_VALIDATOR_REGISTRY_ADDRESS=0x4441299c...\` in each \`coc-node@N.env\`.
- **One-at-a-time rolling restart** with verification gates. Chaos T2 showed parallel restarts of 2+ validators stall the chain ~2.5 min; one-at-a-time prevents it.
- **End-to-end gate**: dry-run with a 7th external validator (fresh EOA, stake 32 ETH, expect BFT inclusion within one poll cycle ≤ 60s, no node restart).
- **Rollback procedure**: remove env var line, restart; the static \`validators\` config is the safety net.

## What this does NOT do

The reader **stays dormant on 88780** post-merge. The env var is not set on any validator yet, and the 6 current validators are not staked into the registry. Both are operator-driven follow-ups (need signing-key access on each validator host plus 32+ ETH pre-funding from the deployer). The SOP is the runbook for executing that follow-up; this PR ships the test safety net + the runbook so the actual enablement can land later as an ops PR with no code surprises.

## Test plan

- [x] \`node --experimental-strip-types --test runtime/lib/validator-registry-reader.test.ts\` — 11/11 pass
- [x] \`node --experimental-strip-types --test runtime/lib/validator-registry-reader.test.ts runtime/lib/contract-reader.test.ts node/src/consensus-validator-set-change.test.ts node/src/bft.test.ts\` — 70/70 pass (no regression in reader-adjacent or BFT-coordinator paths)
- [ ] Follow-up ops PR: enable on 88780 per the SOP

## Refs

- Reader impl: \`runtime/lib/validator-registry-reader.ts\` (392→442 lines)
- Reader wiring: \`node/src/index.ts:1027-1118\` (PR-1B \`consensus.onValidatorSetChange\` path)
- ValidatorRegistry proxy on 88780: \`0x4441299c118373fDC96bE1983d42C79e19CDb4F0\`
- Canary plan: \`/home/bob/.claude/plans/applyblock-delightful-hennessy.md\` § A.1.1