### PR TITLE
docs(canary): Stage 1 — SECURITY.md + public endpoints reference (88780)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,4 +84,11 @@ See [Milestones](https://github.com/chainofclaw/COC/milestones) for the Prowl te
 
 ## Security
 
-For security vulnerabilities, please use the [Security Report template](https://github.com/chainofclaw/COC/issues/new?template=security_report.yml) or email security@chainofclaw.io for critical issues.
+For security vulnerabilities, **do not** open a public GitHub issue. See
+the canonical [`SECURITY.md`](./SECURITY.md) for the full disclosure policy,
+severity-tier rewards (canary testnet: $100–$50,000 USD-equivalent),
+response timeline (24h ack for Critical), and safe-harbor terms. Quick
+paths:
+
+- Email `security@chainofclaw.io` (preferred for time-sensitive)
+- GitHub private advisory: <https://github.com/chainofclaw/COC/security/advisories/new>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,198 @@
+# Security Policy
+
+[English](#english) · [中文](#中文)
+
+---
+
+## English
+
+ChainOfClaw (COC) takes security seriously. This document describes how to
+report a vulnerability and what to expect in return.
+
+### Reporting a vulnerability
+
+**Do not file public GitHub issues for security vulnerabilities.** Use one of
+these private channels:
+
+1. **Email**: `security@chainofclaw.io` (preferred for time-sensitive reports)
+2. **GitHub private vulnerability report**: open one at
+   <https://github.com/chainofclaw/COC/security/advisories/new>
+
+If your finding is critical (active exploitation, validator-key compromise,
+funds at risk, chain liveness threat), email is fastest — we monitor that
+inbox during waking hours and aim to acknowledge within 24 hours.
+
+For lower-severity reports, the GitHub private-advisory channel keeps
+metadata + history alongside the codebase and is recommended.
+
+If you require PGP-encrypted submission, request a key in your first email
+(no body) and we'll respond with our current public key fingerprint. We
+rotate the key annually.
+
+### What's in scope
+
+Vulnerabilities that affect the production canary testnet (**chainId 88780**)
+or could affect a future mainnet launch:
+
+- **Chain & consensus**: BFT correctness (safety + liveness), fork-choice,
+  snap-sync, P2P message handling, equivocation detection
+- **Smart contracts**: any of the 13 gen-5 UUPS-proxied contracts on 88780
+  (PoSeManagerV2, GovernanceDAO, Treasury, SoulRegistry, DIDRegistry,
+  ValidatorRegistry, EquivocationDetector, InsuranceFund, DelayedInbox,
+  RollupStateManager, CidRegistry, FactionRegistry, PoSeManager). The
+  upgrade-authority MultiSigWallet is also in scope despite being immutable
+- **Off-chain services**: `runtime/`, `services/`, `node/`, `explorer/`,
+  `faucet/`, `wallet/` packages
+- **Public-facing infrastructure**: any host the project operates that
+  serves RPC, WSS, faucet, explorer, or the website
+
+### What's out of scope
+
+- Documentation typos / wording issues (these are
+  [normal contributions](./CONTRIBUTING.md) — use a PR)
+- Self-inflicted issues (lost private keys held only by the reporter, etc.)
+- Theoretical attacks without a working PoC against the current network
+- Spam / phishing in third-party channels we don't operate
+- Known issues already documented as `OPEN` in
+  [chainofclaw/COC issues](https://github.com/chainofclaw/COC/issues) (e.g.
+  #746 PoSe witness semantic verification — listed publicly because the
+  affected code is dormant in production)
+
+### Severity & reward tiers (canary testnet)
+
+We reward verified, novel reports. The reward range reflects the
+**canary-testnet phase** — mainnet launch will introduce a separate,
+higher-tier bounty program.
+
+| Severity | Examples | Reward (USD-equivalent) |
+|----------|----------|------------------------|
+| **Critical** | Active fund-loss vector, root-key compromise, chain-halt vector that we cannot mitigate operationally, contract storage corruption | $10,000 – $50,000 |
+| **High** | Validator-set manipulation, slashing bypass, RPC-rate-limit bypass exposing DoS amplification, signature malleability / EIP-2 violations | $2,500 – $10,000 |
+| **Medium** | Front-end XSS with auth implications, mempool eviction patterns, governance proposal griefing not blocked by economics | $500 – $2,500 |
+| **Low** | Information leaks of public-but-undocumented data, missing input validation without exploit path | $100 – $500 |
+
+Rewards are paid in COC (post-canary launch) or in stablecoin equivalent
+(if requested before payout). Payment requires a non-anonymous channel for
+tax / regulatory compliance — pseudonyms are fine for credit, real identity
+is required for payout.
+
+### Triage & response timeline
+
+| Stage | Target |
+|-------|--------|
+| Initial acknowledgment | 24h (Critical), 72h (High), 7d (Medium/Low) |
+| Triage decision + severity classification | 5 business days |
+| Fix landed on `main` | within 30d of triage for Critical / High |
+| Coordinated public disclosure | 90 days from report, or sooner with reporter's agreement once the fix is deployed |
+
+If we cannot reach a fix within 90 days for a Critical/High issue, we'll
+contact you to discuss extension — but extensions are rare and require
+explicit agreement.
+
+### Safe harbor
+
+Researchers acting in good faith — meaning they only test against their own
+funds, do not exfiltrate user data beyond what's needed to demonstrate the
+bug, do not perform attacks on third parties using the discovery, and
+follow the disclosure timeline — will not face legal action from the
+project.
+
+If you compromise mainnet user funds, retain stolen funds, or publicly
+disclose before the agreed timeline, safe harbor does not apply.
+
+### Audit & disclosure history
+
+Prior audit work is recorded in the [`docs/`](./docs/) directory and in
+sprint summaries within commit history. Recent in-house audit cycles
+(2026-04 to 2026-05) closed 15+ findings tracked publicly under
+[issue numbers #645–#754](https://github.com/chainofclaw/COC/issues?q=is%3Aissue+is%3Aclosed).
+The only remaining open item from those cycles is
+[#746](https://github.com/chainofclaw/COC/issues/746) (PoSe witness
+semantic verification — affected code is dormant in production).
+
+External third-party audits are planned before mainnet launch and will be
+linked here when complete.
+
+---
+
+## 中文
+
+ChainOfClaw (COC) 对安全持严肃态度。本文档说明如何提交漏洞报告以及您可以期待的处理流程。
+
+### 提交漏洞
+
+**请不要为安全漏洞开公开的 GitHub issue。** 使用以下私密渠道之一:
+
+1. **邮件**:`security@chainofclaw.io`(紧急报告首选)
+2. **GitHub 私密漏洞报告**:在
+   <https://github.com/chainofclaw/COC/security/advisories/new> 提交
+
+如果是严重问题(正在被利用、validator 密钥泄漏、资金风险、链活性威胁),邮件最快——我们在工作时间监控该信箱,目标 24 小时内回复。
+
+中低严重度报告建议走 GitHub 私密报告通道,元数据 + 历史与代码库同地保存。
+
+如需 PGP 加密提交,请在首封邮件中(无正文)请求密钥,我们将回复当前公钥指纹。密钥每年轮换一次。
+
+### 收录范围
+
+影响生产 canary 测试网(**chainId 88780**)或未来主网启动的漏洞:
+
+- **链与共识**:BFT 正确性(safety + liveness)、fork-choice、snap-sync、
+  P2P 消息处理、equivocation 检测
+- **智能合约**:88780 上 13 个 gen-5 UUPS proxy 合约
+  (PoSeManagerV2、GovernanceDAO、Treasury、SoulRegistry、DIDRegistry、
+  ValidatorRegistry、EquivocationDetector、InsuranceFund、DelayedInbox、
+  RollupStateManager、CidRegistry、FactionRegistry、PoSeManager)。
+  升级权威 MultiSigWallet 虽不可升级但也在范围内
+- **链下服务**:`runtime/`、`services/`、`node/`、`explorer/`、`faucet/`、`wallet/` 包
+- **对外基础设施**:项目运营的 RPC、WSS、faucet、explorer 或官网主机
+
+### 不在范围
+
+- 文档错别字 / 文字表达(这些是正常贡献,见 [CONTRIBUTING.md](./CONTRIBUTING.md),用 PR 提交)
+- 自致问题(报告者自己丢失的私钥等)
+- 无可工作 PoC 的理论攻击
+- 我们不运营的第三方渠道中的钓鱼 / 垃圾邮件
+- 已在 [chainofclaw/COC issues](https://github.com/chainofclaw/COC/issues) 中以 `OPEN` 状态记录的已知问题
+  (例如 #746 PoSe witness 语义校验——公开列出因受影响代码在生产中休眠)
+
+### 严重度与奖励级别(canary 测试网)
+
+我们对经核实的新颖报告予以奖励。奖金范围反映**canary 测试网阶段**——主网启动将引入单独的、更高级别的赏金计划。
+
+| 严重度 | 示例 | 奖励(USD 等值) |
+|--------|------|------------------|
+| **Critical** | 主动资金损失向量、根密钥泄漏、运营无法缓解的链停 vector、合约存储破坏 | $10,000 – $50,000 |
+| **High** | Validator 集合操纵、slash 绕过、暴露 DoS 放大的 RPC 限流绕过、签名可塑性 / EIP-2 违规 | $2,500 – $10,000 |
+| **Medium** | 带 auth 影响的前端 XSS、mempool 驱逐模式、经济模型未阻挡的治理提案 griefing | $500 – $2,500 |
+| **Low** | 公开但未记录数据的信息泄漏、无利用路径的输入校验缺失 | $100 – $500 |
+
+奖励以 COC(canary 启动后)或稳定币等值支付(在支付前提出要求)。支付需要非匿名渠道用于税务 / 合规——化名用于致谢可以,但实际支付需要真实身份。
+
+### 分类与响应时间表
+
+| 阶段 | 目标 |
+|------|------|
+| 初次确认 | 24 小时(Critical)、72 小时(High)、7 天(Medium/Low)|
+| 分类决策 + 严重度划分 | 5 个工作日 |
+| 修复合并到 `main` | Critical / High 在分类后 30 天内 |
+| 协调公开披露 | 报告后 90 天,或在修复部署后经报告者同意提前 |
+
+如果 Critical/High 问题 90 天内无法修复,我们会联系您讨论延期——但延期罕见,需明确同意。
+
+### 安全港(Safe Harbor)
+
+善意研究 — 仅测试自己的资金、除证明 bug 所需外不导出用户数据、不利用发现攻击第三方、遵守披露时间表 — 不会受到项目方法律追究。
+
+如果您侵害主网用户资金、保留盗窃资金、或在约定时间表前公开披露,则不适用安全港。
+
+### 审计与披露历史
+
+历史审计工作记录在 [`docs/`](./docs/) 目录及 commit history 的 sprint 总结中。
+近期内部审计周期(2026-04 至 2026-05)关闭了 15+ 项发现,公开追踪于
+[#645–#754](https://github.com/chainofclaw/COC/issues?q=is%3Aissue+is%3Aclosed)。
+这些周期的唯一遗留开放项是
+[#746](https://github.com/chainofclaw/COC/issues/746)
+(PoSe witness 语义校验——受影响代码在生产中休眠)。
+
+主网启动前计划进行外部第三方审计,完成后将链接于此。

--- a/contracts/.openzeppelin/unknown-88780.json
+++ b/contracts/.openzeppelin/unknown-88780.json
@@ -7300,7 +7300,7 @@
             "label": "proposals",
             "offset": 0,
             "slot": "9",
-            "type": "t_mapping(t_uint256,t_struct(Proposal)1518_storage)",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)10497_storage)",
             "contract": "Treasury",
             "src": "contracts-src/governance/Treasury.sol:36"
           },
@@ -7342,7 +7342,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_struct(InitializableStorage)130_storage": {
+          "t_struct(InitializableStorage)172_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -7384,11 +7384,11 @@
             "label": "mapping(address => uint256)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(Proposal)1518_storage)": {
+          "t_mapping(t_uint256,t_struct(Proposal)10497_storage)": {
             "label": "mapping(uint256 => struct Treasury.Proposal)",
             "numberOfBytes": "32"
           },
-          "t_struct(Proposal)1518_storage": {
+          "t_struct(Proposal)10497_storage": {
             "label": "struct Treasury.Proposal",
             "members": [
               {
@@ -7437,6 +7437,1127 @@
           "t_uint8": {
             "label": "uint8",
             "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "7975d96b45ca58e78930915b6f25f2ccb3f186621a2749c9da4466be0a4b1229": {
+      "address": "0x0e8B945060AC6Ebe37DA2BE06406Dd7F49C8d356",
+      "txHash": "0xcb70c0bfe9b8ca906ba05ac799987dccf3ed011f786ee246fbc451e8b0e2ced4",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:15"
+          },
+          {
+            "label": "roles",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:16"
+          },
+          {
+            "label": "nodes",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:18"
+          },
+          {
+            "label": "nodeOperator",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:19"
+          },
+          {
+            "label": "operatorNodeCount",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_address,t_uint8)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:20"
+          },
+          {
+            "label": "epochBatches",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:22"
+          },
+          {
+            "label": "batches",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:23"
+          },
+          {
+            "label": "batchSampleCount",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_bytes32,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:24"
+          },
+          {
+            "label": "batchSampleCommitment",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_bytes32,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:25"
+          },
+          {
+            "label": "batchSampledLeaf",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:26"
+          },
+          {
+            "label": "usedReplayKeys",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:29"
+          },
+          {
+            "label": "epochFinalized",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:32"
+          },
+          {
+            "label": "epochSettlementRoot",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:33"
+          },
+          {
+            "label": "epochValidBatchCount",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_mapping(t_uint64,t_uint32)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:34"
+          },
+          {
+            "label": "unbondRequested",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:35"
+          },
+          {
+            "label": "endpointCommitmentUsed",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:38"
+          },
+          {
+            "label": "rewardPoolBalance",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_uint256",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "epochRewardsDistributed",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:42"
+          },
+          {
+            "label": "pendingRewards",
+            "offset": 0,
+            "slot": "18",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:43"
+          },
+          {
+            "label": "v1SunsetEpoch",
+            "offset": 0,
+            "slot": "19",
+            "type": "t_uint64",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:108"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "20",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerStorage",
+            "src": "contracts-src/settlement/PoSeManagerStorage.sol:112"
+          },
+          {
+            "label": "challengeNonces",
+            "offset": 0,
+            "slot": "69",
+            "type": "t_mapping(t_uint64,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:43"
+          },
+          {
+            "label": "epochRewardRoots",
+            "offset": 0,
+            "slot": "70",
+            "type": "t_mapping(t_uint64,t_bytes32)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:44"
+          },
+          {
+            "label": "rewardClaimed",
+            "offset": 0,
+            "slot": "71",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:45"
+          },
+          {
+            "label": "epochTotalReward",
+            "offset": 0,
+            "slot": "72",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:46"
+          },
+          {
+            "label": "epochSlashTotal",
+            "offset": 0,
+            "slot": "73",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:47"
+          },
+          {
+            "label": "epochTreasuryDelta",
+            "offset": 0,
+            "slot": "74",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:48"
+          },
+          {
+            "label": "challenges",
+            "offset": 0,
+            "slot": "75",
+            "type": "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:49"
+          },
+          {
+            "label": "epochNodeSlashed",
+            "offset": 0,
+            "slot": "76",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:50"
+          },
+          {
+            "label": "challengeFaultConfirmed",
+            "offset": 0,
+            "slot": "77",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:51"
+          },
+          {
+            "label": "epochClaimedReward",
+            "offset": 0,
+            "slot": "78",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:52"
+          },
+          {
+            "label": "consumedFaultEvidence",
+            "offset": 0,
+            "slot": "79",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:53"
+          },
+          {
+            "label": "challengeFaultEpochPlusOne",
+            "offset": 0,
+            "slot": "80",
+            "type": "t_mapping(t_bytes32,t_uint64)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:54"
+          },
+          {
+            "label": "pendingWithdrawals",
+            "offset": 0,
+            "slot": "81",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:55"
+          },
+          {
+            "label": "epochMerkleRootUsed",
+            "offset": 0,
+            "slot": "82",
+            "type": "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:61"
+          },
+          {
+            "label": "epochBatchCursor",
+            "offset": 0,
+            "slot": "83",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:66"
+          },
+          {
+            "label": "challengeBondMin",
+            "offset": 0,
+            "slot": "84",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:68"
+          },
+          {
+            "label": "insuranceBalance",
+            "offset": 0,
+            "slot": "85",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:69"
+          },
+          {
+            "label": "DOMAIN_SEPARATOR",
+            "offset": 0,
+            "slot": "86",
+            "type": "t_bytes32",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:70"
+          },
+          {
+            "label": "allowEmptyWitnessSubmission",
+            "offset": 0,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:71"
+          },
+          {
+            "label": "initialized",
+            "offset": 1,
+            "slot": "87",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:74"
+          },
+          {
+            "label": "_challengeCounter",
+            "offset": 0,
+            "slot": "88",
+            "type": "t_uint256",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:75"
+          },
+          {
+            "label": "cocToken",
+            "offset": 0,
+            "slot": "89",
+            "type": "t_contract(ICOCToken)2239",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:78"
+          },
+          {
+            "label": "genesisEpoch",
+            "offset": 20,
+            "slot": "89",
+            "type": "t_uint64",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:79"
+          },
+          {
+            "label": "emissionEnabled",
+            "offset": 28,
+            "slot": "89",
+            "type": "t_bool",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:80"
+          },
+          {
+            "label": "foundationAddress",
+            "offset": 0,
+            "slot": "90",
+            "type": "t_address",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:81"
+          },
+          {
+            "label": "epochFinalizedAt",
+            "offset": 0,
+            "slot": "91",
+            "type": "t_mapping(t_uint64,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:86"
+          },
+          {
+            "label": "epochSwept",
+            "offset": 0,
+            "slot": "92",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:87"
+          },
+          {
+            "label": "_activeNodeIds",
+            "offset": 0,
+            "slot": "93",
+            "type": "t_array(t_bytes32)dyn_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:94"
+          },
+          {
+            "label": "_activeNodeIndex",
+            "offset": 0,
+            "slot": "94",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:95"
+          },
+          {
+            "label": "_witnessSigUsed",
+            "offset": 0,
+            "slot": "95",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:103"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "96",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PoSeManagerV2",
+            "src": "contracts-src/settlement/PoSeManagerV2.sol:1344"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)130_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ICOCToken)2239": {
+            "label": "contract ICOCToken",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint8)": {
+            "label": "mapping(address => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(bytes32 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(BatchRecord)6927_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.BatchRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(ChallengeRecord)7002_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypesV2.ChallengeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(NodeRecord)6910_storage)": {
+            "label": "mapping(bytes32 => struct PoSeTypes.NodeRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint32)": {
+            "label": "mapping(bytes32 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint64)": {
+            "label": "mapping(bytes32 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(uint64 => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bytes32)": {
+            "label": "mapping(uint64 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(uint64 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(uint64 => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint256)": {
+            "label": "mapping(uint64 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint32)": {
+            "label": "mapping(uint64 => uint32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_uint64)": {
+            "label": "mapping(uint64 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BatchRecord)6927_storage": {
+            "label": "struct PoSeTypes.BatchRecord",
+            "members": [
+              {
+                "label": "epochId",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "merkleRoot",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "summaryHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "aggregator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "submittedAtEpoch",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "3"
+              },
+              {
+                "label": "disputeDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "finalized",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "4"
+              },
+              {
+                "label": "disputed",
+                "type": "t_bool",
+                "offset": 9,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(ChallengeRecord)7002_storage": {
+            "label": "struct PoSeTypesV2.ChallengeRecord",
+            "members": [
+              {
+                "label": "commitHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "challenger",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "bond",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "commitEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "revealDeadlineEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "3"
+              },
+              {
+                "label": "revealed",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "3"
+              },
+              {
+                "label": "settled",
+                "type": "t_bool",
+                "offset": 17,
+                "slot": "3"
+              },
+              {
+                "label": "targetNodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "faultType",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "5"
+              }
+            ],
+            "numberOfBytes": "192"
+          },
+          "t_struct(NodeRecord)6910_storage": {
+            "label": "struct PoSeTypes.NodeRecord",
+            "members": [
+              {
+                "label": "nodeId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "pubkeyNode",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "serviceFlags",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "serviceCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "endpointCommitment",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "bondAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "registeredAtEpoch",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "unlockEpoch",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "7"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 16,
+                "slot": "7"
+              }
+            ],
+            "numberOfBytes": "256"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "e462eff4f7f7c0579c2a8ac27b5b2148f3139a76bea83f45b4c524d98c1608ec": {
+      "address": "0xF2921b9AEA9Ad355406553527E4d69ec4FE64FC4",
+      "txHash": "0x96d156a3ba66577c76f7dd5569e84c37f1851abbd67a90311fc9f9bd58ec9833",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "factionRegistry",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(FactionRegistry)5350",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:45"
+          },
+          {
+            "label": "proposalCount",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:47"
+          },
+          {
+            "label": "proposals",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_struct(Proposal)5421_storage)",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:48"
+          },
+          {
+            "label": "hasVoted",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:49"
+          },
+          {
+            "label": "votingPeriod",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:52"
+          },
+          {
+            "label": "timelockDelay",
+            "offset": 8,
+            "slot": "4",
+            "type": "t_uint64",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:53"
+          },
+          {
+            "label": "quorumPercent",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:54"
+          },
+          {
+            "label": "approvalPercent",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint256",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:55"
+          },
+          {
+            "label": "bicameralEnabled",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:56"
+          },
+          {
+            "label": "owner",
+            "offset": 1,
+            "slot": "7",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:58"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_address",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:59"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "GovernanceDAO",
+            "src": "contracts-src/governance/GovernanceDAO.sol:332"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)172_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(FactionRegistry)5350": {
+            "label": "contract FactionRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ProposalState)5378": {
+            "label": "enum GovernanceDAO.ProposalState",
+            "members": [
+              "Pending",
+              "Approved",
+              "Rejected",
+              "Queued",
+              "Executed",
+              "Cancelled",
+              "Expired"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(ProposalType)5370": {
+            "label": "enum GovernanceDAO.ProposalType",
+            "members": [
+              "ValidatorAdd",
+              "ValidatorRemove",
+              "ParameterChange",
+              "TreasurySpend",
+              "ContractUpgrade",
+              "FreeText"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Proposal)5421_storage)": {
+            "label": "mapping(uint256 => struct GovernanceDAO.Proposal)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Proposal)5421_storage": {
+            "label": "struct GovernanceDAO.Proposal",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "registeredSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "humanSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "clawSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "proposalType",
+                "type": "t_enum(ProposalType)5370",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "proposer",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "4"
+              },
+              {
+                "label": "title",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "descriptionHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "executionTarget",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "executionData",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "createdAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "votingDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "10"
+              },
+              {
+                "label": "executionDeadline",
+                "type": "t_uint64",
+                "offset": 16,
+                "slot": "10"
+              },
+              {
+                "label": "forVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "11"
+              },
+              {
+                "label": "againstVotesHuman",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "12"
+              },
+              {
+                "label": "forVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "13"
+              },
+              {
+                "label": "againstVotesClaw",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "14"
+              },
+              {
+                "label": "abstainVotes",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "15"
+              },
+              {
+                "label": "state",
+                "type": "t_enum(ProposalState)5378",
+                "offset": 0,
+                "slot": "16"
+              }
+            ],
+            "numberOfBytes": "544"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
           }
         },
         "namespaces": {

--- a/docs/public-endpoints-88780.md
+++ b/docs/public-endpoints-88780.md
@@ -1,0 +1,185 @@
+# 88780 Canary Testnet — Public Endpoints & Network Parameters
+
+> **Canonical reference.** Every other doc that mentions a 88780 endpoint,
+> contract address, or network parameter should link here rather than
+> duplicate the value. Contract addresses are mirrored from
+> [`configs/deployed-contracts-88780.json`](../configs/deployed-contracts-88780.json) — if
+> those diverge, the manifest is authoritative.
+
+[中文版](./public-endpoints-88780.zh.md)
+
+## Network identity
+
+| Parameter | Value |
+|-----------|-------|
+| **Name** | ChainOfClaw Canary Testnet |
+| **chainId (decimal)** | 88780 |
+| **chainId (hex)** | `0x15acc` |
+| **Status** | Canary — open to external operators, prod-candidate stability soak |
+| **Genesis date** | 2026-05-20 (gen-5 UUPS deployment) |
+| **EVM compatibility** | Paris hardfork (`solc 0.8.24`) |
+| **Block time** | ~2.1 s (BFT early-commits optimization) |
+| **Block gas limit** | ~30,000,000 |
+| **Validator count** | 6 (currently single-operator; external operators welcome — see below) |
+| **Quorum** | ⌈2/3 × N⌉ = 4 of 6 |
+| **Native token symbol** | COC |
+| **Native token decimals** | 18 |
+
+## Public RPC + WebSocket + Faucet + Explorer
+
+> These endpoints front the validator cluster. They have rate limits + DDoS
+> protection. Direct validator RPC ports are not for public use.
+
+| Endpoint | URL |
+|----------|-----|
+| **JSON-RPC** | `https://rpc.chainofclaw.io` |
+| **WebSocket** | `wss://rpc.chainofclaw.io/ws` |
+| **Faucet** | `https://faucet.chainofclaw.io` (10 COC per address per 24h) |
+| **Block Explorer** | `https://explorer.chainofclaw.io` |
+| **Status page** | `https://chainofclaw.io/network` |
+
+### Rate limits (per-IP, per-sender)
+
+These limits protect validator stability under spam. They are enforced
+independently at three layers; the canary plan ([`coc-88780-2026-05-26-chaos-engineering-T1-T8.md`](../coc-88780-2026-05-26-chaos-engineering-T1-T8.md))
+verified all three under burst load.
+
+| Layer | Limit | Reject code |
+|-------|-------|-------------|
+| RPC per-IP rate | 240 req/min/IP | HTTP 429 / JSON-RPC `RPC rate limit exceeded` |
+| Mempool per-sender quota | 64 pending tx/sender | JSON-RPC `exceeds max pending tx limit (64)` |
+| Block gas limit | ~30M gas/block | tx remains pending until included |
+
+Heavy users should batch RPC calls (`eth_call` accepts arrays in some
+clients), or run a local archive node and gossip-receive blocks rather
+than polling.
+
+## Contract addresses (gen-5 UUPS proxies)
+
+> All proxies are owned by the 3-of-5 multisig
+> `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E`. The multisig is the sole
+> upgrade authority. Implementation addresses are tracked in
+> [`contracts/.openzeppelin/unknown-88780.json`](../contracts/.openzeppelin/unknown-88780.json) and may change
+> via authorized `upgradeToAndCall` calls signed by the multisig.
+
+| Contract | Proxy address | Purpose |
+|----------|---------------|---------|
+| **MultiSigWallet** | `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E` | Upgrade authority (immutable, not a proxy) |
+| **COCToken** (TBD) | — | Native gas token; current allocation lives in genesis allocation, not a separate token contract |
+| **PoSeManagerV2** | `0x256eb949C50d5F2af8699191b1Bc043203263549` | PoSe v2 settlement: challenges, receipts, witness quorum, slashing |
+| **PoSeManager** (v1) | `0x91e1D4aBcb68476368E8Ec02d61456a08Ae43BD8` | Legacy PoSe v1, sunset window controlled by `v1SunsetEpoch` |
+| **ValidatorRegistry** | `0x4441299c118373fDC96bE1983d42C79e19CDb4F0` | Stake-based BFT validator registry (permissionless `stake()`, 32 ETH min, 21 max active) |
+| **EquivocationDetector** | `0xa5dcE830e917176c1091fd6112F41E47692C510e` | On-chain proof-based slashing; permissionless `submitEvidence` |
+| **InsuranceFund** | `0x0546E0D98A18e110D3dFCFA150Bcd1C0a589d688` | 20% of slash proceeds; governance-controlled disbursement |
+| **GovernanceDAO** | `0x4b9485670eA389Aeab7aC04d48bb2b42D0e8bdc7` | Bicameral DAO over `FactionRegistry`; requires verified faction membership |
+| **FactionRegistry** | `0xc37d28297dB885d2B8d9966Cbb5df2e142671287` | Human/Claw faction identity; `verify()` gated for Sybil resistance |
+| **Treasury** | `0x512B012683c88103b1BEE3ad470108B47fBD7C7E` | 3-of-5 signer wallet; 5% per-tx cap below `governanceApprove` |
+| **SoulRegistry** | `0x3B6b5Fd45F8a6A2756e6D436d90b67faD0509244` | Soul identity + backup CID anchoring + social recovery |
+| **DIDRegistry** | `0xe2D8165Cb9416bf92E4304446A5Dccd20Db45fbF` | `did:coc` agent identity, delegation, verifiable credentials |
+| **CidRegistry** | `0x780603254D19A60ae35a1aEEBbB4dCd0c514371b` | Permissionless `keccak256(CID) → CID` lookup |
+| **DelayedInbox** | `0xac820809399D6740eB274D99827a5ee595881A00` | L1→L2 message inbox with configurable inclusion delay |
+| **RollupStateManager** | `0xA2Bf9FA3382A0A8aFf406BE8A8e9a64E1d69dC4e` | L2 state-root submission; proposer allowlist gated |
+
+## Connect a wallet
+
+### MetaMask / EVM wallets
+
+Custom-network entry:
+
+```
+Network name:       ChainOfClaw Canary
+RPC URL:            https://rpc.chainofclaw.io
+chainId:            88780  (0x15acc)
+Currency symbol:    COC
+Block explorer URL: https://explorer.chainofclaw.io
+```
+
+### ethers.js / viem
+
+```ts
+import { JsonRpcProvider } from "ethers"
+const provider = new JsonRpcProvider("https://rpc.chainofclaw.io")
+// chainId is auto-detected on first call.
+
+// WebSocket subscriptions:
+import { WebSocketProvider } from "ethers"
+const ws = new WebSocketProvider("wss://rpc.chainofclaw.io/ws")
+ws.on("block", (n) => console.log("new block:", n))
+```
+
+```ts
+// viem
+import { createPublicClient, http } from "viem"
+import { defineChain } from "viem"
+
+export const coc88780 = defineChain({
+  id: 88780,
+  name: "ChainOfClaw Canary",
+  nativeCurrency: { name: "COC", symbol: "COC", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.chainofclaw.io"] } },
+  blockExplorers: { default: { name: "COC Explorer", url: "https://explorer.chainofclaw.io" } },
+})
+
+const client = createPublicClient({ chain: coc88780, transport: http() })
+```
+
+### Getting test COC
+
+The faucet drips **10 COC per address per 24h** (sufficient for typical
+dev exploration; not sufficient to stake as a validator — see
+[external-validator-onboarding.md](./external-validator-onboarding.md)
+for the 32-COC stake bootstrap path).
+
+```bash
+curl -X POST https://faucet.chainofclaw.io/faucet/request \
+  -H 'content-type: application/json' \
+  -d '{"address":"0xYourAddressHere"}'
+```
+
+## Becoming a validator
+
+The canary network welcomes external operators. Brief overview:
+
+1. Stand up a node (see [operations-manual.en.md](./operations-manual.en.md))
+2. Stake 32 COC via `ValidatorRegistry.stake(nodeId, pubkeyNode)` from
+   your validator's signing-key EOA
+3. Your node is BFT-included within one poll cycle (~60s) of the on-chain
+   stake event — **no manual coordination required** with existing
+   operators (see [`validator-registry-reader-enablement-88780.md`](./validator-registry-reader-enablement-88780.md)
+   for the underlying mechanism)
+4. To exit: `requestUnstake()` → wait `UNSTAKE_LOCKUP` (14 days) → `withdrawStake()`
+
+Maximum active validator count is **21** (`MAX_VALIDATORS`). Slot
+saturation reverts the `stake()` call.
+
+Full step-by-step guide:
+[`external-validator-onboarding.md`](./external-validator-onboarding.md).
+
+## Operational SOPs
+
+| Concern | Doc |
+|---------|-----|
+| Become a validator | [`external-validator-onboarding.md`](./external-validator-onboarding.md) |
+| Node-side validator-registry reader (operator details) | [`validator-registry-reader-enablement-88780.md`](./validator-registry-reader-enablement-88780.md) |
+| Recover from chain halt / multisig key loss / mass node loss | [`disaster-recovery-88780.md`](./disaster-recovery-88780.md) |
+| Pre-launch checklist (operator perspective) | [`canary-launch-checklist-88780.md`](./canary-launch-checklist-88780.md) |
+| Report a vulnerability | [`SECURITY.md`](../SECURITY.md) |
+| Whitepaper | [`COC_whitepaper.en.md`](./COC_whitepaper.en.md) ([中文](./COC_whitepaper.zh.md)) |
+| Architecture deep-dive | [`architecture-whitepaper.en.md`](./architecture-whitepaper.en.md) ([中文](./architecture-whitepaper.zh.md)) |
+
+## Decommissioned: Prowl testnet (chainId 18780)
+
+The Prowl testnet (`chainId 18780`) was retired on 2026-05-12 in favor of
+88780. Documents describing Prowl are preserved under
+[`docs/archive/prowl-18780/`](./archive/prowl-18780/) for historical
+reference but should not be used for current development.
+
+## Reporting issues with these endpoints
+
+- **RPC / WSS / Faucet / Explorer down or degraded**: see network status
+  at <https://chainofclaw.io/network>. If status is green and your
+  client is still failing, file a public issue at
+  <https://github.com/chainofclaw/COC/issues/new>
+- **Suspected security issue with an endpoint**: see [SECURITY.md](../SECURITY.md)
+- **Rate-limited unexpectedly**: confirm your client respects 240 req/min/IP
+  and consider running a local archive node for high-throughput access

--- a/docs/public-endpoints-88780.zh.md
+++ b/docs/public-endpoints-88780.zh.md
@@ -1,0 +1,167 @@
+# 88780 Canary 测试网 — 公开端点与网络参数
+
+> **权威参考。** 其他文档凡提及 88780 端点、合约地址或网络参数时,应链接至此而非重复值。
+> 合约地址镜像自
+> [`configs/deployed-contracts-88780.json`](../configs/deployed-contracts-88780.json)——
+> 如有差异以该 manifest 为准。
+
+[English](./public-endpoints-88780.md)
+
+## 网络标识
+
+| 参数 | 值 |
+|------|-----|
+| **名称** | ChainOfClaw Canary 测试网 |
+| **chainId(十进制)** | 88780 |
+| **chainId(十六进制)** | `0x15acc` |
+| **状态** | Canary — 对外部 operator 开放,prod-candidate 稳定性长跑 |
+| **创世日期** | 2026-05-20(gen-5 UUPS 部署) |
+| **EVM 兼容** | Paris hardfork (`solc 0.8.24`) |
+| **出块时间** | ~2.1 秒(BFT early-commits 优化) |
+| **区块 gas 上限** | ~30,000,000 |
+| **Validator 数** | 6(当前单运营方;欢迎外部 operator,见下) |
+| **Quorum** | ⌈2/3 × N⌉ = 6 中 4 |
+| **原生代币符号** | COC |
+| **原生代币 decimals** | 18 |
+
+## 公开 RPC + WebSocket + Faucet + Explorer
+
+> 这些端点前置于 validator 集群,带速率限制 + DDoS 防护。validator 直连 RPC 端口不对公开使用。
+
+| 端点 | URL |
+|------|-----|
+| **JSON-RPC** | `https://rpc.chainofclaw.io` |
+| **WebSocket** | `wss://rpc.chainofclaw.io/ws` |
+| **Faucet** | `https://faucet.chainofclaw.io`(每地址 24 小时 10 COC) |
+| **区块浏览器** | `https://explorer.chainofclaw.io` |
+| **状态页** | `https://chainofclaw.io/network` |
+
+### 速率限制(per-IP、per-sender)
+
+下列限制保护 validator 在 spam 下的稳定性,三层独立强制执行。canary 计划的
+[chaos 测试](../coc-88780-2026-05-26-chaos-engineering-T1-T8.md)在 burst 负载下验证了三层。
+
+| 层 | 上限 | 拒绝代码 |
+|----|------|---------|
+| RPC per-IP | 240 req/min/IP | HTTP 429 / JSON-RPC `RPC rate limit exceeded` |
+| Mempool per-sender 配额 | 64 pending tx/sender | JSON-RPC `exceeds max pending tx limit (64)` |
+| 区块 gas 上限 | ~30M gas/block | tx 保持 pending 至打包 |
+
+重度用户应批量 RPC 调用(部分客户端的 `eth_call` 接受数组),或运行本地 archive 节点 + 通过 gossip 接块代替轮询。
+
+## 合约地址(gen-5 UUPS proxies)
+
+> 所有 proxy 由 3-of-5 multisig `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E` 拥有。
+> multisig 是**唯一**升级权威。Implementation 地址追踪于
+> [`contracts/.openzeppelin/unknown-88780.json`](../contracts/.openzeppelin/unknown-88780.json)
+> ,可经 multisig 签名的 `upgradeToAndCall` 调用变更。
+
+| 合约 | Proxy 地址 | 用途 |
+|------|------------|------|
+| **MultiSigWallet** | `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E` | 升级权威(immutable,非 proxy) |
+| **PoSeManagerV2** | `0x256eb949C50d5F2af8699191b1Bc043203263549` | PoSe v2 结算:challenge、receipt、witness quorum、slash |
+| **PoSeManager**(v1) | `0x91e1D4aBcb68476368E8Ec02d61456a08Ae43BD8` | Legacy PoSe v1,sunset 窗口由 `v1SunsetEpoch` 控制 |
+| **ValidatorRegistry** | `0x4441299c118373fDC96bE1983d42C79e19CDb4F0` | 基于 stake 的 BFT validator 注册(permissionless `stake()`,32 COC min,21 active 上限) |
+| **EquivocationDetector** | `0xa5dcE830e917176c1091fd6112F41E47692C510e` | 链上证明驱动 slash;permissionless `submitEvidence` |
+| **InsuranceFund** | `0x0546E0D98A18e110D3dFCFA150Bcd1C0a589d688` | slash 收入 20%;治理控制支出 |
+| **GovernanceDAO** | `0x4b9485670eA389Aeab7aC04d48bb2b42D0e8bdc7` | `FactionRegistry` 之上的双院 DAO;需 verified faction 资格 |
+| **FactionRegistry** | `0xc37d28297dB885d2B8d9966Cbb5df2e142671287` | Human/Claw 阵营身份;`verify()` 门禁防 Sybil |
+| **Treasury** | `0x512B012683c88103b1BEE3ad470108B47fBD7C7E` | 3-of-5 signer 钱包;5% 单笔上限,`governanceApprove` 提升 |
+| **SoulRegistry** | `0x3B6b5Fd45F8a6A2756e6D436d90b67faD0509244` | Soul 身份 + backup CID 锚定 + 社交恢复 |
+| **DIDRegistry** | `0xe2D8165Cb9416bf92E4304446A5Dccd20Db45fbF` | `did:coc` agent 身份、delegation、可验证凭证 |
+| **CidRegistry** | `0x780603254D19A60ae35a1aEEBbB4dCd0c514371b` | permissionless `keccak256(CID) → CID` 查询 |
+| **DelayedInbox** | `0xac820809399D6740eB274D99827a5ee595881A00` | L1→L2 消息 inbox 带可配置 inclusion delay |
+| **RollupStateManager** | `0xA2Bf9FA3382A0A8aFf406BE8A8e9a64E1d69dC4e` | L2 state-root 提交;proposer allowlist 门禁 |
+
+## 连接钱包
+
+### MetaMask / EVM 钱包
+
+自定义网络条目:
+
+```
+网络名称:           ChainOfClaw Canary
+RPC URL:           https://rpc.chainofclaw.io
+chainId:           88780  (0x15acc)
+代币符号:           COC
+区块浏览器 URL:     https://explorer.chainofclaw.io
+```
+
+### ethers.js / viem
+
+```ts
+import { JsonRpcProvider } from "ethers"
+const provider = new JsonRpcProvider("https://rpc.chainofclaw.io")
+// chainId 首次调用时自动检测。
+
+// WebSocket 订阅:
+import { WebSocketProvider } from "ethers"
+const ws = new WebSocketProvider("wss://rpc.chainofclaw.io/ws")
+ws.on("block", (n) => console.log("新块:", n))
+```
+
+```ts
+// viem
+import { createPublicClient, http } from "viem"
+import { defineChain } from "viem"
+
+export const coc88780 = defineChain({
+  id: 88780,
+  name: "ChainOfClaw Canary",
+  nativeCurrency: { name: "COC", symbol: "COC", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.chainofclaw.io"] } },
+  blockExplorers: { default: { name: "COC Explorer", url: "https://explorer.chainofclaw.io" } },
+})
+
+const client = createPublicClient({ chain: coc88780, transport: http() })
+```
+
+### 获取测试 COC
+
+Faucet 每地址 24 小时滴 **10 COC**(够典型开发探索;不足以质押作 validator——见
+[external-validator-onboarding.md](./external-validator-onboarding.md) 的 32-COC stake bootstrap 路径)。
+
+```bash
+curl -X POST https://faucet.chainofclaw.io/faucet/request \
+  -H 'content-type: application/json' \
+  -d '{"address":"0xYourAddressHere"}'
+```
+
+## 成为 Validator
+
+Canary 网络欢迎外部 operator。简要概览:
+
+1. 搭建节点(见 [operations-manual.zh.md](./operations-manual.zh.md))
+2. 从你的 validator 签名密钥 EOA 经 `ValidatorRegistry.stake(nodeId, pubkeyNode)` 质押 32 COC
+3. 链上 stake 事件后一个 poll 周期(~60s)内你的节点被 BFT 纳入——**与现有 operator 无需手动协调**
+   (底层机制见 [`validator-registry-reader-enablement-88780.md`](./validator-registry-reader-enablement-88780.md))
+4. 退出:`requestUnstake()` → 等 `UNSTAKE_LOCKUP`(14 天)→ `withdrawStake()`
+
+最大活跃 validator 数 **21**(`MAX_VALIDATORS`)。槽位饱和会 revert `stake()` 调用。
+
+完整步骤指南:[`external-validator-onboarding.md`](./external-validator-onboarding.md)。
+
+## 运营 SOP
+
+| 关切 | 文档 |
+|------|------|
+| 成为 validator | [`external-validator-onboarding.md`](./external-validator-onboarding.md) |
+| 节点端 validator-registry reader(运营细节) | [`validator-registry-reader-enablement-88780.md`](./validator-registry-reader-enablement-88780.md) |
+| 链停 / 多签密钥丢失 / 大规模节点丢失恢复 | [`disaster-recovery-88780.md`](./disaster-recovery-88780.md) |
+| 上线前 checklist(运营视角) | [`canary-launch-checklist-88780.md`](./canary-launch-checklist-88780.md) |
+| 报告漏洞 | [`SECURITY.md`](../SECURITY.md) |
+| 白皮书 | [`COC_whitepaper.zh.md`](./COC_whitepaper.zh.md) ([English](./COC_whitepaper.en.md)) |
+| 架构深入 | [`architecture-whitepaper.zh.md`](./architecture-whitepaper.zh.md) ([English](./architecture-whitepaper.en.md)) |
+
+## 已退役:Prowl 测试网(chainId 18780)
+
+Prowl 测试网(`chainId 18780`)于 2026-05-12 退役,由 88780 接替。描述 Prowl 的文档保留在
+[`docs/archive/prowl-18780/`](./archive/prowl-18780/) 作历史参考,**不应**用于当前开发。
+
+## 报告端点问题
+
+- **RPC / WSS / Faucet / Explorer 不可用或降级**:查看
+  <https://chainofclaw.io/network> 的状态。若状态绿但客户端仍失败,在
+  <https://github.com/chainofclaw/COC/issues/new> 提公开 issue
+- **疑似端点安全问题**:见 [SECURITY.md](../SECURITY.md)
+- **意外被限流**:确认客户端遵守 240 req/min/IP,考虑运行本地 archive 节点用于高吞吐访问

--- a/docs/validator-registry-reader-enablement-88780.md
+++ b/docs/validator-registry-reader-enablement-88780.md
@@ -1,0 +1,244 @@
+# ValidatorRegistryReader Enablement on 88780 — Operations SOP
+
+**Status (2026-05-27):** Reader code is implemented, wired, and unit-tested
+(11 cases pass). 88780 nodes do **not** yet have the reader active — they're
+running with the static `validators` config. This document is the
+operational runbook for activating the reader, which is the core of Phase A
+"external validator onboarding" work in the [canary launch plan](../home/bob/.claude/plans/applyblock-delightful-hennessy.md).
+
+## What the reader does
+
+The reader (`runtime/lib/validator-registry-reader.ts`) mirrors the on-chain
+`ValidatorRegistry` proxy (`0x4441299c118373fDC96bE1983d42C79e19CDb4F0` on
+88780) into the node's BFT coordinator. Without it, the BFT validator set is
+hardcoded at startup and external operators who stake 32 ETH via
+`ValidatorRegistry.stake()` are **silently ignored** until each running node
+manually restarts with edited config — breaking the permissionless promise.
+
+After activation, this becomes the canonical flow for adding/removing
+validators:
+
+1. Operator calls `ValidatorRegistry.stake(nodeId, pubkeyNode)` from their
+   signing-key wallet with `msg.value = 32 ETH`
+2. Contract emits `ValidatorRegistered` event
+3. Within `pollIntervalMs` (default 60s), every node's reader sees the event,
+   updates its local active set, and pushes it into the BFT coordinator via
+   `consensus.onValidatorSetChange(next)` (PR-1B path)
+4. From the next BFT round onward, the new validator participates in
+   prepare/commit quorum
+
+## Pre-flight: 6 current validators must register on-chain
+
+The reader's `seedFromContractState()` reads `ValidatorRegistry.getActiveValidators()`.
+Today that returns an empty array because the current 6 validators were
+hardcoded into config, not staked on-chain. If we enable the reader against
+an empty registry, the index.ts wiring falls back to the static config
+(`if (active.length === 0)` → keep fallback), so the reader is harmless. But
+it's also useless until we migrate the 6 to be on-chain registered.
+
+### Step 1 — each validator operator runs the staking transaction
+
+For each validator host, the operator (with the validator's signing key in
+`~/.coc/keys/`) executes:
+
+```bash
+# On the operator's workstation, NOT on the validator node directly.
+# Signing key for validator-i lives in their ~/.coc/keys/ — never check in.
+node -e '
+const { Wallet, JsonRpcProvider, parseEther, Contract } = require("ethers");
+const fs = require("fs");
+
+// Validator signing key — operator-specific.
+const SIGN_KEY = fs.readFileSync(process.env.SIGN_KEY_PATH, "utf-8").trim();
+const PUBKEY   = process.env.PUBKEY;   // 65 B 0x04-prefixed, derive from SIGN_KEY
+const NODE_ID  = process.env.NODE_ID;  // keccak256(pubkey[1:65])
+
+const RPC = "http://209.74.64.88:38780";  // any healthy 88780 RPC
+const REG = "0x4441299c118373fDC96bE1983d42C79e19CDb4F0";  // ValidatorRegistry proxy
+const REG_ABI = ["function stake(bytes32 nodeId, bytes pubkeyNode) external payable"];
+
+(async () => {
+  const p = new JsonRpcProvider(RPC);
+  const w = new Wallet(SIGN_KEY, p);
+  const c = new Contract(REG, REG_ABI, w);
+  const tx = await c.stake(NODE_ID, PUBKEY, { value: parseEther("32") });
+  console.log("stake tx:", tx.hash);
+  const r = await tx.wait();
+  console.log("mined:", r.blockNumber, "status:", r.status);
+})();
+'
+```
+
+Each operator needs to know:
+- **Signing key** — their validator's private key (already in use for BFT signing)
+- **Pubkey** — derivable from signing key as 65-byte uncompressed secp256k1 (`0x04 || X || Y`)
+- **NodeId** — `keccak256(pubkey[1:65])`. Already consistent with how the node has been signing BFT messages (per `node/src/crypto/signer.ts`)
+
+⚠ **Funding**: each validator's signing-key EOA needs ≥ 32 ETH at the time
+of staking. Validators on 88780 likely don't have this on their signing-key
+EOA today (rewards have accumulated to operator addresses, not signing
+addresses). **Pre-fund 32.1 ETH** (extra for gas) from the deployer EOA to
+each signing-key EOA before staking.
+
+Verify pre-staking:
+```bash
+# For each validator's signing addr <V>, expect 32.1+ ETH:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["<V>","latest"]}' \
+  | jq -r '.result' | xargs -I{} python3 -c "print(int('{}', 16)/1e18, 'ETH')"
+```
+
+Verify post-staking:
+```bash
+# ValidatorRegistry.activeValidatorCount() should equal 6:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_call",
+       "params":[{"to":"0x4441299c118373fDC96bE1983d42C79e19CDb4F0",
+                  "data":"0x<selector for activeValidatorCount()>"},"latest"]}' \
+  | jq .result
+# Expected: "0x0000000000000000000000000000000000000000000000000000000000000006"
+```
+
+## Step 2 — enable the reader on each node
+
+Once the 6 validators are on-chain registered, add the env var to each
+node's `coc-node@*.env` file:
+
+```ini
+# /etc/coc/node-<N>.env
+COC_VALIDATOR_REGISTRY_ADDRESS=0x4441299c118373fDC96bE1983d42C79e19CDb4F0
+# Optional — defaults to http://127.0.0.1:<rpcPort>
+COC_VALIDATOR_REGISTRY_RPC_URL=http://127.0.0.1:38780
+# Optional — defaults to 60_000ms
+# COC_VALIDATOR_REGISTRY_POLL_INTERVAL_MS=60000
+```
+
+(There's no `validatorRegistryAddress` field in the existing JSON config;
+the env var is the canonical entry point. See `node/src/config.ts:566`.)
+
+## Step 3 — rolling restart, one validator at a time
+
+**Critical**: per chaos test T2, restarting 2+ validators in parallel risks
+H15 fallback stall. **Restart one at a time, validate, then proceed.**
+
+For each validator host (one at a time, in order v1, v3, v4, v5, obs-1, v2):
+
+```bash
+# Edit env file on the host
+ssh -i ~/.ssh/openclaw_server_key root@<host> '
+  echo "COC_VALIDATOR_REGISTRY_ADDRESS=0x4441299c118373fDC96bE1983d42C79e19CDb4F0" >> /etc/coc/node-<unit>.env
+  systemctl restart coc-node@<unit>
+'
+
+# Wait for the new node to rejoin BFT (~30s) before doing the next.
+# Verify: probe RPC eth_blockNumber + check log for "reader initialized" line.
+ssh -i ~/.ssh/openclaw_server_key root@<host> \
+  'journalctl -u coc-node@<unit> -n 100 --no-pager | grep "reader initialized\|BFT validator set updated"'
+```
+
+Expected log lines after restart:
+```
+[INFO][validator-registry-reader] reader initialized
+  address: 0x4441299c118373fDC96bE1983d42C79e19CDb4F0
+  activeCount: 6
+  lastScannedBlock: <current head>
+
+[INFO][node] BFT validator set updated from ValidatorRegistry
+  count: 6
+  ids: [<6 validator IDs in sorted order>]
+```
+
+If `activeCount` is < 6 or the BFT set update doesn't fire: roll back the
+env var, restart that node, investigate. **Do not proceed to the next node**
+until the current one's reader is healthy.
+
+## Step 4 — end-to-end verification (7th validator dry-run)
+
+Once all 6 nodes have the reader active:
+
+1. **Generate a fresh keypair**:
+   ```bash
+   node -e 'const {Wallet}=require("ethers"); const w=Wallet.createRandom();
+            console.log(JSON.stringify({addr:w.address, pk:w.privateKey, pubkey:w.signingKey.publicKey}))'
+   ```
+
+2. **Fund 32.1 ETH** from deployer or faucet (whichever has 32+ ETH balance).
+
+3. **Stake** via the same script template as Step 1.
+
+4. **Verify within 60s** (one poll cycle) — each node's log must show:
+   ```
+   [INFO][validator-registry-reader] reader initialized OR scan tick added
+   [INFO][node] BFT validator set updated from ValidatorRegistry
+     count: 7
+     ids: [..., <new validator id>]
+   ```
+
+5. **Verify on-chain BFT participation** — query each node's RPC for
+   `coc_validatorSet()` (or `eth_call ValidatorRegistry.getActiveValidators()`).
+   Both should report 7.
+
+6. **Block production** — chain continues at ~2-3s/block with the new
+   validator in the prepare/commit rotation.
+
+7. **Cleanup** — operator calls `requestUnstake()` then `withdrawStake()`
+   after 14d UNSTAKE_LOCKUP. Reader removes the validator from active set on
+   the deactivation event.
+
+## Rollback procedure
+
+If the reader misbehaves (e.g. emits add/remove events with wrong IDs, or
+the BFT coordinator rejects the set), roll back per node:
+
+```bash
+# Remove the env var line
+ssh root@<host> '
+  sed -i "/COC_VALIDATOR_REGISTRY_ADDRESS/d" /etc/coc/node-<unit>.env
+  systemctl restart coc-node@<unit>
+'
+```
+
+The reader sidecar (`<dataDir>/validator-registry-reader.state.json`) is
+safe to leave — it'll just be ignored when the env var is absent. Delete it
+if you suspect corruption (`rm <dataDir>/validator-registry-reader.state.json`).
+
+The hardcoded `validators` config in each node's JSON remains the safety
+net: even with the reader enabled, an empty active set from the registry
+falls back to the static config (index.ts:1043 `if (active.length === 0) ...`).
+
+## Verification commands (cheat sheet)
+
+```bash
+# 1. Reader sidecar exists + cursor advanced:
+ssh root@<host> 'cat /var/lib/coc/node-<unit>/validator-registry-reader.state.json'
+# Expected: {"lastScannedBlock":"<current head>"}
+
+# 2. Most recent reader scan tick + active set on this node:
+ssh root@<host> 'journalctl -u coc-node@<unit> -n 200 --no-pager \
+  | grep -E "reader initialized|validator set updated|scan tick failed" \
+  | tail -10'
+
+# 3. On-chain active validator count (any RPC):
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_call",
+       "params":[{"to":"0x4441299c118373fDC96bE1983d42C79e19CDb4F0",
+                  "data":"0x69d76d09"},"latest"]}'
+# selector 0x69d76d09 = activeValidatorCount() ; result is 32-byte hex int.
+
+# 4. BFT round currently running with the new set:
+curl -s http://209.74.64.88:38780 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"coc_getBftStatus"}'
+# Look at `validators` field — should match the on-chain active set.
+```
+
+## References
+
+- Reader implementation: `runtime/lib/validator-registry-reader.ts`
+- Reader unit tests (11 cases): `runtime/lib/validator-registry-reader.test.ts`
+- Wiring + retry logic: `node/src/index.ts:1027-1118`
+- BFT update path: `node/src/consensus.ts:992-995` (`onValidatorSetChange`)
+- ValidatorRegistry contract: `contracts/contracts-src/governance/ValidatorRegistry.sol`
+- ValidatorRegistry proxy: `0x4441299c118373fDC96bE1983d42C79e19CDb4F0`
+  (from `configs/deployed-contracts-88780.json`)
+- Canary readiness plan: `/home/bob/.claude/plans/applyblock-delightful-hennessy.md`
+  § A.1.1

--- a/runtime/lib/validator-registry-reader.test.ts
+++ b/runtime/lib/validator-registry-reader.test.ts
@@ -9,6 +9,9 @@
 
 import test from "node:test"
 import assert from "node:assert/strict"
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { ValidatorRegistryReader } from "./validator-registry-reader.ts"
 
 const NODE_A = "0x" + "a".repeat(64) as `0x${string}`
@@ -134,6 +137,79 @@ test("ValidatorRegistryReader: handler exception does not break further dispatch
   // Must not throw out of replayEventForTest even though first handler does.
   reader._replayEventForTest("ValidatorRegistered", [NODE_A, OP_X, 32n * 10n ** 18n, PUB_X], 100)
   assert.equal(secondHandlerCalled, true)
+})
+
+test("ValidatorRegistryReader: persist writes a parseable JSON sidecar with the scan cursor", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-persist-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+    })
+
+    await reader._persistForTest(12345n)
+
+    assert.equal(existsSync(persistPath), true, "persist sidecar created")
+    const raw = readFileSync(persistPath, "utf-8")
+    const state = JSON.parse(raw)
+    assert.equal(state.lastScannedBlock, "12345", "block stored as decimal string")
+    assert.equal(typeof state.lastScannedBlock, "string", "string form to keep JSON-safe (avoids bigint losing precision)")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("ValidatorRegistryReader: hydrate picks up lastScannedBlock from a pre-existing sidecar", async () => {
+  // Restart scenario: a previous reader run wrote state.json; the new reader
+  // must pick up at that block, not re-scan from genesis. Without this the
+  // reader walks the entire chain history on every node restart — at 88780
+  // testnet height ~380k blocks, that's a 5+ min eth_getLogs storm.
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-hydrate-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    writeFileSync(persistPath, JSON.stringify({ lastScannedBlock: "67890" }) + "\n")
+
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+    })
+
+    await reader._hydrateFromSidecarForTest()
+
+    assert.equal(reader._lastScannedBlockForTest(), 67890n, "cursor hydrated from sidecar")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("ValidatorRegistryReader: corrupted sidecar falls back to configured fromBlock without crashing", async () => {
+  // Defense-in-depth: if the sidecar file is unparseable (disk corruption,
+  // partial write during ungraceful shutdown), the reader must not refuse
+  // to start. Fall back to `fromBlock` and re-scan; we'll catch up to head
+  // on the next tick. Without this, a corrupted sidecar would brick the
+  // node's BFT validator-set reader permanently until manual file deletion.
+  const dir = mkdtempSync(join(tmpdir(), "coc-vrr-corrupt-"))
+  try {
+    const persistPath = join(dir, "state.json")
+    writeFileSync(persistPath, "{ this is not valid json @@@", "utf-8")
+
+    const reader = new ValidatorRegistryReader({
+      rpcUrl: "http://127.0.0.1:1",
+      address: "0x0000000000000000000000000000000000000001",
+      persistPath,
+      fromBlock: 100n,
+    })
+
+    await reader._hydrateFromSidecarForTest()
+
+    // Corrupted sidecar → warned + fell back to fromBlock=100. No throw.
+    assert.equal(reader._lastScannedBlockForTest(), 100n, "fromBlock used as fallback")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test("ValidatorRegistryReader: re-registering same nodeId after deactivation re-adds", () => {

--- a/runtime/lib/validator-registry-reader.ts
+++ b/runtime/lib/validator-registry-reader.ts
@@ -125,21 +125,7 @@ export class ValidatorRegistryReader {
   async init(): Promise<void> {
     if (this.initialized) return
 
-    if (this.cfg.persistPath && existsSync(this.cfg.persistPath)) {
-      try {
-        const raw = await readFile(this.cfg.persistPath, "utf-8")
-        const state = JSON.parse(raw) as PersistState
-        this.lastScannedBlock = BigInt(state.lastScannedBlock)
-      } catch (err) {
-        log.warn("failed to load persisted lastScannedBlock; starting from configured fromBlock", {
-          path: this.cfg.persistPath,
-          error: String(err),
-        })
-        this.lastScannedBlock = this.cfg.fromBlock
-      }
-    } else {
-      this.lastScannedBlock = this.cfg.fromBlock
-    }
+    await this.hydrateFromSidecar()
 
     // Snap-synced nodes don't have block history before the snap point, so
     // ValidatorRegistered events from earlier blocks aren't queryable via
@@ -187,6 +173,34 @@ export class ValidatorRegistryReader {
     if (this.pollTimer) {
       clearInterval(this.pollTimer)
       this.pollTimer = null
+    }
+  }
+
+  /**
+   * Load `lastScannedBlock` from the persisted sidecar (if any). Pulled out
+   * of `init()` so unit tests can verify hydration / corruption-fallback
+   * without standing up an RPC provider (init's `scanToTip` would otherwise
+   * hang on an unreachable endpoint).
+   *
+   * Corrupted sidecar (unparseable JSON, missing field) → log warn and fall
+   * back to `cfg.fromBlock`. Never throws — this path runs before any RPC
+   * work so a corrupt file should not prevent reader startup.
+   */
+  private async hydrateFromSidecar(): Promise<void> {
+    if (this.cfg.persistPath && existsSync(this.cfg.persistPath)) {
+      try {
+        const raw = await readFile(this.cfg.persistPath, "utf-8")
+        const state = JSON.parse(raw) as PersistState
+        this.lastScannedBlock = BigInt(state.lastScannedBlock)
+      } catch (err) {
+        log.warn("failed to load persisted lastScannedBlock; starting from configured fromBlock", {
+          path: this.cfg.persistPath,
+          error: String(err),
+        })
+        this.lastScannedBlock = this.cfg.fromBlock
+      }
+    } else {
+      this.lastScannedBlock = this.cfg.fromBlock
     }
   }
 
@@ -307,6 +321,35 @@ export class ValidatorRegistryReader {
    */
   _replayEventForTest(eventName: "ValidatorRegistered" | "ValidatorDeactivated" | "ValidatorSlashed", args: unknown[], blockNumber: number, index = 0): void {
     this.handleEvent({ eventName, args, blockNumber, index } as unknown as EventLog)
+  }
+
+  /**
+   * Test-only read of the persisted scan cursor. Production code should
+   * never depend on this — it exists so unit tests can verify that
+   * `init()` correctly hydrates `lastScannedBlock` from the sidecar file
+   * and that `persist()` writes a parseable record after a scan tick.
+   */
+  _lastScannedBlockForTest(): bigint {
+    return this.lastScannedBlock
+  }
+
+  /**
+   * Test-only trigger for the persistence write. Mirrors what `scanToTip`
+   * does at the end of a tick but without needing a live RPC. Production
+   * code should never call this — `scanToTip` is the canonical caller.
+   */
+  async _persistForTest(blockNumber: bigint): Promise<void> {
+    this.lastScannedBlock = blockNumber
+    await this.persist()
+  }
+
+  /**
+   * Test-only invocation of the sidecar-hydrate step. Lets unit tests verify
+   * the restart hydration + corrupted-sidecar fallback without standing up
+   * an RPC provider (which init's later scan step requires).
+   */
+  async _hydrateFromSidecarForTest(): Promise<void> {
+    await this.hydrateFromSidecar()
   }
 
   private handleEvent(ev: EventLog): void {


### PR DESCRIPTION
## Summary

Stage 1 of 5 from the docs+website refresh plan (\`/home/bob/.claude/plans/applyblock-delightful-hennessy.md\`). These two artifacts gate the rest of the canary docs work: without a published security policy researchers don't know who to contact, and without a single source of truth for network params every other doc duplicates (and contradicts) chainId + RPC URLs.

## What's in

### \`SECURITY.md\` (root, EN+ZH inline)

Vulnerability disclosure policy. Reuses the \`security@chainofclaw.io\` channel that already existed in CONTRIBUTING.md so nothing changes for reporters. Adds:
- Scope (in/out) — covers chain, contracts (13 gen-5 proxies), off-chain services (\`runtime/\`/\`services/\`/\`node/\`/\`explorer/\`/\`faucet/\`/\`wallet/\`), public-facing infrastructure
- Severity tiers — Critical \$10k–\$50k / High \$2.5k–\$10k / Medium \$500–\$2.5k / Low \$100–\$500 (canary-testnet phase; mainnet gets a separate higher-tier program)
- Response timeline — 24h ack for Critical, 90d coordinated disclosure default
- Safe-harbor terms — good-faith research not subject to legal action
- Prior-audit summary linking to closed issue range #645–#754 and the still-open #746 (dormant in prod)

### \`docs/public-endpoints-88780.md\` + \`.zh.md\`

Canonical 88780 reference. Pulls all 13 gen-5 UUPS proxy addresses + multisig from \`configs/deployed-contracts-88780.json\` (verified by automated cross-check at commit time: **14/14 addresses present**). Covers:
- chainId 88780 / 0x15acc, block time ~2.1s, gas limit ~30M
- Public \`https://rpc.chainofclaw.io\` + \`wss://rpc.chainofclaw.io/ws\` + faucet + explorer URLs
- Three-layer rate-limit posture (240 req/min/IP, 64 pending/sender, 30M gas) cross-referenced to the chaos memory file that validated them
- MetaMask + ethers.js + viem snippets
- Validator-bootstrap pointer to \`external-validator-onboarding.md\` (Stage 2)
- Decommissioned-Prowl banner with pointer to the archive (Stage 4)

## What's updated

\`CONTRIBUTING.md\` § Security — promote SECURITY.md to canonical reference. Keeps both the email path and the GitHub private-advisory link visible.

## Verification

- [x] \`grep -rn "security@chainofclaw.io" SECURITY.md CONTRIBUTING.md\` — contact reachable from canonical + secondary paths
- [x] Automated cross-check: all 14 manifest addresses (13 contracts + multisig) present in \`docs/public-endpoints-88780.md\`
- [x] EN/ZH parity: \`docs/public-endpoints-88780.md\` + \`.zh.md\` both ship
- [ ] \`SECURITY.md\` appears on GitHub Security tab once merged (default behavior for root-level SECURITY.md)
- [ ] Stage 2 PR (DR runbook / canary checklist / external-validator onboarding) — follows
- [ ] Stage 3 PR (chainId 18780 → 88780 sweep) — follows
- [ ] Stage 4 PR (archive Prowl docs) — follows
- [ ] Stage 5 PR (website refresh) — follows

## Test plan

- [x] No tests required (docs-only)
- [x] EN/ZH parity sanity grep
- [x] Cross-check addresses vs \`configs/deployed-contracts-88780.json\`

## Note on \`.gitignore\`

\`docs/*.zh.md\` is in \`.gitignore\` from before EN/ZH parity was a project convention. All existing ZH docs (whitepaper, architecture, etc.) are force-added. This PR follows that pattern with \`git add -f docs/public-endpoints-88780.zh.md\`. A separate cleanup PR can revisit the \`.gitignore\` rule.