### PR TITLE
website(canary): Stage 5 — refresh for 88780 + new /security page

### DIFF
--- a/website/.env.local.example
+++ b/website/.env.local.example
@@ -1,6 +1,13 @@
-# Public RPC/WS (browser). Production: Nginx proxies to the 3-node testnet.
-NEXT_PUBLIC_RPC_URL=https://clawchain.io/api/testnet/rpc
-NEXT_PUBLIC_WS_URL=wss://clawchain.io/api/testnet/ws
+# Canary testnet 88780 — public endpoints.
+# See docs/public-endpoints-88780.md for the canonical RPC/WS/Faucet/Explorer URLs.
+NEXT_PUBLIC_RPC_URL=https://rpc.chainofclaw.io
+NEXT_PUBLIC_WS_URL=wss://rpc.chainofclaw.io/ws
 
-# Server-side SSR & API routes — must match the same chain as NEXT_PUBLIC_*.
-COC_RPC_URL=http://199.192.16.79:28780
+# Server-side SSR & API routes — must point at the same chain as NEXT_PUBLIC_*.
+# Use the public RPC unless running an internal validator/observer node.
+COC_RPC_URL=https://rpc.chainofclaw.io
+
+# Local devnet (alternative): `bash scripts/start-devnet.sh 3`, then
+#   NEXT_PUBLIC_RPC_URL=http://127.0.0.1:28780
+#   NEXT_PUBLIC_WS_URL=ws://127.0.0.1:18781
+#   COC_RPC_URL=http://127.0.0.1:28780

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -15,6 +15,7 @@
     "resources": "Resources",
     "development": "Development",
     "whitepaper": "Whitepaper",
+    "security": "Security",
     "allRightsReserved": "All rights reserved",
     "copyright": "Copyright",
     "services": "Services"
@@ -950,6 +951,11 @@
       "seconds": "Seconds",
       "launchDate": "Launching on March 27, 2026"
     },
+    "canaryBanner": {
+      "title": "Canary testnet 88780 is live",
+      "subtitle": "6-validator BFT network · gen-5 UUPS contracts · public RPC + faucet + explorer open",
+      "cta": "Read the public endpoints"
+    },
     "units": {
       "blocksPerMinute": "blocks/min",
       "authRequests": "auth requests"
@@ -1680,5 +1686,53 @@
     "statusPass": "Pass",
     "statusReview": "Review",
     "statusSuspicious": "Suspicious"
+  },
+  "security": {
+    "title": "Security Disclosure",
+    "subtitle": "Report a vulnerability. Get acknowledged in 24h. Get paid for valid critical findings.",
+    "contact": {
+      "title": "Report a vulnerability",
+      "body": "We accept reports via private channels. Please do not file public issues for security bugs.",
+      "advisory": "Open private advisory on GitHub"
+    },
+    "scope": {
+      "title": "Scope",
+      "inTitle": "In scope",
+      "outTitle": "Out of scope",
+      "in": {
+        "chain": "ChainOfClaw 88780 node code (RPC, P2P, mempool, consensus)",
+        "contracts": "Gen-5 UUPS smart contracts (governance, PoSe, identity, settlement)",
+        "explorer": "Block explorer at explorer.chainofclaw.io",
+        "website": "This website (chainofclaw.io) and the faucet"
+      },
+      "out": {
+        "thirdParty": "Third-party dependencies (report to the upstream project)",
+        "docs": "Documentation typos / dead links / suggestions",
+        "dos": "Generic volumetric DoS (Cloudflare layer)",
+        "social": "Social engineering of project members"
+      }
+    },
+    "rewards": {
+      "title": "Reward tiers (canary phase)",
+      "severity": "Severity",
+      "range": "Range",
+      "example": "Example",
+      "criticalEx": "Direct loss of validator funds, multisig bypass, remote code execution on validator",
+      "highEx": "Stuck consensus, mass slash trigger, contract upgrade abuse",
+      "mediumEx": "RPC privilege escalation, mempool griefing, faucet drain",
+      "lowEx": "Information disclosure, low-impact gas griefing, explorer XSS"
+    },
+    "timeline": {
+      "title": "Response SLA",
+      "ack": "Acknowledge receipt (auto + human for Critical)",
+      "triage": "Triage decision and severity assignment",
+      "fix": "Fix landed for Critical / High (faster on case-by-case)",
+      "disclosure": "Public disclosure window (coordinated with reporter)"
+    },
+    "canonical": {
+      "title": "Canonical policy",
+      "body": "Full disclosure policy, safe-harbor language, and PGP key live in SECURITY.md at the repository root.",
+      "docs": "Read the docs"
+    }
   }
 }

--- a/website/messages/es.json
+++ b/website/messages/es.json
@@ -15,6 +15,7 @@
     "resources": "Recursos",
     "development": "Desarrollo",
     "whitepaper": "Libro blanco",
+    "security": "Seguridad",
     "allRightsReserved": "Todos los derechos reservados",
     "copyright": "Copyright",
     "services": "Services"
