### PR TITLE
chore(website): unify domain to clawchain.io (retire chainofclaw.io)

### DIFF
--- a/website/.env.local.example
+++ b/website/.env.local.example
@@ -1,20 +1,6 @@
-# Canary testnet 88780 — public endpoints.
-# See docs/public-endpoints-88780.md for the canonical RPC/WS/Faucet/Explorer URLs.
-#
-# ⚠ rpc.chainofclaw.io is NOT live yet (DNS/Cloudflare cutover pending). Current
-# production serves chain data via the same-origin Nginx proxy on clawchain.io
-# (/api/testnet/rpc, /api/testnet/ws → live-node failover; see docker/nginx/coc-rpc.conf).
-# A from-scratch deploy should EITHER stand up rpc.chainofclaw.io, OR leave
-# NEXT_PUBLIC_RPC_URL unset and let the client build the same-origin proxy path
-# from window.location (what the live site currently does).
-NEXT_PUBLIC_RPC_URL=https://rpc.chainofclaw.io
-NEXT_PUBLIC_WS_URL=wss://rpc.chainofclaw.io/ws
-
-# Server-side SSR & API routes — must point at the same chain as NEXT_PUBLIC_*.
-# Use the public RPC unless running an internal validator/observer node.
-COC_RPC_URL=https://rpc.chainofclaw.io
-
-# Local devnet (alternative): `bash scripts/start-devnet.sh 3`, then
-#   NEXT_PUBLIC_RPC_URL=http://127.0.0.1:28780
-#   NEXT_PUBLIC_WS_URL=ws://127.0.0.1:18781
-#   COC_RPC_URL=http://127.0.0.1:28780
+# Public site runtime config. NEXT_PUBLIC_* are baked at build time.
+# Production domain: clawchain.io (served from v3 / server1.clawchain.io).
+# rpc.clawchain.io + /ws are live (nginx → local node 28780 / 28790).
+NEXT_PUBLIC_RPC_URL=https://rpc.clawchain.io
+NEXT_PUBLIC_WS_URL=wss://rpc.clawchain.io/ws
+COC_RPC_URL=https://rpc.clawchain.io

