### PR TITLE
fix(web): repoint RPC/WS proxy templates at live nodes (v3 primary + v4/v5 backup)

### DIFF
--- a/docker/nginx/coc-rpc.conf
+++ b/docker/nginx/coc-rpc.conf
@@ -1,4 +1,16 @@
-# COC RPC Reverse Proxy with rate limiting
+# COC RPC Reverse Proxy with rate limiting — REFERENCE TEMPLATE.
+#
+# NOTE: This is a reference template, not the live production config. The
+# live canary (88780) web host serves the public site from
+# /etc/nginx/sites-enabled/clawchain.io, whose /api/testnet/rpc and
+# /api/testnet/ws locations proxy to the upstreams below. Keep them
+# pointing at *live* validator/observer nodes — never at a co-located
+# coc-node that might be stopped (e.g. a retired/equivocating validator),
+# or the proxy returns 502 and the website/explorer show no network status.
+#
+# Browser → same-origin HTTPS proxy → server-to-server HTTP to a live node
+# avoids mixed-content (an http:// node URL from an https:// page is blocked).
+#
 # Place in /etc/nginx/sites-available/ and symlink to sites-enabled/
 
 # Rate limiting zone: 100 req/s per IP
@@ -6,12 +18,17 @@ limit_req_zone $binary_remote_addr zone=coc_rpc:10m rate=100r/s;
 limit_req_zone $binary_remote_addr zone=coc_explorer:10m rate=30r/s;
 limit_req_zone $binary_remote_addr zone=coc_verify:10m rate=2r/s;
 
+# Live-node failover: v3 primary, v4/v5 backup (canary 88780, ports 28780/28790).
 upstream coc_rpc {
-    server 127.0.0.1:18780;
+    server 199.192.16.79:28780 max_fails=3 fail_timeout=15s;   # v3 primary
+    server 159.198.36.3:28780  backup;                          # v4
+    server 159.198.36.25:28780 backup;                          # v5
 }
 
 upstream coc_ws {
-    server 127.0.0.1:18781;
+    server 199.192.16.79:28790 max_fails=3 fail_timeout=15s;   # v3 primary
+    server 159.198.36.3:28790  backup;                          # v4
+    server 159.198.36.25:28790 backup;                          # v5
 }
 
 upstream coc_explorer {

--- a/explorer/.env.local.example
+++ b/explorer/.env.local.example
@@ -1,6 +1,11 @@
-# Public endpoints (browser). Use Nginx paths on clawchain.io to avoid mixed-content.
+# Public endpoints (browser). Use the same-origin Nginx proxy path to avoid
+# mixed-content (an http:// node URL from an https:// page is browser-blocked).
+# The proxy upstream must point at a LIVE node — see docker/nginx/coc-rpc.conf.
+# (The live canary host currently serves these paths under clawchain.io; the
+#  chainofclaw.io cutover + rpc.chainofclaw.io are a separate DNS/Cloudflare task.)
 NEXT_PUBLIC_RPC_URL=https://clawchain.io/api/testnet/rpc
 NEXT_PUBLIC_WS_URL=wss://clawchain.io/api/testnet/ws
 
-# Server-side SSR / Node (same chain as NEXT_PUBLIC — direct testnet RPC recommended)
+# Server-side SSR / Node (same chain as NEXT_PUBLIC). Point at a live node;
+# v3 is the current primary (v4 159.198.36.3 / v5 159.198.36.25 are alternates).
 COC_RPC_URL=http://199.192.16.79:28780

--- a/website/.env.local.example
+++ b/website/.env.local.example
@@ -1,5 +1,12 @@
 # Canary testnet 88780 — public endpoints.
 # See docs/public-endpoints-88780.md for the canonical RPC/WS/Faucet/Explorer URLs.
+#
+# ⚠ rpc.chainofclaw.io is NOT live yet (DNS/Cloudflare cutover pending). Current
+# production serves chain data via the same-origin Nginx proxy on clawchain.io
+# (/api/testnet/rpc, /api/testnet/ws → live-node failover; see docker/nginx/coc-rpc.conf).
+# A from-scratch deploy should EITHER stand up rpc.chainofclaw.io, OR leave
+# NEXT_PUBLIC_RPC_URL unset and let the client build the same-origin proxy path
+# from window.location (what the live site currently does).
 NEXT_PUBLIC_RPC_URL=https://rpc.chainofclaw.io
 NEXT_PUBLIC_WS_URL=wss://rpc.chainofclaw.io/ws
 


### PR DESCRIPTION
## Summary

The public **website (`clawchain.io`)** and **explorer (`explorer.clawchain.io`)** stopped showing network status. Root cause: the live nginx `/api/testnet/rpc` + `/api/testnet/ws` locations proxied to a **co-located coc-node** (`127.0.0.1:28780`) that was **stopped** when v2 was retired as an equivocator (2026-06-02) → **502 Bad Gateway**.

**Already fixed live** on the web host by repointing those nginx upstreams to live nodes (v3 primary + v4/v5 backup) — verified: `/api/testnet/rpc` returns the live height, chainId `0x15acc`, `coc_chainStats` (19 BPM, 4 validators), and the WS path upgrades (`101 Switching Protocols`).

This PR brings the **repo reference templates** in line so a future redeploy doesn't reintroduce the dead upstream.

## Changes (templates + comments only — no app code)

| File | Change |
|---|---|
| `docker/nginx/coc-rpc.conf` | `coc_rpc`/`coc_ws` upstreams `127.0.0.1:18780/18781` → live-node **failover** (v3 `199.192.16.79` primary, v4/v5 `backup`; ports 28780/28790). Header note: keep upstreams on **live** nodes, never a co-located node that can be stopped; same-origin HTTPS proxy avoids mixed-content. |
| `explorer/.env.local.example` | Clarify `NEXT_PUBLIC_*` = same-origin proxy path; `COC_RPC_URL` = a live node (v3 primary, v4/v5 alternates). |
| `website/.env.local.example` | Warn that `rpc.chainofclaw.io` is **not live yet** (DNS/Cloudflare cutover pending); current prod serves via the clawchain.io same-origin proxy. |

## Why a proxy (not a direct node URL in env)

- `http://199.192.16.79:28780` (live) from an **HTTPS** page → browser **mixed-content block**.
- `https://rpc.chainofclaw.io` → doesn't resolve yet (Gate 8 Cloudflare not stood up).
- The site already uses the right pattern — a **same-origin HTTPS proxy**; only the **upstream** was wrong.

## Out of scope (tracked)

- DNS migration `clawchain.io → chainofclaw.io` + Cloudflare TLS for `rpc.chainofclaw.io` (Gate 8).
- Restoring v1/v2 to the validator set (fault-tolerance 0 → 1+).

## Test plan

- [x] Live: `curl -X POST https://clawchain.io/api/testnet/rpc … eth_blockNumber` → live height (not 502); `coc_chainStats` populated; WS path → `101`.
- [x] nginx template braces balanced (15/15).
- [ ] On next explorer/website redeploy, confirm `.env.local.example` guidance produces a working same-origin proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)