@@ -950,6 +951,11 @@
       "seconds": "Segundos",
       "launchDate": "Lanzamiento el 27 de marzo de 2026"
     },
+    "canaryBanner": {
+      "title": "Testnet canario 88780 en vivo",
+      "subtitle": "Red BFT de 6 validadores · contratos gen-5 UUPS · RPC público + faucet + explorer abiertos",
+      "cta": "Ver endpoints públicos"
+    },
     "units": {
       "blocksPerMinute": "bloques/min",
       "authRequests": "solicitudes auth"
@@ -1680,5 +1686,53 @@
     "statusPass": "Pass",
     "statusReview": "Review",
     "statusSuspicious": "Suspicious"
+  },
+  "security": {
+    "title": "Divulgación de Seguridad",
+    "subtitle": "Reporta una vulnerabilidad. Acuse en 24h. Recompensa por hallazgos críticos válidos.",
+    "contact": {
+      "title": "Reportar una vulnerabilidad",
+      "body": "Aceptamos reportes por canales privados. No publiques issues públicos para bugs de seguridad.",
+      "advisory": "Abrir advisory privado en GitHub"
+    },
+    "scope": {
+      "title": "Alcance",
+      "inTitle": "En alcance",
+      "outTitle": "Fuera de alcance",
+      "in": {
+        "chain": "Código del nodo ChainOfClaw 88780 (RPC, P2P, mempool, consenso)",
+        "contracts": "Contratos Gen-5 UUPS (gobernanza, PoSe, identidad, liquidación)",
+        "explorer": "Block explorer en explorer.chainofclaw.io",
+        "website": "Este sitio (chainofclaw.io) y el faucet"
+      },
+      "out": {
+        "thirdParty": "Dependencias de terceros (reportar al proyecto upstream)",
+        "docs": "Errores tipográficos / enlaces rotos / sugerencias en docs",
+        "dos": "DoS volumétrico genérico (capa Cloudflare)",
+        "social": "Ingeniería social a miembros del proyecto"
+      }
+    },
+    "rewards": {
+      "title": "Niveles de recompensa (fase canary)",
+      "severity": "Severidad",
+      "range": "Rango",
+      "example": "Ejemplo",
+      "criticalEx": "Pérdida directa de fondos de validador, bypass de multisig, RCE en validador",
+      "highEx": "Consenso atascado, slash masivo, abuso de upgrade de contratos",
+      "mediumEx": "Escalada de privilegios RPC, mempool griefing, drenaje de faucet",
+      "lowEx": "Divulgación de información, gas griefing de bajo impacto, XSS en explorer"
+    },
+    "timeline": {
+      "title": "SLA de respuesta",
+      "ack": "Acuse de recibo (auto + humano para Critical)",
+      "triage": "Decisión de triage y asignación de severidad",
+      "fix": "Fix desplegado para Critical / High (caso por caso, más rápido)",
+      "disclosure": "Ventana de divulgación pública (coordinada con el reportero)"
+    },
+    "canonical": {
+      "title": "Política canónica",
+      "body": "Política completa de divulgación, safe-harbor y clave PGP en SECURITY.md (raíz del repo).",
+      "docs": "Ver documentación"
+    }
   }
 }

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -15,6 +15,7 @@
     "resources": "リソース",
     "development": "開発",
     "whitepaper": "ホワイトペーパー",
+    "security": "セキュリティ",
     "allRightsReserved": "全著作権所有",
     "copyright": "著作権",
     "services": "Services"
@@ -950,6 +951,11 @@
       "seconds": "秒",
       "launchDate": "2026年3月27日に起動"
     },
