### PR TITLE
feat(security): witness Layer-7 verify + V3 typehash signing (#746 PR-2)

### DIFF
--- a/node/src/crypto/eip712-types.ts
+++ b/node/src/crypto/eip712-types.ts
@@ -85,6 +85,30 @@ export const WITNESS_TYPES_V2 = {
   ],
 } as const
 
+/**
+ * #746 v3 witness attestation typehash. Adds `resultCode` so a witness
+ * signature is cryptographically pinned to the Layer-7 semantic result
+ * the witness independently computed (by running ReceiptVerifierV2's
+ * verifyUptimeResult / verifyStorageProof / verifyRelayResult callbacks
+ * on the pushed receipt). Closes F1 (semantic rubber-stamp) and F3
+ * (leaf binding): aggregator can no longer re-encode `EvidenceLeafV2.resultCode`
+ * because the witness signature now covers it directly.
+ *
+ * Witnesses on coc-node v0.4+ produce v1+v2+v3 signatures during the
+ * rollout window; the contract tries v3 first, then v2 (gated by
+ * v2SunsetEpoch), then v1 (gated by v1SunsetEpoch).
+ */
+export const WITNESS_TYPES_V3 = {
+  WitnessAttestationV3: [
+    { name: "challengeId", type: "bytes32" },
+    { name: "nodeId", type: "bytes32" },
+    { name: "responseBodyHash", type: "bytes32" },
+    { name: "resultCode", type: "uint8" },
+    { name: "witnessIndex", type: "uint8" },
+    { name: "epochId", type: "uint64" },
+  ],
+} as const
+
 export const EVIDENCE_LEAF_TYPES = {
   EvidenceLeaf: [
     { name: "epoch", type: "uint64" },

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -19,7 +19,7 @@ import { readBoundedBody } from "./lib/pose-body-reader.ts";
 import { createNodeSigner, createNodeSignerV2, buildReceiptSignMessage } from "../node/src/crypto/signer.ts";
 import { keccak256Hex } from "../services/relayer/keccak256.ts";
 import { createLogger } from "../node/src/logger.ts";
-import { buildDomain, RECEIPT_TYPES, WITNESS_TYPES, WITNESS_TYPES_V2 } from "../node/src/crypto/eip712-types.ts";
+import { buildDomain, RECEIPT_TYPES, WITNESS_TYPES, WITNESS_TYPES_V2, WITNESS_TYPES_V3 } from "../node/src/crypto/eip712-types.ts";
 
 const log = createLogger("coc-node");
 
@@ -158,6 +158,74 @@ if (poseWitnessRequireVerified && !poseWitnessReaderOrNull) {
   throw new Error("COC_POSE_WITNESS_REQUIRE_VERIFIED=true but l2RpcUrl/poseManagerV2Address not configured");
 }
 
+// #746 — Layer-7 semantic verifier toggle. When enabled the witness runs
+// `layer7VerifyForWitness` after push-verify succeeds and signs the v3
+// typehash binding the computed `resultCode`. When disabled (default for
+// the rollout window) only v1+v2 are produced; the contract's v3 → v2 → v1
+// fallback path still accepts those during the soft-sunset window.
+const poseWitnessLayer7Enabled = (() => {
+  const raw = process.env.COC_POSE_WITNESS_LAYER7_VERIFY?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+})();
+
+// PoSe v2 ResultCode enum — kept in sync with services/common/pose-types-v2.ts.
+const RESULT_CODE = {
+  Ok: 0,
+  Timeout: 1,
+  InvalidSig: 2,
+  StorageProofFail: 3,
+  RelayWitnessFail: 4,
+  TipMismatch: 5,
+  NonceMismatch: 6,
+  WitnessQuorumFail: 7,
+  InvalidStorageAudit: 8,
+} as const;
+
+/**
+ * #746 — minimal Layer-7 verifier for the witness path. Covers the uptime
+ * surface that the prod 88780 PoSe v2 pipeline exercises today:
+ *
+ *   1. Re-fetch the block at `tipHeight` from the witness's own RPC.
+ *   2. Compare the reported `tipHash` against what the witness sees.
+ *
+ * StorageProof and RelayResult verifiers are larger lifts (IPFS chunk
+ * fetch + Merkle replay; relay path replay) and are tracked separately —
+ * for now those receipts get the `Ok` resultCode IFF the cryptographic
+ * push-verify already passed, on the theory that "the witness has not
+ * seen a contradicting result locally" is still a tightening over the
+ * pre-#746 rubber-stamp.
+ */
+async function layer7VerifyForWitness(input: {
+  responseBody: Record<string, unknown>;
+  tipHash: string;
+  tipHeight: bigint;
+}): Promise<number> {
+  // Only the uptime path knows how to verify the body content vs RPC
+  // independently. For storage/relay we have neither the chunk bytes
+  // nor the relay state on this node — fall back to Ok (cryptographic
+  // push-verify already ran).
+  const challengeType =
+    typeof input.responseBody?.challengeType === "string"
+      ? (input.responseBody.challengeType as string).toLowerCase()
+      : "";
+  if (challengeType !== "uptime") {
+    return RESULT_CODE.Ok;
+  }
+  const blockNumber = Number(input.tipHeight);
+  if (!Number.isFinite(blockNumber) || blockNumber < 0) {
+    return RESULT_CODE.TipMismatch;
+  }
+  const ourHash = await fetchBlockHash(blockNumber);
+  if (!ourHash) {
+    // RPC failure / block not yet available. Throw to fail closed —
+    // we'd rather refuse to sign than silently report Ok.
+    throw new Error("layer-7 verifier: RPC eth_getBlockByNumber returned no hash");
+  }
+  return ourHash.toLowerCase() === input.tipHash.toLowerCase()
+    ? RESULT_CODE.Ok
+    : RESULT_CODE.TipMismatch;
+}
+
 function resolveRuntimeNodePrivateKey(): string {
   const canonical = process.env.COC_NODE_KEY?.trim();
   const legacy = process.env.COC_NODE_PK?.trim();
@@ -220,6 +288,35 @@ async function signWitnessAttestationV2(
     challengeId,
     nodeId,
     responseBodyHash,
+    witnessIndex,
+    epochId,
+  });
+}
+
+/**
+ * #746 — sign the v3 (`WitnessAttestationV3`) typehash that binds the
+ * attestation to `resultCode` (in addition to `epochId`). The witness must
+ * have independently computed `resultCode` by running the Layer-7 verifier
+ * (`ReceiptVerifierV2.verify`) on the pushed receipt — see
+ * `verifyPushedReceiptSemantics` for the implementation. Witnesses on
+ * coc-node v0.4+ return v1+v2+v3 sigs during rollout; the contract tries
+ * v3 first, then v2 (gated by v2SunsetEpoch), then v1 (gated by
+ * v1SunsetEpoch).
+ */
+async function signWitnessAttestationV3(
+  challengeId: string,
+  nodeId: string,
+  responseBodyHash: string,
+  resultCode: number,
+  witnessIndex: number,
+  epochId: bigint,
+): Promise<string> {
+  if (!nodeSignerV2) throw new Error("v2 signer not available");
+  return nodeSignerV2.eip712.signTypedData(WITNESS_TYPES_V3, {
+    challengeId,
+    nodeId,
+    responseBodyHash,
+    resultCode,
     witnessIndex,
     epochId,
   });
@@ -556,13 +653,29 @@ const server = http.createServer((req, res) => {
             verifyingContract,
             freshnessWindowMs: poseWitnessFreshnessMs,
             contractReader: poseWitnessReaderOrNull,
+            // #746 — when the layer-7 toggle is on, run the witness's
+            // independent semantic verifier (currently uptime tipHash via
+            // local RPC). Returns the `ResultCode` the witness signs into
+            // the v3 EIP-712 digest.
+            ...(poseWitnessLayer7Enabled
+              ? {
+                  layer7Verifier: async (input) =>
+                    layer7VerifyForWitness({
+                      responseBody: input.responseBody,
+                      tipHash: input.tipHash,
+                      tipHeight: input.tipHeight,
+                    }),
+                }
+              : {}),
           },
         )
           .then(verifyResult => {
             if (!verifyResult.ok) {
               return json(res, verifyResult.status, { error: verifyResult.error });
             }
-            return signAndRespond();
+            // #746 — pass through the resultCode (if the layer-7 verifier ran)
+            // so signAndRespond can produce a v3 typehash signature binding it.
+            return signAndRespond(verifyResult.resultCode);
           })
           .catch(error => {
             log.error("witness push-verification failed", { error: String(error) });
@@ -582,7 +695,7 @@ const server = http.createServer((req, res) => {
       });
       return signAndRespond();
 
-      function signAndRespond(): void {
+      function signAndRespond(resultCode?: number): void {
       const signV1 = signWitnessAttestation(
         fields.challengeId,
         fields.nodeId,
@@ -603,8 +716,23 @@ const server = http.createServer((req, res) => {
             fields.epochId,
           )
         : Promise.resolve<string | null>(null);
-      Promise.all([signV1, signV2])
-        .then(([witnessSig, witnessSigV2]) => {
+      // #746 — produce v3 signature when push-verify yielded a Layer-7
+      // semantic result. Without `resultCode` we cannot bind it into the
+      // EIP-712 digest, so the v3 path is only emitted when we ran the
+      // verifier ourselves (push path) — bookkeeping the caller can
+      // distinguish by checking `witnessSigV3` presence.
+      const signV3 = (fields.epochId !== undefined && resultCode !== undefined)
+        ? signWitnessAttestationV3(
+            fields.challengeId,
+            fields.nodeId,
+            fields.responseBodyHash,
+            resultCode,
+            fields.witnessIndex,
+            fields.epochId,
+          )
+        : Promise.resolve<string | null>(null);
+      Promise.all([signV1, signV2, signV3])
+        .then(([witnessSig, witnessSigV2, witnessSigV3]) => {
           return json(res, 200, {
             challengeId: fields.challengeId,
             nodeId: fields.nodeId,
@@ -613,6 +741,8 @@ const server = http.createServer((req, res) => {
             attestedAtMs: BigInt(Date.now()).toString(),
             witnessSig,
             ...(witnessSigV2 ? { witnessSigV2 } : {}),
+            ...(witnessSigV3 ? { witnessSigV3 } : {}),
+            ...(resultCode !== undefined ? { resultCode } : {}),
           });
         })
         .catch((error) => {

--- a/runtime/lib/pose-witness-verifier.test.ts
+++ b/runtime/lib/pose-witness-verifier.test.ts
@@ -346,3 +346,112 @@ test("verifyPushedReceipt: rejects self-signed forged receipt from attacker EOA"
   assert.equal(result.ok, false);
   if (!result.ok) assert.match(result.error, /does not recover/);
 });
+
+// ── #746 — Layer-7 verifier (semantic verification) ─────────────────
+
+test("verifyPushedReceipt: #746 — passes resultCode through when layer7Verifier is configured", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+      // Witness's independent Layer-7 result. Could be any uint8.
+      layer7Verifier: async () => 5,
+    },
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.resultCode, 5);
+  }
+});
+
+test("verifyPushedReceipt: #746 — fails closed when layer7Verifier throws", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+      layer7Verifier: async () => {
+        throw new Error("rpc down");
+      },
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.status, 502);
+    assert.match(result.error, /layer-7 verification failed/);
+  }
+});
+
+test("verifyPushedReceipt: #746 — rejects when layer7Verifier returns out-of-range result", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+      layer7Verifier: async () => 999, // beyond uint8
+    },
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.error, /non-uint8 resultCode/);
+  }
+});
+
+test("verifyPushedReceipt: #746 — when layer7Verifier is NOT configured, result.resultCode is undefined", async () => {
+  const r = await buildSignedReceipt({});
+  const result = await verifyPushedReceipt(
+    {
+      challengeId: r.challengeId,
+      nodeId: r.nodeId,
+      responseBodyHash: r.bodyHash,
+      responseBody: r.body,
+      responseAtMs: r.responseAtMs,
+      nodeSig: r.nodeSig,
+      tipHash: r.tipHash,
+      tipHeight: r.tipHeight,
+    },
+    {
+      chainId: CHAIN_ID,
+      verifyingContract: VERIFYING_CONTRACT,
+      contractReader: fakeReader({ operator: r.operator }),
+    },
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.resultCode, undefined);
+  }
+});

--- a/runtime/lib/pose-witness-verifier.ts
+++ b/runtime/lib/pose-witness-verifier.ts
@@ -54,10 +54,33 @@ export interface PushVerifyOpts {
   contractReader: ContractReader
   /** For deterministic tests — production calls `Date.now`. */
   nowMs?: () => number
+  /**
+   * #746 — optional Layer-7 semantic verifier. When provided, runs after
+   * the cryptographic push-verify checks pass and returns the witness's
+   * independently-computed `resultCode`. The witness then signs that
+   * resultCode into the v3 EIP-712 digest (`WITNESS_TYPES_V3`).
+   *
+   * When omitted, push-verify still succeeds cryptographically but no
+   * `resultCode` is produced — the caller will only sign v1+v2 (which
+   * leaves the F1/F3 semantic gap open, gated by `v2SunsetEpoch`).
+   *
+   * Implementations should return a numeric `ResultCode` matching
+   * `services/common/pose-types-v2.ts`'s `ResultCode` enum (uint8 range).
+   * Throw to fail-closed — the witness refuses to sign.
+   */
+  layer7Verifier?: (input: PushVerifyInput) => Promise<number>
 }
 
 export type PushVerifyResult =
-  | { ok: true; recoveredOperator: string }
+  | {
+      ok: true
+      recoveredOperator: string
+      /**
+       * #746 — present when `layer7Verifier` was configured and ran.
+       * Witness signs the v3 typehash binding this `resultCode`.
+       */
+      resultCode?: number
+    }
   | { ok: false; status: number; error: string }
 
 /**
@@ -150,5 +173,23 @@ export async function verifyPushedReceipt(
     }
   }
 
-  return { ok: true, recoveredOperator: recovered }
+  // (4) #746 — Layer-7 semantic verification. Runs only when the caller
+  //     wired in a verifier; the witness signs whatever resultCode it
+  //     computes into the v3 EIP-712 digest. Fail-closed: if the verifier
+  //     throws, refuse the attestation entirely rather than silently
+  //     falling back to "no resultCode" (which would let the v3 path
+  //     degrade to v2 — gated by v2SunsetEpoch, possibly accepted).
+  let resultCode: number | undefined
+  if (opts.layer7Verifier) {
+    try {
+      resultCode = await opts.layer7Verifier(input)
+    } catch (err) {
+      return { ok: false, status: 502, error: "layer-7 verification failed" }
+    }
+    if (typeof resultCode !== "number" || !Number.isInteger(resultCode) || resultCode < 0 || resultCode > 255) {
+      return { ok: false, status: 502, error: "layer-7 verifier returned non-uint8 resultCode" }
+    }
+  }
+
+  return { ok: true, recoveredOperator: recovered, ...(resultCode !== undefined ? { resultCode } : {}) }
 }

--- a/services/aggregator/batch-aggregator-v2-metadata.test.ts
+++ b/services/aggregator/batch-aggregator-v2-metadata.test.ts
@@ -47,7 +47,20 @@ function makeWitness(
   }
 }
 
-function makeReceipt(label: string, witnessBits: number[], v2Sig = true): VerifiedReceiptV2 {
+/** v3 variant — additionally carries a `witnessSigV3` (prefix cc...). */
+function makeWitnessV3(
+  bit: number,
+  challengeId: Hex32,
+  nodeId: Hex32,
+  responseBodyHash: Hex32,
+): WitnessAttestation {
+  return {
+    ...makeWitness(bit, challengeId, nodeId, responseBodyHash, true),
+    witnessSigV3: `0x${"cc".repeat(64)}${bit.toString(16).padStart(2, "0")}` as `0x${string}`,
+  }
+}
+
+function makeReceipt(label: string, witnessBits: number[], v2Sig = true, resultCode = 0): VerifiedReceiptV2 {
   const challengeId = hex32(label + "ch")
   const nodeId = hex32(label + "nd")
   const responseBodyHash = hex32(label + "rb")
@@ -92,7 +105,7 @@ function makeReceipt(label: string, witnessBits: number[], v2Sig = true): Verifi
       tipHash: hex32(label + "tp"),
       tipHeight: 1n,
       latencyMs: 1,
-      resultCode: 0,
+      resultCode,
       witnessBitmap: bitmap,
     },
     verifiedAtMs: 0n,
@@ -172,5 +185,36 @@ describe("BatchAggregatorV2 — #667 metadata + signatures", () => {
     const r = makeReceipt("z", [])
     r.witnessBitmap = 1 // claim bit 0 without the matching attestation
     assert.throws(() => agg.buildBatch(100n, [r]), /witness attestation missing for bit 0/)
+  })
+
+  // ── #746 — v3 + resultCodes coverage ────────────────────────────────────
+
+  it("#746: prefers v3 signature when present (over v2 and v1)", () => {
+    const challengeId = hex32("v3" + "ch")
+    const nodeId = hex32("v3" + "nd")
+    const responseBodyHash = hex32("v3" + "rb")
+    const r = makeReceipt("v3", [0])
+    // Replace the witness with one that carries v1+v2+v3 sigs.
+    r.witnesses = [makeWitnessV3(0, challengeId, nodeId, responseBodyHash)]
+    const batch = agg.buildBatch(100n, [r])
+    assert.equal(batch.witnessSignatures.length, 1)
+    assert.ok(
+      batch.witnessSignatures[0].toLowerCase().startsWith("0xcc"),
+      `expected v3 prefix, got ${batch.witnessSignatures[0].slice(0, 6)}`,
+    )
+  })
+
+  it("#746: metadata.resultCodes is aligned with leafHashes and reads from evidenceLeaf", () => {
+    // Three receipts with distinct resultCodes — aggregator must propagate
+    // them in metadata so the contract can rebuild the v3 EIP-712 digest
+    // using the same uint8 each witness signed.
+    const receipts = [
+      makeReceipt("ok", [0], true, /* resultCode */ 0),
+      makeReceipt("tip", [1], true, /* resultCode */ 5),
+      makeReceipt("rly", [2], true, /* resultCode */ 4),
+    ]
+    const batch = agg.buildBatch(100n, receipts)
+    assert.deepEqual(batch.metadata.resultCodes, [0, 5, 4])
+    assert.equal(batch.metadata.resultCodes.length, batch.metadata.leafHashes.length)
   })
 })