--- a/website/messages/en.json
+++ b/website/messages/en.json
@@ -1717,8 +1717,8 @@
       "in": {
         "chain": "ChainOfClaw 88780 node code (RPC, P2P, mempool, consensus)",
         "contracts": "Gen-5 UUPS smart contracts (governance, PoSe, identity, settlement)",
-        "explorer": "Block explorer at explorer.chainofclaw.io",
-        "website": "This website (chainofclaw.io) and the faucet"
+        "explorer": "Block explorer at explorer.clawchain.io",
+        "website": "This website (clawchain.io) and the faucet"
       },
       "out": {
         "thirdParty": "Third-party dependencies (report to the upstream project)",

--- a/website/messages/es.json
+++ b/website/messages/es.json
@@ -1702,8 +1702,8 @@
       "in": {
         "chain": "Código del nodo ChainOfClaw 88780 (RPC, P2P, mempool, consenso)",
         "contracts": "Contratos Gen-5 UUPS (gobernanza, PoSe, identidad, liquidación)",
-        "explorer": "Block explorer en explorer.chainofclaw.io",
-        "website": "Este sitio (chainofclaw.io) y el faucet"
+        "explorer": "Block explorer en explorer.clawchain.io",
+        "website": "Este sitio (clawchain.io) y el faucet"
       },
       "out": {
         "thirdParty": "Dependencias de terceros (reportar al proyecto upstream)",

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -1702,8 +1702,8 @@
       "in": {
         "chain": "ChainOfClaw 88780 ノードコード(RPC, P2P, mempool, 合意)",
         "contracts": "Gen-5 UUPS スマートコントラクト(ガバナンス、PoSe、ID、決済)",
-        "explorer": "ブロックエクスプローラー explorer.chainofclaw.io",
-        "website": "本サイト(chainofclaw.io)と faucet"
+        "explorer": "ブロックエクスプローラー explorer.clawchain.io",
+        "website": "本サイト(clawchain.io)と faucet"
       },
       "out": {
         "thirdParty": "サードパーティ依存(上流プロジェクトへ報告)",

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -1702,8 +1702,8 @@
       "in": {
         "chain": "ChainOfClaw 88780 노드 코드 (RPC, P2P, mempool, 합의)",
         "contracts": "Gen-5 UUPS 스마트 컨트랙트 (거버넌스, PoSe, 신원, 정산)",
-        "explorer": "블록 explorer explorer.chainofclaw.io",
-        "website": "본 사이트 (chainofclaw.io) 와 faucet"
+        "explorer": "블록 explorer explorer.clawchain.io",
+        "website": "본 사이트 (clawchain.io) 와 faucet"
       },
       "out": {
         "thirdParty": "서드파티 의존성 (상위 프로젝트로 보고)",

--- a/website/messages/zh.json
+++ b/website/messages/zh.json
@@ -1717,8 +1717,8 @@
       "in": {
         "chain": "ChainOfClaw 88780 節點代碼(RPC、P2P、mempool、共識)",
         "contracts": "Gen-5 UUPS 智能合約(治理、PoSe、身份、結算)",
-        "explorer": "區塊瀏覽器 explorer.chainofclaw.io",
-        "website": "本網站(chainofclaw.io)和 faucet"
+        "explorer": "區塊瀏覽器 explorer.clawchain.io",
+        "website": "本網站(clawchain.io)和 faucet"
       },
       "out": {
         "thirdParty": "第三方依賴(請向上游項目報告)",

--- a/website/src/app/[locale]/docs/page.tsx
+++ b/website/src/app/[locale]/docs/page.tsx
@@ -255,7 +255,7 @@ export default function DocsPage() {
               title={t('tools.explorer.title')}
               description={t('tools.explorer.description')}
               features={t.raw('tools.explorer.features') as string[]}
-              link="https://explorer.chainofclaw.io"
+              link="https://explorer.clawchain.io"
               openToolText={t('tools.openTool')}
               delay="0.1"
             />

--- a/website/src/app/[locale]/layout.tsx
+++ b/website/src/app/[locale]/layout.tsx
@@ -135,7 +135,7 @@ export default async function LocaleLayout({
                       <ul className="space-y-2">
                         <FooterLink href="/docs">{tCommon('docs')}</FooterLink>
                         <FooterLink href="/plan">{tCommon('whitepaper')}</FooterLink>
-                        <FooterLink href="https://explorer.chainofclaw.io" external>
+                        <FooterLink href="https://explorer.clawchain.io" external>
                           {tCommon('explorer')}
                         </FooterLink>
                         <FooterLink href="/security">{tCommon('security')}</FooterLink>

--- a/website/src/app/[locale]/network/page.tsx
+++ b/website/src/app/[locale]/network/page.tsx
@@ -537,7 +537,7 @@ export default function NetworkPage() {
                 {t('recentBlocks.title')}
               </h2>
               <a
-                href="https://explorer.chainofclaw.io"
+                href="https://explorer.clawchain.io"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group inline-flex items-center gap-2 font-display text-accent-cyan hover:text-accent-blue transition-colors"
@@ -577,7 +577,7 @@ export default function NetworkPage() {
                       <tr key={block.number} className="group hover:bg-accent-cyan/5 transition-colors duration-300">
                         <td className="px-6 py-4 font-display text-sm">
                           <a
-                            href={`https://explorer.chainofclaw.io/block/${block.number}`}
+                            href={`https://explorer.clawchain.io/block/${block.number}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-accent-cyan hover:text-accent-blue transition-colors"
@@ -617,7 +617,7 @@ export default function NetworkPage() {
                 <QuickLink
                   title={t('quickLinks.explorer.title')}
                   description={t('quickLinks.explorer.description')}
-                  href="https://explorer.chainofclaw.io"
+                  href="https://explorer.clawchain.io"
                   external
                 />
                 <QuickLink

--- a/website/src/app/[locale]/security/page.tsx
+++ b/website/src/app/[locale]/security/page.tsx
@@ -50,10 +50,10 @@ export default function SecurityPage() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
               <a
-                href="mailto:security@chainofclaw.io"
+                href="mailto:security@clawchain.io"
                 className="px-6 py-3 rounded-lg bg-gradient-cyber text-white font-display font-semibold hover:shadow-glow-md transition-all text-center"
               >
-                security@chainofclaw.io
+                security@clawchain.io
               </a>
               <a
                 href="https://github.com/chainofclaw/COC/security/advisories/new"

--- a/website/src/app/[locale]/services/page.tsx
+++ b/website/src/app/[locale]/services/page.tsx
@@ -261,7 +261,7 @@ function ServiceCard({
                 {contracts.map((ct) => (
                   <a
                     key={ct.addr}
-                    href={`https://explorer.chainofclaw.io/address/${ct.addr}`}
+                    href={`https://explorer.clawchain.io/address/${ct.addr}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="block bg-bg-primary/40 rounded p-2 hover:bg-bg-primary/60 transition-colors group"

--- a/website/src/app/[locale]/testnet/page.tsx
+++ b/website/src/app/[locale]/testnet/page.tsx
@@ -42,7 +42,7 @@ export default function TestnetPage() {
                 {t('joinNow')}
               </Link>
               <a
-                href="https://faucet.chainofclaw.io"
+                href="https://faucet.clawchain.io"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-8 py-3 rounded-lg border border-accent-cyan/30 text-accent-cyan font-display font-semibold hover:bg-accent-cyan/10 transition-all"
@@ -68,8 +68,8 @@ export default function TestnetPage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             <InfoCard label={t('chainId')} value="88780 (0x15acc)" />
-            <InfoCard label={t('rpcEndpoint')} value="https://rpc.chainofclaw.io" mono />
-            <InfoCard label={t('wsEndpoint')} value="wss://rpc.chainofclaw.io/ws" mono />
+            <InfoCard label={t('rpcEndpoint')} value="https://rpc.clawchain.io" mono />
+            <InfoCard label={t('wsEndpoint')} value="wss://rpc.clawchain.io/ws" mono />
             <InfoCard label={t('blockTime')} value="~2.1s" />
             <InfoCard label={t('consensus')} value="BFT + PoSe" />
             <InfoCard label={t('tokenSymbol')} value="COC" />
@@ -133,10 +133,10 @@ export default function TestnetPage() {
 
               <div className="bg-bg-primary/50 rounded-lg p-6 text-left font-mono text-sm text-text-secondary space-y-2">
                 <p><span className="text-accent-cyan">Network Name:</span> ChainOfClaw Canary 88780</p>
-                <p><span className="text-accent-cyan">RPC URL:</span> https://rpc.chainofclaw.io</p>
+                <p><span className="text-accent-cyan">RPC URL:</span> https://rpc.clawchain.io</p>
                 <p><span className="text-accent-cyan">Chain ID:</span> 88780</p>
                 <p><span className="text-accent-cyan">Currency Symbol:</span> COC</p>
-                <p><span className="text-accent-cyan">Explorer:</span> https://explorer.chainofclaw.io</p>
+                <p><span className="text-accent-cyan">Explorer:</span> https://explorer.clawchain.io</p>
               </div>
             </div>
           </div>
@@ -147,13 +147,13 @@ export default function TestnetPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             <QuickLink
               title={t('links.explorer')}
-              href="https://explorer.chainofclaw.io"
+              href="https://explorer.clawchain.io"
               external
               icon="search"
             />
             <QuickLink
               title={t('links.faucet')}
-              href="https://faucet.chainofclaw.io"
+              href="https://faucet.clawchain.io"
               external
               icon="droplet"
             />


### PR DESCRIPTION
## What

The live website is now served from **clawchain.io** (v3 / server1.clawchain.io) after the v2 host was deleted by the IDC. This replaces all `chainofclaw.io` domain references in the website with their `clawchain.io` equivalents.

Mapping (25 occurrences, 11 files + env example):
- `explorer.chainofclaw.io` → `explorer.clawchain.io` (incl. `/address`, `/block` paths)
- `faucet.chainofclaw.io` → `faucet.clawchain.io`
- `rpc.chainofclaw.io` → `rpc.clawchain.io` (+ `wss://…/ws`)
- `chainofclaw.io` → `clawchain.io` (self-references, footer, testnet card)
- `security@chainofclaw.io` → `security@clawchain.io`
- `website/.env.local.example`: point at `rpc.clawchain.io`, drop the stale "not live yet" note

## Safety

Pure substring replace of `chainofclaw.io`. The GitHub org (`github.com/chainofclaw`) and npm scope (`@chainofclaw/*`) contain no `.io` and are **intentionally untouched** (verified: 7 github + 48 npm refs preserved). Reverses the services-page URL introduced in #770 now that clawchain.io is canonical.

## Verification

Deployed + rebuilt on v3; every page serves **0** `chainofclaw.io` references, and `rpc`/`faucet`/`explorer.clawchain.io` all resolve over HTTPS (Let's Encrypt).

Website content only — no code/contract changes.