+    "canaryBanner": {
+      "title": "Canary テストネット 88780 稼働中",
+      "subtitle": "6 validator BFT ネットワーク · gen-5 UUPS 契約 · 公開 RPC + faucet + explorer オープン",
+      "cta": "公開エンドポイントを見る"
+    },
     "units": {
       "blocksPerMinute": "ブロック/分",
       "authRequests": "認証リクエスト"
@@ -1680,5 +1686,53 @@
     "statusPass": "Pass",
     "statusReview": "Review",
     "statusSuspicious": "Suspicious"
+  },
+  "security": {
+    "title": "セキュリティ開示",
+    "subtitle": "脆弱性を報告。24 時間以内に受信確認。有効な Critical 報告に対し報酬。",
+    "contact": {
+      "title": "脆弱性を報告",
+      "body": "プライベートチャネル経由で受け付けます。セキュリティバグはパブリック issue に書かないでください。",
+      "advisory": "GitHub でプライベート advisory を開く"
+    },
+    "scope": {
+      "title": "スコープ",
+      "inTitle": "スコープ内",
+      "outTitle": "スコープ外",
+      "in": {
+        "chain": "ChainOfClaw 88780 ノードコード(RPC, P2P, mempool, 合意)",
+        "contracts": "Gen-5 UUPS スマートコントラクト(ガバナンス、PoSe、ID、決済)",
+        "explorer": "ブロックエクスプローラー explorer.chainofclaw.io",
+        "website": "本サイト(chainofclaw.io)と faucet"
+      },
+      "out": {
+        "thirdParty": "サードパーティ依存(上流プロジェクトへ報告)",
+        "docs": "ドキュメントの誤字 / リンク切れ / 提案",
+        "dos": "汎用的な容量型 DoS(Cloudflare 層)",
+        "social": "プロジェクトメンバーへのソーシャルエンジニアリング"
+      }
+    },
+    "rewards": {
+      "title": "報酬階層(canary フェーズ)",
+      "severity": "重大度",
+      "range": "範囲",
+      "example": "例",
+      "criticalEx": "validator 資金の直接損失、multisig バイパス、validator での RCE",
+      "highEx": "合意停止、大量 slash 発生、コントラクト upgrade 悪用",
+      "mediumEx": "RPC 権限昇格、mempool グリーフィング、faucet 枯渇",
+      "lowEx": "情報漏洩、低影響 gas グリーフィング、explorer XSS"
+    },
+    "timeline": {
+      "title": "応答 SLA",
+      "ack": "受信確認(自動 + Critical は人手)",
+      "triage": "トリアージ判断と重大度割り当て",
+      "fix": "Critical / High 修正リリース(ケースバイケースで加速)",
+      "disclosure": "公開開示ウィンドウ(報告者と調整)"
+    },
+    "canonical": {
+      "title": "正式ポリシー",
+      "body": "完全な開示ポリシー、safe-harbor、PGP 鍵はリポジトリルートの SECURITY.md に。",
+      "docs": "ドキュメントを読む"
+    }
   }
 }

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -15,6 +15,7 @@
     "resources": "리소스",
     "development": "개발",
     "whitepaper": "백서",
+    "security": "보안",
     "allRightsReserved": "모든 권리 보유",
     "copyright": "Copyright",
     "services": "Services"
@@ -950,6 +951,11 @@
       "seconds": "초",
       "launchDate": "2026년 3월 27일 론칭"
     },
+    "canaryBanner": {
+      "title": "Canary 테스트넷 88780 가동 중",
+      "subtitle": "6 validator BFT 네트워크 · gen-5 UUPS 컨트랙트 · 공개 RPC + faucet + explorer 오픈",
+      "cta": "공개 엔드포인트 보기"
+    },
     "units": {
       "blocksPerMinute": "블록/분",
       "authRequests": "인증 요청"
@@ -1680,5 +1686,53 @@
     "statusPass": "Pass",
     "statusReview": "Review",
     "statusSuspicious": "Suspicious"
+  },
+  "security": {
+    "title": "보안 공개",
+    "subtitle": "취약점 보고. 24시간 내 접수 확인. 유효한 Critical 보고에 대해 보상.",
+    "contact": {
+      "title": "취약점 보고",
+      "body": "비공개 채널로만 접수합니다. 공개 issue에 보안 버그를 올리지 마세요.",
+      "advisory": "GitHub에서 비공개 advisory 열기"
+    },
+    "scope": {
+      "title": "범위",
+      "inTitle": "범위 내",
+      "outTitle": "범위 외",
+      "in": {
+        "chain": "ChainOfClaw 88780 노드 코드 (RPC, P2P, mempool, 합의)",
+        "contracts": "Gen-5 UUPS 스마트 컨트랙트 (거버넌스, PoSe, 신원, 정산)",
+        "explorer": "블록 explorer explorer.chainofclaw.io",
+        "website": "본 사이트 (chainofclaw.io) 와 faucet"
+      },
+      "out": {
+        "thirdParty": "서드파티 의존성 (상위 프로젝트로 보고)",
+        "docs": "문서 오타 / 끊긴 링크 / 제안",
+        "dos": "범용 볼륨 DoS (Cloudflare 계층)",
+        "social": "프로젝트 멤버 대상 소셜 엔지니어링"
+      }
+    },
+    "rewards": {
+      "title": "보상 등급 (canary 단계)",
+      "severity": "심각도",
+      "range": "구간",
+      "example": "예시",
+      "criticalEx": "validator 자금 직접 손실, multisig 우회, validator RCE",
+      "highEx": "합의 정지, 대규모 slash 발생, 컨트랙트 upgrade 악용",
+      "mediumEx": "RPC 권한 상승, mempool griefing, faucet 고갈",
+      "lowEx": "정보 유출, 저영향 gas griefing, explorer XSS"
+    },
+    "timeline": {
+      "title": "응답 SLA",
+      "ack": "접수 확인 (자동 + Critical은 사람)",
+      "triage": "트리아주 결정 및 심각도 할당",
+      "fix": "Critical / High 수정 배포 (사례별 가속)",
+      "disclosure": "공개 공시 윈도우 (보고자와 조율)"
+    },
+    "canonical": {
+      "title": "공식 정책",
+      "body": "완전한 공개 정책, safe-harbor 조항, PGP 키는 저장소 루트의 SECURITY.md에.",
+      "docs": "문서 보기"
+    }
   }
 }

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -15,6 +15,7 @@
     "resources": "資源",
     "development": "開發",
     "whitepaper": "白皮書",