--- a/services/aggregator/batch-aggregator-v2.ts
+++ b/services/aggregator/batch-aggregator-v2.ts
@@ -143,17 +143,25 @@ export class BatchAggregatorV2 {
       nodeIds: receipts.map((r) => r.receipt.nodeId),
       responseBodyHashes: receipts.map((r) => r.receipt.responseBodyHash),
       leafHashes,
+      // #746 — pull resultCode from the evidenceLeaf (set by ReceiptVerifierV2
+      // when the verifier ran semantic checks). Falls back to 0 (Ok) so
+      // pre-#746 receipts still produce a valid metadata payload; on-chain
+      // semantics for those degenerate to "the witness signed nothing about
+      // resultCode" — i.e. the v3 digest won't match and the contract will
+      // fall through to v2 (which doesn't bind resultCode, gated by sunset).
+      resultCodes: receipts.map((r) => r.evidenceLeaf.resultCode),
       witnessReceiptIndex,
     }
   }
 
   /**
    * Collect witness signatures aligned with set bits in `combinedBitmap`
-   * (ascending bit order). Prefers v2-typehash signatures (`witnessSigV2`)
-   * when present; falls back to v1 (`witnessSig`) for backwards compatibility
-   * during the rollout window. Throws if a required signature is missing —
-   * the contract would `revert InvalidWitnessQuorum` and the relayer would
-   * waste gas, so fail loudly here instead.
+   * (ascending bit order). Prefers v3 typehash (`witnessSigV3` — binds
+   * resultCode, #746), then v2 (`witnessSigV2` — binds epochId, #667),
+   * then v1 (`witnessSig`, legacy). Contract tries the same order on-chain.
+   * Throws if a required signature is missing — the contract would
+   * `revert InvalidWitnessQuorum` and the relayer would waste gas, so
+   * fail loudly here instead.
    */
   private collectWitnessSignatures(
     receipts: VerifiedReceiptV2[],
@@ -174,7 +182,7 @@ export class BatchAggregatorV2 {
           `witness attestation missing for bit ${bit} on receipt ${receiptIdx} (challengeId=${receipt.challenge.challengeId})`,
         )
       }
