### PR TITLE
docs(canary): Stage 6 — observability runbook + Gate 10 close

### DIFF
--- a/docker/grafana/dashboards/coc-overview.json
+++ b/docker/grafana/dashboards/coc-overview.json
@@ -1,7 +1,7 @@
 {
   "dashboard": {
-    "title": "COC Prowl Testnet",
-    "uid": "coc-prowl-overview",
+    "title": "COC Canary 88780",
+    "uid": "coc-canary-overview",
     "timezone": "utc",
     "refresh": "10s",
     "time": { "from": "now-1h", "to": "now" },

--- a/docs/canary-launch-checklist-88780.md
+++ b/docs/canary-launch-checklist-88780.md
@@ -107,15 +107,27 @@ has explicit evidence linked — no "trust me, it's done" entries.
    (10 COC drip, 24h cooldown). Refill cron job for canary phase is
    missing; needs SOP + alert if balance drops below 500 COC.
 
-10. **☐ Grafana dashboards committed + Prometheus alerts wired**
-    *Evidence*: `docker/grafana/dashboards/coc-overview.json` +
-    `coc-pose.json` exist and import cleanly into a fresh Grafana
-    instance; `ops/alerts/prometheus-rules.yml` has live alerts each
-    mapped to [`observability-runbook-88780.md`](./observability-runbook-88780.md)
-    pages.
+10. **🟡 Grafana dashboards committed + Prometheus alerts wired**
+    *Evidence*: 4 dashboards (`docker/grafana/dashboards/coc-{overview,consensus,network,resources}.json`)
+    + 11 alerts in `ops/alerts/prometheus-rules.yml` (4 groups: availability,
+    security, performance, network), each mapped to a section in
+    [`observability-runbook-88780.md`](./observability-runbook-88780.md)
+    (Stage 6). SLO encoding: `SlowBlockProduction` (block p99 proxy),
+    `EquivocationDetected` (clean-record gate), `LowPeerCount` /
+    `coc_validators_active` panel (BFT quorum), `HighMempoolBacklog`
+    (mempool ack proxy).
     *Owner*: ops
-    *Current*: Open. Per parent plan A.2.2. SLO targets to encode: block
-    production p99 < 10s, validator uptime ≥ 99.5%, mempool ack p99 < 200ms.
+    *Current*: Assets + per-alert SOP shipped. Outstanding sub-tasks
+    (tracked, non-blocking for Gate 10):
+    - Verify dashboards import cleanly into a fresh Grafana (manual
+      dry-run before launch);
+    - Wire Alertmanager `runbook_url` annotations to point at the new
+      runbook URL once docs are public-served;
+    - Optional: add `ValidatorQuorumAtRisk` alert
+      (`coc_validators_active < 5`) to preempt chaos-T2-style 2-down
+      restart races.
+    - Reconcile dev-stack `docker/prometheus/alerts.yml` against the
+      canonical `ops/alerts/prometheus-rules.yml` (or deprecate it).
 
 ### Discoverability
 
@@ -130,7 +142,7 @@ has explicit evidence linked — no "trust me, it's done" entries.
 
 ## Burn-down
 
-To go live, all 11 gates must be ☑. Current count: 1 ☑ / 10 ☐.
+To go live, all 11 gates must be ☑. Current count: 1 ☑ / 1 🟡 / 9 ☐.
 
 Suggested order (fastest path to launch):
 1. Gates 4 + 7 + 11 are docs-shippable inside this sprint

--- a/docs/canary-launch-checklist-88780.zh.md
+++ b/docs/canary-launch-checklist-88780.zh.md
@@ -88,13 +88,22 @@
    *当前*:待办。当前 `faucet/` 代码是测试网调优(10 COC drip,24h 冷却)。
    canary 阶段的 refill cron job 缺失;需 SOP + 余额降至 500 COC 以下时告警。
 
-10. **☐ Grafana dashboards committed + Prometheus alerts wired**
-    *证据*:`docker/grafana/dashboards/coc-overview.json` + `coc-pose.json` 存在且能
-    干净导入新 Grafana 实例;`ops/alerts/prometheus-rules.yml` 有 live alerts,每个映射到
-    [`observability-runbook-88780.md`](./observability-runbook-88780.md) 页面。
+10. **🟡 Grafana dashboards committed + Prometheus alerts wired**
+    *证据*:4 个 dashboard(`docker/grafana/dashboards/coc-{overview,consensus,network,resources}.json`)
+    + `ops/alerts/prometheus-rules.yml` 中 11 条 alert(4 组:availability、security、
+    performance、network),每条映射到
+    [`observability-runbook-88780.zh.md`](./observability-runbook-88780.zh.md) 一节(Stage 6)。
+    SLO 编码:`SlowBlockProduction`(出块 p99 代理)、`EquivocationDetected`
+    (清白记录 gate)、`LowPeerCount` / `coc_validators_active` panel(BFT quorum)、
+    `HighMempoolBacklog`(mempool ack 代理)。
     *负责*:ops
-    *当前*:待办。按父 plan A.2.2。SLO 目标编码:出块 p99 < 10s,validator uptime ≥ 99.5%,
-    mempool ack p99 < 200ms。
+    *当前*:资产 + 每条 alert SOP 已交付。剩余子任务(已跟踪,不阻塞 Gate 10):
+    - 验证 dashboards 在新 Grafana 干净导入(上线前手动 dry-run);
+    - 接 Alertmanager `runbook_url` annotation 指向公开 runbook URL(docs 站点上线后);
+    - 可选:加 `ValidatorQuorumAtRisk` alert(`coc_validators_active < 5`)
+      预防 chaos T2 风格的 2-down 重启竞速;
+    - 对齐 dev-stack `docker/prometheus/alerts.yml` 与权威 `ops/alerts/prometheus-rules.yml`
+      (或废弃 dev 文件)。
 
 ### 可发现性
 
@@ -108,7 +117,7 @@
 
 ## Burn-down
 
-上线需 11 个全 ☑。当前:1 ☑ / 10 ☐。
+上线需 11 个全 ☑。当前:1 ☑ / 1 🟡 / 9 ☐。
 
 建议顺序(最快上线路径):
 1. Gates 4 + 7 + 11 可在本 sprint 文档级搞定

--- a/docs/observability-runbook-88780.md
+++ b/docs/observability-runbook-88780.md
@@ -1,0 +1,420 @@
+# 88780 Canary Observability Runbook
+
+> Per-alert SOPs for the canary testnet. Every alert in
+> [`ops/alerts/prometheus-rules.yml`](../ops/alerts/prometheus-rules.yml)
+> maps to a section in this document. When a pager fires, search for the
+> alert name and follow the **First response** sub-section.
+
+[中文版](./observability-runbook-88780.zh.md)
+
+## Operator quick reference
+
+| Layer | Endpoint | Default port |
+|---|---|---|
+| Prometheus scrape (per node) | `http://<host>:9100/metrics` | 9100 |
+| Grafana | configured per deployment | 3000 |
+| Alertmanager | configured per deployment | 9093 |
+
+Canonical network parameters: see
+[`public-endpoints-88780.md`](./public-endpoints-88780.md). 6 active
+validators (v1, v2, v3, v4, v5, obs-1) — BFT quorum requires ≥ 4 active.
+
+## SLO targets
+
+These are the canary SLOs each alert serves (per parent canary-readiness
+plan A.1.3):
+
+| SLO | Target | Alert that polices it |
+|---|---|---|
+| Block production p99 latency | < 10 s | `SlowBlockProduction` (warn @ 5 % > 6 s for 10 m) |
+| Validator uptime (rolling 30 d) | ≥ 99.5 % | derived from `NodeDown` + Grafana 30-d panel |
+| Mempool acceptance p99 | < 200 ms | indirect — `HighMempoolBacklog` flags backpressure |
+| BFT equivocations (rolling 30 d) | 0 | `EquivocationDetected` (fires immediately, severity critical) |
+| Active validator count | ≥ 4 | derived from `LowPeerCount` + `coc_validators_active` panel |
+
+## Dashboards
+
+Located in [`docker/grafana/dashboards/`](../docker/grafana/dashboards/).
+Import into a fresh Grafana via "Dashboards → Import → JSON". The four
+dashboards complement each other:
+
+| Dashboard | Use when |
+|---|---|
+| `coc-overview.json` | Top-level health: block height, consensus state, peer count, mempool depth. **Start here.** |
+| `coc-consensus.json` | BFT round detail: prepare/commit votes, equivocations, validator participation. |
+| `coc-network.json` | Topology: HTTP peers, wire connections, DHT nodes, P2P auth rejections. |
+| `coc-resources.json` | Process resources: RSS memory, CPU, file descriptors, disk. |
+
+---
+
+# Alert catalogue
+
+Alerts grouped by `prometheus-rules.yml` group. Severity in the heading
+matches the alert label.
+
+## Availability group (`coc_availability`)
+
+### `NodeDown` — critical
+
+**Expr**: `up{job="coc-node"} == 0` for 2 m
+
+**Symptom**: Prometheus has been unable to scrape this node's `/metrics`
+endpoint for two minutes. Could be process crash, network partition,
+firewall change, or the Prometheus scrape config drift.
+
+**Dashboards**: `coc-overview` → "Node up" panel; `coc-resources` →
+process panels (will be empty for the down node).
+
+**Diagnosis**:
+1. `ssh` to the host and `systemctl status coc-node@<unit>` (validator
+   units use `@88` or `@1` depending on host — see
+   [`public-endpoints-88780.md`](./public-endpoints-88780.md) for the
+   per-host table).
+2. If the service is running but Prometheus cannot scrape, check
+   `iptables -L`, the host's firewall, or any reverse-proxy. The
+   metrics endpoint binds to `127.0.0.1:9100` by default — Prometheus
+   must reach it directly or via SSH tunnel.
+3. `journalctl -u coc-node@<unit> -n 200` for recent crashes.
+
+**First response**:
+- If `systemctl status` shows the unit is `failed` or stopped:
+  `systemctl restart coc-node@<unit>` and watch the logs for ~60 s.
+- If the host is unreachable entirely, escalate (the host itself is
+  down) — but **do not auto-replace** the validator key unless the
+  outage exceeds 1 h (otherwise it self-heals when the host is back
+  and BFT continues with 5/6 quorum).
+- BFT continues with 5/6 quorum (T1 chaos result). With 4/6 the chain
+  still produces blocks; with ≤ 3/6 it stalls (T3 result). Check
+  `LowPeerCount` / `BlockProductionStalled` in parallel.
+
+**Escalation**: if 2+ validators down simultaneously, **DO NOT restart
+both at once** — page the on-call lead. Per chaos T2: parallel restart
+of 2 validators triggers a 2.5 min stall via dead-proposer slot. Stagger
+restarts ≥ 60 s apart.
+
+---
+
+### `BlockProductionStalled` — critical
+
+**Expr**: `increase(coc_block_height[5m]) == 0` for 3 m
+
+**Symptom**: All scraped nodes report no new blocks for the last 5
+minutes. Either the chain has lost quorum or every node is wedged
+locally.
+
+**Dashboards**: `coc-overview` → "Block Height" panel (look for the
+plateau); `coc-consensus` → "BFT Phase" panel (stuck on `propose` or
+`prepare` is the giveaway).
+
+**Diagnosis**:
+1. Cross-check `coc_block_height` across all scraped nodes. If only one
+   is stuck and others are advancing, it's a single-node sync issue —
+   demote the alert to the affected node.
+2. If all are stuck at the same height, query
+   `coc_validators_active` — if < 4, BFT cannot reach quorum.
+3. Curl `/coc_getBftStatus` on a validator: phase + round timer.
+   `phase=propose` + round age > 60 s = dead proposer slot.
+
+**First response**:
+- **All nodes stuck, ≥ 4 active**: likely a dead-proposer slot. Wait up
+  to 60 s for the H15 fallback (it ships at ~600 s in production —
+  this is the proposer-skip fast path landed in PR #641 `c4a330a`).
+  The chain will self-heal.
+- **All nodes stuck, < 4 active**: BFT below quorum. Restore at least
+  one validator (per `NodeDown` flow). Do not attempt a hard fork.
+- **One node stuck while others advance**: that node is locally
+  wedged. Restart it with `systemctl restart coc-node@<unit>` and let
+  snap-sync catch up.
+
+**Escalation**: if quorum cannot be restored within 30 m, follow
+[`disaster-recovery-88780.md` § Chain halt](./disaster-recovery-88780.md).
+
+---
+
+### `ConsensusStateDegraded` — warning
+
+**Expr**: `coc_consensus_state != 0` for 5 m
+
+**Symptom**: A node has been reporting a non-healthy consensus state
+(1 = degraded, 2 = recovering) for 5+ minutes. Often a side effect of a
+partial network partition or transient peer churn.
+
+**Dashboards**: `coc-consensus` → "Consensus State Per Node" timeline.
+
+**Diagnosis**:
+1. Compare across nodes — single-node degraded vs network-wide.
+2. Check `coc_peers_connected` on the affected node. State `1` with low
+   peer count = isolation.
+
+**First response**:
+- Single-node degraded with low peers: check the node's outbound
+  connectivity (DNS, firewall, ISP). Often a peer-list reset
+  (`rm /var/lib/coc/node-*/peers.json; systemctl restart …`) clears
+  it. State `2` (recovering) is informational — node is back-filling
+  via snap-sync, leave it alone unless it stays in state 2 > 30 m.
+
+**Escalation**: pattern across multiple nodes → likely upstream
+incident (RPC gateway, public faucet — see
+[`disaster-recovery-88780.md`](./disaster-recovery-88780.md)).
+
+---
+
+## Security group (`coc_security`)
+
+### `HighAuthRejections` — warning
+
+**Expr**: `rate(coc_p2p_auth_rejected_total[5m]) > 10` for 3 m
+
+**Symptom**: > 10 P2P auth rejections per second on a single node for
+3+ minutes. Possible Sybil flood, brute-force scan, or a misconfigured
+peer attempting reconnection storm.
+
+**Dashboards**: `coc-network` → "P2P Auth Rejections" panel.
+
+**Diagnosis**:
+1. Look at `coc_p2p_auth_rejected_reason_total{reason=…}` to break down
+   reason: `bad_signature`, `unknown_signer`, `expired_nonce`,
+   `roster_mismatch`. The last two during a deploy window mean a stale
+   peer cache — benign.
+2. Identify the source IPs via the node's gossip log
+   (`journalctl -u coc-node@<unit> | grep auth.*rejected`).
+
+**First response**:
+- Most common cause: bootstrap peer dropped out of the validator
+  roster (e.g. retired observer) and stale `peers.json` keeps
+  retrying. Solution: edit `peers.json` to remove the dead peer or
+  let the connection backoff exhaust (~10 min).
+- True attack: temporary block at `iptables` for the burst window;
+  open a security advisory if pattern repeats.
+
+**Escalation**: rejection rate stays > 100/s for 10 m → page
+security-on-call.
+
+---
+
+### `DiscoveryIdentityFailures` — warning
+
+**Expr**: `increase(coc_discovery_identity_failures_total[10m]) > 50` for 5 m
+
+**Symptom**: 50+ peer-discovery identity verification failures in 10 m.
+Same root-cause family as `HighAuthRejections` but at the DNS-seed /
+DHT bootstrap layer.
+
+**Dashboards**: `coc-network` → "Discovery Identity Failures" panel.
+
+**Diagnosis**: same as `HighAuthRejections`. Verify the seed list is
+current (DNS TXT records) and the affected peers are still in the
+expected roster.
+
+**First response**: if a seed peer was retired without DNS update,
+update the DNS TXT records. Otherwise treat as `HighAuthRejections`.
+
+---
+
+### `DhtVerifyFailures` — warning
+
+**Expr**: `increase(coc_dht_verify_failures_total[10m]) > 20` for 5 m
+
+**Symptom**: DHT iterative lookup is failing to verify peer signatures
+on FIND_NODE responses. Often a wire-protocol incompatibility after
+upgrade.
+
+**Dashboards**: `coc-network` → "DHT Stats" panel.
+
+**Diagnosis**: confirm all nodes are on the same release HEAD (per
+[`public-endpoints-88780.md`](./public-endpoints-88780.md) operations
+log). Cross-version `verifyNodeSig` mismatch is the most common
+trigger.
+
+**First response**: roll the affected nodes to the canonical HEAD via
+`scripts/deploy-rolling-safe.sh <HEAD>`. Do not roll all nodes
+simultaneously (per chaos T2/T8 ops SOP — staggered restart).
+
+---
+
+### `EquivocationDetected` — critical
+
+**Expr**: `increase(coc_bft_equivocations_total[5m]) > 0` for 0 m
+
+**Symptom**: A validator has been observed signing two conflicting
+messages for the same BFT height. Chain slashing should fire
+automatically via `EquivocationDetector` at
+`0xa5dcE830e917176c1091fd6112F41E47692C510e` (gen-5 proxy).
+
+**Dashboards**: `coc-consensus` → "Equivocations Total" stat.
+
+**Diagnosis** (operator side — DO NOT debug the slashed validator
+key, treat it as compromised):
+1. Identify the offender via `coc_getEquivocations` RPC on any healthy
+   node.
+2. Confirm the on-chain `EquivocationProven` event fired (Explorer
+   `/address/0xa5dcE830…` events tab).
+3. Check `coc_validators_active` post-slash — if it dropped below 4
+   (BFT quorum), follow `BlockProductionStalled` SOP in parallel.
+
+**First response**: if the equivocating validator is one of yours:
+- **Stop the node immediately** (`systemctl stop coc-node@<unit>`).
+- Follow [`operator-runbook.md` § 3 Slash response](./operator-runbook.md#3-slash-response).
+- Do NOT re-stake the slashed key; generate a fresh keypair.
+- File a post-mortem within 24 h.
+
+**Escalation**: any equivocation is an immediate page to the
+on-call lead. This is the canary 30-day-clean-record gate (Gate 3 in
+[`canary-launch-checklist-88780.md`](./canary-launch-checklist-88780.md))
+— a single event resets the clock.
+
+---
+
+## Performance group (`coc_performance`)
+
+### `SlowBlockProduction` — warning
+
+**Expr**: `coc_block_time_seconds_bucket{le="6"} / coc_block_time_seconds_count < 0.95` for 10 m
+
+**Symptom**: More than 5 % of blocks are taking > 6 s. Canary target is
+p99 < 10 s — this is the early-warning signal.
+
+**Dashboards**: `coc-overview` → "Block Time Histogram"; `coc-resources`
+→ CPU / disk-IO panels.
+
+**Diagnosis**:
+1. Check `coc_resources` dashboard for CPU saturation or disk-IO
+   pressure on validators.
+2. Check `coc-overview` mempool depth — large pending pool (> 200) can
+   throttle block formation.
+3. Check `coc_validators_active` — if a validator is slow to respond,
+   dead-proposer slots inflate p99.
+
+**First response**:
+- CPU/disk saturation: scale the host or move to faster storage.
+- Mempool backlog → `HighMempoolBacklog` SOP.
+- Persistent dead-proposer slots: identify the slow validator (lowest
+  `coc_blocks_produced_total` rate) and restart it.
+
+---
+
+### `HighMempoolBacklog` — warning
+
+**Expr**: `coc_tx_pool_pending > 500` for 5 m
+
+**Symptom**: A validator is holding > 500 pending transactions for 5+
+minutes. Mempool per-sender quota is 64 (per `coc-88780-2026-05-26-chaos-engineering-T1-T8.md`
+T6/T6b), so 500+ pending means active inbound demand.
+
+**Dashboards**: `coc-overview` → "Mempool Depth"; `coc-consensus` →
+"Tx Per Block".
+
+**Diagnosis**:
+1. Compare across nodes — if all are at > 500 it's organic load; if
+   only one, that node is slow to relay (possible peer issue).
+2. Check inbound RPC rate `coc_rpc_requests_total` — limit is 240
+   req/min/IP. If a single IP is dominating, possible misbehaving
+   client.
+
+**First response**:
+- Organic load: raise block gas limit or accept temporary backlog;
+  burst will clear on its own (T6 result — chain remained at ~3s/block
+  during 500-tx burst).
+- Single-IP flooding: blacklist at the nginx/Cloudflare layer.
+
+---
+
+### `HighMemoryUsage` — warning
+
+**Expr**: `coc_process_memory_bytes > 2e9` for 10 m
+
+**Symptom**: A node's process RSS exceeded 2 GB for 10+ minutes. Either
+slow leak (rare) or expected after long uptime + heavy snap-sync.
+
+**Dashboards**: `coc-resources` → "Process Memory" panel.
+
+**Diagnosis**: check uptime via `coc_node_uptime_seconds`. RSS > 2 GB
+after 30+ days of uptime is normal; after 24 h is a leak indicator.
+
+**First response**: rolling restart per
+`scripts/deploy-rolling-safe.sh` — stagger nodes ≥ 60 s apart (chaos
+T2 SOP). For genuine leaks, capture a heap snapshot
+(`kill -USR2 <pid>`) before restart and open a bug.
+
+---
+
+## Network group (`coc_network`)
+
+### `LowPeerCount` — warning
+
+**Expr**: `coc_peers_connected < 2` for 5 m
+
+**Symptom**: A node has < 2 HTTP gossip peers. With 6 active validators
++ 0 observers, healthy is 5 connections per node.
+
+**Dashboards**: `coc-network` → "Peers Connected".
+
+**Diagnosis**:
+1. `cat /var/lib/coc/node-<unit>/peers.json` — verify peer list is
+   intact.
+2. Check `coc_p2p_auth_rejected_total` — if rejection rate is high,
+   peers are present but rejected (see `HighAuthRejections`).
+
+**First response**: reset peer cache + restart:
+```bash
+mv /var/lib/coc/node-<unit>/peers.json /tmp/peers.bak
+systemctl restart coc-node@<unit>
+```
+Node will rediscover via DNS seeds + DHT. If still < 2 after 5 m,
+check outbound firewall.
+
+---
+
+### `NoWireConnections` — warning
+
+**Expr**: `coc_wire_connections == 0 and coc_peers_connected > 0` for 5 m
+
+**Symptom**: Wire (TCP) protocol has zero connections but HTTP gossip
+peers are available. Wire is the high-throughput transport for
+BFT messages — without it BFT runs on HTTP fallback and is slower.
+
+**Dashboards**: `coc-network` → "Wire Connections".
+
+**Diagnosis**:
+1. Check `COC_ENABLE_WIRE_PROTOCOL=true` in the node's env.
+2. Confirm wire port (29790 / 29780 depending on host) is reachable
+   from peers (`nc -zv <peer-ip> 29790`).
+3. Inspect `journalctl -u coc-node@<unit> -e | grep wire` for
+   handshake failures.
+
+**First response**: if config is right and ports are open, restart the
+node. If wire stays at 0 across all nodes after the restart, open an
+issue — likely a wire-protocol regression.
+
+---
+
+# Alerts deliberately not implemented (yet)
+
+| Signal | Why deferred | Tracking |
+|---|---|---|
+| `MultisigSignerUnreachable` | Out-of-band (3-of-5 still safe with 1 down) — manual check before canary launch | Gate 8 in checklist |
+| Block production p99 absolute (vs ratio) | `SlowBlockProduction` covers it indirectly; native p99 query is more expensive | Backlog |
+| Faucet drain | Currently informational; `MempoolBacklog` catches the symptom | Gate 9 in checklist |
+| RPC public-endpoint 5xx rate | Belongs to Cloudflare layer (not yet stood up) | Gate 8 |
+
+# Notes for future work
+
+- The dev-stack file `docker/prometheus/alerts.yml` partially overlaps
+  with `ops/alerts/prometheus-rules.yml` but uses different thresholds.
+  The canonical prod file is `ops/alerts/prometheus-rules.yml` — keep
+  the dev file in sync or deprecate it in a future cleanup.
+- Add `runbook_url` annotation to every alert pointing at this doc
+  (Alertmanager renders it as a link in pages). Out of scope for this
+  PR; tracked alongside Gate 10 polish.
+- Per chaos memory (T1–T8 results), the validator-restart SOP is
+  enforced via observer judgement, not by an automated alert. A
+  `ValidatorQuorumAtRisk` alert (`coc_validators_active < 5`) would
+  preempt this — also tracked as a follow-up.
+
+# See also
+
+- [`disaster-recovery-88780.md`](./disaster-recovery-88780.md) — what to do when an alert
+  escalates to a disaster scenario.
+- [`canary-launch-checklist-88780.md`](./canary-launch-checklist-88780.md) — Gate 10 evidence pointer.
+- [`operator-runbook.md`](./operator-runbook.md) — daily ops SOP.
+- [`public-endpoints-88780.md`](./public-endpoints-88780.md) — host inventory + ports.

--- a/docs/observability-runbook-88780.zh.md
+++ b/docs/observability-runbook-88780.zh.md
@@ -1,0 +1,361 @@
+# 88780 Canary 可觀測性 Runbook
+
+> Canary 測試網每個告警的 SOP。
+> [`ops/alerts/prometheus-rules.yml`](../ops/alerts/prometheus-rules.yml)
+> 中每條告警都對應本文檔一節。被 page 時搜索告警名,跟隨 **首響應** 子節執行。
+
+[English](./observability-runbook-88780.md)
+
+## 運維快速參考
+
+| 層 | 端點 | 默認端口 |
+|---|---|---|
+| Prometheus scrape (每節點) | `http://<host>:9100/metrics` | 9100 |
+| Grafana | 按部署配置 | 3000 |
+| Alertmanager | 按部署配置 | 9093 |
+
+權威網絡參數見 [`public-endpoints-88780.zh.md`](./public-endpoints-88780.zh.md)。
+6 個 active validator (v1、v2、v3、v4、v5、obs-1) — BFT quorum 需 ≥ 4 active。
+
+## SLO 目標
+
+每條告警服務的 canary SLO(按父 canary-readiness plan A.1.3):
+
+| SLO | 目標 | 對應告警 |
+|---|---|---|
+| 出塊 p99 延遲 | < 10 s | `SlowBlockProduction` (warn @ 5% > 6 s 持續 10 m) |
+| Validator 在線率 (滾動 30 天) | ≥ 99.5% | 從 `NodeDown` + Grafana 30d panel 推導 |
+| Mempool 入隊 p99 | < 200 ms | 間接 — `HighMempoolBacklog` 反映背壓 |
+| BFT equivocation (滾動 30 天) | 0 | `EquivocationDetected` (即時觸發,severity critical) |
+| Active validator 數量 | ≥ 4 | 從 `LowPeerCount` + `coc_validators_active` panel 推導 |
+
+## Dashboards
+
+位於 [`docker/grafana/dashboards/`](../docker/grafana/dashboards/)。
+新 Grafana 通過 "Dashboards → Import → JSON" 導入。四個 dashboard 相互補充:
+
+| Dashboard | 何時用 |
+|---|---|
+| `coc-overview.json` | 頂層健康度:塊高、共識狀態、peer 數、mempool 深度。**先看這裡。** |
+| `coc-consensus.json` | BFT 輪詳情:prepare/commit 投票、equivocation、validator 參與率 |
+| `coc-network.json` | 拓撲:HTTP peers、wire 連接、DHT 節點、P2P auth 拒絕 |
+| `coc-resources.json` | 進程資源:RSS、CPU、文件描述符、磁盤 |
+
+---
+
+# 告警目錄
+
+告警按 `prometheus-rules.yml` 分組。標題嚴重度與告警 label 一致。
+
+## 可用性組 (`coc_availability`)
+
+### `NodeDown` — critical
+
+**表達式**:`up{job="coc-node"} == 0` 持續 2m
+
+**症狀**:Prometheus 已 2 分鐘無法抓取此節點的 `/metrics` 端點。可能是進程崩潰、
+網絡分區、防火牆變更或 Prometheus 抓取配置漂移。
+
+**Dashboards**:`coc-overview` → "Node up" panel;`coc-resources` → 進程 panels
+(down 節點會顯示空)。
+
+**診斷**:
+1. `ssh` 到主機跑 `systemctl status coc-node@<unit>` (validator unit 為 `@88`
+   或 `@1`,各主機不同 — 見 [`public-endpoints-88780.zh.md`](./public-endpoints-88780.zh.md))。
+2. 服務在跑但 Prometheus 抓不到,檢查 `iptables -L`、主機防火牆、反代。
+   metrics 端點默認綁 `127.0.0.1:9100` — Prometheus 必須直連或經 SSH tunnel。
+3. `journalctl -u coc-node@<unit> -n 200` 查最近崩潰。
+
+**首響應**:
+- 若 `systemctl status` 顯示 unit 為 `failed` 或 stopped:
+  `systemctl restart coc-node@<unit>`,觀察日誌 ~60s。
+- 若主機完全不可達,upgrade(主機本身 down)— 但 **不要自動換 validator 密鑰**,
+  除非中斷超過 1h(否則主機恢復後 BFT 用 5/6 quorum 繼續運轉,自愈)。
+- 5/6 quorum BFT 繼續(T1 chaos 結果);4/6 仍出塊;≤ 3/6 stall(T3 結果)。
+  並行檢查 `LowPeerCount` / `BlockProductionStalled`。
+
+**升級**:2+ validator 同時 down 時 **不要同時重啟** — page on-call lead。
+按 chaos T2:並行重啟 2 validator 觸發 2.5 分鐘 stall(雙 dead-proposer slot)。
+重啟間隔 ≥ 60s。
+
+---
+
+### `BlockProductionStalled` — critical
+
+**表達式**:`increase(coc_block_height[5m]) == 0` 持續 3m
+
+**症狀**:所有 scraped 節點過去 5 分鐘無新塊。鏈失去 quorum 或所有節點本地卡死。
+
+**Dashboards**:`coc-overview` → "Block Height" panel(看平線);`coc-consensus`
+→ "BFT Phase" panel(卡 `propose` 或 `prepare` 是 giveaway)。
+
+**診斷**:
+1. 交叉檢查 `coc_block_height`。只有一個卡而其他在推進 → 單節點同步問題,
+   把告警降級到該節點。
+2. 全部卡同一高度,查 `coc_validators_active` — 若 < 4,BFT 無法達 quorum。
+3. validator 上 curl `/coc_getBftStatus`:phase + round timer。
+   `phase=propose` + round age > 60s = dead proposer slot。
+
+**首響應**:
+- **全卡,≥ 4 active**:可能 dead-proposer slot。等 H15 fallback 至 60s
+  (production 600s — fast path 在 PR #641 `c4a330a`)。鏈自愈。
+- **全卡,< 4 active**:BFT 在 quorum 下。按 `NodeDown` 流程恢復至少一個
+  validator。不要嘗試 hard fork。
+- **一節點卡,其他推進**:該節點本地卡死。`systemctl restart coc-node@<unit>`,
+  讓 snap-sync 追上。
+
+**升級**:quorum 30 分鐘內無法恢復 → 按
+[`disaster-recovery-88780.zh.md` § 鏈停](./disaster-recovery-88780.zh.md)。
+
+---
+
+### `ConsensusStateDegraded` — warning
+
+**表達式**:`coc_consensus_state != 0` 持續 5m
+
+**症狀**:節點報告非健康共識狀態(1 = degraded,2 = recovering)持續 5+ 分鐘。
+通常是部分網絡分區或瞬態 peer churn 的副作用。
+
+**Dashboards**:`coc-consensus` → "Consensus State Per Node" 時間線。
+
+**診斷**:
+1. 跨節點比較 — 單節點 degraded vs 全網。
+2. 受影響節點查 `coc_peers_connected`。State `1` + 低 peer 數 = 隔離。
+
+**首響應**:
+- 單節點 degraded + 低 peer:檢查節點 outbound 連接(DNS、防火牆、ISP)。
+  通常 peer-list reset 解決:
+  `rm /var/lib/coc/node-*/peers.json; systemctl restart …`。
+  State `2`(recovering)是信息級別 — 節點正通過 snap-sync 回填,別動,
+  除非超過 30 分鐘還在 state 2。
+
+**升級**:多節點同步出現 → 可能上游事件(RPC 網關、公開 faucet —
+見 [`disaster-recovery-88780.zh.md`](./disaster-recovery-88780.zh.md))。
+
+---
+
+## 安全組 (`coc_security`)
+
+### `HighAuthRejections` — warning
+
+**表達式**:`rate(coc_p2p_auth_rejected_total[5m]) > 10` 持續 3m
+
+**症狀**:單節點 P2P auth 拒絕率 > 10/秒持續 3+ 分鐘。可能 Sybil flood、
+暴力掃描或配置錯的 peer 反復嘗試重連。
+
+**Dashboards**:`coc-network` → "P2P Auth Rejections" panel。
+
+**診斷**:
+1. 查 `coc_p2p_auth_rejected_reason_total{reason=…}` 拆分原因:
+   `bad_signature`、`unknown_signer`、`expired_nonce`、`roster_mismatch`。
+   部署窗口中後兩個 = 過期 peer 緩存,benign。
+2. 從節點 gossip 日誌找源 IP
+   (`journalctl -u coc-node@<unit> | grep auth.*rejected`)。
+
+**首響應**:
+- 最常見:bootstrap peer 退出 validator roster(如已退役 observer),
+  過期 `peers.json` 反復重試。解決:編輯 `peers.json` 刪除死 peer,
+  或讓連接 backoff 自動耗盡(~10 分鐘)。
+- 真實攻擊:`iptables` 臨時封鎖突發窗口;模式重複時開 security advisory。
+
+**升級**:拒絕率持續 > 100/秒 10 分鐘 → page security-on-call。
+
+---
+
+### `DiscoveryIdentityFailures` — warning
+
+**表達式**:`increase(coc_discovery_identity_failures_total[10m]) > 50` 持續 5m
+
+**症狀**:10 分鐘內 50+ peer-discovery 身份驗證失敗。與 `HighAuthRejections`
+同根因家族,但在 DNS-seed / DHT bootstrap 層。
+
+**Dashboards**:`coc-network` → "Discovery Identity Failures" panel。
+
+**診斷**:同 `HighAuthRejections`。驗證 seed 列表是當前的(DNS TXT 記錄),
+受影響 peer 仍在預期 roster 中。
+
+**首響應**:seed peer 退役而未更新 DNS 時更新 DNS TXT 記錄。否則按
+`HighAuthRejections` 處理。
+
+---
+
+### `DhtVerifyFailures` — warning
+
+**表達式**:`increase(coc_dht_verify_failures_total[10m]) > 20` 持續 5m
+
+**症狀**:DHT 迭代查找在驗證 FIND_NODE response 的 peer 簽名時失敗。
+通常是升級後的 wire-protocol 不兼容。
+
+**Dashboards**:`coc-network` → "DHT Stats" panel。
+
+**診斷**:確認所有節點跑同一個發布 HEAD(見
+[`public-endpoints-88780.zh.md`](./public-endpoints-88780.zh.md) 運維日誌)。
+跨版本 `verifyNodeSig` 不匹配是最常見觸發。
+
+**首響應**:用 `scripts/deploy-rolling-safe.sh <HEAD>` 把受影響節點滾到
+權威 HEAD。不要同時滾所有節點(按 chaos T2/T8 ops SOP — 錯峰重啟)。
+
+---
+
+### `EquivocationDetected` — critical
+
+**表達式**:`increase(coc_bft_equivocations_total[5m]) > 0` 持續 0m
+
+**症狀**:觀察到 validator 對同一 BFT 高度簽名了兩條衝突消息。鏈上 slash
+應自動觸發,經 `EquivocationDetector`(`0xa5dcE830e917176c1091fd6112F41E47692C510e` gen-5 proxy)。
+
+**Dashboards**:`coc-consensus` → "Equivocations Total" stat。
+
+**診斷**(運維方 — **不要** debug 被 slash 的 validator 密鑰,當作已泄漏處理):
+1. 通過健康節點的 `coc_getEquivocations` RPC 識別違反者。
+2. 確認鏈上 `EquivocationProven` 事件觸發了
+   (Explorer `/address/0xa5dcE830…` events tab)。
+3. slash 後查 `coc_validators_active` — 若降到 4 以下(BFT quorum),
+   並行跑 `BlockProductionStalled` SOP。
+
+**首響應**:若 equivocating validator 是你的:
+- **立即停節點** (`systemctl stop coc-node@<unit>`)。
+- 按 [`operator-runbook.zh.md` § 3 Slash 響應](./operator-runbook.zh.md#3-slash-response)。
+- **不要** 重新 stake 被 slash 的密鑰;生成新 keypair。
+- 24h 內提交事後復盤。
+
+**升級**:任何 equivocation 立即 page on-call lead。這是 canary 30 天清白記錄 Gate
+(在 [`canary-launch-checklist-88780.zh.md`](./canary-launch-checklist-88780.zh.md) 為 Gate 3)
+— 單次事件重置 30 天時鐘。
+
+---
+
+## 性能組 (`coc_performance`)
+
+### `SlowBlockProduction` — warning
+
+**表達式**:`coc_block_time_seconds_bucket{le="6"} / coc_block_time_seconds_count < 0.95` 持續 10m
+
+**症狀**:超過 5% 的塊耗時 > 6s。Canary 目標 p99 < 10s — 這是早期預警信號。
+
+**Dashboards**:`coc-overview` → "Block Time Histogram";`coc-resources`
+→ CPU / disk-IO panels。
+
+**診斷**:
+1. 查 `coc_resources` dashboard 看 validator 的 CPU 飽和或 disk-IO 壓力。
+2. 查 `coc-overview` mempool 深度 — 大 pending 池(> 200)會節流出塊。
+3. 查 `coc_validators_active` — validator 響應慢 dead-proposer slot 拉高 p99。
+
+**首響應**:
+- CPU/disk 飽和:擴主機或換更快存儲。
+- mempool backlog → `HighMempoolBacklog` SOP。
+- 持續 dead-proposer slot:識別慢 validator(最低 `coc_blocks_produced_total` rate)並重啟。
+
+---
+
+### `HighMempoolBacklog` — warning
+
+**表達式**:`coc_tx_pool_pending > 500` 持續 5m
+
+**症狀**:validator 在 5+ 分鐘內持有 > 500 pending tx。Mempool per-sender quota
+為 64(見 `coc-88780-2026-05-26-chaos-engineering-T1-T8.md` T6/T6b),
+500+ pending 意味著真實 inbound 需求。
+
+**Dashboards**:`coc-overview` → "Mempool Depth";`coc-consensus` → "Tx Per Block"。
+
+**診斷**:
+1. 跨節點比較 — 全部 > 500 是有機負載;單個是 relay 慢(可能 peer 問題)。
+2. 查 inbound RPC 速率 `coc_rpc_requests_total` — 限制 240 req/min/IP。
+   單 IP 占主導,可能是 misbehaving client。
+
+**首響應**:
+- 有機負載:提高塊 gas 上限或接受臨時 backlog;突發自動清理
+  (T6 結果 — 500-tx 突發期間鏈保持 ~3s/塊)。
+- 單 IP 灌爆:在 nginx/Cloudflare 層 blacklist。
+
+---
+
+### `HighMemoryUsage` — warning
+
+**表達式**:`coc_process_memory_bytes > 2e9` 持續 10m
+
+**症狀**:節點進程 RSS 超 2GB 持續 10+ 分鐘。要麼慢泄漏(罕見),
+要麼長 uptime + 重 snap-sync 後的預期。
+
+**Dashboards**:`coc-resources` → "Process Memory" panel。
+
+**診斷**:查 `coc_node_uptime_seconds` 看 uptime。30+ 天 uptime 後 RSS > 2GB
+正常;24h 內就 > 2GB 是泄漏跡象。
+
+**首響應**:用 `scripts/deploy-rolling-safe.sh` 滾動重啟 — 錯峰 ≥ 60s
+(chaos T2 SOP)。真實泄漏前先抓 heap snapshot(`kill -USR2 <pid>`),
+再開 bug。
+
+---
+
+## 網絡組 (`coc_network`)
+
+### `LowPeerCount` — warning
+
+**表達式**:`coc_peers_connected < 2` 持續 5m
+
+**症狀**:節點 HTTP gossip peer < 2。6 個 active validator + 0 observer,
+健康每節點 5 個連接。
+
+**Dashboards**:`coc-network` → "Peers Connected"。
+
+**診斷**:
+1. `cat /var/lib/coc/node-<unit>/peers.json` — 驗證 peer 列表完整。
+2. 查 `coc_p2p_auth_rejected_total` — 拒絕率高 → peer 在但被拒
+   (見 `HighAuthRejections`)。
+
+**首響應**:重置 peer 緩存 + 重啟:
+```bash
+mv /var/lib/coc/node-<unit>/peers.json /tmp/peers.bak
+systemctl restart coc-node@<unit>
+```
+節點通過 DNS seeds + DHT 重新發現。5 分鐘後仍 < 2,查 outbound 防火牆。
+
+---
+
+### `NoWireConnections` — warning
+
+**表達式**:`coc_wire_connections == 0 and coc_peers_connected > 0` 持續 5m
+
+**症狀**:Wire(TCP)協議零連接但 HTTP gossip peer 在。Wire 是 BFT 消息
+的高吞吐傳輸 — 沒有它 BFT 跑 HTTP fallback,慢。
+
+**Dashboards**:`coc-network` → "Wire Connections"。
+
+**診斷**:
+1. 檢查節點 env 中 `COC_ENABLE_WIRE_PROTOCOL=true`。
+2. 確認 wire 端口(29790 / 29780 視主機而定)能從 peer 訪問
+   (`nc -zv <peer-ip> 29790`)。
+3. 查 `journalctl -u coc-node@<unit> -e | grep wire` 看 handshake 失敗。
+
+**首響應**:配置對 + 端口開,重啟節點。重啟後所有節點 wire 仍為 0,
+開 issue — 可能 wire-protocol 回歸。
+
+---
+
+# 有意未實現的告警(待後續)
+
+| 信號 | 為何 defer | 跟蹤 |
+|---|---|---|
+| `MultisigSignerUnreachable` | 帶外(3-of-5 仍安全,1 down 可接受)— canary 上線前手動檢查 | 清單 Gate 8 |
+| 出塊 p99 絕對值(vs 比率) | `SlowBlockProduction` 間接覆蓋;原生 p99 查詢更貴 | Backlog |
+| Faucet 抽空 | 目前信息級;`MempoolBacklog` 捕捉症狀 | 清單 Gate 9 |
+| RPC 公開端點 5xx 率 | 屬於 Cloudflare 層(尚未架起) | Gate 8 |
+
+# 未來工作備註
+
+- dev-stack 文件 `docker/prometheus/alerts.yml` 與 `ops/alerts/prometheus-rules.yml`
+  部分重疊但 threshold 不同。權威 prod 文件是 `ops/alerts/prometheus-rules.yml` —
+  未來清理時保持 dev 文件同步或廢棄。
+- 每條告警加 `runbook_url` annotation 指向本文檔(Alertmanager 在 page 中渲染為鏈接)。
+  超出本 PR 範圍;跟 Gate 10 polish 一起做。
+- 按 chaos memory(T1–T8 結果),validator 重啟 SOP 靠運維判斷,而非自動告警強制。
+  新增 `ValidatorQuorumAtRisk` 告警(`coc_validators_active < 5`)能提前阻止 —
+  作為後續任務跟蹤。
+
+# 另見
+
+- [`disaster-recovery-88780.zh.md`](./disaster-recovery-88780.zh.md) — 告警升級為災難場景時的處理。
+- [`canary-launch-checklist-88780.zh.md`](./canary-launch-checklist-88780.zh.md) — Gate 10 證據指針。
+- [`operator-runbook.zh.md`](./operator-runbook.zh.md) — 日常運維 SOP。
+- [`public-endpoints-88780.zh.md`](./public-endpoints-88780.zh.md) — 主機清單 + 端口。


### PR DESCRIPTION
## Summary

Closes the SOP gap in canary-launch-checklist Gate 10. The Grafana dashboards (4 files in `docker/grafana/dashboards/`) and the Prometheus alert rules (11 alerts in `ops/alerts/prometheus-rules.yml`) were **already in the repo**; what was missing is the per-alert runbook a paged ops engineer needs to actually act on them. Without it, Gate 10's \"every alert maps to a runbook page\" requirement was unenforceable.

## New

**`docs/observability-runbook-88780.md`** (+ `.zh.md`) — one section per alert, in the same grouping as the alert YAML:

| Group | Alert | Severity |
|---|---|---|
| Availability | NodeDown, BlockProductionStalled, ConsensusStateDegraded | critical / critical / warning |
| Security | HighAuthRejections, DiscoveryIdentityFailures, DhtVerifyFailures, EquivocationDetected | warning × 3 + critical |
| Performance | SlowBlockProduction, HighMempoolBacklog, HighMemoryUsage | warning × 3 |
| Network | LowPeerCount, NoWireConnections | warning × 2 |

Each section follows a consistent template:
- **Expr**: the PromQL + duration that fires the alert
- **Symptom**: what the operator sees
- **Dashboards**: which Grafana panel(s) to check
- **Diagnosis**: ordered triage steps
- **First response**: concrete commands + decision tree
- **Escalation**: criteria for paging on-call

The runbook references real chaos-engineering results (T1 = 1 validator stop, T2 = 2 down at once = bad, T3 = 3 down = clean stall, T6 = 500-tx burst) so first-response advice is grounded in tested behavior. It also cross-links into `disaster-recovery-88780.md`, `operator-runbook.md`, `public-endpoints-88780.md`.

A final section honestly lists alerts we **didn't** implement and why (MultisigSignerUnreachable, native p99 block-time alert, faucet drain, RPC 5xx) with the gate where each is tracked.

## Updated

**`docs/canary-launch-checklist-88780.md`** (+ `.zh.md`):
- Gate 10: ☐ → 🟡 (assets + SOP shipped; remaining work is non-blocking: manual fresh-Grafana import dry-run, Alertmanager `runbook_url` wiring once docs are public-served, optional `ValidatorQuorumAtRisk` alert, reconcile dev-stack vs ops alerts file)
- Burn-down: `1 ☑ / 10 ☐` → `1 ☑ / 1 🟡 / 9 ☐`

## Cosmetic

**`docker/grafana/dashboards/coc-overview.json`**: title \"COC Prowl Testnet\" → \"COC Canary 88780\", uid `coc-prowl-overview` → `coc-canary-overview`. The other 3 dashboards were already neutrally titled.

## Verification

\`\`\`
$ python3 -c "import json; [json.load(open(f)) for f in ['docker/grafana/dashboards/coc-overview.json','docker/grafana/dashboards/coc-consensus.json','docker/grafana/dashboards/coc-network.json','docker/grafana/dashboards/coc-resources.json']]; print('all 4 dashboards parse')"
all 4 dashboards parse

$ python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['ops/alerts/prometheus-rules.yml','docker/prometheus/alerts.yml']]; print('both alert files parse')"
both alert files parse
\`\`\`

## Why this PR was the right next pick

Of the three follow-up workstreams (Cloudflare proxy / Grafana-alerts / external-validator dry-run), this is the only one fully completable inside one engineering session without external coordination — Cloudflare needs DNS+account setup, external-validator needs a willing third-party operator. Observability is also the **prerequisite** for the 30-day clean-record gates (Gates 2 + 3) — those clocks can't sensibly start until we know we'd actually see a slash or stall when it happened.

## Test plan

- [x] Schema validation of all touched JSON + YAML files
- [x] EN + ZH parity on the runbook + checklist updates
- [ ] **Manual** (out of scope of this PR, tracked in checklist Gate 10): import the 4 dashboards into a fresh Grafana instance to confirm they render
- [ ] **Manual**: load `ops/alerts/prometheus-rules.yml` in a fresh Prometheus to confirm rules evaluate (PromQL syntax verified by visual inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)