+    "security": "安全",
     "allRightsReserved": "保留所有權利",
     "copyright": "版權所有",
     "services": "服务"
@@ -950,6 +951,11 @@
       "seconds": "秒",
       "launchDate": "啟動日期：2026年3月27日"
     },
+    "canaryBanner": {
+      "title": "Canary 測試網 88780 已上線",
+      "subtitle": "6 個 validator BFT 網絡 · gen-5 UUPS 合約 · 公開 RPC + faucet + explorer 已開放",
+      "cta": "查看公開端點"
+    },
     "units": {
       "blocksPerMinute": "塊/分鐘",
       "authRequests": "認證請求"
@@ -1680,5 +1686,53 @@
     "statusPass": "Pass",
     "statusReview": "Review",
     "statusSuspicious": "Suspicious"
+  },
+  "security": {
+    "title": "安全披露",
+    "subtitle": "報告漏洞。24 小時內確認。Critical 級別有效漏洞獲得獎勵。",
+    "contact": {
+      "title": "報告漏洞",
+      "body": "請通過私密渠道提交。請勿在公開 issue 中提報安全問題。",
+      "advisory": "在 GitHub 發起私密 advisory"
+    },
+    "scope": {
+      "title": "範圍",
+      "inTitle": "範圍內",
+      "outTitle": "範圍外",
+      "in": {
+        "chain": "ChainOfClaw 88780 節點代碼(RPC、P2P、mempool、共識)",
+        "contracts": "Gen-5 UUPS 智能合約(治理、PoSe、身份、結算)",
+        "explorer": "區塊瀏覽器 explorer.chainofclaw.io",
+        "website": "本網站(chainofclaw.io)和 faucet"
+      },
+      "out": {
+        "thirdParty": "第三方依賴(請向上游項目報告)",
+        "docs": "文檔錯字 / 失效鏈接 / 建議",
+        "dos": "通用容量 DoS(Cloudflare 層)",
+        "social": "對項目成員的社會工程"
+      }
+    },
+    "rewards": {
+      "title": "獎勵層級(canary 階段)",
+      "severity": "嚴重度",
+      "range": "區間",
+      "example": "示例",
+      "criticalEx": "直接損失 validator 資金、multisig 繞過、validator 遠程代碼執行",
+      "highEx": "共識卡死、大規模 slash 觸發、合約升級濫用",
+      "mediumEx": "RPC 權限提升、mempool griefing、faucet 抽空",
+      "lowEx": "信息洩露、低影響 gas griefing、explorer XSS"
+    },
+    "timeline": {
+      "title": "響應 SLA",
+      "ack": "確認收到(自動 + Critical 級別人工)",
+      "triage": "分類決定和嚴重度分級",
+      "fix": "Critical / High 級別修復上鏈(視情況加快)",
+      "disclosure": "公開披露窗口(與報告者協調)"
+    },
+    "canonical": {
+      "title": "權威政策",
+      "body": "完整披露政策、safe-harbor 條款、PGP 密鑰見倉庫根目錄的 SECURITY.md。",
+      "docs": "閱讀文檔"
+    }
   }
 }

