### PR TITLE
fix(coc-agent): pin agent epoch to chain clock, not wall clock (#772 layer 3)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -668,8 +668,12 @@ const TICK_HANG_TIMEOUT_MS = 5 * 60 * 1000;
 let lastTickOverlapLogAtMs = 0;
 let tickOverlapSuppressedSinceLastLog = 0;
 let selfNodeRegistered = false;
+// #772 layer 3 — seed the chain-clock offset before computing the first
+// epoch, so we start aligned with the contract instead of the wall clock.
+await refreshChainClockOffset();
 let currentEpoch = currentEpochId();
 log.info("endpoint fingerprint mode", { mode: endpointFingerprintMode });
+log.info("chain clock offset seeded", { offsetMs: chainClockOffsetMs, epochId: currentEpoch });
 
 if (agentMetricsPort > 0) {
   try {
@@ -884,6 +888,12 @@ async function tick(): Promise<void> {
   tickStartedAtMs = Date.now();
   try {
     await refreshLatestBlock();
+    // #772 layer 3 — keep the agent's epoch pinned to the chain's clock
+    // BEFORE any epoch decision (rollover, quorum lookup, batch submit).
+    // Otherwise `currentEpochId()` returns wall-time epochs that the
+    // contract's `_currentEpoch()` (block.timestamp / 3600) hasn't
+    // reached yet, and every submit reverts with InvalidBatch().
+    await refreshChainClockOffset();
     await refreshSelfNodeStatus();
     const nowEpoch = currentEpochId();
     const nowMs = Date.now();
@@ -2154,9 +2164,43 @@ function resolveNodeEndpointStrict(nodeId: string): string | null {
   return nodeEndpointMap.get(nodeId.toLowerCase()) ?? null;
 }
 
+// #772 layer 3 — the contract computes its epoch from `block.timestamp`,
+// not from wall clock. On 88780 the chain has run slower than real time
+// (block cadence lag + validator clock drift), producing a persistent
+// ~2.8 h skew as of 2026-07-01. If the agent submits a batch with
+// `epochId = floor(Date.now() / 3600 000)` and the tx is mined against
+// `block.timestamp / 3600 < epochId`, the contract rejects with
+// `InvalidBatch()` (PoSeManagerV2.sol:344, `epochId > _currentEpoch()`).
+// Sync the agent's clock to the last observed on-chain timestamp so
+// submissions land in an epoch the contract also considers current.
+//
+// The offset is refreshed by `refreshChainClockOffset()` — called at
+// startup and periodically before epoch decisions. Between refreshes
+// the offset is stable so `currentEpochId()` stays synchronous
+// (required by existing callers).
+let chainClockOffsetMs = 0; // wall_ms − chain_ms; positive when chain lags
+
+async function refreshChainClockOffset(): Promise<void> {
+  if (!poseV2Contract) return; // devnet / offline — keep wall-clock behaviour
+  const provider = (poseV2Contract as unknown as {
+    runner?: { provider?: { getBlock?: (tag: string) => Promise<{ timestamp: number } | null> } };
+  }).runner?.provider;
+  if (!provider?.getBlock) return;
+  try {
+    const block = await provider.getBlock("latest");
+    if (!block?.timestamp) return;
+    chainClockOffsetMs = Date.now() - Number(block.timestamp) * 1000;
+  } catch {
+    // Silent: don't destabilise the tick loop on a transient RPC blip;
+    // the previous offset stays in effect.
+  }
+}
+
 function currentEpochId(): number {
-  const now = Date.now();
-  return Math.floor(now / (60 * 60 * 1000));
+  // Use chain-adjusted clock so `agentEpoch <= contract._currentEpoch()`
+  // even when the chain lags wall time.
+  const chainNowMs = Date.now() - chainClockOffsetMs;
+  return Math.floor(chainNowMs / (60 * 60 * 1000));
 }
 
 function normalizeInt(raw: unknown, fallback: number): number {


### PR DESCRIPTION
Third and hopefully final bug layer surfaced after PR #775 landed on v3 canary today.

## Progress log

| PR | Fix | v3 canary result after deploy |
|---|---|---|
| #774 | Dynamic witnessSet (position vs static config) | witnessBitmap went ``0x1b`` → ``0x05`` (correct sparse layout) ✓ but still reverted |
| #775 | Agent ABI adds ``resultCodes`` (r4 6-field metadata) | Selector went ``0xef5f1192`` → ``0xd36ae1bb`` (correct dispatcher) ✓ but still reverted |
| **this PR** | Chain-clock epoch alignment | expected: batches finally settle |

## The measurement

On the v3 canary at 2026-07-01 03:36 UTC, revert error selector changed from ``0x`` (no data, dispatcher miss) to ``0x33b094a1`` = ``InvalidBatch()``, defined at multiple spots in ``PoSeManagerV2.sol``. The failing calldata carried ``epochId = 495243``, but a live ``eth_getBlockByNumber("latest")`` at the same moment returned:

```
chain block.timestamp / 3600 = 495240
wall Date.now()      / 3600 = 495243
chain lags wall by 10 214 s (~2.8 h, 3 epochs)
```

That hits ``PoSeManagerV2.sol:344`` — ``if (epochId > currentEpoch) revert InvalidBatch();`` — every single time. 88780's block cadence + validator NTP drift has produced a persistent ~3-epoch skew, and the coc-agent tick uses ``Math.floor(Date.now() / 3600 000)`` as its epoch source, which is wall-time-based.

## Fix

Maintain a cached ``chainClockOffsetMs`` (= ``Date.now() − blockTimestampMs``, refreshed from ``provider.getBlock('latest')``) and subtract it before computing the agent's epoch. ``currentEpochId()`` **stays synchronous** so existing callers don't have to change.

- ``runtime/coc-agent.ts:2157`` — new ``chainClockOffsetMs`` + async ``refreshChainClockOffset()`` + updated ``currentEpochId()``.
- ``runtime/coc-agent.ts:672`` — seed the offset at startup, before the first ``let currentEpoch = ...``.
- ``runtime/coc-agent.ts:890`` — refresh the offset at the top of every tick, before any epoch decision.

Between refreshes the offset is stable. A transient RPC blip during refresh keeps the last known offset (silent try/catch, no tick disturbance).

## Test plan

- [x] ``node --check --experimental-strip-types runtime/coc-agent.ts`` — clean
- [x] ``runtime/lib`` — **241/241 pass** (no regressions from PRs #774/#775)
- [ ] Post-merge: v3 canary pull + restart; expect first ``BatchSubmittedV2`` event within one epoch (finally!)

## Not addressed here

The underlying chain-clock lag itself. Validator NTP + block cadence tuning is separate ops work — the fix above makes the agent tolerant of the lag rather than papering over it.

Refs #772 #746 #774 #775