### PR TITLE
fix(coc-agent): resolve witnessSet per epoch to match contract's PRNG-sampled subset (#772 Option A)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -33,7 +33,11 @@ import { createLogger } from "../node/src/logger.ts";
 import { createNodeSigner, createNodeSignerV2, buildReceiptSignMessage } from "../node/src/crypto/signer.ts";
 import { buildDomain, CHALLENGE_TYPES, RECEIPT_TYPES, REWARD_MANIFEST_TYPES } from "../node/src/crypto/eip712-types.ts";
 import { buildSignedPosePayload } from "../node/src/pose-http.ts";
-import { collectBatchWitnessSignatures, collectWitnesses } from "./lib/witness-collector.ts";
+import {
+  collectBatchWitnessSignatures,
+  collectWitnesses,
+  type WitnessNodeConfig,
+} from "./lib/witness-collector.ts";
 import { ContractReader } from "./lib/contract-reader.ts";
 import { extractPendingV1Epoch, extractPendingV2Epoch, pruneStoreByEpoch } from "./lib/pending-retention.ts";
 import { buildPrometheusMetrics, shouldWriteMetrics, writeMetricsSnapshot, writePrometheusMetrics, type RuntimeMetricsSnapshot } from "./lib/runtime-metrics.ts";
@@ -229,6 +233,77 @@ const contractReader = useV2 ? new ContractReader({
 
 const v2WitnessNodes = config.witnessNodes ?? [];
 const v2RequiredWitnesses = config.requiredWitnesses ?? 0;
+
+// #772 — off-chain / on-chain witnessSet mismatch cache.
+//
+// The contract's `_validateWitnessQuorumV2` recovers each sig against
+// `nodeOperator[witnessSet[i]]`, where `witnessSet = getWitnessSet(epochId)`
+// is a per-epoch PRNG-selected subset of size ~ceil(sqrt(activeCount)).
+// The pre-#772 pipeline broadcast to `config.witnessNodes` using each
+// entry's static `witnessIndex` — that index-space has no relationship
+// to the contract's dynamic subset positioning, so recovered signers
+// never sat at the expected slots and every batch reverted
+// `InvalidWitnessQuorum()`.
+//
+// Fix (Option A per #772): resolve the witnessSet on-chain per epoch,
+// map each nodeId to its endpoint via the existing operator-address
+// resolver, and assign `witnessIndex = position in getWitnessSet(...)`.
+// Cache per epoch to avoid an eth_call for every receipt.
+const dynamicWitnessSetCache = new Map<number, WitnessNodeConfig[]>();
+const DYNAMIC_WITNESS_CACHE_MAX = 4;
+
+async function computeDynamicWitnessNodesForEpoch(epochId: number): Promise<WitnessNodeConfig[]> {
+  // Local devnet / offline fallback: no on-chain manager wired ⇒ keep the
+  // static config behaviour so single-node tests still exercise the
+  // pipeline.
+  if (!poseV2Contract) return v2WitnessNodes;
+  const cached = dynamicWitnessSetCache.get(epochId);
+  if (cached) return cached;
+  let witnessSet: `0x${string}`[];
+  try {
+    const raw = (await poseV2Contract.getWitnessSet(BigInt(epochId))) as string[];
+    witnessSet = raw.map((x) => x.toLowerCase() as `0x${string}`);
+  } catch (err) {
+    log.warn("dynamic witnessSet lookup failed, using config fallback", {
+      epochId,
+      error: String(err),
+    });
+    return v2WitnessNodes;
+  }
+  // Shared bearer token — the fleet uses a single witness auth token
+  // (see memory: r3 sprint stored the same token across every host).
+  // Falling through to `undefined` is safe for auth-off setups.
+  const sharedAuthToken =
+    v2WitnessNodes.find((w) => typeof w.authToken === "string" && w.authToken.length > 0)?.authToken;
+
+  const dynamicNodes: WitnessNodeConfig[] = [];
+  for (let idx = 0; idx < witnessSet.length && idx < 32; idx++) {
+    const nodeId = witnessSet[idx];
+    const url = resolveNodeEndpointStrict(nodeId);
+    if (!url) {
+      // Endpoint unknown for this nodeId — usually because the operator's
+      // host is offline (e.g. obs-1 post-2026-06-10). We simply skip; the
+      // contract's `_validateWitnessQuorumV2` treats a missing bit as
+      // "not counted", so as long as the remaining live members reach
+      // the ⌈2m/3⌉ threshold the batch still settles.
+      log.warn("dynamic witness node has no reachable endpoint — skipped for this epoch", {
+        epochId,
+        nodeId,
+        witnessIndex: idx,
+      });
+      continue;
+    }
+    dynamicNodes.push({ url, witnessIndex: idx, authToken: sharedAuthToken });
+  }
+
+  dynamicWitnessSetCache.set(epochId, dynamicNodes);
+  // Cap cache size — chain moves forward; old epochs never come back.
+  if (dynamicWitnessSetCache.size > DYNAMIC_WITNESS_CACHE_MAX) {
+    const oldestKey = Math.min(...dynamicWitnessSetCache.keys());
+    dynamicWitnessSetCache.delete(oldestKey);
+  }
+  return dynamicNodes;
+}
 // Production default: strict (false). Set to true only for dev/test environments.
 const allowEmptyBatchWitnessSubmission = config.allowEmptyBatchWitnessSubmission ?? false;
 const v2TipTolerance = config.tipToleranceBlocks ?? 10;
@@ -1135,9 +1210,14 @@ async function tryChallengeV2(nodeId: string, kind: keyof typeof ChallengeType):
     // silently fall back to the legacy rubber-stamp path. Pushing the
     // fields keeps the agent's behaviour identical regardless of which
     // mode each witness operator chose.
-    const witnessResult = v2WitnessNodes.length > 0
+    // #772 — resolve the witnessSet on-chain per epoch and translate it to
+    // WitnessNodeConfig entries whose `witnessIndex` matches the contract's
+    // slot position, not the static `runtime-pose.json` layout. See
+    // `computeDynamicWitnessNodesForEpoch` for the rationale.
+    const dynamicWitnessNodes = await computeDynamicWitnessNodesForEpoch(currentEpoch);
+    const witnessResult = dynamicWitnessNodes.length > 0
       ? await collectWitnesses(
-          { witnessNodes: v2WitnessNodes, requiredWitnesses: v2RequiredWitnesses, timeoutMs: 5000 },
+          { witnessNodes: dynamicWitnessNodes, requiredWitnesses: v2RequiredWitnesses, timeoutMs: 5000 },
           challenge.challengeId,
           nodeId as any,
           responseBodyHash,

--- a/runtime/lib/dynamic-witness-set.test.ts
+++ b/runtime/lib/dynamic-witness-set.test.ts
@@ -1,0 +1,175 @@
+// #772 — regression test for the per-epoch dynamic witnessSet resolution.
+//
+// The pipeline pre-#772 broadcast to `config.witnessNodes` (static) with
+// each entry's hardcoded `witnessIndex`. That index-space had no relation
+// to `getWitnessSet(epochId)`'s per-epoch PRNG-sampled subset, so
+// `_validateWitnessQuorumV2` recovered signers that didn't sit at the
+// contract-expected slots and every batch reverted `InvalidWitnessQuorum()`.
+//
+// Fix (Option A, coc-agent.ts:computeDynamicWitnessNodesForEpoch): call
+// `getWitnessSet(epochId)` at every tick and translate the returned
+// nodeIds into WitnessNodeConfig entries whose `witnessIndex = position
+// in getWitnessSet(...) result`. The tests below assert the alignment
+// contract that keeps the on-chain and off-chain index spaces in sync.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import type { WitnessNodeConfig } from "./witness-collector.ts"
+import { collectWitnesses, type WitnessCollectorConfig } from "./witness-collector.ts"
+
+type Hex32 = `0x${string}`
+
+const CHALLENGE_ID: Hex32 = ("0x" + "aa".repeat(32)) as Hex32
+const NODE_ID: Hex32 = ("0x" + "bb".repeat(32)) as Hex32
+const RESPONSE_BODY_HASH: Hex32 = ("0x" + "cc".repeat(32)) as Hex32
+
+/**
+ * Simulate the per-epoch dynamic witnessSet build. This mirrors the shape
+ * `computeDynamicWitnessNodesForEpoch` produces in coc-agent.ts, minus
+ * the on-chain lookup — we're testing that the resulting shape drives
+ * `collectWitnesses` to write a bitmap whose bit positions match the
+ * on-chain witnessSet indices.
+ */
+function buildDynamicWitnessNodes(witnessSet: Hex32[], resolveEndpoint: (nodeId: Hex32) => string | null): WitnessNodeConfig[] {
+  const nodes: WitnessNodeConfig[] = []
+  for (let idx = 0; idx < witnessSet.length && idx < 32; idx++) {
+    const url = resolveEndpoint(witnessSet[idx])
+    if (!url) continue
+    nodes.push({ url, witnessIndex: idx })
+  }
+  return nodes
+}
+
+test("#772: dynamic witnessNodes assigns witnessIndex == position in on-chain witnessSet", () => {
+  const witnessSet: Hex32[] = [
+    ("0x" + "11".repeat(32)) as Hex32,
+    ("0x" + "22".repeat(32)) as Hex32,
+    ("0x" + "33".repeat(32)) as Hex32,
+  ]
+  const nodes = buildDynamicWitnessNodes(witnessSet, () => "http://witness.example")
+  assert.equal(nodes.length, 3)
+  assert.equal(nodes[0].witnessIndex, 0)
+  assert.equal(nodes[1].witnessIndex, 1)
+  assert.equal(nodes[2].witnessIndex, 2)
+})
+
+test("#772: nodeIds with missing endpoints are skipped (dead witness), preserving the index of live members", () => {
+  const witnessSet: Hex32[] = [
+    ("0x" + "11".repeat(32)) as Hex32, // live
+    ("0x" + "22".repeat(32)) as Hex32, // DEAD — no endpoint
+    ("0x" + "33".repeat(32)) as Hex32, // live
+  ]
+  const nodes = buildDynamicWitnessNodes(witnessSet, (id) =>
+    id === ("0x" + "22".repeat(32)) as Hex32 ? null : "http://witness.example",
+  )
+  assert.equal(nodes.length, 2, "dead node[1] must be filtered out")
+  // Critical: nodes[1]'s witnessIndex must stay 2, NOT collapse to 1 —
+  // otherwise the contract expects nodeOperator[witnessSet[1]] (dead) at
+  // bit 1 while we'd be sending live node[2]'s signer there.
+  assert.equal(nodes[0].witnessIndex, 0)
+  assert.equal(nodes[1].witnessIndex, 2)
+})
+
+test("#772: bitmap from collectWitnesses matches the sparse witnessIndex layout after skipping dead nodes", async () => {
+  const witnessSet: Hex32[] = [
+    ("0x" + "11".repeat(32)) as Hex32,
+    ("0x" + "22".repeat(32)) as Hex32, // dead
+    ("0x" + "33".repeat(32)) as Hex32,
+  ]
+  const dynamicNodes = buildDynamicWitnessNodes(witnessSet, (id) =>
+    id === ("0x" + "22".repeat(32)) as Hex32 ? null : `http://w-${id.slice(2, 6)}`,
+  )
+  assert.equal(dynamicNodes.length, 2)
+
+  const collectorConfig: WitnessCollectorConfig = {
+    witnessNodes: dynamicNodes,
+    requiredWitnesses: 2,
+    timeoutMs: 500,
+  }
+
+  // Mock requestFn: each witness echoes the exact witnessIndex the
+  // collector sent, plus a fake sig. This is what a well-behaved
+  // coc-pose-witness does after our fix — the index it signs with is
+  // the one the challenger assigned, not one it picked itself.
+  let sigCounter = 0
+  const requestFn = async (
+    url: string,
+    _method: string,
+    body?: unknown,
+  ) => {
+    const req = body as { challengeId: string; nodeId: string; responseBodyHash: string; witnessIndex: number }
+    return {
+      status: 200,
+      json: {
+        challengeId: req.challengeId,
+        nodeId: req.nodeId,
+        responseBodyHash: req.responseBodyHash,
+        witnessIndex: req.witnessIndex,
+        attestedAtMs: 1,
+        witnessSig: ("0x" + (++sigCounter).toString(16).padStart(130, "0")) as `0x${string}`,
+      },
+    }
+  }
+
+  const result = await collectWitnesses(
+    collectorConfig,
+    CHALLENGE_ID,
+    NODE_ID,
+    RESPONSE_BODY_HASH,
+    requestFn,
+  )
+
+  // bitmap should have bits 0 and 2 set (the live members), NOT bits 0
+  // and 1. That's the whole point of the fix.
+  assert.equal(result.bitmap, 0b101, `expected sparse bitmap 0b101, got ${result.bitmap.toString(2)}`)
+  assert.equal(result.attestations.length, 2)
+})
+
+test("#772: witness that echoes a different witnessIndex is rejected (guards against collision/replay across slots)", async () => {
+  const witnessSet: Hex32[] = [
+    ("0x" + "11".repeat(32)) as Hex32,
+    ("0x" + "33".repeat(32)) as Hex32,
+  ]
+  const dynamicNodes = buildDynamicWitnessNodes(witnessSet, () => "http://witness.example")
+  assert.equal(dynamicNodes.length, 2)
+
+  // Malicious witness: server echoes witnessIndex=0 for every request,
+  // trying to double-count as bit 0. The collector's per-request guard
+  // must reject the second attempt so the bitmap only has bit 0 set.
+  const requestFn = async (
+    _url: string,
+    _method: string,
+    body?: unknown,
+  ) => {
+    const req = body as { challengeId: string; nodeId: string; responseBodyHash: string; witnessIndex: number }
+    return {
+      status: 200,
+      json: {
+        challengeId: req.challengeId,
+        nodeId: req.nodeId,
+        responseBodyHash: req.responseBodyHash,
+        witnessIndex: 0, // ← malicious: echoes 0 regardless
+        attestedAtMs: 1,
+        witnessSig: ("0x" + "de".repeat(65)) as `0x${string}`,
+      },
+    }
+  }
+
+  const result = await collectWitnesses(
+    {
+      witnessNodes: dynamicNodes,
+      requiredWitnesses: 1,
+      timeoutMs: 500,
+    },
+    CHALLENGE_ID,
+    NODE_ID,
+    RESPONSE_BODY_HASH,
+    requestFn,
+  )
+
+  // Only the witness assigned index 0 should pass — the one assigned
+  // index 1 gets rejected because attest.witnessIndex !== w.witnessIndex.
+  // Bitmap ends up 0b01, NOT 0b11.
+  assert.equal(result.bitmap, 0b01, `expected 0b01 after collision rejection, got ${result.bitmap.toString(2)}`)
+  assert.equal(result.attestations.length, 1)
+})


### PR DESCRIPTION
Closes #772 (the witnessSet mismatch that caused every ``submitBatchV2WithMetadata`` call to revert ``InvalidWitnessQuorum()`` for 19 days).

## Root cause recap

- ``PoSeManagerV2.getWitnessSet(epochId)`` returns a **per-epoch PRNG-selected subset** of size ``ceil(sqrt(activeCount))``. With 6 active operators on 88780 that's a rotating **3-element** slice, seeded by ``challengeNonces[epochId]``.
- The pre-fix pipeline broadcast to ``config.witnessNodes`` (a **static** list) using each entry's hardcoded ``witnessIndex``.
- The contract's ``_validateWitnessQuorumV2`` recovers each sig against ``nodeOperator[witnessSet[i]]`` where ``i`` iterates the dynamic subset. Those two index-spaces have no relationship ⇒ recovered signers never sat at the expected slots ⇒ every batch reverted.

Detailed diagnosis lives in [#772 (comment)](https://github.com/chainofclaw/COC/issues/772#issuecomment-4849428439).

## Fix (Option A from that comment)

Off-chain agent resolves the witnessSet on-chain at every batch tick and translates it into ``WitnessNodeConfig`` entries whose ``witnessIndex == position in getWitnessSet(...) result``. No contract change; no multisig round.

### ``runtime/coc-agent.ts``

- New per-epoch cache ``dynamicWitnessSetCache`` (bounded at 4 epochs — chain moves forward, old epochs never come back).
- New ``computeDynamicWitnessNodesForEpoch(epochId)``:
  - **Local-devnet fallback**: no ``poseV2Contract`` ⇒ keep ``v2WitnessNodes`` so single-node tests keep exercising the pipeline.
  - Calls ``poseV2Contract.getWitnessSet(BigInt(epochId))``; on ``eth_call`` failure logs a warning and falls back to the static list rather than dropping all witnesses.
  - Shares the fleet's single bearer token (fleet-common per r3/r4 runbooks) across dynamic entries.
  - ``warn``-logs any nodeId whose endpoint is unresolvable so operators can spot silent obs-1-style drift.
- ``collectWitnesses`` call site now consumes ``dynamicWitnessNodes`` instead of ``v2WitnessNodes``.

### ``runtime/lib/dynamic-witness-set.test.ts`` (NEW)

4 regression tests covering the alignment contract:

| # | What it asserts |
|---|---|
| 1 | ``witnessIndex == on-chain witnessSet position`` when all endpoints are reachable |
| 2 | Dead nodes are skipped **without collapsing** the remaining members' indices (this was the exact bug — bit 1 must stay bit 1 even if bit 2 is missing) |
| 3 | Bitmap from ``collectWitnesses`` reflects the sparse layout (``0b101`` not ``0b011``) |
| 4 | Malicious witness echoing a different ``witnessIndex`` is rejected (pre-existing guard, verified survives the dynamic-index change) |

## Test plan

- [x] ``node --experimental-strip-types --test runtime/lib/dynamic-witness-set.test.ts`` — **4/4 pass**
- [x] Full ``runtime/lib`` suite — **241/241 pass** (+4 from this PR)
- [x] Full ``services`` suite — **150/150 pass** (unchanged)
- [x] ``node --check --experimental-strip-types runtime/coc-agent.ts`` — clean
- [ ] Post-merge: rolling restart of ``coc-agent`` on v1/v2/v3/v4/v5. Watch for the first ``BatchSubmittedV2`` event on 88780 within one epoch after restart (currently 0 in the last 7 days).
- [ ] Post-merge: retire the stuck ``obs-1`` registration via ``requestUnbond`` + 168 h wait, then withdraw (pure hygiene, doesn't affect correctness post-fix).
- [ ] Post-merge: enable ``COC_POSE_WITNESS_LAYER7_VERIFY=1`` per host once the fleet is producing real batches again (deferred from #746).

## Why coc-pose-witness doesn't need to change

The witness server always respects the ``witnessIndex`` value the challenger sends it — it never picks its own. So per-host restart is enough. No coordinated multisig or contract upgrade required.

## What this PR does NOT fix

- **The "silent 19-day failure" observability gap** — no metric fires when ``coc-agent`` reverts every batch. Should be tracked as a separate follow-up: add a Prometheus counter ``coc_agent_batch_revert_total{error="InvalidWitnessQuorum"}`` and an alert at 10+ reverts/min.
- **``l1ChainId: null``** in ``runtime-pose.json`` on some hosts — cosmetic (not read by the code paths involved in ``_validateWitnessQuorumV2``); fix during ops housekeeping.

Refs #746 #766 #767 #773