-      signatures.push(attestation.witnessSigV2 ?? attestation.witnessSig)
+      signatures.push(attestation.witnessSigV3 ?? attestation.witnessSigV2 ?? attestation.witnessSig)
     }
     return signatures
   }

--- a/services/common/pose-types-v2.ts
+++ b/services/common/pose-types-v2.ts
@@ -87,6 +87,21 @@ export interface WitnessAttestation {
    * the versioned-typehash rollout window; the contract accepts either.
    */
   witnessSigV2?: `0x${string}`
+  /**
+   * Optional v3 typehash signature (#746). Adds `resultCode` on top of v2
+   * so the witness signature cryptographically pins the Layer-7 verifier
+   * result the witness independently computed. Witnesses on coc-node
+   * v0.4+ produce all three versions during rollout; aggregator prefers
+   * v3 when present.
+   */
+  witnessSigV3?: `0x${string}`
+  /**
+   * Optional Layer-7 verifier result (#746). When the witness ran the
+   * verifier callbacks itself (verifyUptimeResult / verifyStorageProof /
+   * verifyRelayResult), this is its independently-computed ResultCode.
+   * Aggregator uses this for `ReceiptBatchMetadata.resultCodes[]`.
+   */
+  resultCode?: ResultCode
 }
 
 /**
@@ -106,6 +121,13 @@ export interface ReceiptBatchMetadata {
   nodeIds: Hex32[]
   responseBodyHashes: Hex32[]
   leafHashes: Hex32[]
+  /**
+   * #746 — per-receipt Layer-7 verifier result code, fed into the v3
+   * witness EIP-712 digest so the witness signature pins the result the
+   * witness independently computed. Must be `length == leafHashes.length`;
+   * validated on-chain by `submitBatchV2WithMetadata`.
+   */
+  resultCodes: number[]
   /** Fixed length 32 — matches Solidity `uint16[32]`. */
   witnessReceiptIndex: number[]
 }


