### PR TITLE
fix(coc-agent): hoist chainClockOffsetMs above module-top currentEpochId call (#772 layer 3 TDZ)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -668,8 +668,14 @@ const TICK_HANG_TIMEOUT_MS = 5 * 60 * 1000;
 let lastTickOverlapLogAtMs = 0;
 let tickOverlapSuppressedSinceLastLog = 0;
 let selfNodeRegistered = false;
-// #772 layer 3 — seed the chain-clock offset before computing the first
-// epoch, so we start aligned with the contract instead of the wall clock.
+// #772 layer 3 storage — declared here (near the other startup-time
+// bindings) so the module-top `currentEpochId()` call below can read
+// it without hitting TDZ. `refreshChainClockOffset()` and
+// `currentEpochId()` themselves live near the bottom of the file
+// alongside the other helper functions.
+let chainClockOffsetMs = 0; // wall_ms − chain_ms; positive when chain lags
+// Seed the offset before computing the first epoch, so we start
+// aligned with the contract instead of the wall clock.
 await refreshChainClockOffset();
 let currentEpoch = currentEpochId();
 log.info("endpoint fingerprint mode", { mode: endpointFingerprintMode });
@@ -2178,8 +2184,13 @@ function resolveNodeEndpointStrict(nodeId: string): string | null {
 // startup and periodically before epoch decisions. Between refreshes
 // the offset is stable so `currentEpochId()` stays synchronous
 // (required by existing callers).
-let chainClockOffsetMs = 0; // wall_ms − chain_ms; positive when chain lags
-
+//
+// NOTE: the storage lives near the top of the module (see the
+// declaration next to the other startup-time `let` bindings). This
+// function block just holds the read/write helpers. Colocating the
+// `let` with the functions would put the module-top `let currentEpoch
+// = currentEpochId()` (which reads this storage) in the TDZ, hard-
+// crashing the agent at boot.
 async function refreshChainClockOffset(): Promise<void> {
   if (!poseV2Contract) return; // devnet / offline — keep wall-clock behaviour
   const provider = (poseV2Contract as unknown as {


### PR DESCRIPTION
Emergency hotfix. PR #776 introduced a Temporal Dead Zone crash at coc-agent boot:

```
ReferenceError: Cannot access 'chainClockOffsetMs' before initialization
    at currentEpochId (runtime/coc-agent.ts:2202:35)
    at runtime/coc-agent.ts:674:20
Node.js v22.22.0
coc-agent.service: Main process exited, code=exited, status=1/FAILURE
```

The ``let chainClockOffsetMs`` declaration was colocated with its helper functions near line 2181, but the module-top ``let currentEpoch = currentEpochId()`` at line 674 reads it during ES-module top-level init — before line 2181 executes. ``let``/``const`` in TDZ throws on any read or write, so the process crash-looped 22 times when v3 canary deployed #776.

## Fix

Split state from helpers:
- Move only ``let chainClockOffsetMs = 0;`` up to line 676, next to the other startup-time ``let currentEpoch = ...`` binding it needs to precede.
- Keep ``refreshChainClockOffset()`` + ``currentEpochId()`` near the bottom of the file where the other helpers live.
- Add explanatory comments at both sites so nobody re-colocates them.

## Test plan

- [x] ``grep '^let chainClockOffsetMs'`` — exactly one declaration
- [x] ``node --check --experimental-strip-types runtime/coc-agent.ts`` — clean
- [x] ``runtime/lib`` — **241/241 pass**
- [ ] Post-merge: v3 canary re-deploy (currently crash-looping on #776); expect ``chain clock offset seeded`` log and first ``BatchSubmittedV2``

## Related memory pattern

Same class of bug as ``f379c2d`` / ``0dc653e`` snap-sync strict-mode TDZ hits documented in ``coc-88780-obs1-5th-validator-snap-sync-bugs-2026-05-24.md`` — ``--experimental-strip-types`` performs no type checking; cross-scope ``let`` misuse only surfaces at runtime.

Refs #772 #746 #774 #775 #776