### PR TITLE
feat(contracts): generic multisig caller + PR-5 setV2SunsetEpoch(495236) execution record

### DIFF
--- a/contracts/scripts/multisig-execute-pose-call.js
+++ b/contracts/scripts/multisig-execute-pose-call.js
@@ -1,0 +1,206 @@
+/**
+ * Generic multisig-executed call to a contract owned by the 88780 3-of-5
+ * MultiSigWallet (`0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E`).
+ *
+ * Mirrors `multisig-execute-security-upgrades.js` but encodes an arbitrary
+ * function call instead of `upgradeToAndCall`. Use cases include:
+ *   - `setV2SunsetEpoch(uint64)` (#746 PR-5)
+ *   - `setV1SunsetEpoch(uint64)` (#748)
+ *   - other one-off owner-only calls that aren't proxy upgrades
+ *
+ * USAGE
+ *   COC_RPC_URL=https://clawchain.io/api/testnet/rpc \
+ *   COC_CHAIN_ID=88780 \
+ *   DEPLOYER_PRIVATE_KEY=0x<...> \
+ *   PHASE_B_INPUT=tmp/<your-prepared.json> \
+ *   npx hardhat run scripts/multisig-execute-pose-call.js --network coc
+ *
+ * PHASE_B_INPUT JSON shape (one batch can contain multiple calls):
+ *   {
+ *     "chainId": 88780,
+ *     "multisig": "0x3c055D83...",
+ *     "calls": [
+ *       {
+ *         "name": "setV2SunsetEpoch",
+ *         "target": "0x256eb949...",        // contract to call (e.g. PoSeManagerV2 proxy)
+ *         "value": "0",                      // wei (string, parsed via BigInt)
+ *         "signature": "setV2SunsetEpoch(uint64)",
+ *         "args": ["495256"],                // strings; encoded via ethers Interface
+ *         "issue": "#746",
+ *         "pr": "PR #?",
+ *         // Optional: post-call sanity check
+ *         "verify": {
+ *           "signature": "v2SunsetEpoch() view returns (uint64)",
+ *           "expected": "495256"
+ *         }
+ *       }
+ *     ]
+ *   }
+ */
+
+const fs = require("node:fs")
+const path = require("node:path")
+const os = require("node:os")
+const { ethers } = require("hardhat")
+
+const MULTISIG_KEYS_DIR = path.join(os.homedir(), ".coc", "keys", "88780-multisig")
+const PREPARED_PATH = process.env.PHASE_B_INPUT
+  ? path.resolve(process.env.PHASE_B_INPUT)
+  : path.join(__dirname, "..", "tmp", "multisig-call-prepared.json")
+
+const MULTISIG_ABI = [
+  "function submitTransaction(address to, uint256 value, bytes calldata data) external returns (uint256)",
+  "function confirmTransaction(uint256 txId) external",
+  "function executeTransaction(uint256 txId) external",
+  "function getTransactionCount() external view returns (uint256)",
+  "function transactions(uint256) external view returns (address to, uint256 value, bytes data, bool executed, uint256 confirmCount)",
+  "event Submit(uint256 indexed txId, address indexed to, uint256 value)",
+]
+
+function loadOwnerWallet(i, provider) {
+  const keyPath = path.join(MULTISIG_KEYS_DIR, `owner-${i}.json`)
+  const data = JSON.parse(fs.readFileSync(keyPath, "utf8"))
+  return new ethers.Wallet(data.privateKey, provider)
+}
+
+async function topUpOwner(deployer, owner, target) {
+  const bal = await ethers.provider.getBalance(owner.address)
+  if (bal >= target) {
+    return { funded: false, balance: bal }
+  }
+  const need = target - bal
+  const tx = await deployer.sendTransaction({ to: owner.address, value: need })
+  await tx.wait()
+  const newBal = await ethers.provider.getBalance(owner.address)
+  return { funded: true, sent: need, balance: newBal }
+}
+
+function encodeCall(call) {
+  const iface = new ethers.Interface([`function ${call.signature}`])
+  // function name is the first token before `(`
+  const fnName = call.signature.split("(")[0].trim()
+  return iface.encodeFunctionData(fnName, call.args)
+}
+
+async function verifyAfter(call) {
+  if (!call.verify) return
+  const iface = new ethers.Interface([`function ${call.verify.signature}`])
+  const fnName = call.verify.signature.split("(")[0].trim()
+  const data = iface.encodeFunctionData(fnName, [])
+  const result = await ethers.provider.call({ to: call.target, data })
+  const decoded = iface.decodeFunctionResult(fnName, result)
+  const actual = decoded[0].toString()
+  if (actual !== String(call.verify.expected)) {
+    throw new Error(`verify failed for ${call.name}: got ${actual}, expected ${call.verify.expected}`)
+  }
+  return actual
+}
+
+async function main() {
+  const prepared = JSON.parse(fs.readFileSync(PREPARED_PATH, "utf8"))
+  if (prepared.chainId !== 88780) throw new Error(`prepared chainId mismatch: ${prepared.chainId}`)
+
+  const network = await ethers.provider.getNetwork()
+  if (Number(network.chainId) !== 88780) {
+    throw new Error(`network mismatch: connected to chainId=${network.chainId}, expected 88780`)
+  }
+  console.log(`multisig generic call — executing via ${prepared.multisig}`)
+  console.log("")
+
+  const [deployer] = await ethers.getSigners()
+  console.log(`deployer: ${deployer.address}`)
+  const deployerBal = await ethers.provider.getBalance(deployer.address)
+  console.log(`  balance: ${ethers.formatEther(deployerBal)} ETH`)
+  console.log("")
+
+  // Load 3 owners + top-up gas (mirrors security-upgrades flow)
+  const owners = []
+  for (let i = 1; i <= 3; i++) {
+    owners.push(loadOwnerWallet(i, ethers.provider))
+  }
+  const GAS_TARGETS = [ethers.parseEther("0.3"), ethers.parseEther("0.1"), ethers.parseEther("0.1")]
+  for (let i = 0; i < 3; i++) {
+    const result = await topUpOwner(deployer, owners[i], GAS_TARGETS[i])
+    if (result.funded) {
+      console.log(`  funded owner-${i + 1} (${owners[i].address}): +${ethers.formatEther(result.sent)} ETH → balance ${ethers.formatEther(result.balance)} ETH`)
+    } else {
+      console.log(`  owner-${i + 1} (${owners[i].address}) already at ${ethers.formatEther(result.balance)} ETH (no top-up)`)
+    }
+  }
+  console.log("")
+
+  const msigO1 = new ethers.Contract(prepared.multisig, MULTISIG_ABI, owners[0])
+  const msigO2 = new ethers.Contract(prepared.multisig, MULTISIG_ABI, owners[1])
+  const msigO3 = new ethers.Contract(prepared.multisig, MULTISIG_ABI, owners[2])
+
+  const results = []
+  for (const call of prepared.calls) {
+    console.log(`[${call.pr || call.issue || "call"}] ${call.name}`)
+    console.log(`    target:    ${call.target}`)
+    console.log(`    signature: ${call.signature}`)
+    console.log(`    args:      [${call.args.join(", ")}]`)
+    console.log(`    value:     ${call.value || "0"} wei`)
+
+    const data = encodeCall(call)
+    const value = BigInt(call.value || "0")
+
+    // 1. submit
+    const submitTx = await msigO1.submitTransaction(call.target, value, data)
+    const submitReceipt = await submitTx.wait()
+    const submitTopic = ethers.id("Submit(uint256,address,uint256)")
+    const submitLog = submitReceipt.logs.find(
+      (l) => l.address.toLowerCase() === prepared.multisig.toLowerCase() && l.topics[0] === submitTopic,
+    )
+    if (!submitLog) throw new Error(`Submit event not found for ${call.name}`)
+    const txId = Number(BigInt(submitLog.topics[1]))
+    console.log(`    submitted txId=${txId} (tx ${submitTx.hash})`)
+
+    // 2. confirm × 3
+    for (let i = 0; i < 3; i++) {
+      const msig = [msigO1, msigO2, msigO3][i]
+      const ctx = await msig.confirmTransaction(txId)
+      await ctx.wait()
+      console.log(`      confirmed by owner-${i + 1} (${owners[i].address.slice(0, 10)}…)`)
+    }
+
+    // 3. execute
+    const execTx = await msigO1.executeTransaction(txId)
+    const execReceipt = await execTx.wait()
+    if (execReceipt.status !== 1) throw new Error(`execute failed for txId=${txId}`)
+    console.log(`    executed (tx ${execTx.hash})`)
+
+    // 4. verify (optional)
+    if (call.verify) {
+      const actual = await verifyAfter(call)
+      console.log(`    ✓ verify: ${call.verify.signature.split("(")[0]} = ${actual} (matches expected ${call.verify.expected})`)
+    }
+
+    console.log("")
+    results.push({
+      ...call,
+      txId,
+      submitTxHash: submitTx.hash,
+      executedTxHash: execTx.hash,
+    })
+  }
+
+  const out = {
+    chainId: 88780,
+    multisig: prepared.multisig,
+    executedAt: new Date().toISOString(),
+    results,
+  }
+  const outPath = path.join(__dirname, "..", "tmp", "multisig-call-executed.json")
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n")
+  console.log(`wrote ${outPath}`)
+  console.log("")
+  console.log(`All ${results.length} multisig calls complete.`)
+  for (const r of results) {
+    console.log(`  ${r.pr || r.issue || "call"} ${r.name} → txId=${r.txId}, exec=${r.executedTxHash}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/contracts/tmp/upgrade-746-pr5-v2-sunset.json
+++ b/contracts/tmp/upgrade-746-pr5-v2-sunset.json
@@ -1,0 +1,19 @@
+{
+  "chainId": 88780,
+  "multisig": "0x3c055D83a9aA12Bba4a2ed53F8970DF4081eBC7E",
+  "calls": [
+    {
+      "name": "setV2SunsetEpoch (#746 PR-5 — observation window waived per ops decision 2026-07-01)",
+      "target": "0x256eb949C50d5F2af8699191b1Bc043203263549",
+      "value": "0",
+      "signature": "setV2SunsetEpoch(uint64)",
+      "args": ["495236"],
+      "issue": "#746",
+      "pr": "PR-5",
+      "verify": {
+        "signature": "v2SunsetEpoch() view returns (uint64)",
+        "expected": "495236"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

PR-5 of the #746 series. Tightens the v2 typehash sunset on 88780 and adds the missing tooling to execute non-upgrade multisig calls. **Observation window waived** — see § Why now.

## Changes

### NEW ``contracts/scripts/multisig-execute-pose-call.js``

Generic multisig-executed call to any contract owned by the 88780 3-of-5 ``MultiSigWallet``. Sister script to ``multisig-execute-security-upgrades.js`` — same top-up + submit + 3-confirm + execute pattern, but encodes an arbitrary function call instead of ``upgradeToAndCall``. PR-4.1's runbook (PR #771) pre-announced this wrapper for "non-upgrade calls"; this PR materializes it.

Input schema (one batch can contain multiple calls):

```json
{
  "chainId": 88780,
  "multisig": "0x3c055D83...",
  "calls": [{
    "name": "setV2SunsetEpoch",
    "target": "0x256eb949...",
    "value": "0",
    "signature": "setV2SunsetEpoch(uint64)",
    "args": ["495236"],
    "issue": "#746",
    "pr": "PR-5",
    "verify": { "signature": "v2SunsetEpoch() view returns (uint64)", "expected": "495236" }
  }]
}
```

The optional ``verify`` block runs a post-execute ``eth_call`` to confirm the state change actually landed.

### NEW ``contracts/tmp/upgrade-746-pr5-v2-sunset.json``

The exact prepared ``PHASE_B_INPUT`` JSON for PR-5 — kept under ``tmp/`` (committed via ``-f``) as an immutable audit trail of what the multisig actually executed today.

## Execution record (2026-07-01)

| Item | Value |
|---|---|
| Multisig txId | **11** |
| Submit tx | ``0xa9162f9c8a3b7f18250eba72bd617752fae6ba42698e1c6e8dda6add1ebe5053`` |
| Execute tx | ``0x807b4afcebb001332250b84e433121aa4aeb19fb99f3d130731b0a32c9ca1a79`` |
| Setter | ``setV2SunsetEpoch(495236)`` |
| Setter == tip | Yes (block 1213587 ts 1782852871 → epoch 495236) |
| Post-call ``v2SunsetEpoch()`` (independent ``eth_call``) | ``0x078e84`` = 495236 ✓ |
| ``v1SunsetEpoch()`` | ``0`` (unchanged — still unlimited) |
| Confirmers (3-of-5) | owner-1 (``0x9Fe2502c…``) + owner-2 (``0x47679770…``) + owner-3 (``0x25480D6E…``) |

## Why now (observation window waived)

PR-1 / PR-4 runbooks suggested ~30 days of "100% v3 traffic" observation before tightening. That gate is **waived** here:

- chainofclaw/COC#772 surfaced that the PoSe v2 pipeline has been producing **0 batches since fleet bring-up (2026-06-11)** — 19 days of ``InvalidWitnessQuorum()`` revert loop. The observation window can't ever "tick" because there is no traffic to observe.
- Tightening now is structurally safe: PR-2 binaries (which produce v3 sigs) are already on every host; v1 fallback (epoch ≤ 0) is unchanged. Any future fleet binary still signing only v2 without v3 will be rejected for epochs > 495236 — that's the desired behaviour.
- #772's fix will require regenerating ``runtime-pose.json`` on every host regardless, so whatever rolls out next will naturally pick up the PR-2 v3 signing path.

Trade-off acknowledged: rolling forward to fleet traffic post-#772 fix, v2-only emitters break immediately rather than degrading gracefully. Ops decision 2026-07-01.

## Test plan

- [x] ``npx hardhat run scripts/multisig-execute-pose-call.js --network coc`` against 88780 with ``PHASE_B_INPUT=tmp/upgrade-746-pr5-v2-sunset.json`` — **executed**, all 4 steps clean, post-execute ``verify`` passed.
- [x] Independent ``eth_call`` of ``v2SunsetEpoch()`` from the public RPC ``https://clawchain.io/api/testnet/rpc`` returns ``0x078e84`` = 495236 ✓.
- [x] ``v1SunsetEpoch()`` still ``0`` (unchanged) — confirms the call only touched the v2 slot.

## Refs

- #746 series: #766 PR-1 / #769 PR-1.5 / #767 PR-2 / NGPlateform/claw-mem#51 PR-3 / #768 PR-4 / #771 PR-4.1 / this PR (PR-5)
- chainofclaw/COC#772 (PoSe v2 pipeline failing for 19 days — the reason the observation window was waived)

#746 protocol-level work concludes here.