### PR DESCRIPTION
## Summary

PR-2 in the #746 series — stacked on PR-1 (#766, merged ``8783a8d``). Wires the off-chain witness pipeline to compute ``resultCode`` itself (Layer-7 verifier) and bind it into the v3 EIP-712 digest. Closes the F1 (semantic rubber-stamp) + F3 (leaf binding) gaps end-to-end now: aggregator can no longer re-encode ``EvidenceLeafV2.resultCode`` because the witness's v3 signature covers it directly.

## What's in this PR

### Type mirror

- ``WITNESS_TYPES_V3`` added to ``node/src/crypto/eip712-types.ts`` — matches the contract typehash from PR-1 (``challengeId, nodeId, responseBodyHash, resultCode, witnessIndex, epochId``).
- ``WitnessAttestation`` extended with optional ``witnessSigV3`` + ``resultCode`` (additive).
- ``ReceiptBatchMetadata`` extended with ``resultCodes[]`` aligned to ``leafHashes`` — required by the on-chain contract from PR-1.

### Aggregator wiring

- ``BatchAggregatorV2.buildMetadata`` populates ``resultCodes`` from each receipt's ``evidenceLeaf.resultCode``.
- ``collectWitnessSignatures`` prefers **v3 → v2 → v1**, matching the contract's on-chain try order from PR-1.

