### PR TITLE
fix(pose): witness signs its OWN nodeId into the EIP-712 digest, matching the contract (#772 layer 5)

### DIFF
--- a/runtime/coc-agent.ts
+++ b/runtime/coc-agent.ts
@@ -293,7 +293,11 @@ async function computeDynamicWitnessNodesForEpoch(epochId: number): Promise<Witn
       });
       continue;
     }
-    dynamicNodes.push({ url, witnessIndex: idx, authToken: sharedAuthToken });
+    // #772 layer 5 — include the witness's own nodeId so the collector
+    // forwards it as `witnessNodeId` and the witness signs the digest
+    // the contract actually reconstructs (`witnessSet[i]`, not the
+    // prover's nodeId).
+    dynamicNodes.push({ url, witnessIndex: idx, authToken: sharedAuthToken, nodeId });
   }
 
   dynamicWitnessSetCache.set(epochId, dynamicNodes);

--- a/runtime/coc-node.ts
+++ b/runtime/coc-node.ts
@@ -696,9 +696,15 @@ const server = http.createServer((req, res) => {
       return signAndRespond();
 
       function signAndRespond(resultCode?: number): void {
+      // #772 layer 5 — the contract's `_recoverWitnessSigner` binds the
+      // WITNESS's own nodeId (`witnessSet[i]`) into every digest version,
+      // not the prover's. Challengers on post-#772 code pass it as
+      // `witnessNodeId`; legacy callers omit it and get the (contract-
+      // rejected) prover-nodeId signature for wire compatibility.
+      const digestNodeId = fields.witnessNodeId ?? fields.nodeId;
       const signV1 = signWitnessAttestation(
         fields.challengeId,
-        fields.nodeId,
+        digestNodeId,
         fields.responseBodyHash,
         fields.witnessIndex,
       );
@@ -710,7 +716,7 @@ const server = http.createServer((req, res) => {
       const signV2 = fields.epochId !== undefined
         ? signWitnessAttestationV2(
             fields.challengeId,
-            fields.nodeId,
+            digestNodeId,
             fields.responseBodyHash,
             fields.witnessIndex,
             fields.epochId,
@@ -724,7 +730,7 @@ const server = http.createServer((req, res) => {
       const signV3 = (fields.epochId !== undefined && resultCode !== undefined)
         ? signWitnessAttestationV3(
             fields.challengeId,
-            fields.nodeId,
+            digestNodeId,
             fields.responseBodyHash,
             resultCode,
             fields.witnessIndex,
@@ -743,6 +749,9 @@ const server = http.createServer((req, res) => {
             ...(witnessSigV2 ? { witnessSigV2 } : {}),
             ...(witnessSigV3 ? { witnessSigV3 } : {}),
             ...(resultCode !== undefined ? { resultCode } : {}),
+            // #772 layer 5 — echo which nodeId went into the digest so
+            // the collector can assert the binding it asked for.
+            ...(fields.witnessNodeId ? { witnessNodeId: fields.witnessNodeId } : {}),
           });
         })
         .catch((error) => {

--- a/runtime/lib/dynamic-witness-set.test.ts
+++ b/runtime/lib/dynamic-witness-set.test.ts
@@ -173,3 +173,60 @@ test("#772: witness that echoes a different witnessIndex is rejected (guards aga
   assert.equal(result.bitmap, 0b01, `expected 0b01 after collision rejection, got ${result.bitmap.toString(2)}`)
   assert.equal(result.attestations.length, 1)
 })
+
+// ── #772 layer 5 — witnessNodeId digest binding ─────────────────────
+
+test("#772 layer 5: collectWitnesses forwards witnessNodeId from WitnessNodeConfig.nodeId", async () => {
+  const witnessSet: Hex32[] = [
+    ("0x" + "11".repeat(32)) as Hex32,
+    ("0x" + "33".repeat(32)) as Hex32,
+  ]
+  const dynamicNodes = buildDynamicWitnessNodes(witnessSet, () => "http://witness.example")
+    .map((n, i) => ({ ...n, nodeId: witnessSet[i] }))
+
+  const seenBodies: Array<Record<string, unknown>> = []
+  const requestFn = async (_url: string, _method: string, body?: unknown) => {
+    const req = body as { challengeId: string; nodeId: string; responseBodyHash: string; witnessIndex: number; witnessNodeId?: string }
+    seenBodies.push(req)
+    return {
+      status: 200,
+      json: {
+        challengeId: req.challengeId,
+        nodeId: req.nodeId,
+        responseBodyHash: req.responseBodyHash,
+        witnessIndex: req.witnessIndex,
+        attestedAtMs: 1,
+        witnessSig: ("0x" + "ab".repeat(65)) as `0x${string}`,
+      },
+    }
+  }
+
+  await collectWitnesses(
+    { witnessNodes: dynamicNodes, requiredWitnesses: 2, timeoutMs: 500 },
+    CHALLENGE_ID,
+    NODE_ID,
+    RESPONSE_BODY_HASH,
+    requestFn,
+  )
+
+  assert.equal(seenBodies.length, 2)
+  // The contract binds witnessSet[i] into the digest — the request MUST
+  // carry each witness's own nodeId, distinct from the prover NODE_ID.
+  assert.equal(seenBodies[0].witnessNodeId, witnessSet[0])
+  assert.equal(seenBodies[1].witnessNodeId, witnessSet[1])
+  for (const b of seenBodies) assert.equal(b.nodeId, NODE_ID, "prover nodeId unchanged for push-verify")
+})
+
+test("#772 layer 5: legacy config without nodeId omits witnessNodeId (wire compat)", async () => {
+  const dynamicNodes: WitnessNodeConfig[] = [{ url: "http://w", witnessIndex: 0 }]
+  let sawField: unknown = "sentinel"
+  const requestFn = async (_u: string, _m: string, body?: unknown) => {
+    sawField = (body as Record<string, unknown>).witnessNodeId
+    return { status: 200, json: null }
+  }
+  await collectWitnesses(
+    { witnessNodes: dynamicNodes, requiredWitnesses: 0, timeoutMs: 500 },
+    CHALLENGE_ID, NODE_ID, RESPONSE_BODY_HASH, requestFn,
+  )
+  assert.equal(sawField, undefined)
+})

--- a/runtime/lib/pose-witness-validator.ts
+++ b/runtime/lib/pose-witness-validator.ts
@@ -27,6 +27,18 @@ export interface PoseWitnessFields {
    */
   epochId?: bigint;
   /**
+   * #772 layer 5 — optional witness-side nodeId for the EIP-712 digest.
+   * The contract's `_recoverWitnessSigner` binds `witnessSet[i]` (the
+   * WITNESS's own nodeId) into the v1/v2/v3 digests — NOT the prover's
+   * nodeId that lives in the top-level `nodeId` field (which is still
+   * needed for Push-verification of the prover's receipt sig). When the
+   * challenger supplies `witnessNodeId`, the witness signs over it;
+   * when absent (legacy caller) the prover nodeId is signed as before,
+   * which the contract will reject — that pre-#772 behaviour is kept
+   * only for wire compatibility.
+   */
+  witnessNodeId?: string;
+  /**
    * #667 (audit follow-up, 2026-05-26) — optional Push-verification
    * fields. When all five are present, the witness re-derives
    * `responseBodyHash` from `responseBody` and ecrecovers the prover's
@@ -117,6 +129,16 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
     epochId = parsed;
   }
 
+  // #772 layer 5 — optional witnessNodeId (32-byte hex). See the field
+  // doc on PoseWitnessFields for why this exists alongside `nodeId`.
+  let witnessNodeId: string | undefined;
+  if (p.witnessNodeId !== undefined && p.witnessNodeId !== null) {
+    if (typeof p.witnessNodeId !== "string" || !HEX32_RE.test(p.witnessNodeId)) {
+      return { ok: false, status: 400, error: "witnessNodeId must match 0x-prefixed 32-byte hex" };
+    }
+    witnessNodeId = p.witnessNodeId;
+  }
+
   // #667 (audit follow-up, 2026-05-26) — Push-verification fields. All
   // five must appear together or none at all; partial sets are a strict
   // 400 to avoid downgrade attacks where a malicious caller omits one
@@ -181,6 +203,7 @@ export function validatePoseWitnessPayload(payload: unknown): ValidateResult {
       responseBodyHash: p.responseBodyHash.toLowerCase(),
       witnessIndex: p.witnessIndex,
       epochId,
+      witnessNodeId: witnessNodeId?.toLowerCase(),
       responseBody,
       responseAtMs,
       nodeSig,

--- a/runtime/lib/witness-collector.ts
+++ b/runtime/lib/witness-collector.ts
@@ -10,6 +10,16 @@ export interface WitnessNodeConfig {
   url: string
   witnessIndex: number
   authToken?: string
+  /**
+   * #772 layer 5 — the witness's OWN on-chain nodeId (its position-i
+   * entry in `getWitnessSet(epochId)`). The contract binds THIS value
+   * into the EIP-712 digest (`_recoverWitnessSigner(witnessSet[i], …)`),
+   * not the prover's nodeId. When set, `collectWitnesses` forwards it as
+   * `witnessNodeId` so the witness server signs the contract-expected
+   * digest. Absent for legacy static configs (signatures then bind the
+   * prover nodeId and the contract rejects them).
+   */
+  nodeId?: Hex32
 }
 
 export interface WitnessEndpointConfig {
@@ -82,6 +92,9 @@ export async function collectWitnesses(
       // the witness server returns a `witnessSigV2` alongside the v1
       // signature. The aggregator prefers v2 when building the batch.
       if (epochId !== undefined) body.epochId = epochId.toString()
+      // #772 layer 5 — tell the witness which nodeId the contract will
+      // bind into the digest (the witness's own witnessSet[i] entry).
+      if (w.nodeId) body.witnessNodeId = w.nodeId
       // #667 (audit follow-up, 2026-05-26) — push the prover's signed
       // receipt fields when available so the witness can run
       // Push-verification before signing. Stringify tipHeight/responseAtMs


### PR DESCRIPTION
Fifth mismatch layer in the #772 series — found via full calldata forensics after layers 1-4 were live on the 4-val fleet and batches still reverted ``InvalidWitnessQuorum()`` with a numerically-sufficient bitmap.

## The forensic

Decoded the failing tx, rebuilt v1/v2/v3 digests against the live ``domainSeparator()`` (verified byte-identical to the off-chain domain: ``0x8b80503c…``), ecrecovered each signature:

| Bit | Digest over PROVER nodeId | Digest over WITNESS nodeId |
|---|---|---|
| 1 (v4) | ✓ recovers v4 operator | ✓ (coincidence: self-attestation, both ids equal) |
| 2 (v5) | ✓ recovers v5 operator | ✗ garbage address |

## Root cause — day-one semantic split (r3 ``2b1cb01`` inline code has it too; NOT a #746 regression)

- **Contract**: ``_recoverWitnessSigner(witnessSet[i], …)`` binds the **witness's own nodeId** into every digest version.
- **Off-chain**: the witness signs over the top-level ``nodeId`` field = the **prover's** nodeId.

Both sides' test suites mock their own convention → never caught until real traffic flowed.

## Fix (off-chain side; no UUPS round needed)

``challengeId`` + ``responseBodyHash`` already uniquely identify the receipt, so binding the witness's own id loses nothing semantically.

- ``witness-collector.ts`` — ``WitnessNodeConfig.nodeId`` (optional) forwarded as ``witnessNodeId`` in the request.
- ``coc-agent.ts`` — dynamic witnessSet entries carry ``nodeId: witnessSet[idx]``.
- ``pose-witness-validator.ts`` — accepts + hex32-validates optional ``witnessNodeId``.
- ``coc-node.ts`` — signs v1/v2/v3 over ``witnessNodeId ?? nodeId``; push-verification still uses the prover's ``nodeId``; echoes ``witnessNodeId`` for collector assertions.

## Test plan

- [x] ``runtime/lib`` — **243/243 pass** (+2: forwarding + legacy-omit wire compat)
- [x] Syntax checks on all 4 touched files
- [ ] Post-merge: fleet deploy (agent + witness on 4 hosts) → expect first ``BatchSubmittedV2``

Refs #772 #774 #775 #776 #777