--- a/website/src/app/[locale]/docs/page.tsx
+++ b/website/src/app/[locale]/docs/page.tsx
@@ -255,7 +255,7 @@ export default function DocsPage() {
               title={t('tools.explorer.title')}
               description={t('tools.explorer.description')}
               features={t.raw('tools.explorer.features') as string[]}
-              link="https://explorer.clawchain.io"
+              link="https://explorer.chainofclaw.io"
               openToolText={t('tools.openTool')}
               delay="0.1"
             />

--- a/website/src/app/[locale]/layout.tsx
+++ b/website/src/app/[locale]/layout.tsx
@@ -135,9 +135,10 @@ export default async function LocaleLayout({
                       <ul className="space-y-2">
                         <FooterLink href="/docs">{tCommon('docs')}</FooterLink>
                         <FooterLink href="/plan">{tCommon('whitepaper')}</FooterLink>
-                        <FooterLink href="https://explorer.clawchain.io" external>
+                        <FooterLink href="https://explorer.chainofclaw.io" external>
                           {tCommon('explorer')}
                         </FooterLink>
+                        <FooterLink href="/security">{tCommon('security')}</FooterLink>
                       </ul>
                     </div>
 

--- a/website/src/app/[locale]/network/page.tsx
+++ b/website/src/app/[locale]/network/page.tsx
@@ -102,13 +102,6 @@ type DaoStats = {
   treasuryBalance?: string
 }
 
-type CountdownTime = {
-  days: number
-  hours: number
-  minutes: number
-  seconds: number
-}
-
 export default function NetworkPage() {
   const t = useTranslations('network')
   const locale = useLocale()
@@ -124,7 +117,6 @@ export default function NetworkPage() {
   const [networkStats, setNetworkStats] = useState<NetworkStats | null>(null)
   const [memPoolStatus, setMemPoolStatus] = useState<MemPoolStatus | null>(null)
   const [daoStats, setDaoStats] = useState<DaoStats | null>(null)
-  const [countdown, setCountdown] = useState<CountdownTime>({ days: 0, hours: 0, minutes: 0, seconds: 0 })
 
   useEffect(() => {
     async function fetchData() {
@@ -215,30 +207,6 @@ export default function NetworkPage() {
     return () => clearInterval(interval)
   }, [])
 
-  // Countdown timer for testnet launch
-  useEffect(() => {
-    const calculateCountdown = () => {
-      // Target date: March 27, 2026, 00:00:00 UTC
-      const launchDate = new Date('2026-03-27T00:00:00Z').getTime()
-      const now = new Date().getTime()
-      const diff = launchDate - now
-
-      if (diff <= 0) {
-        setCountdown({ days: 0, hours: 0, minutes: 0, seconds: 0 })
-      } else {
-        const days = Math.floor(diff / (1000 * 60 * 60 * 24))
-        const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
-        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
-        const seconds = Math.floor((diff % (1000 * 60)) / 1000)
-        setCountdown({ days, hours, minutes, seconds })
-      }
-    }
-
-    calculateCountdown()
-    const timer = setInterval(calculateCountdown, 1000)
-    return () => clearInterval(timer)
-  }, [])
-
   return (
     <div className="relative min-h-screen">
       {/* Hero Header */}
@@ -269,20 +237,19 @@ export default function NetworkPage() {
               {t('subtitle')}
             </p>
 
-            {/* Testnet Launch Countdown */}
+            {/* Canary 88780 status banner (replaces obsolete launch countdown) */}
             <div className="mt-12 mb-6 fade-in-delay-3">
               <div className="inline-block px-6 py-4 rounded-lg border border-accent-cyan/50 bg-accent-cyan/10 backdrop-blur-sm">
-                <p className="text-sm text-accent-cyan font-display uppercase tracking-widest mb-4">
-                  ⏱️ {t('countdown.title')}
+                <p className="text-sm text-accent-cyan font-display uppercase tracking-widest mb-2">
+                  🟢 {t('canaryBanner.title')}
                 </p>
-                <div className="grid grid-cols-4 gap-4">
-                  <CountdownUnit value={countdown.days} label={t('countdown.days')} />
-                  <CountdownUnit value={countdown.hours} label={t('countdown.hours')} />
-                  <CountdownUnit value={countdown.minutes} label={t('countdown.minutes')} />
-                  <CountdownUnit value={countdown.seconds} label={t('countdown.seconds')} />
-                </div>
-                <p className="text-xs text-accent-cyan/70 mt-4">
-                  {t('countdown.launchDate')}
+                <p className="text-base text-text-primary font-display">
+                  {t('canaryBanner.subtitle')}
+                </p>
+                <p className="text-xs text-accent-cyan/70 mt-3">
+                  <Link href="/docs" className="hover:text-accent-blue transition-colors">
+                    {t('canaryBanner.cta')} →
+                  </Link>
                 </p>
               </div>
             </div>
@@ -570,7 +537,7 @@ export default function NetworkPage() {
                 {t('recentBlocks.title')}
               </h2>
               <a
-                href="https://explorer.clawchain.io"
+                href="https://explorer.chainofclaw.io"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group inline-flex items-center gap-2 font-display text-accent-cyan hover:text-accent-blue transition-colors"
@@ -610,7 +577,7 @@ export default function NetworkPage() {
                       <tr key={block.number} className="group hover:bg-accent-cyan/5 transition-colors duration-300">
                         <td className="px-6 py-4 font-display text-sm">
                           <a
-                            href={`https://explorer.clawchain.io/block/${block.number}`}
+                            href={`https://explorer.chainofclaw.io/block/${block.number}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-accent-cyan hover:text-accent-blue transition-colors"
@@ -650,7 +617,7 @@ export default function NetworkPage() {
                 <QuickLink
                   title={t('quickLinks.explorer.title')}
                   description={t('quickLinks.explorer.description')}
-                  href="https://explorer.clawchain.io"
+                  href="https://explorer.chainofclaw.io"
                   external
                 />
                 <QuickLink
@@ -811,20 +778,6 @@ function QuickLink({
       {/* Bottom Border Accent */}
       <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent-cyan to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
     </Component>
-  )
-}
-
-function CountdownUnit({ value, label }: { value: number; label: string }) {
-  const formattedValue = value.toString().padStart(2, '0')
-  return (
-    <div className="flex flex-col items-center">
-      <div className="bg-gradient-cyan/20 border border-accent-cyan/30 rounded-lg px-3 py-2 mb-2">
-        <span className="text-2xl font-display font-bold text-accent-cyan">
-          {formattedValue}
-        </span>
-      </div>
-      <span className="text-xs font-body text-text-secondary">{label}</span>
-    </div>
   )
 }
 

--- a/website/src/app/[locale]/page.tsx
+++ b/website/src/app/[locale]/page.tsx
@@ -127,7 +127,7 @@ export default function HomePage() {
             {/* Decorative Code Lines */}
             <div className="mt-16 font-display text-sm text-text-muted/50 space-y-1 fade-in-delay-3">
               <div className="data-flow">
-                <span className="text-accent-cyan">$</span> coc node start --network prowl-testnet
+                <span className="text-accent-cyan">$</span> coc node start --network canary-88780
               </div>
               <div className="data-flow" style={{ animationDelay: '0.5s' }}>
                 <span className="text-accent-blue">✓</span> did:coc:0xA1F7...Ca9e registered · soul anchored

--- a/website/src/app/[locale]/security/page.tsx
+++ b/website/src/app/[locale]/security/page.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { Link } from '@/i18n/routing'
+
+export default function SecurityPage() {
+  const t = useTranslations('security')
+
+  return (
+    <div className="relative min-h-screen">
+      <section className="relative py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-bg-primary via-bg-secondary to-bg-primary">
+          <div className="absolute inset-0 opacity-20">
+            <div className="absolute top-10 left-10 w-96 h-96 bg-accent-cyan rounded-full blur-[100px] animate-pulse-slow" />
+            <div className="absolute bottom-10 right-10 w-96 h-96 bg-accent-blue rounded-full blur-[100px] animate-pulse-slow delay-1000" />
+          </div>
+        </div>
+
+        <div className="container mx-auto px-4 relative z-10">
+          <div className="max-w-4xl mx-auto text-center">
+            <div className="inline-block mb-6 fade-in">
+              <div className="px-4 py-2 rounded-full border border-accent-cyan/30 bg-accent-cyan/5 backdrop-blur-sm">
+                <span className="font-display text-sm text-accent-cyan tracking-wider">
+                  &gt; SECURITY_DISCLOSURE
+                </span>
+              </div>
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-display font-bold mb-4 fade-in-delay-1">
+              <span className="gradient-text glow-text">{t('title')}</span>
+            </h1>
+            <p className="text-xl text-text-secondary font-body fade-in-delay-2">
+              {t('subtitle')}
+            </p>
+          </div>
+        </div>
+
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-accent-cyan to-transparent" />
+      </section>
+
+      <div className="container mx-auto px-4 py-12 max-w-5xl">
+        {/* Contact card — first thing visible */}
+        <section className="mb-12 fade-in-up">
+          <div className="bg-bg-elevated rounded-xl p-8 border border-accent-cyan/30 shadow-glow-sm">
+            <h2 className="text-2xl md:text-3xl font-display font-bold mb-4 text-text-primary">
+              {t('contact.title')}
+            </h2>
+            <p className="text-text-secondary font-body mb-6 leading-relaxed">
+              {t('contact.body')}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <a
+                href="mailto:security@chainofclaw.io"
+                className="px-6 py-3 rounded-lg bg-gradient-cyber text-white font-display font-semibold hover:shadow-glow-md transition-all text-center"
+              >
+                security@chainofclaw.io
+              </a>
+              <a
+                href="https://github.com/chainofclaw/COC/security/advisories/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-6 py-3 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display font-semibold hover:bg-accent-cyan/10 transition-all text-center"
+              >
+                {t('contact.advisory')}
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* Scope */}
+        <section className="mb-12 fade-in-up">
+          <h2 className="text-2xl md:text-3xl font-display font-bold mb-6 text-text-primary">
+            {t('scope.title')}
+          </h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="bg-bg-elevated rounded-xl p-6 border border-green-500/20">
+              <h3 className="font-display font-bold text-green-400 mb-3">{t('scope.inTitle')}</h3>
+              <ul className="space-y-2 text-text-secondary font-body text-sm">
+                <li>• {t('scope.in.chain')}</li>
+                <li>• {t('scope.in.contracts')}</li>
+                <li>• {t('scope.in.explorer')}</li>
+                <li>• {t('scope.in.website')}</li>
+              </ul>
+            </div>
+            <div className="bg-bg-elevated rounded-xl p-6 border border-red-500/20">
+              <h3 className="font-display font-bold text-red-400 mb-3">{t('scope.outTitle')}</h3>
+              <ul className="space-y-2 text-text-secondary font-body text-sm">
+                <li>• {t('scope.out.thirdParty')}</li>
+                <li>• {t('scope.out.docs')}</li>
+                <li>• {t('scope.out.dos')}</li>
+                <li>• {t('scope.out.social')}</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Reward tiers */}
+        <section className="mb-12 fade-in-up">
+          <h2 className="text-2xl md:text-3xl font-display font-bold mb-6 text-text-primary">
+            {t('rewards.title')}
+          </h2>
+          <div className="bg-bg-elevated rounded-xl overflow-hidden border border-text-muted/10">
+            <div className="overflow-x-auto">
+              <table className="min-w-full">
+                <thead className="bg-bg-secondary border-b border-text-muted/10">
+                  <tr>
+                    <th className="px-6 py-4 text-left text-xs font-display font-semibold text-text-muted uppercase tracking-wider">{t('rewards.severity')}</th>
+                    <th className="px-6 py-4 text-left text-xs font-display font-semibold text-text-muted uppercase tracking-wider">{t('rewards.range')}</th>
+                    <th className="px-6 py-4 text-left text-xs font-display font-semibold text-text-muted uppercase tracking-wider">{t('rewards.example')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-text-muted/10">
+                  <tr><td className="px-6 py-4 font-display text-red-400">Critical</td><td className="px-6 py-4 font-display text-text-primary">$10,000 – $50,000</td><td className="px-6 py-4 font-body text-sm text-text-secondary">{t('rewards.criticalEx')}</td></tr>
+                  <tr><td className="px-6 py-4 font-display text-orange-400">High</td><td className="px-6 py-4 font-display text-text-primary">$2,500 – $10,000</td><td className="px-6 py-4 font-body text-sm text-text-secondary">{t('rewards.highEx')}</td></tr>
+                  <tr><td className="px-6 py-4 font-display text-yellow-400">Medium</td><td className="px-6 py-4 font-display text-text-primary">$500 – $2,500</td><td className="px-6 py-4 font-body text-sm text-text-secondary">{t('rewards.mediumEx')}</td></tr>
+                  <tr><td className="px-6 py-4 font-display text-accent-cyan">Low</td><td className="px-6 py-4 font-display text-text-primary">$100 – $500</td><td className="px-6 py-4 font-body text-sm text-text-secondary">{t('rewards.lowEx')}</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        {/* Response timeline */}
+        <section className="mb-12 fade-in-up">
+          <h2 className="text-2xl md:text-3xl font-display font-bold mb-6 text-text-primary">
+            {t('timeline.title')}
+          </h2>
+          <div className="bg-bg-elevated rounded-xl p-8 border border-text-muted/10">
+            <ul className="space-y-3 text-text-secondary font-body">
+              <li><span className="font-display text-accent-cyan">24h</span> — {t('timeline.ack')}</li>
+              <li><span className="font-display text-accent-cyan">7d</span> — {t('timeline.triage')}</li>
+              <li><span className="font-display text-accent-cyan">30d</span> — {t('timeline.fix')}</li>
+              <li><span className="font-display text-accent-cyan">90d</span> — {t('timeline.disclosure')}</li>
+            </ul>
+          </div>
+        </section>
+
+        {/* Canonical link */}
+        <section className="fade-in-up">
+          <div className="bg-gradient-to-br from-accent-cyan/10 via-accent-blue/10 to-accent-purple/10 rounded-xl p-8 border border-accent-cyan/20">
+            <h3 className="font-display font-bold text-text-primary mb-3">
+              {t('canonical.title')}
+            </h3>
+            <p className="text-text-secondary font-body mb-4">
+              {t('canonical.body')}
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href="https://github.com/chainofclaw/COC/blob/main/SECURITY.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-5 py-2 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display text-sm hover:bg-accent-cyan/10 transition-all"
+              >
+                SECURITY.md
+              </a>
+              <Link
+                href="/docs"
+                className="px-5 py-2 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display text-sm hover:bg-accent-cyan/10 transition-all"
+              >
+                {t('canonical.docs')}
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/website/src/app/[locale]/testnet/page.tsx
+++ b/website/src/app/[locale]/testnet/page.tsx
@@ -22,7 +22,7 @@ export default function TestnetPage() {
             <div className="inline-block mb-6 fade-in">
               <div className="px-4 py-2 rounded-full border border-accent-cyan/30 bg-accent-cyan/5 backdrop-blur-sm">
                 <span className="font-display text-sm text-accent-cyan tracking-wider">
-                  &gt; PROWL_TESTNET_LIVE
+                  &gt; CANARY_TESTNET_88780_LIVE
                 </span>
               </div>
             </div>
@@ -42,7 +42,7 @@ export default function TestnetPage() {
                 {t('joinNow')}
               </Link>
               <a
-                href="https://faucet.clawchain.io"
+                href="https://faucet.chainofclaw.io"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-8 py-3 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display font-semibold hover:bg-accent-cyan/10 transition-all"
@@ -67,10 +67,10 @@ export default function TestnetPage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <InfoCard label={t('chainId')} value="88780" />
-            <InfoCard label={t('rpcEndpoint')} value="https://clawchain.io/api/testnet/rpc" mono />
-            <InfoCard label={t('wsEndpoint')} value="wss://clawchain.io/api/testnet/ws" mono />
-            <InfoCard label={t('blockTime')} value="3s" />
+            <InfoCard label={t('chainId')} value="88780 (0x15acc)" />
+            <InfoCard label={t('rpcEndpoint')} value="https://rpc.chainofclaw.io" mono />
+            <InfoCard label={t('wsEndpoint')} value="wss://rpc.chainofclaw.io/ws" mono />
+            <InfoCard label={t('blockTime')} value="~2.1s" />
             <InfoCard label={t('consensus')} value="BFT + PoSe" />
             <InfoCard label={t('tokenSymbol')} value="COC" />
           </div>
@@ -132,11 +132,11 @@ export default function TestnetPage() {
               <p className="text-text-secondary font-body mb-8">{t('connectDescription')}</p>
 
               <div className="bg-bg-primary/50 rounded-lg p-6 text-left font-mono text-sm text-text-secondary space-y-2">
-                <p><span className="text-accent-cyan">Network Name:</span> COC Prowl Testnet (R3.2)</p>
-                <p><span className="text-accent-cyan">RPC URL:</span> https://clawchain.io/api/testnet/rpc</p>
+                <p><span className="text-accent-cyan">Network Name:</span> ChainOfClaw Canary 88780</p>
+                <p><span className="text-accent-cyan">RPC URL:</span> https://rpc.chainofclaw.io</p>
                 <p><span className="text-accent-cyan">Chain ID:</span> 88780</p>
                 <p><span className="text-accent-cyan">Currency Symbol:</span> COC</p>
-                <p><span className="text-accent-cyan">Explorer:</span> https://explorer.clawchain.io</p>
+                <p><span className="text-accent-cyan">Explorer:</span> https://explorer.chainofclaw.io</p>
               </div>
             </div>
           </div>
@@ -147,13 +147,13 @@ export default function TestnetPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             <QuickLink
               title={t('links.explorer')}
-              href="https://explorer.clawchain.io"
+              href="https://explorer.chainofclaw.io"
               external
               icon="search"
             />
             <QuickLink
               title={t('links.faucet')}
-              href="https://faucet.clawchain.io"
+              href="https://faucet.chainofclaw.io"
               external
               icon="droplet"
             />


### PR DESCRIPTION
## Summary

Final stage of the canary docs+website refresh. Independent of the docs PR chain (#757/#758/#759) — branches off `main` directly so it can land in parallel.

## Routes touched

| Route | Change |
|---|---|
| `/[locale]/network` | Replace expired Mar-27 launch countdown with a live "Canary 88780" banner; explorer URLs → `explorer.chainofclaw.io`; drop now-unused countdown state/type/component |
| `/[locale]/testnet` | Branding `PROWL_TESTNET_LIVE` → `CANARY_TESTNET_88780_LIVE`; RPC + WS + faucet + explorer URLs → \`chainofclaw.io\` subdomains; chainId now also shows hex \`0x15acc\`; block time \`~2.1s\`; MetaMask network name → \"ChainOfClaw Canary 88780\" |
| `/[locale]/docs` | Tool card explorer URL → `explorer.chainofclaw.io` |
| `/[locale]` (home) | CLI hint `--network prowl-testnet` → `--network canary-88780` |
| `layout` (footer) | Add Security link in Resources column; explorer URL update |

## New route

- **`/[locale]/security`** — public-facing summary of [SECURITY.md](https://github.com/chainofclaw/COC/blob/main/SECURITY.md):
  - Contact CTA: `security@chainofclaw.io` + GitHub private-advisory button
  - Scope table (in/out)
  - Reward tier table (Critical \$10-50k → Low \$100-500 canary phase)
  - Response SLA timeline (24h ack / 7d triage / 30d fix / 90d disclosure)
  - Link back to canonical SECURITY.md and to docs

## Env

\`.env.local.example\`:
\`\`\`diff
- NEXT_PUBLIC_RPC_URL=https://clawchain.io/api/testnet/rpc
- NEXT_PUBLIC_WS_URL=wss://clawchain.io/api/testnet/ws
- COC_RPC_URL=http://199.192.16.79:28780
+ NEXT_PUBLIC_RPC_URL=https://rpc.chainofclaw.io
+ NEXT_PUBLIC_WS_URL=wss://rpc.chainofclaw.io/ws
+ COC_RPC_URL=https://rpc.chainofclaw.io
\`\`\`

Matches `docs/public-endpoints-88780.md`. Local-devnet override kept as a comment block.

## i18n

Added to **all 5 locale bundles** (en/zh/es/ja/ko):
- `network.canaryBanner.{title,subtitle,cta}`
- `security.*` (full block: contact, scope.{in,out}, rewards, timeline, canonical)
- `common.security`

EN + ZH copy is canonical; ES/JA/KO are translated stubs per the parent plan (\"key-stubs to prevent next-intl crashes, copy not professionally translated\"). Native-speaker polish welcome in a follow-up.

## Build

\`\`\`
cd website && npm run build  # ✓ exit 0
                              # /security route → 4.44 kB First Load JS
                              # all 18 routes generated cleanly
\`\`\`

## Out of scope (intentionally — separate sprints per parent plan)

- Deep Prowl → Canary rebrand of legacy i18n strings (footer hero / roadmap labels still mention \"Prowl\")
- Docusaurus / full doc-site integration
- Cloudflare proxy stand-up for public RPC (`rpc.chainofclaw.io`)
- CI auto-deploy for website (existing manual `scripts/deploy-to-server.sh` is the canonical path)

## Test plan

- [x] `npm run build` succeeds with zero TypeScript errors
- [x] `/security` route appears in build output
- [ ] Local dev: `cd website && npm run dev` → `/en/security`, `/zh/security`, `/es/security`, `/ja/security`, `/ko/security` all render without crash
- [ ] `/en/network` shows Canary 88780 banner (no countdown)
- [ ] `/en/testnet` shows chainId 88780 + new chainofclaw.io URLs + MetaMask network name "ChainOfClaw Canary 88780"
- [ ] Footer Security link visible on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)