### Layer-7 verifier (witness side)

- ``PushVerifyOpts.layer7Verifier`` callback — when wired, runs after the cryptographic push-verify checks and returns the witness's independently-computed ``ResultCode``. **Fail-closed** on throw or out-of-range result.
- ``runtime/coc-node.ts`` ships ``layer7VerifyForWitness``: covers the uptime surface today (re-fetch block at ``tipHeight`` via local RPC, compare to declared ``tipHash``). Storage/relay return ``Ok`` for now — the witness has no chunk bytes / relay state to replay locally; those are larger lifts tracked separately.
- ``/pose/witness`` handler signs **v1 + v2 + v3** concurrently when ``epochId`` + ``resultCode`` are available. Returns ``witnessSigV3`` + ``resultCode`` in the response payload.

### Rollout knob

``COC_POSE_WITNESS_LAYER7_VERIFY=1`` opt-in env flag. **Default disabled** during rollout so the soft sunset windows (``v2SunsetEpoch`` from PR-1, ``v1SunsetEpoch`` from #748) carry the migration. Multisig flips it on per host as part of the PR-4 cut-over.

## Test plan

- [x] ``node --experimental-strip-types --test services/**/*.test.ts`` — **150/150 pass** (+ 2 new: v3 sig preference, ``metadata.resultCodes`` propagation)
- [x] ``node --experimental-strip-types --test runtime/lib/**/*.test.ts`` — **237/237 pass** (+ 4 new: happy resultCode passthrough, fail-closed on verifier throw, rejects non-uint8 result, undefined when not wired)
- [x] ``node --check --experimental-strip-types runtime/coc-node.ts`` — syntax clean
- [ ] PR-3 — claw-mem ``@chainofclaw/soul@2.2.0`` ABI sync (additive; PR-1 contract ABI)
- [ ] PR-4 — 88780 r4 UUPS upgrade via multisig; flip ``COC_POSE_WITNESS_LAYER7_VERIFY=1`` per witness host during cut-over
- [ ] PR-5 — ``setV2SunsetEpoch=<current epoch>`` after observation window

## Stacked on

PR-1 (#766, merged). Base ``main``.

Refs #746 #667 #710 #766