### PR TITLE
fix(bft): replay unfinalized votes on restart — break the vote-ledger liveness deadlock

### DIFF
--- a/node/src/bft-coordinator.test.ts
+++ b/node/src/bft-coordinator.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { BftCoordinator } from "./bft-coordinator.ts"
+import { BftVoteLedger } from "./bft-vote-ledger.ts"
 import type { BftMessage } from "./bft.ts"
 import type { ChainBlock, Hex } from "./blockchain-types.ts"
 
@@ -920,5 +924,103 @@ describe("BftCoordinator", () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 120))
 
     assert.equal(stuckCalls.length, 0, "proposer with at least 1 peer prepare is NOT stuck")
+  })
+})
+
+describe("BftCoordinator.replayUnfinalizedVotes (restart liveness, 2026-08-05)", () => {
+  const mkPath = () => join(mkdtempSync(join(tmpdir(), "bft-replay-")), "vote-ledger.json")
+  const HASH_A = ("0x" + "aa".repeat(32)) as Hex
+  const HASH_B = ("0x" + "bb".repeat(32)) as Hex
+  const HASH_C = ("0x" + "cc".repeat(32)) as Hex
+
+  it("re-broadcasts a committed vote after a simulated restart (the 88780 deadlock)", async () => {
+    const path = mkPath()
+    // Before the crash: we prepared AND committed block A at height 100, but it
+    // was never finalized (peers were one commit short — exactly v4/v1 on 08-05).
+    const pre = new BftVoteLedger(path)
+    pre.recordPrepared(100n, HASH_A)
+    pre.recordCommitted(100n, HASH_A)
+
+    // Restart: a fresh coordinator rehydrates from the same ledger path.
+    const sent: BftMessage[] = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      voteLedgerPath: path,
+      getChainHeight: () => 99n, // chain tip below 100 → height 100 still unfinalized
+      broadcastMessage: async (m) => { sent.push(m) },
+      onFinalized: async () => {},
+    })
+
+    const res = await coord.replayUnfinalizedVotes()
+    assert.equal(res.commits, 1, "one commit replayed")
+    assert.equal(res.prepares, 0, "commit supersedes the prepare — no separate prepare replay")
+    const commit = sent.find((m) => m.type === "commit")
+    assert.ok(commit, "a commit message was broadcast")
+    assert.equal(commit!.height, 100n)
+    assert.equal(commit!.blockHash, HASH_A, "replays the SAME blockHash (idempotent, no equivocation)")
+    assert.equal(commit!.senderId, "v1")
+  })
+
+  it("does NOT replay heights at or below the chain tip (already finalized)", async () => {
+    const path = mkPath()
+    const pre = new BftVoteLedger(path)
+    pre.recordCommitted(100n, HASH_A)
+    pre.recordCommitted(101n, HASH_B)
+
+    const sent: BftMessage[] = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      voteLedgerPath: path,
+      getChainHeight: () => 100n, // 100 finalized, 101 not
+      broadcastMessage: async (m) => { sent.push(m) },
+      onFinalized: async () => {},
+    })
+
+    const res = await coord.replayUnfinalizedVotes()
+    assert.equal(res.commits, 1, "only the above-tip height replays")
+    assert.equal(sent.length, 1)
+    assert.equal(sent[0].height, 101n)
+  })
+
+  it("replays a prepare when we prepared but never committed", async () => {
+    const path = mkPath()
+    const pre = new BftVoteLedger(path)
+    pre.recordPrepared(100n, HASH_C) // prepared only, no commit
+
+    const sent: BftMessage[] = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      voteLedgerPath: path,
+      getChainHeight: () => 99n,
+      broadcastMessage: async (m) => { sent.push(m) },
+      onFinalized: async () => {},
+    })
+
+    const res = await coord.replayUnfinalizedVotes()
+    assert.equal(res.commits, 0)
+    assert.equal(res.prepares, 1, "the uncommitted prepare is replayed")
+    assert.equal(sent[0].type, "prepare")
+    assert.equal(sent[0].height, 100n)
+    assert.equal(sent[0].blockHash, HASH_C)
+  })
+
+  it("is a no-op when the ledger holds nothing unfinalized", async () => {
+    const path = mkPath()
+    const sent: BftMessage[] = []
+    const coord = new BftCoordinator({
+      localId: "v1",
+      validators,
+      voteLedgerPath: path,
+      getChainHeight: () => 100n,
+      broadcastMessage: async (m) => { sent.push(m) },
+      onFinalized: async () => {},
+    })
+    const res = await coord.replayUnfinalizedVotes()
+    assert.equal(res.commits, 0)
+    assert.equal(res.prepares, 0)
+    assert.equal(sent.length, 0)
   })
 })

--- a/node/src/bft-coordinator.ts
+++ b/node/src/bft-coordinator.ts
@@ -1115,6 +1115,66 @@ export class BftCoordinator {
     msg.signature = this.cfg.signer.sign(canonical) as Hex
   }
 
