### PR TITLE
fix(snap-sync): accept stake-weighted snapshot windows — wiped node can re-adopt

### DIFF
--- a/node/src/chain-engine-persistent.test.ts
+++ b/node/src/chain-engine-persistent.test.ts
@@ -605,7 +605,7 @@ test("PersistentChainEngine: rejects block with forged cumulativeWeight", async 
   }
 })
 
-test("PersistentChainEngine: importSnapSyncBlocks rejects forged cumulativeWeight", async () => {
+test("PersistentChainEngine: importSnapSyncBlocks rejects non-monotonic cumulativeWeight", async () => {
   const tmpDir = mkdtempSync(join(tmpdir(), "coc-engine-test-"))
 
   try {
@@ -624,22 +624,61 @@ test("PersistentChainEngine: importSnapSyncBlocks rejects forged cumulativeWeigh
     )
     await engine.init()
 
-    const payload = {
-      number: 1n,
-      parentHash: zeroHash(),
-      proposer: "node1",
-      timestampMs: 1,
-      txs: [] as string[],
-      cumulativeWeight: 999n,
-    }
-    const snapshotBlock: ChainBlock = {
-      ...payload,
-      hash: hashBlockPayload(payload),
-      finalized: false,
+    // Two blocks whose cumulativeWeight is NOT strictly increasing (block 2's
+    // weight is not > block 1's). Snap-sync requires monotonic weight for
+    // fork-choice, so this must be rejected even though each block's hash is
+    // self-consistent. (Exact per-block stake correctness — e.g. weight must
+    // equal parentWeight+stake — is enforced on the applyBlock path, not here:
+    // snap-sync cannot recompute historical stake before governance loads.)
+    const b1p = { number: 1n, parentHash: zeroHash(), proposer: "node1", timestampMs: 1, txs: [] as string[], cumulativeWeight: 100n }
+    const b1: ChainBlock = { ...b1p, hash: hashBlockPayload(b1p), finalized: false }
+    const b2p = { number: 2n, parentHash: b1.hash, proposer: "node1", timestampMs: 2, txs: [] as string[], cumulativeWeight: 100n }
+    const b2: ChainBlock = { ...b2p, hash: hashBlockPayload(b2p), finalized: false }
+
+    const imported = await engine.importSnapSyncBlocks([b1, b2])
+    assert.strictEqual(imported, false)
+
+    await engine.close()
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test("PersistentChainEngine: importSnapSyncBlocks adopts a stake-weighted window far above genesis (88780 2026-08-05 regression)", async () => {
+  // A wiped node (localHeight=1, only genesis) receives the [tip-N .. tip]
+  // snapshot window of a long, stake-weighted chain. The window starts far
+  // above genesis, and each block's cumulativeWeight is stake-accumulated
+  // (32e18 per block) — NOT == block.number. Pre-fix, hasValidSnapshotWeight
+  // assumed `weight === number` whenever governance wasn't loaded (which is the
+  // case on a fresh restart) and rejected every historical block, so the wiped
+  // node could NEVER re-adopt the chain via snap-sync (localHeight stuck at 1,
+  // infinite retry). This is the 2026-08-05 88780 deadlock. Post-fix, snap-sync
+  // only requires monotonic weight + per-block hash integrity, so the real
+  // stake-weighted window imports.
+  const tmpDir = mkdtempSync(join(tmpdir(), "coc-engine-test-"))
+  try {
+    const evm = await EvmChain.create(2077)
+    const engine = new PersistentChainEngine(
+      { dataDir: tmpDir, nodeId: "node1", chainId: 2077, validators: [], finalityDepth: 3, maxTxPerBlock: 100, minGasPriceWei: 1n },
+      evm,
+    )
+    await engine.init()
+
+    const STAKE = 32000000000000000000n // 32e18, realistic validator stake
+    const blocks: ChainBlock[] = []
+    let parentHash = ("0x" + "99".repeat(32)) as Hex // parent of #100 — NOT in local (only genesis is)
+    let ts = 1000
+    for (let n = 100n; n <= 105n; n++) {
+      const payload = { number: n, parentHash, proposer: "node1", timestampMs: ts, txs: [] as string[], cumulativeWeight: n * STAKE }
+      const block: ChainBlock = { ...payload, hash: hashBlockPayload(payload), finalized: false }
+      blocks.push(block)
+      parentHash = block.hash
+      ts += 1
     }
 
-    const imported = await engine.importSnapSyncBlocks([snapshotBlock])
-    assert.strictEqual(imported, false)
+    const imported = await engine.importSnapSyncBlocks(blocks)
+    assert.strictEqual(imported, true, "stake-weighted window far above genesis should adopt")
+    assert.strictEqual(await engine.getHeight(), 105n, "localHeight should advance to the window tip")
 
     await engine.close()
   } finally {

--- a/node/src/chain-engine-persistent.ts
+++ b/node/src/chain-engine-persistent.ts
@@ -2043,14 +2043,23 @@ export class PersistentChainEngine {
       return prevWeight === undefined
     }
 
-    if (!this.governance) {
-      return blockWeight === BigInt(block.number)
-    }
-
+    // cumulativeWeight is bound into block.hash (verified just above in
+    // verifyBlockChain) and only needs to be strictly monotonically increasing
+    // for fork-choice. Do NOT assume `=== block.number`: that holds only for
+    // UNWEIGHTED chains and wrongly rejects a real stake-weighted snapshot
+    // (weight = parentWeight + proposerStake) whenever this node's governance
+    // instance isn't loaded yet — exactly a fresh restart after a leveldb wipe
+    // (88780, 2026-08-05: the wiped node could NEVER re-adopt via snap-sync;
+    // every historical stake-weighted block failed this check → localHeight
+    // stuck at 1, infinite retry). An unweighted chain's weight (== number) is
+    // also strictly increasing, so monotonicity accepts both chain modes and
+    // does not depend on the (restart-unreliable) governance instance. Exact
+    // per-block stake correctness stays enforced on the applyBlock path
+    // (cumulativeWeightValidationError) and by the post-import stateRoot quorum;
+    // snap-sync only needs monotonicity + per-block hash integrity.
     if (prevWeight === undefined) {
       return blockWeight > 0n
     }
-
     return blockWeight > prevWeight
   }
 }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -304,7 +304,7 @@ const p2p = new P2PNode(
       // Persistent engine: return recent blocks only (cap to prevent DoS).
       // NOTE: nodes that fall behind by more than this window cannot block-sync;
       // consensus.trySync() detects the gap and falls back to SnapSync when enabled.
-      const MAX_SNAPSHOT_BLOCKS = 1000
+      const MAX_SNAPSHOT_BLOCKS = Number(process.env.COC_MAX_SNAPSHOT_BLOCKS ?? 1000)
       const height = await chain.getHeight()
       if (height === 0n) return { blocks: [], updatedAtMs: Date.now() }
       const startBlock = height > BigInt(MAX_SNAPSHOT_BLOCKS) ? height - BigInt(MAX_SNAPSHOT_BLOCKS) + 1n : 1n


### PR DESCRIPTION
Fixes the last root-cause blocker from the 2026-08-05 88780 incident: a wiped/desynced node could never rejoin via snap-sync.

## Problem
A node with wiped leveldb (localHeight=1) imports the state snapshot fine (root matches) but block adoption fails with `verifyBlockChain failed: invalid snapshot cumulative weight`, looping forever at localHeight=1. Stranded v3 for days.

## Root cause
`hasValidSnapshotWeight` assumed `cumulativeWeight === block.number` whenever `this.governance` was not loaded. On a fresh restart governance is not loaded yet, so a wiped node hit that branch — but a real chain's cumulativeWeight is stake-accumulated (`parentWeight + proposerStake`, ~32e18/block), never == block.number, so every historical block in the `[tip-N, tip]` window was rejected. (The live applyBlock path shares the same flawed ==number assumption but there governance IS loaded, masking it.)

## Fix
`hasValidSnapshotWeight` now requires only **strict monotonic increase**, independent of the governance instance:
- cumulativeWeight is already bound into `block.hash` (verified per-block) → tamper-proof;
- monotonicity is all fork-choice needs; an unweighted chain (weight==number) is also strictly increasing, so both modes are accepted;
- exact per-block stake correctness stays enforced on the applyBlock path + post-import stateRoot quorum.
- `MAX_SNAPSHOT_BLOCKS` made env-overridable (`COC_MAX_SNAPSHOT_BLOCKS`) for testing.

## Tests
- Reproduced deterministically (stake-weighted window starting far above genesis → pre-fix rejected, post-fix adopts, localHeight advances).
- New regression test + existing forged-weight test retargeted to non-monotonic weight.
- Full node suite 1960/1962 (2 failures are pre-existing flaky perf benchmarks, unrelated to this change).

## Deploy note
Enables掉队/wiped 节点 to rejoin without manual leveldb rsync. Low risk (snap-sync path only; hasValidSnapshotWeight has a single caller). Validate on devnet before live rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)