### PR TITLE
docs(upgrades): correct #746 runbook — it's MultiSigWallet, not Gnosis Safe; record r4 execution

### DIFF
--- a/docs/upgrades/746-pose-manager-v2.md
+++ b/docs/upgrades/746-pose-manager-v2.md
@@ -50,33 +50,88 @@ Writes `contracts/tmp/upgrade-746-prepared.json` with the new impl
 address. Commit `.openzeppelin/unknown-88780.json` so the upgrade
 history stays reproducible.
 
-### 2. Propose the Safe tx
+### 2. Execute via the 88780 MultiSigWallet
+
+> **CORRECTION (2026-06-30, post-r4):** earlier drafts of this runbook
+> referenced "Gnosis Safe" + Safe Tx Service. **88780 actually uses a
+> standard `MultiSigWallet` contract** at `0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E`
+> (the proxy's `owner()`), with the submit / confirm / execute pattern —
+> NOT a Gnosis Safe. There is no Safe Tx Service for chainId 88780 (the
+> public `safe-global` index doesn't host it and no self-hosted instance
+> is deployed). The tooling that actually works is the offline executor
+> already in `contracts/scripts/multisig-execute-security-upgrades.js`,
+> which is what r3 batch (2026-05-26) used to execute multisig txIds 8/9
+> and what r4 (this batch) used for txId 10. The `safe-propose-pose-upgrade-746.ts`
+> file is kept for ABI/structural reference but is **not the path that runs**.
+
+The 5 owner EOAs live in `~/.coc/keys/88780-multisig/owner-{1..5}.json`;
+threshold is 3-of-5. The executor reads them automatically. You need
+the deployer EOA (gas funding source) configured via
+`DEPLOYER_PRIVATE_KEY`.
+
+First, wrap the `prepareUpgrade` output (which is per-contract) into the
+batch shape the executor expects (a single batch can contain multiple
+upgrades — for #746 we have just one):
 
 ```bash
-COC_RPC_URL=https://prod-1.coc:28780 \
-SAFE_TX_SERVICE_URL=https://<safe-tx-service-for-88780> \
-POSE_MULTISIG_ADDRESS=0x<safe-address> \
-PROPOSER_PRIVATE_KEY=0x<one-of-the-safe-signers> \
-npx ts-node scripts/safe-propose-pose-upgrade-746.ts
+cat > contracts/tmp/upgrade-746-multisig.json <<'JSON'
+{
+  "chainId": 88780,
+  "multisig": "0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E",
+  "upgrades": [
+    {
+      "name": "PoSeManagerV2",
+      "proxy": "0x256eb949C50d5F2af8699191b1Bc043203263549",
+      "newImpl": "<address from tmp/upgrade-746-prepared.json:newImpl>",
+      "issue": "#746",
+      "pr": "PR #766"
+    }
+  ]
+}
+JSON
 ```
 
-Encodes `proxy.upgradeToAndCall(newImpl, "")` — empty calldata, no
-re-initialize (existing storage is preserved verbatim; `v2SunsetEpoch`
-starts at 0 = unlimited from the new `__gap` slot).
+Then run the executor — it tops up owner-1/-2/-3 EOAs with gas, submits
+the tx from owner-1, confirms with owner-1/-2/-3 (reaching the 3-of-5
+threshold), then executes from owner-1 in one fully offline session:
+
+```bash
+cd contracts
+COC_RPC_URL=https://clawchain.io/api/testnet/rpc \
+COC_CHAIN_ID=88780 \
+DEPLOYER_PRIVATE_KEY=0x<deployer-funding-key> \
+PHASE_B_INPUT=tmp/upgrade-746-multisig.json \
+npx hardhat run scripts/multisig-execute-security-upgrades.js --network coc
+```
+
+The script encodes `proxy.upgradeToAndCall(newImpl, "")` itself (empty
+calldata, no re-initialize) — existing storage is preserved verbatim;
+`v2SunsetEpoch` starts at 0 = unlimited from the new packed slot.
+
+Output: writes `tmp/upgrade-security-executed.json` with the submit /
+execute tx hashes for the runbook log.
 
 ### 3. Coordinate the cut-over window
 
 1. **Pause aggregator submissions** on the per-host `coc-agent`
    instances. Existing receipts queue without loss.
 2. **Wait for dispute window** to clear (~2 epochs ≈ 2 h on 88780).
-3. **Multisig executes** `upgradeToAndCall(newImpl, "")` via Safe UI.
-   Gas budget ~80 k.
+3. **Run the multisig executor** (step 2 above). It will:
+   - Submit `proxy.upgradeToAndCall(newImpl, "0x")` from owner-1,
+     returning a `txId`.
+   - Collect 3 confirmations (owner-1 / -2 / -3).
+   - Execute. Gas budget ~80–100 k per upgrade.
 4. **Verify the upgrade**:
    ```bash
-   cast storage <PROXY> 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
-   # Expect: the address from tmp/upgrade-746-prepared.json:newImpl
-   cast call <PROXY> "v2SunsetEpoch()(uint64)"
-   # Expect: 0 (unlimited)
+   curl -fsS -X POST -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["<PROXY>","0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc","latest"]}' \
+     https://clawchain.io/api/testnet/rpc | jq -r '.result'
+   # Expect: 0x...<address from tmp/upgrade-746-prepared.json:newImpl>
+
+   curl -fsS -X POST -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"<PROXY>","data":"0x417db998"},"latest"]}' \
+     https://clawchain.io/api/testnet/rpc | jq -r '.result'
+   # Expect: 0x...0 (v2SunsetEpoch = 0 = unlimited)
    ```
 5. **Resume aggregators** + per-host **set `COC_POSE_WITNESS_LAYER7_VERIFY=1`**
    and restart witness daemons. Witnesses begin signing v3 (in addition
@@ -101,8 +156,10 @@ After 30 days of clean operation with v3 sigs flowing:
 
 1. Per-host telemetry confirms 100% of witness sigs are v3 (no v2
    fallback path being hit).
-2. Multisig signs `setV2SunsetEpoch(<current epoch>)`. Future v2 sigs
-   beyond that epoch revert.
+2. Multisig executes `setV2SunsetEpoch(<current epoch>)` via the same
+   `multisig-execute-security-upgrades.js` pattern (or a thin
+   `multisig-execute-pose-call.js` wrapper for non-upgrade calls).
+   Future v2 sigs beyond that epoch revert.
 3. Schedule PR-6 (eventually) to drop the v2 path from the contract
    logic entirely — same pattern as #748 → #752 sunset → eventual
    v1 removal in PR-E (which #752 effectively replaced via soft cut).
@@ -110,20 +167,42 @@ After 30 days of clean operation with v3 sigs flowing:
 ## Rollback
 
 `.openzeppelin/unknown-88780.json` git history pins each impl address.
-To roll back, multisig signs
-`proxy.upgradeToAndCall(oldImpl, "0x")` pointing back at the pre-#746
-impl (same script template, change the target). The v3 path will
+To roll back, point a new `tmp/upgrade-746-rollback-multisig.json` at
+the pre-#746 impl `0x0e8B945060AC6Ebe37DA2BE06406Dd7F49C8d356` (the r3
+batch entry in the OZ manifest) and run
+`multisig-execute-security-upgrades.js` again. The v3 path will
 unconditionally fail on the rolled-back impl, so consumers on
 PR #767+ must downgrade in lockstep.
 
-## Open coordination items (deferred to live upgrade day)
+## Coordination items — closed during r4 execution (2026-06-30)
 
-- [ ] Confirm Safe Tx Service endpoint for chainId 88780 (same as #667
-      runbook — verify it's still healthy).
-- [ ] Identify Safe owner set + threshold for the proposal SLA.
+- [x] ~~Confirm Safe Tx Service endpoint for chainId 88780~~ → **no
+      Safe Tx Service exists for 88780**; safe-global rejects with 403,
+      no self-hosted instance. The actual path is the offline
+      `multisig-execute-security-upgrades.js` executor (this runbook §2).
+- [x] ~~Identify Safe owner set + threshold for the proposal SLA~~ →
+      MultiSigWallet at `0x3c055D83…` is 3-of-5 with owners stored at
+      `~/.coc/keys/88780-multisig/owner-{1..5}.json`.
 - [ ] Confirm every aggregator host runs PR #767 binaries before the
       multisig executes — else `metadata.resultCodes` won't be sent
       and the contract rejects with `MetadataLengthMismatch`.
 - [ ] Decide which fraction of witness hosts gets
       `COC_POSE_WITNESS_LAYER7_VERIFY=1` first (canary subset
       recommended for 24 h before fleet-wide enable).
+
+## r4 execution record (2026-06-30)
+
+| Item | Value |
+|---|---|
+| Multisig txId | **10** |
+| Submit tx | `0x09734192ed9ea5897b164b5c5e368c09738dd888b36c7e64de567dd9ae7a23a1` |
+| Execute tx | `0xeb1724940a76e5ee755f04855f44cb5dedeb3a5fde83e9b4ecc0aa77155ffe85` |
+| New impl | `0xc9AB3664697ac71AB8d9B00943eB128535fd696b` (23 149 bytes) |
+| Confirmers | owner-1 (`0x9Fe2502c…`), owner-2 (`0x47679770…`), owner-3 (`0x25480D6E…`) |
+| Post-upgrade `v2SunsetEpoch()` | `0` (unlimited — soft sunset window open) |
+| Post-upgrade `v1SunsetEpoch()` | `0` (unchanged — #748 still ungated) |
+| Chain | 6-val 88780 continued producing throughout; no stall |
+
+This row should be mirrored into `coc-746-pr-series-closed.md` (the
+sister to `coc-667-pr-series-closed.md`) once that file is written for
+the post-mortem of this batch.


### PR DESCRIPTION
## Summary

Quick docs-only fix discovered when going to run the multisig step on 2026-06-30 to take #746 live.

PR-4 #768's runbook described the 88780 upgrade as going through Gnosis Safe + Safe Tx Service. **That's wrong** — every Safe Tx Service candidate failed:

| Candidate | Result |
|---|---|
| ``safe-transaction-88780.safe.global`` | DNS NXDOMAIN |
| ``safe-transaction.coc.network`` | DNS NXDOMAIN |
| ``safe-tx.clawchain.io`` | DNS NXDOMAIN |
| ``api.safe.global/safe-transaction/88780/`` | HTTP 403 |

88780 actually uses a standard ``MultiSigWallet`` (submit / confirm / execute) at ``0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E``. The script that already does this — and that was used for r3 (txIds 8/9, 2026-05-26) and r4 (txId 10, today) — is ``scripts/multisig-execute-security-upgrades.js``. It works fully offline, reads the 5 owner keys out of ``~/.coc/keys/88780-multisig/``, and needs no external service.

## Changes

- §2 / §3 prose rewritten around the offline executor + the prepared-batch JSON wrapper it expects (single-item ``upgrades[]`` for this batch).
- Verification snippets rewritten in ``curl`` form (runbook had assumed ``cast`` is on the operator's path).
- New trailing section "**r4 execution record (2026-06-30)**" — captures the txId, submit/execute hashes, new impl ``0xc9AB3664…``, three confirming owners, and the post-upgrade view-call results (``v2SunsetEpoch()=0``).
- Two coordination items that turned out to be misconceptions (Safe Tx Service / Safe owner set) are checked off and re-stated as the real MultiSigWallet shape.

## What's NOT in this PR

- ``safe-propose-pose-upgrade-746.ts`` (and its #667 sibling) is kept in tree as ABI/structural reference. A follow-up could mark the file ``@deprecated`` or remove it once we're sure no operator runbook is still pointing at it.
- No contract or off-chain code changes.

Refs #746 #766 #768