### PR TITLE
docs(upgrades): PR-4 — 88780 PoSeManagerV2 #746 upgrade scripts + runbook

### DIFF
--- a/contracts/scripts/safe-propose-pose-upgrade-746.ts
+++ b/contracts/scripts/safe-propose-pose-upgrade-746.ts
@@ -1,0 +1,160 @@
+/**
+ * Propose the PoSeManagerV2 #746 upgrade tx to the Gnosis Safe owning the
+ * proxy. Reads the prepared impl from `tmp/upgrade-746-prepared.json`
+ * (output of `upgrade-pose-manager-v2-746.js`) and submits a Safe Tx
+ * Service proposal that, when executed by N-of-M multisig signers,
+ * points the live proxy at the new implementation.
+ *
+ * USAGE
+ *   COC_RPC_URL=https://<88780-rpc> \
+ *   SAFE_TX_SERVICE_URL=https://<safe-tx-service-for-88780> \
+ *   PROPOSER_PRIVATE_KEY=0x<proposer-eoa> \
+ *   POSE_MULTISIG_ADDRESS=0x<safe-address> \
+ *   npx ts-node scripts/safe-propose-pose-upgrade-746.ts
+ *
+ * Required env
+ *   - COC_RPC_URL         JSON-RPC for 88780.
+ *   - SAFE_TX_SERVICE_URL Safe Tx Service base URL. If your network is not
+ *                         in Safe Global's hosted index, run your own
+ *                         instance (https://github.com/safe-global/safe-tx-service).
+ *   - POSE_MULTISIG_ADDRESS  The Safe holding ownership of the PoSeManagerV2
+ *                            proxy (must match the proxy's `owner()`).
+ *   - PROPOSER_PRIVATE_KEY EOA that signs the proposal (must be one of the
+ *                          Safe owners). DOES NOT execute; signers approve
+ *                          via Safe UI afterwards.
+ *
+ * Safety
+ * ------
+ * - Constructs an `upgradeToAndCall(newImpl, "")` call with empty init data.
+ *   No re-initialization runs on the proxy; pre-upgrade storage is fully
+ *   preserved (UUPS, OZ upgrade-safety validated already).
+ * - Calls `proxy.owner()` and asserts it equals POSE_MULTISIG_ADDRESS — if
+ *   the owner changed (e.g. ownership was transferred to GovernanceDAO),
+ *   ABORT and re-coordinate.
+ * - The proposal is created but NOT executed. Signers approve through the
+ *   Safe UI; quorum is the Safe's own threshold (not this script's choice).
+ *
+ * After execution
+ * ---------------
+ * - Verify the upgrade via `eth_call` on `proxy.implementation()` (ERC-1967
+ *   slot). The address should now match `prepared.newImpl`.
+ * - Submit a sentinel `submitBatchV2WithMetadata` batch from a privileged
+ *   aggregator with a tiny metadata payload to assert the new path works.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { ethers } from "ethers"
+import Safe from "@safe-global/protocol-kit"
+import SafeApiKit from "@safe-global/api-kit"
+import {
+  type SafeTransactionDataPartial,
+  type MetaTransactionData,
+  OperationType,
+} from "@safe-global/safe-core-sdk-types"
+
+const PREPARED_PATH = join(__dirname, "..", "tmp", "upgrade-746-prepared.json")
+
+const UUPS_ABI = [
+  "function upgradeToAndCall(address newImplementation, bytes data) external payable",
+  "function owner() external view returns (address)",
+] as const
+
+interface PreparedUpgrade {
+  proxy: string
+  newImpl: string
+  contractName: string
+  chainId: number
+  preparedAt: string
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name]
+  if (!v || v.length === 0) {
+    throw new Error(`required env ${name} is not set`)
+  }
+  return v
+}
+
+async function main(): Promise<void> {
+  const rpcUrl = requireEnv("COC_RPC_URL")
+  const safeTxServiceUrl = requireEnv("SAFE_TX_SERVICE_URL")
+  const safeAddress = ethers.getAddress(requireEnv("POSE_MULTISIG_ADDRESS"))
+  const proposerKey = requireEnv("PROPOSER_PRIVATE_KEY")
+
+  const prepared = JSON.parse(readFileSync(PREPARED_PATH, "utf8")) as PreparedUpgrade
+  if (prepared.chainId !== 88780) {
+    throw new Error(`prepared upgrade chainId=${prepared.chainId}, expected 88780`)
+  }
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl)
+  const network = await provider.getNetwork()
+  if (Number(network.chainId) !== 88780) {
+    throw new Error(`RPC chainId=${network.chainId}, expected 88780`)
+  }
+
+  // Owner sanity check before submitting anything.
+  const proxy = new ethers.Contract(prepared.proxy, UUPS_ABI, provider)
+  const liveOwner = ethers.getAddress(await proxy.owner())
+  if (liveOwner !== safeAddress) {
+    throw new Error(
+      `proxy ${prepared.proxy} owner=${liveOwner} does not match POSE_MULTISIG_ADDRESS=${safeAddress}. ` +
+      `Ownership may have been transferred — verify with the team before proceeding.`
+    )
+  }
+  console.log(`✓ proxy ${prepared.proxy} owned by Safe ${safeAddress}`)
+
+  // Encode the upgradeToAndCall calldata.
+  const iface = new ethers.Interface(UUPS_ABI)
+  const data = iface.encodeFunctionData("upgradeToAndCall", [prepared.newImpl, "0x"])
+  console.log(`  upgradeToAndCall(${prepared.newImpl}, 0x) — ${data.length / 2 - 1} bytes calldata`)
+
+  // Build Safe SDK transaction.
+  const proposer = new ethers.Wallet(proposerKey, provider)
+  const safeSdk = await Safe.init({
+    provider: rpcUrl,
+    signer: proposerKey,
+    safeAddress,
+  })
+
+  const safeTransactionData: MetaTransactionData = {
+    to: prepared.proxy,
+    value: "0",
+    data,
+    operation: OperationType.Call,
+  }
+  const safeTransaction = await safeSdk.createTransaction({
+    transactions: [safeTransactionData],
+  })
+  const safeTxHash = await safeSdk.getTransactionHash(safeTransaction)
+  const senderSignature = await safeSdk.signHash(safeTxHash)
+
+  // Push to Safe Tx Service for the other signers to approve.
+  const apiKit = new SafeApiKit({
+    chainId: BigInt(88780),
+    txServiceUrl: safeTxServiceUrl,
+  })
+  await apiKit.proposeTransaction({
+    safeAddress,
+    safeTransactionData: safeTransaction.data,
+    safeTxHash,
+    senderAddress: proposer.address,
+    senderSignature: senderSignature.data,
+    origin: "PoSeManagerV2 #746 upgrade",
+  })
+
+  console.log("")
+  console.log(`✓ Safe Tx proposed`)
+  console.log(`  safeTxHash:  ${safeTxHash}`)
+  console.log(`  txService:   ${safeTxServiceUrl}`)
+  console.log(`  proposer:    ${proposer.address}`)
+  console.log(`  to (proxy):  ${prepared.proxy}`)
+  console.log(`  new impl:    ${prepared.newImpl}`)
+  console.log("")
+  console.log(`Other signers should approve via the Safe UI; once the threshold is met any owner can execute.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/contracts/scripts/test-upgrade-dry-run-746.js
+++ b/contracts/scripts/test-upgrade-dry-run-746.js
@@ -1,0 +1,147 @@
+/**
+ * Local dry-run of the PoSeManagerV2 #746 upgrade.
+ *
+ * USAGE
+ *   npx hardhat run scripts/test-upgrade-dry-run-746.js
+ *
+ * Runs against the default Hardhat in-process EVM (no real chain touched).
+ * Simulates the full upgrade lifecycle:
+ *
+ *   1. Deploy a fresh `PoSeManagerV2` proxy (UUPS, owned by a test EOA).
+ *   2. Read pre-upgrade view state (`challengeBondMin`, `DOMAIN_SEPARATOR`,
+ *      `getActiveNodeCount`) — these MUST survive the upgrade unchanged.
+ *   3. Call `upgrades.upgradeProxy(proxy, NewImpl, { kind: 'uups' })` to
+ *      point the proxy at the same `PoSeManagerV2` source compiled from
+ *      head — this is the OZ-validated drop-in of the new logic.
+ *   4. Read the same view state post-upgrade and assert equality.
+ *   5. Submit a tiny `submitBatchV2WithMetadata` call to assert the new
+ *      method dispatches successfully on the upgraded proxy.
+ *
+ * Used as a CI smoke gate before triggering the live 88780 upgrade
+ * (`scripts/upgrade-pose-manager-v2-746.js` + multisig propose). Catches
+ * storage-layout / initializer / DOMAIN_SEPARATOR regressions that the
+ * OZ layout validator alone might miss.
+ */
+
+const { ethers, upgrades } = require("hardhat")
+
+async function main() {
+  const [deployer, witness] = await ethers.getSigners()
+
+  // ---- Phase 1: deploy a fresh proxy ----------------------------------
+  const Factory = await ethers.getContractFactory("PoSeManagerV2")
+  const proxy = await upgrades.deployProxy(
+    Factory,
+    [ethers.parseEther("0.01"), deployer.address],
+    { initializer: "initialize", kind: "uups" },
+  )
+  await proxy.waitForDeployment()
+  const proxyAddr = await proxy.getAddress()
+  console.log(`[dry-run] proxy deployed: ${proxyAddr}`)
+
+  await proxy.setAllowEmptyWitnessSubmission(true) // bootstrap-mode
+
+  const preChallengeBondMin = await proxy.challengeBondMin()
+  const preDomain = await proxy.DOMAIN_SEPARATOR()
+  const preActiveCount = await proxy.getActiveNodeCount()
+  console.log(`[dry-run] pre-upgrade state captured:`)
+  console.log(`           challengeBondMin = ${preChallengeBondMin}`)
+  console.log(`           DOMAIN_SEPARATOR = ${preDomain}`)
+  console.log(`           activeNodeCount  = ${preActiveCount}`)
+
+  // ---- Phase 2: upgrade (same source — production upgrade is identical) -----
+  console.log(`[dry-run] running upgrades.validateUpgrade...`)
+  await upgrades.validateUpgrade(proxyAddr, Factory, { kind: "uups" })
+  console.log(`[dry-run]   ✓ layout compatible`)
+
+  console.log(`[dry-run] running upgrades.upgradeProxy...`)
+  const upgraded = await upgrades.upgradeProxy(proxyAddr, Factory, { kind: "uups" })
+  await upgraded.waitForDeployment()
+  console.log(`[dry-run]   ✓ proxy upgraded`)
+
+  // ---- Phase 3: post-upgrade state must match pre-upgrade -------------
+  const postChallengeBondMin = await upgraded.challengeBondMin()
+  const postDomain = await upgraded.DOMAIN_SEPARATOR()
+  const postActiveCount = await upgraded.getActiveNodeCount()
+
+  if (preChallengeBondMin !== postChallengeBondMin) {
+    throw new Error(`challengeBondMin drifted: pre=${preChallengeBondMin} post=${postChallengeBondMin}`)
+  }
+  if (preDomain !== postDomain) {
+    throw new Error(`DOMAIN_SEPARATOR drifted: pre=${preDomain} post=${postDomain}`)
+  }
+  if (preActiveCount !== postActiveCount) {
+    throw new Error(`activeNodeCount drifted: pre=${preActiveCount} post=${postActiveCount}`)
+  }
+  console.log(`[dry-run]   ✓ challengeBondMin / DOMAIN_SEPARATOR / activeNodeCount preserved`)
+
+  // ---- Phase 4: new method dispatches on the upgraded proxy -----------
+  // Owner-only empty-witness path; lightest possible call that exercises
+  // `submitBatchV2WithMetadata` glue without needing a registered witness set.
+  const latestBlock = await ethers.provider.getBlock("latest")
+  const epochId = Math.floor(Number(latestBlock.timestamp) / 3600)
+  const leafHash = ethers.keccak256(ethers.toUtf8Bytes("dry-run-leaf"))
+  const pairRoot = ethers.keccak256(
+    ethers.solidityPacked(["bytes32", "bytes32"], leafHash <= leafHash ? [leafHash, leafHash] : [leafHash, leafHash])
+  )
+  const sampleProofs = [{ leaf: leafHash, merkleProof: [leafHash], leafIndex: 0 }]
+  const sampleCommitment = ethers.keccak256(
+    ethers.solidityPacked(["bytes32", "uint32", "bytes32"], [ethers.ZeroHash, 0, leafHash])
+  )
+  const summaryHash = ethers.keccak256(
+    ethers.solidityPacked(["uint64", "bytes32", "bytes32", "uint32"], [epochId, pairRoot, sampleCommitment, 1])
+  )
+  const metadata = {
+    challengeIds: [ethers.keccak256(ethers.toUtf8Bytes("ch"))],
+    nodeIds: [ethers.keccak256(ethers.toUtf8Bytes("nd"))],
+    responseBodyHashes: [ethers.keccak256(ethers.toUtf8Bytes("rb"))],
+    leafHashes: [leafHash],
+    // #746 PR-1: resultCodes[] aligned with leafHashes is now REQUIRED.
+    // 0 = Ok. v3 EIP-712 digest is rebuilt from this; without it the
+    // contract reverts MetadataLengthMismatch.
+    resultCodes: [0],
+    witnessReceiptIndex: new Array(32).fill(0xffff),
+  }
+
+  // No witnesses registered ⇒ contract takes the empty-witness owner-only
+  // branch (allowEmptyWitnessSubmission=true was set above).
+  await upgraded.submitBatchV2WithMetadata(
+    BigInt(epochId),
+    pairRoot,
+    summaryHash,
+    sampleProofs,
+    0, // witnessBitmap
+    [], // witnessSignatures
+    metadata,
+  )
+  console.log(`[dry-run]   ✓ submitBatchV2WithMetadata (with resultCodes) dispatched on upgraded proxy`)
+
+  // ---- Phase 5: #746 v2SunsetEpoch is exposed and onlyOwner -----------
+  const v2Sunset = await upgraded.v2SunsetEpoch()
+  console.log(`[dry-run]   ✓ v2SunsetEpoch() = ${v2Sunset} (expected 0 = unlimited at deploy time)`)
+  await upgraded.setV2SunsetEpoch(42n)
+  const v2SunsetAfter = await upgraded.v2SunsetEpoch()
+  if (v2SunsetAfter !== 42n) throw new Error(`setV2SunsetEpoch didn't take: ${v2SunsetAfter}`)
+  console.log(`[dry-run]   ✓ setV2SunsetEpoch(42) round-trips on the upgraded proxy`)
+  // Reset to 0 — production multisig keeps this at 0 immediately after upgrade
+  // (the soft sunset window stays open until fleet finishes v3 rollout).
+  await upgraded.setV2SunsetEpoch(0n)
+
+  // ---- Phase 6: #746 legacy submitBatchV2 hard-reverts ---------------
+  let legacyReverted = false
+  try {
+    await upgraded.submitBatchV2(BigInt(epochId), pairRoot, summaryHash, sampleProofs, 0, [])
+  } catch (err) {
+    if (String(err).match(/LegacyBatchPathSunset/)) legacyReverted = true
+  }
+  if (!legacyReverted) throw new Error("legacy submitBatchV2 did not revert LegacyBatchPathSunset")
+  console.log(`[dry-run]   ✓ legacy submitBatchV2 reverts LegacyBatchPathSunset on the upgraded proxy`)
+
+  console.log(``)
+  console.log(`[dry-run] PASS — live upgrade should be safe.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/contracts/scripts/upgrade-pose-manager-v2-746.js
+++ b/contracts/scripts/upgrade-pose-manager-v2-746.js
@@ -1,0 +1,101 @@
+/**
+ * Upgrade preparation for PoSeManagerV2 #746 fix.
+ *
+ * USAGE
+ *   COC_RPC_URL=https://<88780-rpc> \
+ *   npx hardhat run scripts/upgrade-pose-manager-v2-746.js --network coc
+ *
+ * What this script does
+ * ---------------------
+ * 1. Runs `upgrades.validateUpgrade` against the live PoSeManagerV2 proxy to
+ *    assert the new implementation's storage layout is compatible (i.e. the
+ *    `__gap` reduction + `_witnessSigUsed` addition introduced in PR #766
+ *    are append-only and do NOT relocate any existing slot).
+ * 2. Runs `upgrades.prepareUpgrade` which:
+ *    - Deploys the new implementation bytecode to 88780.
+ *    - Writes the impl entry into `.openzeppelin/unknown-88780.json` so the
+ *      OZ plugin tracks it for future upgrades.
+ *    - Returns the new implementation address — DO NOT call `upgradeProxy`
+ *      from here; the proxy is owned by a Gnosis Safe multisig, and the
+ *      actual `upgradeToAndCall` tx must come from the multisig (see
+ *      scripts/safe-propose-pose-upgrade-746.ts).
+ *
+ * Outputs
+ * -------
+ * - `tmp/upgrade-746-prepared.json` — { proxy, newImpl, contractName,
+ *   chainId, preparedAt } — consumed by safe-propose-pose-upgrade-746.ts.
+ *
+ * Safety
+ * ------
+ * - No live proxy state is touched. The new impl ends up at a fresh address
+ *   and is wired to the proxy only when the multisig executes the proposal.
+ * - The script aborts if `validateUpgrade` reports any layout violation;
+ *   inspect the OZ output and fix the storage definition before retrying.
+ */
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { ethers, upgrades } = require("hardhat")
+
+const DEPLOYED_88780 = path.join(__dirname, "..", "..", "configs", "deployed-contracts-88780.json")
+
+async function main() {
+  const deployed = JSON.parse(fs.readFileSync(DEPLOYED_88780, "utf8"))
+  if (deployed.chainId !== 88780) {
+    throw new Error(`expected deployed-contracts manifest for chainId=88780, got ${deployed.chainId}`)
+  }
+  const proxy = deployed.contracts.PoSeManagerV2
+  if (!/^0x[0-9a-fA-F]{40}$/.test(proxy)) {
+    throw new Error(`PoSeManagerV2 address missing or malformed in ${DEPLOYED_88780}: ${proxy}`)
+  }
+
+  const provider = ethers.provider
+  const network = await provider.getNetwork()
+  if (Number(network.chainId) !== 88780) {
+    throw new Error(
+      `network mismatch: connected to chainId=${network.chainId}, expected 88780. ` +
+      `Set COC_RPC_URL / COC_CHAIN_ID for the 88780 testnet before running.`
+    )
+  }
+
+  console.log(`PoSeManagerV2 #746 upgrade — preparing new implementation`)
+  console.log(`  proxy:       ${proxy}`)
+  console.log(`  network:     ${network.name} (chainId ${network.chainId})`)
+
+  const Factory = await ethers.getContractFactory("PoSeManagerV2")
+
+  console.log(`  validating storage layout compatibility...`)
+  await upgrades.validateUpgrade(proxy, Factory, { kind: "uups" })
+  console.log(`    ✓ layout compatible`)
+
+  console.log(`  deploying new implementation (no proxy state changes)...`)
+  const newImplAddress = await upgrades.prepareUpgrade(proxy, Factory, { kind: "uups" })
+  if (typeof newImplAddress !== "string") {
+    throw new Error(`prepareUpgrade returned non-string: ${String(newImplAddress)}`)
+  }
+  console.log(`    ✓ new impl deployed: ${newImplAddress}`)
+
+  const out = {
+    proxy,
+    newImpl: newImplAddress,
+    contractName: "PoSeManagerV2",
+    chainId: 88780,
+    preparedAt: new Date().toISOString(),
+    refs: ["#746", "PR #766", "PR #713"],
+  }
+  const outDir = path.join(__dirname, "..", "tmp")
+  fs.mkdirSync(outDir, { recursive: true })
+  const outPath = path.join(outDir, "upgrade-746-prepared.json")
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n")
+  console.log(`  wrote ${outPath}`)
+
+  console.log("")
+  console.log(`Next step: propose the upgradeToAndCall tx to the Safe owning ${proxy}:`)
+  console.log(`  npx ts-node scripts/safe-propose-pose-upgrade-746.ts`)
+  console.log(`(Reads ${outPath}; multisig signers approve via the Safe UI.)`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/docs/upgrades/746-pose-manager-v2.md
+++ b/docs/upgrades/746-pose-manager-v2.md
@@ -1,0 +1,129 @@
+# PoSeManagerV2 #746 Upgrade Runbook
+
+Upgrade target: live 88780 `PoSeManagerV2` proxy →
+implementation containing the protocol fix for issue #746 (V3 typehash
+binds `resultCode`, `v2SunsetEpoch` soft sunset, legacy `submitBatchV2`
+no-metadata path hard-cut), [PR #766](https://github.com/chainofclaw/COC/pull/766) + [PR #767](https://github.com/chainofclaw/COC/pull/767).
+
+This runbook is the structural sibling of [`667-pose-manager-v2.md`](./667-pose-manager-v2.md);
+read that first for general context on UUPS multisig upgrades. This file
+captures only the #746-specific details.
+
+## What's structurally different from the #667 r3 upgrade
+
+1. **Witness ABI change is observable** — clients constructing
+   `ReceiptBatchMetadata` in TypeScript MUST add the new `resultCodes[]`
+   field (aligned with `leafHashes`); the contract reverts
+   `MetadataLengthMismatch` otherwise. ABI consumers that only decode
+   events / read state are unaffected.
+2. **Legacy `submitBatchV2` hard-reverts** post-upgrade with
+   `LegacyBatchPathSunset()`. The witness-on-batch-root rubber-stamp
+   surface is gone. Anything still calling that path needs migration
+   to `submitBatchV2WithMetadata` **before** the multisig executes.
+3. **Off-chain rollout knob** `COC_POSE_WITNESS_LAYER7_VERIFY=1` enables
+   the witness's independent Layer-7 verifier on each host. Default
+   off — the soft sunset on `v2SunsetEpoch` carries the migration
+   gracefully without forcing fleet-wide simultaneous restarts.
+
+## Pre-flight
+
+| Check | Command |
+|---|---|
+| Storage layout compatible | `npx hardhat run scripts/upgrade-pose-manager-v2-746.js --network coc` (step 1 internally — validates without writing) |
+| Local dry-run upgrade simulation | `npx hardhat run scripts/test-upgrade-dry-run-746.js` |
+| Proxy owner is the expected Safe | `cast call <PROXY> "owner()"`; compare to `POSE_MULTISIG_ADDRESS` |
+| New ABI in `@chainofclaw/soul@2.2.0` matches | PR #51 on claw-mem, merged |
+| Aggregator/agent fleet running PR #767 (off-chain v3 path) | `coc-agent --version` on each operator host; check that `services/aggregator/batch-aggregator-v2.ts` includes `metadata.resultCodes` |
+| No live consumers of `submitBatchV2` (no-metadata) | grep prod ops scripts; any still on that path must migrate first |
+
+## Order of operations
+
+### 1. Prepare new implementation
+
+```bash
+cd contracts
+COC_RPC_URL=https://prod-1.coc:28780 \
+npx hardhat run scripts/upgrade-pose-manager-v2-746.js --network coc
+```
+
+Writes `contracts/tmp/upgrade-746-prepared.json` with the new impl
+address. Commit `.openzeppelin/unknown-88780.json` so the upgrade
+history stays reproducible.
+
+### 2. Propose the Safe tx
+
+```bash
+COC_RPC_URL=https://prod-1.coc:28780 \
+SAFE_TX_SERVICE_URL=https://<safe-tx-service-for-88780> \
+POSE_MULTISIG_ADDRESS=0x<safe-address> \
+PROPOSER_PRIVATE_KEY=0x<one-of-the-safe-signers> \
+npx ts-node scripts/safe-propose-pose-upgrade-746.ts
+```
+
+Encodes `proxy.upgradeToAndCall(newImpl, "")` — empty calldata, no
+re-initialize (existing storage is preserved verbatim; `v2SunsetEpoch`
+starts at 0 = unlimited from the new `__gap` slot).
+
+### 3. Coordinate the cut-over window
+
+1. **Pause aggregator submissions** on the per-host `coc-agent`
+   instances. Existing receipts queue without loss.
+2. **Wait for dispute window** to clear (~2 epochs ≈ 2 h on 88780).
+3. **Multisig executes** `upgradeToAndCall(newImpl, "")` via Safe UI.
+   Gas budget ~80 k.
+4. **Verify the upgrade**:
+   ```bash
+   cast storage <PROXY> 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
+   # Expect: the address from tmp/upgrade-746-prepared.json:newImpl
+   cast call <PROXY> "v2SunsetEpoch()(uint64)"
+   # Expect: 0 (unlimited)
+   ```
+5. **Resume aggregators** + per-host **set `COC_POSE_WITNESS_LAYER7_VERIFY=1`**
+   and restart witness daemons. Witnesses begin signing v3 (in addition
+   to v1 + v2) immediately.
+6. **Smoke test the new path** — submit one v3-signed batch via an
+   aggregator and confirm `ReceiptBatchMetadataSubmitted` event emits
+   along with v3 sigs that recover correctly on-chain.
+
+### 4. Roll forward and monitor (48 h)
+
+- `BatchSubmittedV2` event volume — should remain steady (witnesses
+  produce v1+v2+v3 during rollout; aggregator prefers v3).
+- `LegacyBatchPathSunset` reverts in tx receipts — should be zero
+  in steady state; non-zero means some aggregator host hasn't migrated.
+- `V2SunsetEpochUpdated` event — emitted only when the multisig
+  tightens the v2 sunset cap, which happens in PR-5 after the
+  observation window.
+
+## PR-5 — sunset tighten (deferred)
+
+After 30 days of clean operation with v3 sigs flowing:
+
+1. Per-host telemetry confirms 100% of witness sigs are v3 (no v2
+   fallback path being hit).
+2. Multisig signs `setV2SunsetEpoch(<current epoch>)`. Future v2 sigs
+   beyond that epoch revert.
+3. Schedule PR-6 (eventually) to drop the v2 path from the contract
+   logic entirely — same pattern as #748 → #752 sunset → eventual
+   v1 removal in PR-E (which #752 effectively replaced via soft cut).
+
+## Rollback
+
+`.openzeppelin/unknown-88780.json` git history pins each impl address.
+To roll back, multisig signs
+`proxy.upgradeToAndCall(oldImpl, "0x")` pointing back at the pre-#746
+impl (same script template, change the target). The v3 path will
+unconditionally fail on the rolled-back impl, so consumers on
+PR #767+ must downgrade in lockstep.
+
+## Open coordination items (deferred to live upgrade day)
+
+- [ ] Confirm Safe Tx Service endpoint for chainId 88780 (same as #667
+      runbook — verify it's still healthy).
+- [ ] Identify Safe owner set + threshold for the proposal SLA.
+- [ ] Confirm every aggregator host runs PR #767 binaries before the
+      multisig executes — else `metadata.resultCodes` won't be sent
+      and the contract rejects with `MetadataLengthMismatch`.
+- [ ] Decide which fraction of witness hosts gets
+      `COC_POSE_WITNESS_LAYER7_VERIFY=1` first (canary subset
+      recommended for 24 h before fleet-wide enable).


### PR DESCRIPTION
## Summary

PR-4 in the #746 series. Adds the **preparation tooling and runbook** for upgrading the live 88780 ``PoSeManagerV2`` proxy to the new implementation containing the protocol fix landed in #766 + #767. This PR does **not** execute the upgrade — the proxy is owned by a Gnosis Safe multisig and the actual ``upgradeToAndCall`` must come from the Safe.

Structural sibling of PR #714 (#667 r3 upgrade scripts); the same template adapted for the #746 deltas.

## What's in this PR

### Scripts (``contracts/scripts/``)

- **``upgrade-pose-manager-v2-746.js``** — reads ``configs/deployed-contracts-88780.json``, runs ``upgrades.validateUpgrade`` + ``upgrades.prepareUpgrade`` (deploys new impl, writes OZ manifest), emits ``contracts/tmp/upgrade-746-prepared.json``. **No proxy state touched.**
- **``safe-propose-pose-upgrade-746.ts``** — consumes the prepared output, asserts ``proxy.owner() == POSE_MULTISIG_ADDRESS``, encodes ``upgradeToAndCall(newImpl, "")`` with empty calldata, signs with proposer EOA, pushes to Safe Tx Service.
- **``test-upgrade-dry-run-746.js``** — local Hardhat dry-run extending the #667 template with:
  - ``submitBatchV2WithMetadata`` accepts new ``metadata.resultCodes`` field
  - ``v2SunsetEpoch()`` exposed; ``setV2SunsetEpoch`` round-trips
  - Legacy ``submitBatchV2`` hard-reverts ``LegacyBatchPathSunset``
  
  **PASS confirmed locally.**

### Runbook (``docs/upgrades/746-pose-manager-v2.md``)

Documents only the #746-specific deltas vs. the #667 runbook:
- Caller migration prerequisite (any host still on legacy ``submitBatchV2`` must upgrade first or batches revert post-upgrade)
- ``COC_POSE_WITNESS_LAYER7_VERIFY=1`` per-host rollout knob
- Cut-over phases + 48 h monitoring + PR-5 sunset tighten path

## Open coordination items (deferred to live upgrade day)

- [ ] Confirm Safe Tx Service endpoint health (same Safe as #667)
- [ ] Verify aggregator fleet is fully on PR #767 binaries before multisig executes
- [ ] Canary subset for ``COC_POSE_WITNESS_LAYER7_VERIFY=1`` (24 h before fleet-wide)

## Test plan

- [x] ``cd contracts && npm install`` — clean
- [x] ``cd contracts && npx hardhat run scripts/test-upgrade-dry-run-746.js`` — **PASS**: layout compatible, state preserved, V3 metadata round-trips, v2SunsetEpoch works, legacy path reverts
- [ ] Live upgrade day: run ``scripts/upgrade-pose-manager-v2-746.js --network coc``; commit updated ``.openzeppelin/unknown-88780.json``
- [ ] Live upgrade day: run ``scripts/safe-propose-pose-upgrade-746.ts`` and coordinate signers
- [ ] Live upgrade day: verify ERC-1967 impl slot + ``v2SunsetEpoch == 0`` + flip layer-7 flag per host + smoke test ``submitBatchV2WithMetadata`` with v3 sig

Refs #746 #667 #766 #767 #714