+  /**
+   * Liveness recovery after a restart. The durable vote-ledger rehydrates
+   * localPreparedAt / localCommittedAt (constructor) so we REFUSE to re-vote a
+   * different block for a height we already voted on — that preserves safety
+   * (no self-equivocation). But nothing re-broadcasts those votes: a height
+   * that was partly voted but NOT finalized when we crashed then stays silent
+   * forever. Peers waiting on OUR commit to reach quorum never receive it, and
+   * we refuse to prepare a fresh candidate — a permanent deadlock that a plain
+   * atomic restart cannot break (88780, 2026-08-05: v4/v1 had committed block A
+   * but on restart never re-broadcast it, so v5 sat one commit short forever).
+   *
+   * The fix is to REPLAY the exact votes we already persisted. Replaying an
+   * identical (height, blockHash) is idempotent and never triggers
+   * equivocation: the canonical signed message carries no round, and peers'
+   * EquivocationDetector only flags a DIFFERENT blockHash for the same
+   * (height, phase). We only replay heights still above the staleness floor
+   * (i.e. unfinalized) — finalized heights are already pruned / on-chain.
+   *
+   * Commits are replayed before prepares: a commit implies we already
+   * prepared, and it is the commit that unblocks peers stuck one vote short of
+   * commit quorum. Prepares are replayed only for heights we prepared but did
+   * NOT commit. Safe to call once on startup (after peers have had a moment to
+   * connect); a no-op when the ledger holds nothing unfinalized.
+   */
+  async replayUnfinalizedVotes(): Promise<{ prepares: number; commits: number }> {
+    const floor = await this.computeStalenessFloor()
+    let commits = 0
+    let prepares = 0
+
+    for (const [height, blockHash] of this.localCommittedAt) {
+      if (height <= floor) continue
+      const msg: BftMessage = { type: "commit", height, blockHash, senderId: this.cfg.localId, signature: "" as Hex }
+      this.signMessage(msg)
+      try {
+        await this.cfg.broadcastMessage(msg)
+        commits++
+      } catch (err) {
+        log.warn("replayUnfinalizedVotes: commit broadcast failed", { height: height.toString(), error: String(err) })
+      }
+    }
+
+    for (const [height, blockHash] of this.localPreparedAt) {
+      if (height <= floor) continue
+      if (this.localCommittedAt.has(height)) continue // a commit already supersedes this prepare
+      const msg: BftMessage = { type: "prepare", height, blockHash, senderId: this.cfg.localId, signature: "" as Hex }
+      this.signMessage(msg)
+      try {
+        await this.cfg.broadcastMessage(msg)
+        prepares++
+      } catch (err) {
+        log.warn("replayUnfinalizedVotes: prepare broadcast failed", { height: height.toString(), error: String(err) })
+      }
+    }
+
+    if (commits > 0 || prepares > 0) {
+      log.info("BFT replayed unfinalized votes after restart", { commits, prepares, floor: floor.toString() })
+    }
+    return { commits, prepares }
+  }
+
   private async processDeferredBlock(): Promise<void> {
     const block = this.deferredBlock
     this.deferredBlock = null

--- a/node/src/consensus.ts
+++ b/node/src/consensus.ts
@@ -58,6 +58,13 @@ const FETCH_SNAPSHOTS_TIMEOUT_MS = 30_000
 // + a tolerance for trySnapSync's per-peer fan-out so a normal slow sync
 // completes naturally; only genuinely-stuck syncs trip the watchdog.
 const SYNC_INFLIGHT_WATCHDOG_MS = 90_000
+// After a restart, wait this long before replaying unfinalized BFT votes so
+// peers have had a moment to (re)connect and will actually receive the replay.
+// Without it, a height that was partly voted but not finalized at crash time
+// can deadlock BFT permanently (88780, 2026-08-05). Env-overridable for tests.
+const BFT_VOTE_REPLAY_STARTUP_DELAY_MS = Number(
+  process.env.COC_BFT_VOTE_REPLAY_DELAY_MS ?? 8_000,
+)
 
 // Phase H15: how long without a BFT-finalized block before the fallback
 // proposer fires the no-progress override. Primary fallback (+1 in rotation)
@@ -475,6 +482,15 @@ export class ConsensusEngine {
       if (this.bft) {
         this.noProgressWatchdogTimer = setInterval(() => { void this.checkNoProgressWatchdog() }, NO_PROGRESS_STAGGER_MS)
         this.noProgressWatchdogTimer.unref()
+        // Restart liveness (2026-08-05): the durable vote-ledger makes a
+        // restarted validator REFUSE to re-vote a conflicting block (safety),
+        // but nothing re-broadcasts the votes it already cast for a still-
+        // unfinalized height — so peers one vote short of quorum deadlock.
+        // Replay those exact votes once, after a short grace for peers to
+        // connect. Idempotent: replaying the same (height, blockHash) never
+        // equivocates (canonical msg carries no round).
+        const replayTimer = setTimeout(() => { void this.bft!.replayUnfinalizedVotes() }, BFT_VOTE_REPLAY_STARTUP_DELAY_MS)
+        replayTimer.unref?.()
       }
       void this.trySync()
     }


### PR DESCRIPTION
Fixes the liveness deadlock introduced by PR #779.

## Problem
PR #779 durable vote-ledger stops self-equivocation on restart (safety), but nothing re-broadcasts the votes already cast for a still-unfinalized height → peers one vote short of quorum deadlock forever; a plain atomic restart cannot break it. This froze 88780 on 2026-08-05 (v4/v1 had committed block A but never re-broadcast it; v5 sat one commit short). Symptom: `Phase R: refusing self-equivocation` spam, frozen tip, equivTotal NOT growing (not equivocation).

## Fix
`BftCoordinator.replayUnfinalizedVotes()` re-broadcasts the exact persisted votes (commits first, then uncommitted prepares) for heights above the staleness floor. Replaying an identical (height, blockHash) is idempotent and never equivocates (canonical msg carries no round). `consensus.start()` calls it once after a short startup grace (`COC_BFT_VOTE_REPLAY_DELAY_MS`, default 8s).

## Tests
4 new coordinator tests (restart replay / floor filter / prepare-only / no-op); 138 BFT+consensus+ledger tests pass; devnet smoke: normal production + SIGKILL/restart → chain continues, 0 equivocation.

## Deploy note
Consensus change — validate on devnet before live rollout. End-to-end deadlock reproduction is timing-specific (same caveat as #779); correctness rests on unit tests + idempotent-replay argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)