### PR TITLE
fix(bft): durable fsync'd vote ledger — no self-equivocation on restart

### DIFF
--- a/node/src/bft-coordinator.ts
+++ b/node/src/bft-coordinator.ts
@@ -7,6 +7,7 @@
 
 import { BftRound, EquivocationDetector } from "./bft.ts"
 import type { BftMessage, BftRoundConfig, EquivocationEvidence } from "./bft.ts"
+import { BftVoteLedger } from "./bft-vote-ledger.ts"
 import type { ChainBlock, Hex } from "./blockchain-types.ts"
 import type { NodeSigner, SignatureVerifier } from "./crypto/signer.ts"
 import { createLogger } from "./logger.ts"
@@ -31,6 +32,15 @@ export interface BftCoordinatorConfig {
   signer?: NodeSigner
   /** Signature verifier for validating BFT messages */
   verifier?: SignatureVerifier
+  /**
+   * Path to the durable BFT vote ledger (fsync'd `(height → blockHash)` record
+   * of our own prepare/commit votes). When set, a mid-round restart cannot
+   * re-sign a conflicting vote for an unfinalized height → no self-equivocation
+   * on restart. Omit (or leave undefined) to run the ledger in-memory only
+   * (legacy behavior — used by tests). Node wires this to
+   * `join(config.dataDir, "bft-vote-ledger.json")`.
+   */
+  voteLedgerPath?: string
   /**
    * Speculatively execute `block` against the node's current state and return
    * the post-execution stateRoot. Called before emitting our prepare vote so
@@ -176,9 +186,20 @@ export class BftCoordinator {
   // to a freshly-built block (which Phase R correctly refuses, but then
   // the chain stalls because no one re-sends the original).
   private localPreparedBlock = new Map<bigint, ChainBlock>()
+  // Durable, fsync'd mirror of localPreparedAt/localCommittedAt so a mid-round
+  // restart does not re-sign a conflicting vote for an unfinalized height
+  // (which peers flag as equivocation → BFT deadlock). See bft-vote-ledger.ts.
+  private readonly voteLedger: BftVoteLedger
 
   constructor(cfg: BftCoordinatorConfig) {
     this.cfg = cfg
+    // Rehydrate our prior prepare/commit commitments from disk. On a clean
+    // start the ledger is empty; after a mid-round restart it carries the
+    // heights we already voted on, so the Phase R self-equivocation guards
+    // (localPreparedAt/localCommittedAt) survive the restart.
+    this.voteLedger = new BftVoteLedger(cfg.voteLedgerPath ?? null)
+    this.localPreparedAt = this.voteLedger.snapshotPrepared()
+    this.localCommittedAt = this.voteLedger.snapshotCommitted()
     // Liveness watchdog: if no block finalizes for LIVENESS_TIMEOUT_MS while
     // we have an active round, the BFT state is likely deadlocked at a phase
     // mismatch (observed 2026-04-26: node-1 timed out in commit, node-3 in
@@ -320,18 +341,22 @@ export class BftCoordinator {
     // Handle the propose phase
     const outgoing = this.activeRound.handlePropose(block, block.proposer, localStateRoot)
 
-    // Sign and broadcast prepare votes
-    for (const msg of outgoing) {
-      this.signMessage(msg)
-      await this.cfg.broadcastMessage(msg)
-    }
-
-    // Phase R: record what we voted prepare on so a future startRound at
-    // the same height with a different block can refuse self-equivocation.
+    // Phase R + durable ledger: record what we are about to prepare BEFORE
+    // broadcasting (write-ahead). Persisting the commitment first (fsync)
+    // means a crash any time after the vote hits the wire still remembers it
+    // on restart, so we never re-prepare a different block at this height —
+    // the self-equivocation that used to deadlock BFT after a restart.
     if (outgoing.length > 0) {
       this.localPreparedAt.set(block.number, block.hash)
       // Phase R3: stash the full block too so re-broadcast can replay it.
       this.localPreparedBlock.set(block.number, block)
+      this.voteLedger.recordPrepared(block.number, block.hash)
+    }
+
+    // Sign and broadcast prepare votes
+    for (const msg of outgoing) {
+      this.signMessage(msg)
+      await this.cfg.broadcastMessage(msg)
     }
 
     // Set timeout
@@ -494,12 +519,13 @@ export class BftCoordinator {
               })
               continue
             }
+            // Write-ahead: persist the commit commitment (fsync) BEFORE
+            // broadcasting, so a restart cannot re-commit a different block.
+            this.localCommittedAt.set(out.height, out.blockHash)
+            this.voteLedger.recordCommitted(out.height, out.blockHash)
           }
           this.signMessage(out)
           await this.cfg.broadcastMessage(out)
-          if (out.type === "commit") {
-            this.localCommittedAt.set(out.height, out.blockHash)
-          }
         }
         // Start commit retry when transitioning to commit phase
         if (this.activeRound?.state.phase === "commit") {
@@ -648,6 +674,7 @@ export class BftCoordinator {
     this.localPreparedAt.clear()
     this.localCommittedAt.clear()
     this.localPreparedBlock.clear()
+    this.voteLedger.clearAll()
     // Pending messages may carry senderIds that are no longer validators;
     // drop them so handleMessage doesn't reject them one-by-one (and so
     // a removed peer's stale prepare can't influence quorum after they're out).
@@ -1285,6 +1312,7 @@ export class BftCoordinator {
     for (const h of this.localPreparedBlock.keys()) {
       if (h <= finalizedHeight) this.localPreparedBlock.delete(h)
     }
+    this.voteLedger.prune(finalizedHeight)
   }
 
   /**

--- a/node/src/bft-vote-ledger.test.ts
+++ b/node/src/bft-vote-ledger.test.ts
@@ -1,0 +1,109 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BftVoteLedger } from "./bft-vote-ledger.ts"
+import type { Hex } from "./blockchain-types.ts"
+
+function tmpPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "bft-ledger-"))
+  return join(dir, "sub", "bft-vote-ledger.json") // nested dir tests mkdirSync
+}
+
+const HASH_A = ("0x" + "a".repeat(64)) as Hex
+const HASH_B = ("0x" + "b".repeat(64)) as Hex
+
+test("records and reads prepare/commit commitments in-memory", () => {
+  const l = new BftVoteLedger(null)
+  l.recordPrepared(10n, HASH_A)
+  l.recordCommitted(10n, HASH_A)
+  assert.equal(l.getPrepared(10n), HASH_A)
+  assert.equal(l.getCommitted(10n), HASH_A)
+  assert.equal(l.getPrepared(11n), undefined)
+})
+
+test("persists across a simulated restart (durability)", () => {
+  const path = tmpPath()
+  const l1 = new BftVoteLedger(path)
+  l1.recordPrepared(100n, HASH_A)
+  l1.recordCommitted(100n, HASH_A)
+  l1.recordPrepared(101n, HASH_B)
+  assert.ok(existsSync(path), "ledger file written")
+
+  // simulate process restart: brand new instance, same path
+  const l2 = new BftVoteLedger(path)
+  assert.equal(l2.getPrepared(100n), HASH_A, "prepare survives restart")
+  assert.equal(l2.getCommitted(100n), HASH_A, "commit survives restart")
+  assert.equal(l2.getPrepared(101n), HASH_B)
+  // the snapshot maps rehydrate the coordinator's in-memory copies
+  assert.equal(l2.snapshotPrepared().get(100n), HASH_A)
+  assert.equal(l2.snapshotCommitted().get(100n), HASH_A)
+  rmSync(join(path, "..", ".."), { recursive: true, force: true })
+})
+
+test("this is exactly the no-double-vote-on-restart guard the coordinator needs", () => {
+  const path = tmpPath()
+  // Node prepares height 200 with block A, then crashes.
+  const before = new BftVoteLedger(path)
+  before.recordPrepared(200n, HASH_A)
+
+  // Restart: coordinator rehydrates localPreparedAt from the ledger.
+  const after = new BftVoteLedger(path)
+  const localPreparedAt = after.snapshotPrepared()
+  const previouslyPrepared = localPreparedAt.get(200n)
+
+  // The Phase R guard: a freshly-built candidate (block B) at the same height
+  // must be refused because we already committed to A — no self-equivocation.
+  assert.equal(previouslyPrepared, HASH_A)
+  assert.notEqual(previouslyPrepared, HASH_B)
+  rmSync(join(path, "..", ".."), { recursive: true, force: true })
+})
+
+test("prune drops entries at or below finalized height", () => {
+  const path = tmpPath()
+  const l = new BftVoteLedger(path)
+  l.recordPrepared(5n, HASH_A)
+  l.recordPrepared(6n, HASH_A)
+  l.recordPrepared(7n, HASH_B)
+  l.prune(6n)
+  assert.equal(l.getPrepared(5n), undefined)
+  assert.equal(l.getPrepared(6n), undefined)
+  assert.equal(l.getPrepared(7n), HASH_B, "above-finalized entry retained")
+
+  // pruning persists too
+  const reloaded = new BftVoteLedger(path)
+  assert.equal(reloaded.getPrepared(6n), undefined)
+  assert.equal(reloaded.getPrepared(7n), HASH_B)
+  rmSync(join(path, "..", ".."), { recursive: true, force: true })
+})
+
+test("clearAll wipes on validator-set change and persists", () => {
+  const path = tmpPath()
+  const l = new BftVoteLedger(path)
+  l.recordPrepared(9n, HASH_A)
+  l.recordCommitted(9n, HASH_A)
+  l.clearAll()
+  assert.equal(l.getPrepared(9n), undefined)
+  assert.equal(l.getCommitted(9n), undefined)
+  const reloaded = new BftVoteLedger(path)
+  assert.equal(reloaded.snapshotPrepared().size, 0)
+  assert.equal(reloaded.snapshotCommitted().size, 0)
+  rmSync(join(path, "..", ".."), { recursive: true, force: true })
+})
+
+test("idempotent record of the same hash is a no-op (allows re-broadcast)", () => {
+  const l = new BftVoteLedger(null)
+  l.recordPrepared(1n, HASH_A)
+  l.recordPrepared(1n, HASH_A) // must not throw / must stay A
+  assert.equal(l.getPrepared(1n), HASH_A)
+})
+
+test("corrupt ledger file starts empty instead of crashing", () => {
+  const path = tmpPath()
+  mkdirSync(join(path, ".."), { recursive: true })
+  writeFileSync(path, "{ this is not json")
+  const l = new BftVoteLedger(path)
+  assert.equal(l.snapshotPrepared().size, 0, "corrupt file → empty, no throw")
+  rmSync(join(path, "..", ".."), { recursive: true, force: true })
+})

--- a/node/src/bft-vote-ledger.ts
+++ b/node/src/bft-vote-ledger.ts
@@ -1,0 +1,146 @@
+import {
+  openSync,
+  writeSync,
+  fsyncSync,
+  closeSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  mkdirSync,
+} from "node:fs"
+import { dirname } from "node:path"
+import type { Hex } from "./blockchain-types.ts"
+import { createLogger } from "./logger.ts"
+
+const log = createLogger("bft-vote-ledger")
+
+interface VoteLedgerSnapshot {
+  prepared: Record<string, Hex>
+  committed: Record<string, Hex>
+}
+
+/**
+ * Durable, fsync'd record of which `(height → blockHash)` this validator has
+ * already voted `prepare` / `commit` on.
+ *
+ * Why this exists: BFT round state (the in-memory `localPreparedAt` /
+ * `localCommittedAt` maps in bft-coordinator.ts) is lost on process restart.
+ * A validator that restarts mid-round — before the in-progress height was
+ * finalized — used to come back with an empty ledger and re-`prepare` a
+ * *freshly-built* candidate for that same unfinalized height (a different
+ * `blockHash`). Peers' `EquivocationDetector` correctly flags that as
+ * double-signing and drop both votes, deadlocking consensus until a manual
+ * atomic restart. This was the root cause of the recurring 88780 stalls.
+ *
+ * This ledger closes that gap: each commitment is persisted with `fsync`
+ * **write-ahead** (before the vote is broadcast), and rehydrated on startup,
+ * so a restarted validator refuses to sign a conflicting vote for a height it
+ * already voted on. Safety (no equivocation) is preserved across crashes.
+ *
+ * Storage: a single small JSON file rewritten atomically (temp file → fsync →
+ * rename). It only ever holds *unfinalized* heights (pruned on finalize), so
+ * it stays tiny — a handful of entries at most.
+ *
+ * When constructed with `path = null` (e.g. unit tests, or a node without a
+ * data dir) it operates purely in-memory — same behavior as before this fix,
+ * minus the durability.
+ */
+export class BftVoteLedger {
+  private readonly prepared = new Map<bigint, Hex>()
+  private readonly committed = new Map<bigint, Hex>()
+  private readonly path: string | null
+
+  constructor(path: string | null) {
+    this.path = path
+    if (path) this.load()
+  }
+
+  private load(): void {
+    if (!this.path || !existsSync(this.path)) return
+    try {
+      const snap = JSON.parse(readFileSync(this.path, "utf8")) as VoteLedgerSnapshot
+      for (const [h, hash] of Object.entries(snap.prepared ?? {})) this.prepared.set(BigInt(h), hash)
+      for (const [h, hash] of Object.entries(snap.committed ?? {})) this.committed.set(BigInt(h), hash)
+      log.info("BFT vote ledger rehydrated", {
+        preparedHeights: this.prepared.size,
+        committedHeights: this.committed.size,
+      })
+    } catch (err) {
+      // Corrupt/unreadable file: start empty. Safety degrades to the
+      // pre-fix (in-memory only) behavior for THIS restart, no worse.
+      log.warn("BFT vote ledger unreadable — starting empty", { error: String(err) })
+    }
+  }
+
+  getPrepared(height: bigint): Hex | undefined {
+    return this.prepared.get(height)
+  }
+
+  getCommitted(height: bigint): Hex | undefined {
+    return this.committed.get(height)
+  }
+
+  /** Persist a prepare commitment (fsync). Call BEFORE broadcasting the vote. */
+  recordPrepared(height: bigint, blockHash: Hex): void {
+    const prev = this.prepared.get(height)
+    if (prev === blockHash) return // idempotent
+    this.prepared.set(height, blockHash)
+    this.flush()
+  }
+
+  /** Persist a commit commitment (fsync). Call BEFORE broadcasting the vote. */
+  recordCommitted(height: bigint, blockHash: Hex): void {
+    const prev = this.committed.get(height)
+    if (prev === blockHash) return // idempotent
+    this.committed.set(height, blockHash)
+    this.flush()
+  }
+
+  /** Drop all entries at or below a finalized height (they are dead weight). */
+  prune(finalizedHeight: bigint): void {
+    let changed = false
+    for (const h of this.prepared.keys()) if (h <= finalizedHeight) { this.prepared.delete(h); changed = true }
+    for (const h of this.committed.keys()) if (h <= finalizedHeight) { this.committed.delete(h); changed = true }
+    if (changed) this.flush()
+  }
+
+  /** Wipe everything (validator-set change: prior votes were under stale rotation). */
+  clearAll(): void {
+    if (this.prepared.size === 0 && this.committed.size === 0) return
+    this.prepared.clear()
+    this.committed.clear()
+    this.flush()
+  }
+
+  /** Snapshot for rehydrating the coordinator's in-memory working copies. */
+  snapshotPrepared(): Map<bigint, Hex> {
+    return new Map(this.prepared)
+  }
+
+  snapshotCommitted(): Map<bigint, Hex> {
+    return new Map(this.committed)
+  }
+
+  private flush(): void {
+    if (!this.path) return // in-memory mode
+    const snap: VoteLedgerSnapshot = { prepared: {}, committed: {} }
+    for (const [h, hash] of this.prepared) snap.prepared[h.toString()] = hash
+    for (const [h, hash] of this.committed) snap.committed[h.toString()] = hash
+    const tmp = `${this.path}.tmp`
+    try {
+      mkdirSync(dirname(this.path), { recursive: true })
+      const fd = openSync(tmp, "w")
+      try {
+        writeSync(fd, JSON.stringify(snap))
+        fsyncSync(fd) // durability: survive a crash after this returns
+      } finally {
+        closeSync(fd)
+      }
+      renameSync(tmp, this.path) // atomic swap into place
+    } catch (err) {
+      // A failed flush must NOT crash consensus. Worst case we lose durability
+      // for this write and fall back to in-memory guard for a restart.
+      log.warn("BFT vote ledger flush failed", { error: String(err) })
+    }
+  }
+}

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -586,6 +586,10 @@ if (bftEnabled) {
     signer: nodeSigner,
     verifier: nodeSigner,
     relaxedQuorum,
+    // Durable BFT vote ledger — fsync'd record of our prepare/commit votes so
+    // a mid-round restart cannot re-sign a conflicting vote (self-equivocation
+    // that used to deadlock consensus). See bft-vote-ledger.ts.
+    voteLedgerPath: join(config.dataDir, "bft-vote-ledger.json"),
     // Issue #73: gate startRound + processDeferredBlock against stale
     // proposals (height ≤ chain tip). `lastFinalizedHeight` alone misses
     // gossip-block catch-up after a restart; this closes the gap.


### PR DESCRIPTION
## Root cause

The recurring 88780 BFT stalls (periodic freeze needing a manual atomic restart; rpc avg BPM seen as low as 1.93; repeated "vN equivocating" incidents) trace to a single gap: the coordinator's **no-double-vote ledger** (`localPreparedAt` / `localCommittedAt` in `bft-coordinator.ts`) is **in-memory only**.

A validator that restarts mid-round — before the in-progress height finalized — comes back with an **empty** ledger and re-`prepare`s a *freshly built* candidate for that same unfinalized height (a different `blockHash`). Peers' `EquivocationDetector` correctly flags the double-sign and drop both votes → consensus deadlocks until a human atomic-restarts the fleet.

(Confirmed by code map: `fsync`/`fdatasync` appear nowhere in `node/`; the ledger maps reset empty in the constructor; the only restart guard is the chain-engine height, which does not cover an unfinalized in-progress height.)

## Fix — persist the vote commitments durably

- **New `node/src/bft-vote-ledger.ts`** — `BftVoteLedger`: an fsync'd `(height → blockHash)` record of our own prepare/commit votes. One small JSON file, written **atomically** (temp → `fsync` → `rename`), holding only *unfinalized* heights (pruned on finalize → stays tiny, a handful of entries). `path = null` runs in-memory (backward compatible for tests).
- **`bft-coordinator.ts`**:
  - constructor **rehydrates** `localPreparedAt`/`localCommittedAt` from the ledger, so the existing Phase R self-equivocation guards survive a restart;
  - prepare + commit now persist the commitment **write-ahead** (`fsync` **before** broadcasting the vote), closing the crash-after-broadcast window;
  - prune-on-finalize and clear-on-validator-set-change mirror to the ledger.
- **`index.ts`** wires `voteLedgerPath = join(config.dataDir, "bft-vote-ledger.json")`.

**Safety over liveness preserved**: a restarted validator stays committed to its earlier vote (re-broadcasts the same block, idempotent) and refuses to sign a conflicting one → no equivocation, no deadlock, no manual restart.

## Tests

- `node/src/bft-vote-ledger.test.ts` — **7/7**: durability across a simulated restart, the exact no-double-vote-on-restart guard, prune, `clearAll`, idempotency, in-memory mode, corrupt-file recovery.
- Existing BFT suite unaffected: **149/149** pass across `bft*`, `consensus-bft*`.

## ⚠ Deployment note (consensus change)

Validate on devnet first — `bash scripts/start-devnet.sh 4`, kill a validator mid-round, confirm **no equivocation** + chain resumes cleanly — **before** any live 88780 rollout. A stall-detection + conditional-atomic-restart daemon (`coc-stall-monitor`) is protecting the live chain in the meantime, so there is no urgency to hot-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)