### PR TITLE
fix(coc-agent): add resultCodes to submitBatchV2WithMetadata ABI (#772 layer 2)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -312,9 +312,19 @@ const poseV2Abi = [
   "event NodeRegistered(bytes32 indexed nodeId, address indexed operator, uint8 serviceFlags, uint256 bondAmount)",
   "function initEpochNonce(uint64 epochId)",
   "function submitBatchV2(uint64 epochId, bytes32 merkleRoot, bytes32 summaryHash, tuple(bytes32 leaf, bytes32[] merkleProof, uint32 leafIndex)[] sampleProofs, uint32 witnessBitmap, bytes[] witnessSignatures) returns (bytes32 batchId)",
-  // #667 — `submitBatchV2WithMetadata`. ReceiptBatchMetadata struct fields:
-  //   challengeIds[]; nodeIds[]; responseBodyHashes[]; leafHashes[]; witnessReceiptIndex[32]
-  "function submitBatchV2WithMetadata(uint64 epochId, bytes32 merkleRoot, bytes32 summaryHash, tuple(bytes32 leaf, bytes32[] merkleProof, uint32 leafIndex)[] sampleProofs, uint32 witnessBitmap, bytes[] witnessSignatures, tuple(bytes32[] challengeIds, bytes32[] nodeIds, bytes32[] responseBodyHashes, bytes32[] leafHashes, uint16[32] witnessReceiptIndex) metadata) returns (bytes32 batchId)",
+  // #746 PR-2 (#767) added `uint8[] resultCodes` to ReceiptBatchMetadata
+  // (aligned with leafHashes) so the contract can rebuild the v3 EIP-712
+  // digest that binds the witness's independently-computed ResultCode.
+  // Selector changed from 0xef5f1192 (r3, 5-field) to 0x77fd36b0 (r4,
+  // 6-field). The aggregator writes `resultCodes` in its metadata output
+  // and the r4 upgrade (2026-06-30, multisig txId=10) sunset the 5-field
+  // selector, so this ABI declaration MUST include `resultCodes` or every
+  // submit reverts require(false) at the EVM dispatcher.
+  // (#772 root-cause layer 2 — PR-2 shipped the aggregator/output half
+  // but missed this dispatch-half.)
+  //   challengeIds[]; nodeIds[]; responseBodyHashes[]; leafHashes[];
+  //   resultCodes[]; witnessReceiptIndex[32]
+  "function submitBatchV2WithMetadata(uint64 epochId, bytes32 merkleRoot, bytes32 summaryHash, tuple(bytes32 leaf, bytes32[] merkleProof, uint32 leafIndex)[] sampleProofs, uint32 witnessBitmap, bytes[] witnessSignatures, tuple(bytes32[] challengeIds, bytes32[] nodeIds, bytes32[] responseBodyHashes, bytes32[] leafHashes, uint8[] resultCodes, uint16[32] witnessReceiptIndex) metadata) returns (bytes32 batchId)",
   "function getActiveNodeCount() view returns (uint256)",
   "function getActiveNodeIds(uint256 offset, uint256 limit) view returns (bytes32[])",
   "function getWitnessSet(uint64 epochId) view returns (bytes32[])",
@@ -1465,6 +1475,9 @@ async function flushBatchV2(epochId: number, receipts: VerifiedReceiptV2[]): Pro
               nodeIds: batch.metadata.nodeIds,
               responseBodyHashes: batch.metadata.responseBodyHashes,
               leafHashes: batch.metadata.leafHashes,
+              // #746 PR-2 — aligned with leafHashes; contract rebuilds the
+              // v3 EIP-712 digest from this to bind the ResultCode.
+              resultCodes: batch.metadata.resultCodes,
               witnessReceiptIndex: batch.metadata.witnessReceiptIndex,
             },
           ),


### PR DESCRIPTION
Second bug layer discovered while deploying #774 to the v3 canary. #774 fixed the witnessBitmap alignment (dynamic witnessSet index) — the bitmap changed from ``0x1b`` to ``0x05`` exactly as its regression tests asserted — but every submit **still** reverted, this time with ``require(false)`` / empty data (not ``InvalidWitnessQuorum()``).

Root cause: **PR-2 (#767) only updated half the metadata story.**

- ✅ Aggregator (``services/aggregator/batch-aggregator-v2.ts``) writes ``resultCodes`` in metadata output — done in PR-2.
- ❌ Agent ABI declaration (``runtime/coc-agent.ts:311``) still declared the r3 5-field shape.
- ❌ Agent call-site (line 1466) built the metadata object without ``resultCodes``.

Result: encoded selector ``0xef5f1192`` (r3 5-field) instead of ``0xd36ae1bb`` (r4 6-field). The r4 impl dropped the 5-field overload, so every call hit the EVM dispatcher's fallback and reverted with empty data. Indistinguishable at the tx-receipt level from the ``InvalidWitnessQuorum()`` path #774 fixed.

## Changes

- ``runtime/coc-agent.ts:311`` — ABI declaration for ``submitBatchV2WithMetadata`` gains ``uint8[] resultCodes`` before ``witnessReceiptIndex``, matching the r4 impl's tuple layout exactly. Selector recomputed via ethers Interface = ``0xd36ae1bb``.
- ``runtime/coc-agent.ts:1473`` — call site now passes ``resultCodes: batch.metadata.resultCodes``.

## Test plan

- [x] ``node --check --experimental-strip-types runtime/coc-agent.ts`` — clean
- [x] ``runtime/lib`` — **241/241 pass** (no regressions from PR #774's baseline)
- [x] ``services`` — **150/150 pass**
- [x] Independent selector recompute from ``artifacts/.../PoSeManagerV2.json`` — ``0xd36ae1bb`` confirmed
- [ ] Post-merge: v3 canary pull + restart; expect first ``BatchSubmittedV2`` event within one epoch

Refs #772 #746 #767 #774